### PR TITLE
feat: update characters table schema (drop soul, add notification channels)

### DIFF
--- a/apps/web/lib/db/migrations-sqlite/0088_drop_soul_from_characters.sql
+++ b/apps/web/lib/db/migrations-sqlite/0088_drop_soul_from_characters.sql
@@ -1,0 +1,3 @@
+-- Drop soul column from characters table (removed from schema)
+-- Using simple DROP COLUMN - will fail if column doesn't exist (idempotent after first run)
+ALTER TABLE "characters" DROP COLUMN "soul";

--- a/apps/web/lib/db/migrations-sqlite/0092_add_notification_channels_to_characters.sql
+++ b/apps/web/lib/db/migrations-sqlite/0092_add_notification_channels_to_characters.sql
@@ -1,0 +1,2 @@
+-- Add notification_channels column to characters table for notification channel configuration
+ALTER TABLE "characters" ADD COLUMN "notification_channels" text NOT NULL DEFAULT '[]';

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -134,6 +134,27 @@
       "when": 1772200000000,
       "tag": "0085_add_characters_table",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1772250000000,
+      "tag": "0087_add_topics_to_characters",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1772300000000,
+      "tag": "0088_drop_soul_from_characters",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1772500000000,
+      "tag": "0092_add_notification_channels_to_characters",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/migrations/0091_drop_soul_from_characters.sql
+++ b/apps/web/lib/db/migrations/0091_drop_soul_from_characters.sql
@@ -1,0 +1,2 @@
+-- Drop soul column from characters table (removed from schema)
+ALTER TABLE "characters" DROP COLUMN IF EXISTS "soul";

--- a/apps/web/lib/db/migrations/0092_add_notification_channels_to_characters.sql
+++ b/apps/web/lib/db/migrations/0092_add_notification_channels_to_characters.sql
@@ -1,0 +1,2 @@
+-- Add notification_channels column to characters table for notification channel configuration
+ALTER TABLE "characters" ADD COLUMN "notification_channels" jsonb NOT NULL DEFAULT '[]';

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -561,6 +561,20 @@
       "when": 1772200000000,
       "tag": "0088_add_characters_table",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1772350000000,
+      "tag": "0091_drop_soul_from_characters",
+      "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1772500000000,
+      "tag": "0092_add_notification_channels_to_characters",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema-sqlite.ts
+++ b/apps/web/lib/db/schema-sqlite.ts
@@ -2167,8 +2167,6 @@ export const characters = sqliteTable("characters", {
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
-  description: text("description"),
-  soul: text("soul").notNull(),
   avatarConfig: text("avatar_config").default(JSON.stringify({})),
   jobId: text("job_id")
     .notNull()
@@ -2183,6 +2181,9 @@ export const characters = sqliteTable("characters", {
   lastExecutionStatus: text("last_execution_status"),
   sources: text("sources").default(JSON.stringify([])),
   topics: text("topics").default(JSON.stringify([])),
+  notificationChannels: text("notification_channels").default(
+    JSON.stringify([]),
+  ),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch() * 1000)`),

--- a/apps/web/lib/db/schema.pg.ts
+++ b/apps/web/lib/db/schema.pg.ts
@@ -1975,8 +1975,6 @@ export const characters = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     name: varchar("name", { length: 50 }).notNull(),
-    description: text("description"),
-    soul: text("soul").notNull(),
     avatarConfig: jsonb("avatar_config")
       .$type<Record<string, unknown>>()
       .default({}),
@@ -1995,6 +1993,10 @@ export const characters = pgTable(
       .$type<Array<{ type: "file" | "channel"; name: string; id?: string }>>()
       .default([]),
     topics: jsonb("topics").$type<string[]>().default([]).notNull(),
+    notificationChannels: jsonb("notification_channels")
+      .$type<string[]>()
+      .default([])
+      .notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),


### PR DESCRIPTION
## Summary
- Remove `soul` column from characters table
- Add `notification_channels` column for notification channel configuration
- Update both PostgreSQL and SQLite schemas
- Add database migration files

## Test plan
- [ ] Run migrations on database
- [ ] Verify characters table schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)