### PR TITLE
feat: add now parameter to timeBeforeHours and timeBeforeMinutes

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -125,16 +125,16 @@ export function coerceDate(input: unknown): Date {
   return new Date();
 }
 
-export function timeBeforeHours(hours: number): number {
-  return Math.floor((Date.now() - hours * 60 * 60 * 1000) / 1000);
+export function timeBeforeHours(hours: number, now: number = Date.now()): number {
+  return Math.floor((now - hours * 60 * 60 * 1000) / 1000);
 }
 
 export function timeBeforeHoursMs(hours: number, now: number = Date.now()): number {
   return now - hours * 60 * 60 * 1000;
 }
 
-export function timeBeforeMinutes(minutes: number): number {
-  return Math.floor((Date.now() - minutes * 60 * 1000) / 1000);
+export function timeBeforeMinutes(minutes: number, now: number = Date.now()): number {
+  return Math.floor((now - minutes * 60 * 1000) / 1000);
 }
 
 export const delay = (ms: number) =>


### PR DESCRIPTION
## Summary
- Add optional `now` parameter to `timeBeforeHours` and `timeBeforeMinutes` functions for testability and consistency with `timeBeforeHoursMs`

## Test plan
- [ ] Run existing tests to verify no regressions
- [ ] Verify the new `now` parameter works correctly when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)