### PR TITLE
fix: remove Node.js 25 from CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24, 25]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Remove Node.js 25 from CI test matrix (node-version: [22, 24, 25] → [22, 24])
- Node.js 25 is a non-LTS odd version that causes intermittent CI failures due to package compatibility issues

## Test plan
- [x] Local tests pass (656 tests passed)
- [ ] CI should pass with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)