### PR TITLE
fix: correct timestamp order in timeBeforeHoursMs test

### DIFF
--- a/apps/web/tests/unit/shared-utils.test.ts
+++ b/apps/web/tests/unit/shared-utils.test.ts
@@ -113,8 +113,8 @@ describe("shared utils", () => {
   describe("timeBeforeHoursMs", () => {
     // SU-10: timeBeforeHoursMs
     it("SU-10: should return milliseconds timestamp N hours ago", () => {
-      const now = Date.now();
       const twoHoursAgo = timeBeforeHoursMs(2);
+      const now = Date.now();
       // 2 hours = 7200 seconds = 7200000 ms
       expect(now - twoHoursAgo).toBe(7200000);
     });


### PR DESCRIPTION
## Summary
- Fix test in `timeBeforeHoursMs` where `Date.now()` was called before `timeBeforeHoursMs(2)`, causing the timestamp calculation to be incorrect
- Call `timeBeforeHoursMs(2)` first, then `Date.now()` to ensure `now - twoHoursAgo` equals exactly 7200000ms

## Test plan
- [x] Unit tests pass