### PR TITLE
feat: add alloomi-memory skill

### DIFF
--- a/skills/alloomi-memory/SKILL.md
+++ b/skills/alloomi-memory/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: alloomi-memory
+description: "Alloomi Memory tools - search memory files, knowledge base, and chat insights. Triggers: memory search, knowledge base, documents, insights"
+metadata:
+  version: 0.1.0
+allowed-tools: Bash(node $SKILL_DIR/scripts/alloomi-memory.cjs *)
+---
+
+# Alloomi Memory Skill
+
+Alloomi Memory is a personal knowledge management tool that searches and manages three types of information:
+
+| Type | Description | Data Location |
+|------|-------------|--------------|
+| **Memory Files** | Personal memory files (markdown/json) | `~/.alloomi/data/memory/` |
+| **Knowledge Base** | Uploaded documents via RAG/embeddings | Alloomi server |
+| **Insights** | Structured info extracted from chat history | Alloomi server |
+
+---
+
+## What is Alloomi?
+
+Most AI assistants function as workflow tools—users give commands, they execute tasks, with no persistent knowledge of who you are or what matters to you.
+
+**Alloomi takes a fundamentally different approach: it operates as a proactive digital partner** that watches, learns, remembers, and acts on your behalf. The difference is architectural.
+
+### How It Works
+
+When users connect messaging platforms and integrations to Alloomi, they sync with permission:
+- Raw messages and communications
+- Meetings and calendar events
+- Emails and tweets
+- Voice calls
+- Notes and captured ideas
+
+This aggregated data becomes "the single source of truth for Alloomi's brain."
+
+### The Continuous Sync Loop
+
+Alloomi runs a background agent on a continuous sync loop, actively gathering information from all connected sources. An agent without this loop can only respond based on stale context. With it, every conversation—and every moment—makes Alloomi smarter and more aligned with you.
+
+### Memory Architecture
+
+Inside Alloomi, memory is layered into multiple levels:
+
+- **Raw information:** Original messages, files, transcripts
+- **Information insights:** Extracted entities, decisions, key events
+- **Contextual memory:** Recent conversation state
+- **Knowledge-base memory:** Long-term people/projects/preferences knowledge graph
+
+This enables reasoning across both immediate context and deep historical knowledge simultaneously.
+
+---
+
+## Authentication
+
+The CLI auto-reads your token from `~/.alloomi/token` (base64 encoded JWT).
+
+---
+
+## Local Memory Filesystem
+
+### Overview
+
+Memory files are stored locally at `~/.alloomi/data/memory/` and searched via direct filesystem access. This is a **read-only** operation that performs case-insensitive text search across `.md` and `.json` files.
+
+### Directory Structure
+
+```
+~/.alloomi/data/memory/
+├── chats/           # Chat conversation exports
+├── weixin/          # WeChat exports
+├── people/          # Person profiles
+├── projects/       # Project notes
+├── notes/          # General notes
+└── strategy/       # Strategy documents
+```
+
+### How search-memory Works
+
+1. **Path**: `~/.alloomi/data/memory/` (or subdirectory if specified)
+2. **Search Type**: Case-insensitive full-text search
+3. **Files**: Scans `.md` and `.json` files recursively (max depth 5)
+4. **Matching**: Each line is searched; returns first match per file
+5. **Output**: File path, line number, and line preview (first 200 chars)
+
+### Example Output
+
+```json
+{
+  "results": [
+    {
+      "file": "people/boss.md",
+      "line": 42,
+      "preview": "My boss John mentioned the deadline is next Friday"
+    },
+    {
+      "file": "projects/app/notes.md",
+      "line": 10,
+      "preview": "Boss wants the app launched by end of month"
+    }
+  ],
+  "total": 2
+}
+```
+
+---
+
+## API Endpoints
+
+### Knowledge Base (RAG)
+
+#### POST `/api/rag/search` - Search Documents
+Semantic search of uploaded documents using embeddings.
+
+```bash
+curl -X POST http://localhost:3415/api/rag/search \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "project plan", "limit": 5}'
+```
+
+**Parameters:**
+- `query` (string, required) - Search query
+- `limit` (number, default 5) - Max results to return
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "id": "doc_xxx",
+      "title": "Project Document",
+      "content": "...",
+      "score": 0.95
+    }
+  ]
+}
+```
+
+---
+
+#### GET `/api/rag/documents` - List Documents
+List all documents in the knowledge base.
+
+```bash
+curl http://localhost:3415/api/rag/documents?limit=50 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Parameters:**
+- `limit` (number, default 50) - Max results to return
+
+**Response:**
+```json
+{
+  "documents": [
+    {
+      "id": "doc_xxx",
+      "name": "document.pdf",
+      "type": "pdf",
+      "size": 102400,
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "total": 10
+}
+```
+
+---
+
+#### GET `/api/rag/documents/[id]` - Get Document
+Get a single document by ID.
+
+```bash
+curl http://localhost:3415/api/rag/documents/doc_xxx \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+```json
+{
+  "id": "doc_xxx",
+  "name": "Project Document.pdf",
+  "type": "pdf",
+  "size": 102400,
+  "content": "Document text content...",
+  "createdAt": "2024-01-01T00:00:00Z",
+  "updatedAt": "2024-01-01T00:00:00Z"
+}
+```
+
+---
+
+### Insights
+
+Insights are structured information extracted from chat history, such as key decisions, action items, and relationship notes.
+
+#### GET `/api/insights` - List Insights
+List all insights from a time period.
+
+```bash
+curl "http://localhost:3415/api/insights?days=7&limit=50" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Parameters:**
+- `days` (number, default 7) - Look back period in days
+- `limit` (number, default 50) - Max results to return
+
+**Response:**
+```json
+{
+  "insights": [
+    {
+      "id": "insight_xxx",
+      "chatId": "chat_xxx",
+      "type": "decision",
+      "content": "User decided to start new project next month",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "total": 5
+}
+```
+
+---
+
+#### GET `/api/insights/[id]?fetch=true` - Get Insight
+Get a single insight by ID, including associated chat.
+
+```bash
+curl "http://localhost:3415/api/insights/insight_xxx?fetch=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+```json
+{
+  "id": "insight_xxx",
+  "chatId": "chat_xxx",
+  "type": "decision",
+  "content": "User decided to start new project next month",
+  "chat": {
+    "id": "chat_xxx",
+    "title": "Chat with John",
+    "messages": [...]
+  },
+  "createdAt": "2024-01-01T00:00:00Z"
+}
+```
+
+---
+
+#### DELETE `/api/insights/[id]` - Delete Insight
+Delete a specific insight.
+
+```bash
+curl -X DELETE http://localhost:3415/api/insights/insight_xxx \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+```json
+{
+  "success": true
+}
+```
+
+---
+
+#### GET `/api/chat-insights?chatId=xxx` - Get Chat Insights
+Get all insights for a specific chat.
+
+```bash
+curl "http://localhost:3415/api/chat-insights?chatId=chat_xxx" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## CLI Script
+
+### Quick Start
+
+```bash
+# Search local memory files (full-text, case-insensitive)
+node $SKILL_DIR/scripts/alloomi-memory.cjs search-memory "boss"
+
+# Search local memory files in specific subdirectory
+node $SKILL_DIR/scripts/alloomi-memory.cjs search-memory "project" --directory=projects
+
+# Search knowledge base (RAG, semantic search)
+node $SKILL_DIR/scripts/alloomi-memory.cjs search-knowledge "project plan"
+
+# List knowledge base documents
+node $SKILL_DIR/scripts/alloomi-memory.cjs list-documents
+
+# Get document content
+node $SKILL_DIR/scripts/alloomi-memory.cjs get-document doc_xxx
+
+# List recent insights (last 7 days)
+node $SKILL_DIR/scripts/alloomi-memory.cjs list-insights --days=7
+
+# Get single insight
+node $SKILL_DIR/scripts/alloomi-memory.cjs get-insight insight_xxx
+
+# Delete insight
+node $SKILL_DIR/scripts/alloomi-memory.cjs delete-insight insight_xxx
+```
+
+---
+
+## AI Agent Workflow
+
+Triggered when the user asks about:
+
+1. Memory file search - "search my memory", "find what I said about..."
+2. Knowledge base search - "search uploaded documents", "find in knowledge base"
+3. Insights management - "list insights", "delete an insight"
+
+**Execution Flow:**
+
+1. **Identify intent** - memory files / knowledge base / insights
+2. **Choose command** - see command table above
+3. **Execute** - use Bash tool
+4. **Format output** - report results naturally in user's language

