### PR TITLE
fix: prevent guest login redirect loops and update home path

### DIFF
--- a/apps/web/app/(auth)/guest-login/page.tsx
+++ b/apps/web/app/(auth)/guest-login/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { getSession } from "next-auth/react";
 
 /**
  * Guest login page - automatically creates a guest account and redirects to home.
@@ -9,22 +10,33 @@ import { useRouter } from "next/navigation";
  */
 export default function GuestLoginPage() {
   const router = useRouter();
+  const [isCreating, setIsCreating] = useState(false);
 
   useEffect(() => {
     // Create guest account and sign in
     const createGuestAndLogin = async () => {
+      if (isCreating) return;
+      setIsCreating(true);
+
       try {
+        // Check if already authenticated (to avoid loops when middleware redirects back)
+        const session = await getSession();
+        if (session?.user) {
+          // Already logged in, go to home
+          router.push("/");
+          return;
+        }
+
         const response = await fetch("/api/auth/guest", {
           method: "POST",
+          credentials: "include",
         });
 
         if (response.ok) {
-          // Successful login, reload the page to get the new session
+          // Successful login, go to home
           router.push("/");
-          router.refresh();
         } else {
           console.error("[GuestLogin] Failed to create guest account");
-          // Fallback: try normal login page
           router.push("/");
         }
       } catch (error) {
@@ -34,7 +46,7 @@ export default function GuestLoginPage() {
     };
 
     createGuestAndLogin();
-  }, [router]);
+  }, [router, isCreating]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -103,7 +103,10 @@ export { TimePicker } from "./time-picker";
 export { SidebarInset, SidebarProvider } from "./sidebar";
 export { PageSectionHeader } from "./page-section-header";
 export { PageContentCard } from "./page-content-card";
-export { HorizontalScrollContainer, hasDragged } from "./horizontal-scroll-container";
+export {
+  HorizontalScrollContainer,
+  hasDragged,
+} from "./horizontal-scroll-container";
 export {
   Command,
   CommandList,

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -96,10 +96,4 @@ const SelectItem = React.forwardRef<
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
-export {
-  Select,
-  SelectValue,
-  SelectTrigger,
-  SelectContent,
-  SelectItem,
-};
+export { Select, SelectValue, SelectTrigger, SelectContent, SelectItem };

--- a/apps/web/lib/utils/fetcher.ts
+++ b/apps/web/lib/utils/fetcher.ts
@@ -142,5 +142,5 @@ export function judgeGuest(session: Session) {
  * In character tab mode, returns "/character", otherwise returns "/".
  */
 export function getHomePath(): string {
-  return "/character";
+  return "/";
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -101,6 +101,7 @@ export async function proxy(request: NextRequest) {
 
   // ========== Original permission logic (compatible with file-read token) ==========
   const publicPaths = new Set([
+    "/",
     "/login",
     "/guest-login",
     "/register",
@@ -172,7 +173,10 @@ export async function proxy(request: NextRequest) {
   const isGuest = token.type === "guest";
   const hasValidSessionVersion = token.sessionVersion === authSessionVersion;
 
-  if (!isPublicPath && (!hasValidSessionVersion || isGuest)) {
+  // Allow guests to access "/" - they need a landing page after login
+  // Guests are still redirected from other non-public paths
+  const isRootPath = pathname === "/";
+  if (!isPublicPath && (!hasValidSessionVersion || (isGuest && !isRootPath))) {
     return buildLoginRedirect();
   }
 

--- a/packages/integrations/dingtalk/src/index.ts
+++ b/packages/integrations/dingtalk/src/index.ts
@@ -254,7 +254,11 @@ export class DingTalkAdapter extends MessagePlatformAdapter {
   ): Promise<string> {
     const token = await this.getAccessToken();
     const formData = new FormData();
-    formData.append("media", new Blob([new Uint8Array(content)], { type: mimeType }), fileName);
+    formData.append(
+      "media",
+      new Blob([new Uint8Array(content)], { type: mimeType }),
+      fileName,
+    );
     // Note: Must use oapi.dingtalk.com not api.dingtalk.com
     const uploadUrl = `https://oapi.dingtalk.com/media/upload?access_token=${encodeURIComponent(token)}&type=${encodeURIComponent(fileType)}`;
     const resp = await fetch(uploadUrl, { method: "POST", body: formData });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -129,7 +129,10 @@ export function timeBeforeHours(hours: number): number {
   return Math.floor((Date.now() - hours * 60 * 60 * 1000) / 1000);
 }
 
-export function timeBeforeHoursMs(hours: number, now: number = Date.now()): number {
+export function timeBeforeHoursMs(
+  hours: number,
+  now: number = Date.now(),
+): number {
   return now - hours * 60 * 60 * 1000;
 }
 


### PR DESCRIPTION
## Summary

- Prevent guest login redirect loops by adding session check to detect when user is already authenticated
- Fix race condition during guest account creation with `isCreating` state flag
- Include `credentials: "include"` in fetch for proper cookie handling
- Allow guests to access root path "/" — add "/" to public paths in proxy middleware
- Update `getHomePath()` to return "/" instead of "/character" for cleaner UX
- Minor formatting improvements in UI components and DingTalk integration

## Test plan

- [ ] Verify guest login flow completes without redirect loops
- [ ] Confirm guests can access "/" after login
- [ ] Test that authenticated users are properly redirected away from guest-login page
- [ ] Verify DingTalk file upload still works after formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)