### PR TITLE
fix: eliminate race condition in timeBeforeHoursMs test

### DIFF
--- a/apps/web/tests/unit/shared-utils.test.ts
+++ b/apps/web/tests/unit/shared-utils.test.ts
@@ -114,7 +114,7 @@ describe("shared utils", () => {
     // SU-10: timeBeforeHoursMs
     it("SU-10: should return milliseconds timestamp N hours ago", () => {
       const now = Date.now();
-      const twoHoursAgo = timeBeforeHoursMs(2);
+      const twoHoursAgo = timeBeforeHoursMs(2, now);
       // 2 hours = 7200 seconds = 7200000 ms
       expect(now - twoHoursAgo).toBe(7200000);
     });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -129,8 +129,8 @@ export function timeBeforeHours(hours: number): number {
   return Math.floor((Date.now() - hours * 60 * 60 * 1000) / 1000);
 }
 
-export function timeBeforeHoursMs(hours: number): number {
-  return Date.now() - hours * 60 * 60 * 1000;
+export function timeBeforeHoursMs(hours: number, now: number = Date.now()): number {
+  return now - hours * 60 * 60 * 1000;
 }
 
 export function timeBeforeMinutes(minutes: number): number {


### PR DESCRIPTION
## Summary

- Fix flaky test SU-10 in `shared-utils.test.ts` where `Date.now()` was called twice (once in test, once inside `timeBeforeHoursMs`), causing a 1ms race condition that failed on Node.js 24
- Add optional `now` parameter to `timeBeforeHoursMs` in `packages/shared/src/utils.ts`

## Test plan

- [x] Run `pnpm test -- tests/unit/shared-utils.test.ts` — all 32 tests pass
- [x] Run `pnpm tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)