--- a/skills/alloomi-memory/scripts/alloomi-memory.cjs
+++ b/skills/alloomi-memory/scripts/alloomi-memory.cjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const API_BASE = 'http://localhost:3415';
+const MEMORY_DIR = path.join(os.homedir(), '.alloomi', 'data', 'memory');
+const TOKEN_PATH = path.join(os.homedir(), '.alloomi', 'token');
+
+function getAuthToken() {
+  try {
+    const encoded = fs.readFileSync(TOKEN_PATH, 'utf8').trim();
+    // Token is stored as base64 encoded JWT, decode it
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function apiRequest(endpoint, method = 'GET', body = null) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(endpoint, API_BASE);
+    const token = getAuthToken();
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token && { 'Authorization': `Bearer ${token}` })
+      }
+    };
+
+    const req = http.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json);
+        } catch {
+          resolve(data);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+async function searchMemory(query, directory = null) {
+  const searchDir = directory
+    ? path.join(MEMORY_DIR, directory)
+    : MEMORY_DIR;
+
+  if (!fs.existsSync(searchDir)) {
+    return { results: [], message: `Directory not found: ${searchDir}` };
+  }
+
+  const queryLower = query.toLowerCase();
+  const results = [];
+
+  function searchDirRecursive(dir, depth = 0) {
+    if (depth > 5) return;
+
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        searchDirRecursive(fullPath, depth + 1);
+      } else if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.json'))) {
+        try {
+          const content = fs.readFileSync(fullPath, 'utf8');
+          const lines = content.split('\n');
+
+          for (let i = 0; i < lines.length; i++) {
+            if (lines[i].toLowerCase().includes(queryLower)) {
+              const relPath = path.relative(MEMORY_DIR, fullPath);
+              results.push({
+                file: relPath,
+                line: i + 1,
+                preview: lines[i].trim().substring(0, 200)
+              });
+              break;
+            }
+          }
+        } catch (e) {
+          // Skip unreadable files
+        }
+      }
+    }
+  }
+
+  searchDirRecursive(searchDir);
+  return { results, total: results.length };
+}
+
+async function searchKnowledge(query, limit = 5) {
+  return apiRequest('/api/rag/search', 'POST', { query, limit });
+}
+
+async function listDocuments(limit = 50) {
+  return apiRequest(`/api/rag/documents?limit=${limit}`);
+}
+
+async function getDocument(id) {
+  return apiRequest(`/api/rag/documents/${id}`);
+}
+
+async function listInsights(days = 7, limit = 50) {
+  return apiRequest(`/api/insights?days=${days}&limit=${limit}`);
+}
+
+async function getInsight(id) {
+  return apiRequest(`/api/insights/${id}?fetch=true`);
+}
+
+async function deleteInsight(id) {
+  return apiRequest(`/api/insights/${id}`, 'DELETE');
+}
+
+const command = process.argv[2];
+const args = process.argv.slice(3);
+
+async function main() {
+  try {
+    switch (command) {
+      case 'search-memory': {
+        const query = args[0];
+        if (!query) throw new Error('Query required: search-memory <query>');
+
+        let directory = null;
+        const dirArg = args.find(a => a.startsWith('--directory='));
+        if (dirArg) directory = dirArg.split('=')[1];
+
+        const result = await searchMemory(query, directory);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'search-knowledge': {
+        const query = args[0];
+        if (!query) throw new Error('Query required: search-knowledge <query>');
+
+        let limit = 5;
+        const limitArg = args.find(a => a.startsWith('--limit='));
+        if (limitArg) limit = Number.parseInt(limitArg.split('=')[1]);
+
+        const result = await searchKnowledge(query, limit);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'list-documents': {
+        let limit = 50;
+        const limitArg = args.find(a => a.startsWith('--limit='));
+        if (limitArg) limit = parseInt(limitArg.split('=')[1]);
+
+        const result = await listDocuments(limit);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'get-document': {
+        const id = args[0];
+        if (!id) throw new Error('Document ID required: get-document <id>');
+        const result = await getDocument(id);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'list-insights': {
+        let days = 7;
+        let limit = 50;
+
+        for (const arg of args) {
+          if (arg.startsWith('--days=')) days = Number.parseInt(arg.split('=')[1]);
+          if (arg.startsWith('--limit=')) limit = Number.parseInt(arg.split('=')[1]);
+        }
+
+        const result = await listInsights(days, limit);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'get-insight': {
+        const id = args[0];
+        if (!id) throw new Error('Insight ID required: get-insight <id>');
+        const result = await getInsight(id);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      case 'delete-insight': {
+        const id = args[0];
+        if (!id) throw new Error('Insight ID required: delete-insight <id>');
+        const result = await deleteInsight(id);
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      default:
+        console.log(JSON.stringify({
+          error: 'Unknown command',
+          usage: `
+Commands:
+  search-memory <query> [--directory=<subdir>]    Search local memory files
+  search-knowledge <query> [--limit=5]             Search knowledge base (RAG)
+  list-documents [--limit=50]                      List knowledge base documents
+  get-document <id>                                Get document content
+  list-insights [--days=7] [--limit=50]           List recent insights
+  get-insight <id>                                 Get single insight
+  delete-insight <id>                              Delete an insight
+          `.trim()
+        }, null, 2));
+    }
+  } catch (error) {
+    console.error(JSON.stringify({ error: error.message }, null, 2));
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `alloomi-memory` skill for searching personal memory files, knowledge base (RAG), and chat insights
- Memory files: Case-insensitive full-text search in `~/.alloomi/data/memory/`
- Knowledge base: RAG API integration for semantic document search
- Insights: Structured information extracted from chat history

## Commands
| Command | Description |
|---------|-------------|
| `search-memory <query>` | Search local markdown/json files |
| `search-knowledge <query>` | Search knowledge base via RAG |
| `list-documents` | List knowledge base files |
| `get-document <id>` | Get document content |
| `list-insights [--days=7]` | List recent insights |
| `get-insight <id>` | Get single insight |
| `delete-insight <id>` | Delete an insight |

## Test plan
- [ ] Test `search-memory` with local files
- [ ] Test `search-knowledge` with RAG API
- [ ] Test `list-insights` with API

🤖 Generated with [Claude Code](https://claude.com/claude-code)