### PR TITLE
feat: add Tauri notification support and desktop config updates

### DIFF
--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-notification = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }

--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ use tauri::{Emitter, Listener};
 
 mod menu;
 mod node;
+mod notify;
 mod storage;
 mod system;
 mod update;
@@ -243,6 +244,7 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             // Storage
@@ -277,6 +279,8 @@ fn main() {
             // Telegram
             telegram::desktop::detect_telegram_desktop,
             telegram::desktop::check_custom_telegram_path,
+            // Notifications
+            notify::send_notification,
         ])
         .setup(|app| {
             // Deliver AppHandle to the background server thread immediately

--- a/apps/web/src-tauri/src/notify.rs
+++ b/apps/web/src-tauri/src/notify.rs
@@ -1,0 +1,28 @@
+use tauri_plugin_notification::NotificationExt;
+
+#[tauri::command]
+pub fn send_notification(
+    app_handle: tauri::AppHandle,
+    title: String,
+    body: String,
+) -> Result<(), String> {
+    let notification = app_handle.notification();
+
+    // Check and request permission if needed
+    let permission_state = notification
+        .permission_state()
+        .map_err(|e| e.to_string())?;
+
+    if permission_state != tauri_plugin_notification::PermissionState::Granted {
+        notification
+            .request_permission()
+            .map_err(|e| e.to_string())?;
+    }
+
+    notification
+        .builder()
+        .title(&title)
+        .body(&body)
+        .show()
+        .map_err(|e| e.to_string())
+}


### PR DESCRIPTION
## Summary
- Add tauri-plugin-notification dependency
- Add notify module with send_notification command
- Register notification plugin in Tauri builder

## Test plan
- [ ] Test desktop notifications work

🤖 Generated with [Claude Code](https://claude.com/claude-code)