### PR TITLE
feat(insights): add insight usage frequency analysis

### DIFF
--- a/apps/web/app/(chat)/api/insights/[id]/view/route.ts
+++ b/apps/web/app/(chat)/api/insights/[id]/view/route.ts
@@ -1,0 +1,87 @@
+import { auth } from "@/app/(auth)/auth";
+import { db } from "@/lib/db/queries";
+import { bot, insight } from "@/lib/db/schema";
+import { recordInsightView } from "@/lib/insights/weight-adjustment";
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const VIEW_SOURCES = new Set(["list", "detail", "search", "favorite"]);
+type ViewSource = "list" | "detail" | "search" | "favorite";
+
+function normalizeViewSource(value: unknown): ViewSource {
+  if (typeof value === "string" && VIEW_SOURCES.has(value)) {
+    return value as ViewSource;
+  }
+  return "detail";
+}
+
+function normalizeViewContext(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+async function parsePayload(request: Request): Promise<{
+  viewSource: ViewSource;
+  viewContext: Record<string, unknown> | null;
+}> {
+  if (!request.headers.get("content-type")?.includes("application/json")) {
+    return { viewSource: "detail", viewContext: null };
+  }
+
+  try {
+    const body = await request.json();
+    return {
+      viewSource: normalizeViewSource(body?.viewSource),
+      viewContext: normalizeViewContext(body?.viewContext),
+    };
+  } catch {
+    return { viewSource: "detail", viewContext: null };
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json(
+      { error: "Insight ID is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const ownedInsight = await db
+      .select({ id: insight.id })
+      .from(insight)
+      .innerJoin(bot, eq(insight.botId, bot.id))
+      .where(and(eq(insight.id, id), eq(bot.userId, session.user.id)))
+      .limit(1);
+
+    if (ownedInsight.length === 0) {
+      return NextResponse.json({ error: "Insight not found" }, { status: 404 });
+    }
+
+    const { viewSource, viewContext } = await parsePayload(request);
+    await recordInsightView(id, session.user.id, viewSource, viewContext, db);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[InsightView] Failed to record insight view:", error);
+    return NextResponse.json(
+      { error: "Failed to record insight view" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/(chat)/api/insights/analytics/export/route.ts
+++ b/apps/web/app/(chat)/api/insights/analytics/export/route.ts
@@ -1,0 +1,119 @@
+import { auth } from "@/app/(auth)/auth";
+import {
+  getInsightUsageAnalytics,
+  type InsightAnalyticsInsight,
+} from "@/lib/insights/analytics";
+import { AppError } from "@alloomi/shared/errors";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function parseBoolean(value: string | null) {
+  return value === "true" || value === "1";
+}
+
+function csvEscape(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const text = String(value);
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replaceAll('"', '""')}"`;
+  }
+  return text;
+}
+
+function formatCsvDate(value: Date | string | number | null | undefined) {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+}
+
+function buildAnalyticsCsv(insights: InsightAnalyticsInsight[]) {
+  const headers = [
+    "id",
+    "title",
+    "description",
+    "platform",
+    "account",
+    "task_label",
+    "importance",
+    "urgency",
+    "access_count_total",
+    "access_count_7d",
+    "access_count_30d",
+    "last_accessed_at",
+    "trend",
+    "recent_7d_access_count",
+    "previous_7d_access_count",
+    "value_score",
+    "recommendation",
+    "recommendation_reason",
+    "is_favorited",
+    "is_archived",
+    "created_at",
+    "updated_at",
+  ];
+
+  const rows = insights.map((item) => [
+    item.id,
+    item.title,
+    item.description,
+    item.platform ?? "",
+    item.account ?? "",
+    item.taskLabel,
+    item.importance,
+    item.urgency,
+    item.accessCountTotal,
+    item.accessCount7d,
+    item.accessCount30d,
+    formatCsvDate(item.lastAccessedAt),
+    item.trend,
+    item.recent7dAccessCount,
+    item.previous7dAccessCount,
+    item.valueScore,
+    item.recommendation.action,
+    item.recommendation.reason,
+    item.isFavorited,
+    item.isArchived,
+    formatCsvDate(item.createdAt),
+    formatCsvDate(item.updatedAt),
+  ]);
+
+  return [headers, ...rows]
+    .map((row) => row.map(csvEscape).join(","))
+    .join("\r\n");
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new AppError("unauthorized:insight").toResponse();
+  }
+
+  const includeArchived = parseBoolean(
+    request.nextUrl.searchParams.get("includeArchived"),
+  );
+
+  try {
+    const analytics = await getInsightUsageAnalytics({
+      userId: session.user.id,
+      includeArchived,
+    });
+    const csv = buildAnalyticsCsv(analytics.insights);
+    const exportDate = new Date().toISOString().slice(0, 10);
+
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="insight-analytics-${exportDate}.csv"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    console.error("[InsightAnalytics] Failed to export analytics CSV:", error);
+    return new AppError("bad_request:database", String(error)).toResponse();
+  }
+}

--- a/apps/web/app/(chat)/api/insights/analytics/route.ts
+++ b/apps/web/app/(chat)/api/insights/analytics/route.ts
@@ -1,0 +1,48 @@
+import { auth } from "@/app/(auth)/auth";
+import { getInsightUsageAnalytics } from "@/lib/insights/analytics";
+import { AppError } from "@alloomi/shared/errors";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+function parseLimit(value: string | null) {
+  if (!value) return DEFAULT_LIMIT;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function parseBoolean(value: string | null) {
+  return value === "true" || value === "1";
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new AppError("unauthorized:insight").toResponse();
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = parseLimit(searchParams.get("limit"));
+  const includeArchived = parseBoolean(searchParams.get("includeArchived"));
+
+  try {
+    const analytics = await getInsightUsageAnalytics({
+      userId: session.user.id,
+      limit,
+      includeArchived,
+    });
+
+    return Response.json(analytics, { status: 200 });
+  } catch (error) {
+    console.error("[InsightAnalytics] Failed to load analytics:", error);
+    return new AppError("bad_request:database", String(error)).toResponse();
+  }
+}

--- a/apps/web/app/(chat)/home.tsx
+++ b/apps/web/app/(chat)/home.tsx
@@ -291,6 +291,9 @@ export function Home() {
   useEffect(() => {
     // Only redirect when page is null and localActiveChatId is available
     if (page !== null || !localActiveChatId) return;
+    // /inbox is a standalone page that also has no page query parameter.
+    // Keep it on the insight/events surface instead of forcing it into chat.
+    if (pathname !== "/") return;
 
     const newPath = buildNavigationUrl({
       pathname: "/",
@@ -301,7 +304,7 @@ export function Home() {
       },
     });
     router.replace(newPath, { scroll: false });
-  }, [page, localActiveChatId, searchParams, router]);
+  }, [page, localActiveChatId, pathname, searchParams, router]);
 
   // Mobile panel state
   // Note: When initializing, need to consider pathname, ensure value in localStorage matches current path

--- a/apps/web/app/api/insights/maintenance/daily-analytics/route.ts
+++ b/apps/web/app/api/insights/maintenance/daily-analytics/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { verifyCronAuth } from "@/lib/auth/remote-auth-utils";
+import { runDailyInsightAnalyticsMaintenance } from "@/lib/insights/maintenance";
+
+export const dynamic = "force-dynamic";
+
+async function handleDailyInsightAnalyticsMaintenance(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 500 },
+    );
+  }
+
+  if (!verifyCronAuth(request, secret)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await runDailyInsightAnalyticsMaintenance();
+
+  return NextResponse.json({ ok: true, ...result });
+}
+
+export async function GET(request: Request) {
+  return await handleDailyInsightAnalyticsMaintenance(request);
+}
+
+export async function POST(request: Request) {
+  return await handleDailyInsightAnalyticsMaintenance(request);
+}

--- a/apps/web/components/agent/events-panel.tsx
+++ b/apps/web/components/agent/events-panel.tsx
@@ -22,6 +22,8 @@ const InsightTabsDialogLazy = lazy(() =>
   })),
 );
 
+const ANALYTICS_TAB_VALUE = "analytics";
+
 import { useChatContext } from "@/components/chat-context";
 import {
   GoogleAuthForm,
@@ -86,6 +88,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { CombinedFilterButton } from "./combined-filter-button";
 import type { QuickFilterValue, ViewOptionValue } from "./events-panel-types";
+import { InsightAnalyticsPanel } from "./insight-analytics-panel";
 import {
   deduplicateInsights,
   filterEmptyInsights,
@@ -1376,6 +1379,11 @@ export function AgentEventsPanel({
       return;
     }
 
+    if (selectedValue === ANALYTICS_TAB_VALUE) {
+      lastValidatedSelectedValueRef.current = ANALYTICS_TAB_VALUE;
+      return;
+    }
+
     const isValidCustomTab = enabledTabsRef.current.some(
       (tab) => tab.id === selectedValue,
     );
@@ -1422,7 +1430,7 @@ export function AgentEventsPanel({
       return;
     }
 
-    if (selectedValue === "all") {
+    if (selectedValue === "all" || selectedValue === ANALYTICS_TAB_VALUE) {
       if (subTab !== "all") {
         setSubTab("all");
         lastSyncedSubTabRef.current = "all";
@@ -1750,6 +1758,7 @@ export function AgentEventsPanel({
   const effectiveSelectedInsight = externalSelectedInsight ?? selectedInsight;
   /** Desktop with selected event: list + middle card displays Insight details, convenient for coexistence with right person detail column */
   const showEmbeddedInsight = !isMobile && !!effectiveSelectedInsight;
+  const isAnalyticsView = selectedValue === ANALYTICS_TAB_VALUE;
 
   return (
     <>
@@ -1792,6 +1801,7 @@ export function AgentEventsPanel({
                       "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 h-8 text-xs font-semibold transition-colors shrink-0",
                       selectedValue === "all" ||
                         (selectedValue !== "other" &&
+                          selectedValue !== ANALYTICS_TAB_VALUE &&
                           !enabledTabs.some((tab) => tab.id === selectedValue))
                         ? "border-primary/20 bg-primary/10 text-primary"
                         : "border-border bg-background text-muted-foreground hover:bg-muted",
@@ -1810,6 +1820,20 @@ export function AgentEventsPanel({
                         </span>
                       ) : null;
                     })()}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => handleSubTabChange(ANALYTICS_TAB_VALUE)}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 h-8 text-xs font-semibold transition-colors shrink-0",
+                      isAnalyticsView
+                        ? "border-primary/20 bg-primary/10 text-primary"
+                        : "border-border bg-background text-muted-foreground hover:bg-muted",
+                    )}
+                  >
+                    <RemixIcon name="chart_gantt" size="size-3.5" />
+                    <span>{t("insight.analytics.tab", "Analytics")}</span>
                   </button>
 
                   {/* Enabled custom and preset Tabs */}
@@ -1877,7 +1901,7 @@ export function AgentEventsPanel({
             >
               {/* Right side actions */}
               {/* Combined filter button - desktop display, left of refresh button */}
-              {!isMobile && (
+              {!isMobile && !isAnalyticsView && (
                 <CombinedFilterButton
                   readStatus={sharedReadStatus}
                   onReadStatusChange={setSharedReadStatus}
@@ -1888,7 +1912,7 @@ export function AgentEventsPanel({
               )}
 
               {/* Refresh button - desktop display, right of filter button */}
-              {!isMobile && (
+              {!isMobile && !isAnalyticsView && (
                 <Button
                   variant="outline"
                   size="icon"
@@ -2013,8 +2037,14 @@ export function AgentEventsPanel({
             />
 
             <div className="px-6 pt-0 pb-6 flex flex-col justify-start items-center w-full h-full">
-              {selectedValue === "all" && renderAllView()}
-              {selectedValue !== "all" && renderTabView(selectedValue)}
+              {isAnalyticsView ? (
+                <InsightAnalyticsPanel />
+              ) : (
+                <>
+                  {selectedValue === "all" && renderAllView()}
+                  {selectedValue !== "all" && renderTabView(selectedValue)}
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/components/agent/insight-analytics-panel.tsx
+++ b/apps/web/components/agent/insight-analytics-panel.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { Button } from "@alloomi/ui";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import useSWR from "swr";
+import { RemixIcon } from "@/components/remix-icon";
+import { Spinner } from "@/components/spinner";
+import { cn, fetcher } from "@/lib/utils";
+
+type AccessTrend = "rising" | "falling" | "stable";
+type OrganizationAction = "keep" | "archive" | "delete";
+
+type AnalyticsInsight = {
+  id: string;
+  title: string;
+  description: string;
+  platform: string | null;
+  account: string | null;
+  accessCountTotal: number;
+  accessCount7d: number;
+  accessCount30d: number;
+  lastAccessedAt: string | null;
+  trend: AccessTrend;
+  recent7dAccessCount: number;
+  previous7dAccessCount: number;
+  valueScore: number;
+  recommendation: {
+    action: OrganizationAction;
+    reason: string;
+  };
+};
+
+type AnalyticsRelationship = {
+  insightId: string;
+  insightTitle: string;
+  relatedInsightId: string;
+  relatedInsightTitle: string;
+  sharedConversationCount: number;
+  combinedAccessCount30d: number;
+  combinedValueScore: number;
+};
+
+type InsightUsageAnalyticsResponse = {
+  generatedAt: string;
+  summary: {
+    totalInsights: number;
+    activeInsights: number;
+    dormantInsights: number;
+    totalAccesses30d: number;
+    averageValueScore: number;
+    risingInsights: number;
+    fallingInsights: number;
+    stableInsights: number;
+  };
+  topInsights: AnalyticsInsight[];
+  bottomInsights: AnalyticsInsight[];
+  relationships: AnalyticsRelationship[];
+  insights: AnalyticsInsight[];
+};
+
+const ACTION_STYLES: Record<OrganizationAction, string> = {
+  keep: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  archive: "border-amber-200 bg-amber-50 text-amber-700",
+  delete: "border-rose-200 bg-rose-50 text-rose-700",
+};
+
+const TREND_STYLES: Record<AccessTrend, string> = {
+  rising: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  falling: "border-rose-200 bg-rose-50 text-rose-700",
+  stable: "border-sky-200 bg-sky-50 text-sky-700",
+};
+
+function formatDate(value: string | null, fallback: string) {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function actionLabel(
+  action: OrganizationAction,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
+  if (action === "archive") {
+    return t("insight.analytics.action.archive", "Archive");
+  }
+  if (action === "delete") {
+    return t("insight.analytics.action.delete", "Delete");
+  }
+  return t("insight.analytics.action.keep", "Keep");
+}
+
+function trendLabel(
+  trend: AccessTrend,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
+  if (trend === "rising") {
+    return t("insight.analytics.trend.rising", "Rising");
+  }
+  if (trend === "falling") {
+    return t("insight.analytics.trend.falling", "Falling");
+  }
+  return t("insight.analytics.trend.stable", "Stable");
+}
+
+function trendIcon(trend: AccessTrend) {
+  if (trend === "rising") return "arrow_up";
+  if (trend === "falling") return "arrow_down";
+  return "chart_gantt";
+}
+
+function recommendationReasonLabel(
+  reason: string,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
+  const reasonKeyByText: Record<string, string> = {
+    "Favorited insights are treated as intentionally retained.":
+      "insight.analytics.reason.favorited",
+    "No recent usage and low value score for more than 90 days.":
+      "insight.analytics.reason.deleteDormant",
+    "Dormant for at least 30 days with low recent value.":
+      "insight.analytics.reason.archiveDormant",
+    "Usage is falling and value score is below the active threshold.":
+      "insight.analytics.reason.archiveFalling",
+    "Usage, freshness, or relevance still supports keeping it active.":
+      "insight.analytics.reason.keepActive",
+  };
+  const key = reasonKeyByText[reason];
+  return key ? t(key, reason) : reason;
+}
+
+function InsightMetricCard({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | number;
+  icon: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background px-4 py-3">
+      <div className="mb-2 flex items-center justify-between gap-3 text-muted-foreground">
+        <span className="truncate text-xs font-medium">{label}</span>
+        <RemixIcon name={icon} size="size-4" />
+      </div>
+      <div className="text-2xl font-semibold tabular-nums text-foreground">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function InsightAnalyticsRow({
+  item,
+  rank,
+  mode,
+}: {
+  item: AnalyticsInsight;
+  rank: number;
+  mode: "top" | "bottom";
+}) {
+  const { t } = useTranslation();
+  const fallback =
+    mode === "bottom"
+      ? t("insight.analytics.neverAccessed", "Never")
+      : t("insight.analytics.noAccess", "No access");
+
+  return (
+    <div className="grid min-h-[76px] grid-cols-[28px_minmax(0,1fr)_auto] items-center gap-3 rounded-lg border border-border bg-background px-3 py-3">
+      <div className="flex size-7 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+        {rank}
+      </div>
+      <div className="min-w-0">
+        <div className="truncate text-sm font-semibold text-foreground">
+          {item.title || t("insight.analytics.untitled", "Untitled insight")}
+        </div>
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span className="tabular-nums">
+            {t("insight.analytics.accesses30dShort", "{{count}} / 30d", {
+              count: item.accessCount30d,
+            })}
+          </span>
+          <span className="tabular-nums">
+            {t("insight.analytics.totalAccessesShort", "{{count}} total", {
+              count: item.accessCountTotal,
+            })}
+          </span>
+          <span>{formatDate(item.lastAccessedAt, fallback)}</span>
+        </div>
+      </div>
+      <div className="flex min-w-[86px] flex-col items-end gap-2">
+        <span
+          className={cn(
+            "inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] font-semibold capitalize",
+            TREND_STYLES[item.trend],
+          )}
+        >
+          <RemixIcon name={trendIcon(item.trend)} size="size-3.5" />
+          {trendLabel(item.trend, t)}
+        </span>
+        <span className="text-xs font-semibold tabular-nums text-foreground">
+          {item.valueScore}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function InsightRelationshipRow({ item }: { item: AnalyticsRelationship }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border border-border bg-background px-3 py-3">
+      <div className="flex min-w-0 items-center gap-2 text-sm font-semibold text-foreground">
+        <span className="truncate">{item.insightTitle}</span>
+        <RemixIcon
+          name="link"
+          size="size-4"
+          className="shrink-0 text-muted-foreground"
+        />
+        <span className="truncate">{item.relatedInsightTitle}</span>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span className="tabular-nums">
+          {t("insight.analytics.conversationCount", "{{count}} conversations", {
+            count: item.sharedConversationCount,
+          })}
+        </span>
+        <span className="tabular-nums">
+          {t("insight.analytics.accessCount30d", "{{count}} accesses / 30d", {
+            count: item.combinedAccessCount30d,
+          })}
+        </span>
+        <span className="tabular-nums">
+          {t("insight.analytics.scoreValue", "score {{score}}", {
+            score: item.combinedValueScore,
+          })}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function InsightRecommendationRow({ item }: { item: AnalyticsInsight }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border border-border bg-background px-3 py-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="min-w-0 truncate text-sm font-semibold text-foreground">
+          {item.title || t("insight.analytics.untitled", "Untitled insight")}
+        </div>
+        <span
+          className={cn(
+            "inline-flex h-6 shrink-0 items-center rounded-full border px-2 text-[11px] font-semibold",
+            ACTION_STYLES[item.recommendation.action],
+          )}
+        >
+          {actionLabel(item.recommendation.action, t)}
+        </span>
+      </div>
+      <div className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+        {recommendationReasonLabel(item.recommendation.reason, t)}
+      </div>
+    </div>
+  );
+}
+
+export function InsightAnalyticsPanel() {
+  const { t } = useTranslation();
+  const { data, error, isLoading, mutate } =
+    useSWR<InsightUsageAnalyticsResponse>(
+      "/api/insights/analytics?limit=10",
+      fetcher,
+    );
+
+  const organizationCandidates = useMemo(() => {
+    return (data?.insights ?? [])
+      .filter((item) => item.recommendation.action !== "keep")
+      .sort(
+        (left, right) =>
+          left.valueScore - right.valueScore ||
+          left.accessCount30d - right.accessCount30d,
+      )
+      .slice(0, 6);
+  }, [data?.insights]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full min-h-[320px] items-center justify-center text-muted-foreground">
+        <Spinner size={20} />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 text-center">
+        <div className="text-sm font-semibold text-foreground">
+          {t("insight.analytics.loadFailed", "Analytics failed to load")}
+        </div>
+        <Button variant="outline" size="sm" onClick={() => mutate()}>
+          <RemixIcon name="refresh" size="size-4" />
+          {t("common.refresh", "Refresh")}
+        </Button>
+      </div>
+    );
+  }
+
+  const generatedAt = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(data.generatedAt));
+
+  return (
+    <div className="w-full space-y-4 pb-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-lg font-semibold text-foreground">
+            {t("insight.analytics.title", "Usage Analytics")}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {t("insight.analytics.generatedAt", "Updated {{time}}", {
+              time: generatedAt,
+            })}
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0"
+          onClick={() => {
+            window.location.href = "/api/insights/analytics/export";
+          }}
+        >
+          <RemixIcon name="download" size="size-4" />
+          {t("common.export", "Export")}
+        </Button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <InsightMetricCard
+          label={t("insight.analytics.totalInsights", "Total insights")}
+          value={data.summary.totalInsights}
+          icon="layers"
+        />
+        <InsightMetricCard
+          label={t("insight.analytics.activeInsights", "Active / 30d")}
+          value={data.summary.activeInsights}
+          icon="eye"
+        />
+        <InsightMetricCard
+          label={t("insight.analytics.dormantInsights", "Dormant")}
+          value={data.summary.dormantInsights}
+          icon="bell_off"
+        />
+        <InsightMetricCard
+          label={t("insight.analytics.averageScore", "Average score")}
+          value={data.summary.averageValueScore}
+          icon="chart_gantt"
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-foreground">
+              {t("insight.analytics.topInsights", "Top insights")}
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              {data.summary.totalAccesses30d} / 30d
+            </span>
+          </div>
+          <div className="space-y-2">
+            {data.topInsights.length > 0 ? (
+              data.topInsights.map((item, index) => (
+                <InsightAnalyticsRow
+                  key={item.id}
+                  item={item}
+                  rank={index + 1}
+                  mode="top"
+                />
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+                {t("insight.analytics.noUsageData", "No usage data yet")}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-foreground">
+              {t("insight.analytics.bottomInsights", "Dormant insights")}
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              {data.summary.dormantInsights}
+            </span>
+          </div>
+          <div className="space-y-2">
+            {data.bottomInsights.length > 0 ? (
+              data.bottomInsights.map((item, index) => (
+                <InsightAnalyticsRow
+                  key={item.id}
+                  item={item}
+                  rank={index + 1}
+                  mode="bottom"
+                />
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+                {t("insight.analytics.noDormantData", "No dormant insights")}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[0.9fr_1.1fr]">
+        <section className="rounded-lg border border-border bg-background p-4">
+          <h3 className="text-sm font-semibold text-foreground">
+            {t("insight.analytics.trends", "Trend analysis")}
+          </h3>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            {[
+              {
+                label: t("insight.analytics.trend.rising", "Rising"),
+                value: data.summary.risingInsights,
+                trend: "rising" as const,
+              },
+              {
+                label: t("insight.analytics.trend.stable", "Stable"),
+                value: data.summary.stableInsights,
+                trend: "stable" as const,
+              },
+              {
+                label: t("insight.analytics.trend.falling", "Falling"),
+                value: data.summary.fallingInsights,
+                trend: "falling" as const,
+              },
+            ].map((item) => (
+              <div
+                key={item.trend}
+                className={cn(
+                  "rounded-lg border px-3 py-3",
+                  TREND_STYLES[item.trend],
+                )}
+              >
+                <div className="flex items-center gap-1.5 text-xs font-semibold">
+                  <RemixIcon name={trendIcon(item.trend)} size="size-4" />
+                  {item.label}
+                </div>
+                <div className="mt-2 text-2xl font-semibold tabular-nums">
+                  {item.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-semibold text-foreground">
+            {t("insight.analytics.relationships", "Relationship analysis")}
+          </h3>
+          <div className="space-y-2">
+            {data.relationships.length > 0 ? (
+              data.relationships.map((item) => (
+                <InsightRelationshipRow
+                  key={`${item.insightId}:${item.relatedInsightId}`}
+                  item={item}
+                />
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+                {t(
+                  "insight.analytics.noRelationships",
+                  "No repeated relationships yet",
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">
+          {t(
+            "insight.analytics.organizationRecommendations",
+            "Organization recommendations",
+          )}
+        </h3>
+        <div className="grid gap-2 xl:grid-cols-2">
+          {organizationCandidates.length > 0 ? (
+            organizationCandidates.map((item) => (
+              <InsightRecommendationRow key={item.id} item={item} />
+            ))
+          ) : (
+            <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground xl:col-span-2">
+              {t("insight.analytics.noRecommendations", "No cleanup needed")}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -902,6 +902,77 @@ export function AppSidebar() {
                           );
                         })()}
 
+                      {/* Insight analytics entry - exposes /inbox from the primary sidebar. */}
+                      {isNavVisible("chat") && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              className={cn(
+                                "w-full gap-2 px-3 py-2 h-auto rounded-md transition-colors",
+                                pathname === "/inbox"
+                                  ? "text-primary bg-sidebar-hover"
+                                  : "text-sidebar-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground",
+                                isCollapsed
+                                  ? "justify-center"
+                                  : "justify-start",
+                              )}
+                              aria-current={
+                                pathname === "/inbox" ? "page" : undefined
+                              }
+                              asChild
+                            >
+                              <Link
+                                href="/inbox"
+                                onClick={() => {
+                                  if (isMobile) {
+                                    setIsCollapsed(true);
+                                    window.dispatchEvent(
+                                      new CustomEvent("alloomi:close-sidebar"),
+                                    );
+                                  }
+                                }}
+                                className={cn(
+                                  "flex items-center w-full min-h-0",
+                                  isCollapsed
+                                    ? "justify-center"
+                                    : "gap-2 justify-start",
+                                )}
+                              >
+                                <RemixIcon
+                                  name="radar"
+                                  size={SIDEBAR_NAV_ICON_SIZE}
+                                  filled={pathname === "/inbox"}
+                                  className={
+                                    pathname === "/inbox" ? "text-primary" : ""
+                                  }
+                                />
+                                {!isCollapsed && (
+                                  <span
+                                    className={cn(
+                                      "truncate font-normal",
+                                      pathname === "/inbox"
+                                        ? "text-primary"
+                                        : "text-sidebar-foreground",
+                                    )}
+                                  >
+                                    {t("nav.insights", "Tracking Events")}
+                                  </span>
+                                )}
+                              </Link>
+                            </Button>
+                          </TooltipTrigger>
+                          {isCollapsed && (
+                            <TooltipContent
+                              side="right"
+                              className="border border-border bg-card text-card-foreground z-[9999]"
+                            >
+                              <p>{t("nav.insights", "Tracking Events")}</p>
+                            </TooltipContent>
+                          )}
+                        </Tooltip>
+                      )}
+
                       {/* Collection - temporarily hidden */}
                       {/* <Tooltip>
                   <TooltipTrigger asChild>

--- a/apps/web/components/insight-detail-drawer.tsx
+++ b/apps/web/components/insight-detail-drawer.tsx
@@ -785,6 +785,7 @@ function InsightDetailDrawerContent({
 
   // rerender-move-effect-to-event: use ref to track recorded insight, avoid duplicate calls
   const lastRecordedInsightRef = useRef<string | null>(null);
+  const lastRecordedInsightViewRef = useRef<string | null>(null);
 
   // Single insight refresh hook
   const { isRefreshing, handleRefresh: refreshInsight } =
@@ -829,6 +830,51 @@ function InsightDetailDrawerContent({
       }
     }
   }, [isOpen, normalizedInsight]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      lastRecordedInsightViewRef.current = null;
+      return;
+    }
+
+    const insightId = normalizedInsight.id;
+    if (lastRecordedInsightViewRef.current === insightId) {
+      return;
+    }
+
+    lastRecordedInsightViewRef.current = insightId;
+    const controller = new AbortController();
+
+    void fetch(`/api/insights/${encodeURIComponent(insightId)}/view`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        viewSource: "detail",
+        viewContext: {
+          surface: embedInLayout ? "embedded" : "drawer",
+          isInBriefContext,
+          initialTab: initialTab ?? null,
+        },
+      }),
+      signal: controller.signal,
+    }).catch((error) => {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      console.warn(
+        "[InsightDetailDrawer] Failed to record insight view:",
+        error,
+      );
+    });
+
+    return () => controller.abort();
+  }, [
+    embedInLayout,
+    initialTab,
+    isInBriefContext,
+    isOpen,
+    normalizedInsight.id,
+  ]);
 
   const shouldHideReplyWorkspace =
     normalizedInsight.taskLabel === "rss_feed" ||

--- a/apps/web/hooks/use-insight-tabs.ts
+++ b/apps/web/hooks/use-insight-tabs.ts
@@ -527,7 +527,14 @@ export function useInsightTabs() {
     const updatedPresetTabs = presetTabs.map((presetTab) => {
       const userTab = userTabsMap.get(presetTab.id);
       if (userTab) {
-        return { ...presetTab, ...userTab };
+        return {
+          ...presetTab,
+          ...userTab,
+          name: presetTab.name,
+          title: presetTab.title,
+          description: presetTab.description,
+          rules: presetTab.rules,
+        };
       }
       return { ...presetTab, enabled: true };
     });

--- a/apps/web/hooks/use-insight-weights.ts
+++ b/apps/web/hooks/use-insight-weights.ts
@@ -52,19 +52,22 @@ export function useInsightWeights(
   const [error, setError] = useState<Error | null>(null);
   const [version, setVersion] = useState(0); // Used to trigger re-fetch
 
-  // Dedupe insightIds to avoid unnecessary requests
+  // Dedupe and stabilize insightIds to avoid re-fetching when callers create
+  // a new array instance with the same IDs on every render.
+  const insightIdsKey = [...new Set(insightIds)].sort().join("\u0000");
   const memoizedInsightIds = useMemo(() => {
-    return [...new Set(insightIds)];
-  }, [insightIds]);
+    return insightIdsKey ? insightIdsKey.split("\u0000") : [];
+  }, [insightIdsKey]);
 
   useEffect(() => {
     let isMounted = true;
 
     async function fetchWeights() {
       if (memoizedInsightIds.length === 0) {
-        setWeightMultipliers(new Map());
-        setLastViewedAtMap(new Map());
-        setIsLoading(false);
+        setWeightMultipliers((prev) => (prev.size === 0 ? prev : new Map()));
+        setLastViewedAtMap((prev) => (prev.size === 0 ? prev : new Map()));
+        setIsLoading((prev) => (prev ? false : prev));
+        setError((prev) => (prev === null ? prev : null));
         return;
       }
 

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -3,9 +3,78 @@ import baseEn from "@alloomi/i18n/locales/en-US";
 
 const en = {
   ...baseEn,
+  common: {
+    ...baseEn.common,
+    export: "Export",
+  },
   nav: {
     ...baseEn.nav,
+    insights: "Insight Tracking",
+    inbox: "Insight Tracking",
     termsAndPolicies: "Terms & Policies",
+  },
+  insight: {
+    ...(baseEn.insight ?? {}),
+    tabs: {
+      ...(baseEn.insight?.tabs ?? {}),
+      preset: {
+        ...(baseEn.insight?.tabs?.preset ?? {}),
+        importantPeople: "Important people",
+        importantPeopleDesc: "Filter insights from important people or key contacts",
+      },
+    },
+    analytics: {
+      ...(
+        (baseEn.insight as typeof baseEn.insight & {
+          analytics?: Record<string, unknown>;
+        }).analytics ?? {}
+      ),
+      tab: "Analytics",
+      title: "Usage Analytics",
+      generatedAt: "Updated {{time}}",
+      loadFailed: "Analytics failed to load",
+      totalInsights: "Total insights",
+      activeInsights: "Active / 30d",
+      dormantInsights: "Dormant",
+      averageScore: "Average score",
+      topInsights: "Top insights",
+      bottomInsights: "Dormant insights",
+      noUsageData: "No usage data yet",
+      noDormantData: "No dormant insights",
+      trends: "Trend analysis",
+      relationships: "Relationship analysis",
+      noRelationships: "No repeated relationships yet",
+      organizationRecommendations: "Organization recommendations",
+      noRecommendations: "No cleanup needed",
+      neverAccessed: "Never",
+      noAccess: "No access",
+      untitled: "Untitled insight",
+      accesses30dShort: "{{count}} / 30d",
+      totalAccessesShort: "{{count}} total",
+      conversationCount: "{{count}} conversations",
+      accessCount30d: "{{count}} accesses / 30d",
+      scoreValue: "score {{score}}",
+      trend: {
+        rising: "Rising",
+        stable: "Stable",
+        falling: "Falling",
+      },
+      action: {
+        keep: "Keep",
+        archive: "Archive",
+        delete: "Delete",
+      },
+      reason: {
+        favorited: "Favorited insights are treated as intentionally retained.",
+        deleteDormant:
+          "No recent usage and low value score for more than 90 days.",
+        archiveDormant: "Dormant for at least 30 days with low recent value.",
+        archiveFalling:
+          "Usage is falling and value score is below the active threshold.",
+        keepActive:
+          "Usage, freshness, or relevance still supports keeping it active.",
+      },
+    },
   },
   character: {
     ...baseEn.character,

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -3,9 +3,75 @@ import baseZh from "@alloomi/i18n/locales/zh-Hans";
 
 const zh = {
   ...baseZh,
+  common: {
+    ...baseZh.common,
+    export: "导出",
+  },
   nav: {
     ...baseZh.nav,
+    insights: "Insight 追踪",
+    inbox: "Insight 追踪",
     termsAndPolicies: "条款与政策",
+  },
+  insight: {
+    ...(baseZh.insight ?? {}),
+    tabs: {
+      ...(baseZh.insight?.tabs ?? {}),
+      preset: {
+        ...(baseZh.insight?.tabs?.preset ?? {}),
+        importantPeople: "重要人物",
+        importantPeopleDesc: "筛选来自重要人物或重点联系人的 Insight",
+      },
+    },
+    analytics: {
+      ...(
+        (baseZh.insight as typeof baseZh.insight & {
+          analytics?: Record<string, unknown>;
+        }).analytics ?? {}
+      ),
+      tab: "分析",
+      title: "使用分析",
+      generatedAt: "更新于 {{time}}",
+      loadFailed: "分析数据加载失败",
+      totalInsights: "Insight 总数",
+      activeInsights: "30 天活跃",
+      dormantInsights: "休眠",
+      averageScore: "平均评分",
+      topInsights: "高频 Insight",
+      bottomInsights: "休眠 Insight",
+      noUsageData: "暂无使用数据",
+      noDormantData: "暂无休眠 Insight",
+      trends: "趋势分析",
+      relationships: "关系分析",
+      noRelationships: "暂无重复关联",
+      organizationRecommendations: "整理建议",
+      noRecommendations: "暂无需要清理的 Insight",
+      neverAccessed: "从未访问",
+      noAccess: "暂无访问",
+      untitled: "未命名 Insight",
+      accesses30dShort: "{{count}} / 30天",
+      totalAccessesShort: "共 {{count}} 次",
+      conversationCount: "{{count}} 个会话",
+      accessCount30d: "30 天 {{count}} 次访问",
+      scoreValue: "评分 {{score}}",
+      trend: {
+        rising: "上升",
+        stable: "稳定",
+        falling: "下降",
+      },
+      action: {
+        keep: "保留",
+        archive: "归档",
+        delete: "删除",
+      },
+      reason: {
+        favorited: "已收藏的 Insight 会被视为需要保留。",
+        deleteDormant: "超过 90 天没有近期使用，且价值评分较低。",
+        archiveDormant: "至少 30 天未活跃，近期价值较低。",
+        archiveFalling: "使用趋势下降，且价值评分低于活跃阈值。",
+        keepActive: "使用情况、新鲜度或相关性仍支持继续保留。",
+      },
+    },
   },
   character: {
     ...baseZh.character,

--- a/apps/web/lib/cron/insight-maintenance.ts
+++ b/apps/web/lib/cron/insight-maintenance.ts
@@ -7,19 +7,32 @@ import {
   getUserInsightSettings,
   updateUserInsightSettings,
 } from "../db/queries";
-import { runWeeklyInsightMaintenance } from "@/lib/insights/maintenance";
+import {
+  runDailyInsightAnalyticsMaintenance,
+  runWeeklyInsightMaintenance,
+} from "@/lib/insights/maintenance";
 
+const DAILY_ANALYTICS_INTERVAL = 24 * 60 * 60 * 1000;
 const WEEKLY_MAINTENANCE_INTERVAL = 7 * 24 * 60 * 60 * 1000;
 
 // Desktop caches the last successful maintenance run in memory, but also mirrors it to insight settings so restarts keep the same weekly window.
 let lastInsightMaintenanceRunAt: Date | null = null;
+let lastInsightAnalyticsMaintenanceRunAt: Date | null = null;
 
 export function getLastInsightMaintenanceRunAt(): Date | null {
   return lastInsightMaintenanceRunAt;
 }
 
+export function getLastInsightAnalyticsMaintenanceRunAt(): Date | null {
+  return lastInsightAnalyticsMaintenanceRunAt;
+}
+
 export function setLastInsightMaintenanceRunAt(date: Date | null) {
   lastInsightMaintenanceRunAt = date;
+}
+
+export function setLastInsightAnalyticsMaintenanceRunAt(date: Date | null) {
+  lastInsightAnalyticsMaintenanceRunAt = date;
 }
 
 async function loadPersistedInsightMaintenanceRunAt(userId: string) {
@@ -31,6 +44,31 @@ async function persistInsightMaintenanceRunAt(userId: string, runAt: Date) {
   await updateUserInsightSettings(userId, {
     lastInsightMaintenanceRunAt: runAt,
   });
+}
+
+// Keep rolling insight analytics fresh in desktop mode even when no new view event is recorded.
+export async function runDailyInsightAnalyticsMaintenanceIfDue(
+  schedulerUserId: string | undefined,
+) {
+  if (!schedulerUserId) {
+    return;
+  }
+
+  const now = new Date();
+  if (
+    lastInsightAnalyticsMaintenanceRunAt &&
+    now.getTime() - lastInsightAnalyticsMaintenanceRunAt.getTime() <
+      DAILY_ANALYTICS_INTERVAL
+  ) {
+    return;
+  }
+
+  console.log("[LocalScheduler] Running daily insight analytics maintenance");
+  await runDailyInsightAnalyticsMaintenance({
+    userId: schedulerUserId,
+    now,
+  });
+  lastInsightAnalyticsMaintenanceRunAt = now;
 }
 
 // Run insight maintenance on the same minute loop as scheduled jobs, but only once per persisted weekly window per user.

--- a/apps/web/lib/cron/local-scheduler.ts
+++ b/apps/web/lib/cron/local-scheduler.ts
@@ -21,6 +21,10 @@ import { db } from "../db/index";
 import { characters, jobExecutions, scheduledJobs } from "../db/schema";
 import { eq } from "drizzle-orm";
 import type { ScheduledJob } from "@/lib/db/schema";
+import {
+  runDailyInsightAnalyticsMaintenanceIfDue,
+  runInsightMaintenanceIfDue,
+} from "./insight-maintenance";
 
 // Track running jobs to prevent duplicate executions within the same scheduler cycle
 const runningJobs = new Set<string>();
@@ -179,6 +183,9 @@ async function checkAndExecuteDueJobs() {
     // Then clean up zombie jobs that have been stuck for over 4 hours
     // These are beyond recovery and are simply deleted
     await cleanupStuckJobs();
+
+    await runDailyInsightAnalyticsMaintenanceIfDue(schedulerUserId);
+    await runInsightMaintenanceIfDue(schedulerUserId);
 
     // Get all jobs that are due to run for the current user
     const dueJobs = await getDueJobs(new Date(), schedulerUserId);

--- a/apps/web/lib/db/migrations-sqlite/0098_add_insight_access_frequency.sql
+++ b/apps/web/lib/db/migrations-sqlite/0098_add_insight_access_frequency.sql
@@ -1,0 +1,50 @@
+ALTER TABLE "insight_weights"
+ADD COLUMN "access_count_total" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN "access_count_7d" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN "access_count_30d" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN "last_accessed_at" integer;
+
+CREATE INDEX IF NOT EXISTS "weights_access_count_30d_idx"
+ON "insight_weights" ("user_id", "access_count_30d");
+
+CREATE INDEX IF NOT EXISTS "weights_last_accessed_idx"
+ON "insight_weights" ("user_id", "last_accessed_at");
+
+UPDATE "insight_weights"
+SET
+  "access_count_total" = (
+    SELECT COUNT(*)
+    FROM "insight_view_history"
+    WHERE
+      "insight_view_history"."insight_id" = "insight_weights"."insight_id"
+      AND "insight_view_history"."user_id" = "insight_weights"."user_id"
+  ),
+  "access_count_7d" = (
+    SELECT COUNT(*)
+    FROM "insight_view_history"
+    WHERE
+      "insight_view_history"."insight_id" = "insight_weights"."insight_id"
+      AND "insight_view_history"."user_id" = "insight_weights"."user_id"
+      AND "insight_view_history"."viewed_at" >= (unixepoch() * 1000) - (7 * 24 * 60 * 60 * 1000)
+  ),
+  "access_count_30d" = (
+    SELECT COUNT(*)
+    FROM "insight_view_history"
+    WHERE
+      "insight_view_history"."insight_id" = "insight_weights"."insight_id"
+      AND "insight_view_history"."user_id" = "insight_weights"."user_id"
+      AND "insight_view_history"."viewed_at" >= (unixepoch() * 1000) - (30 * 24 * 60 * 60 * 1000)
+  ),
+  "last_accessed_at" = (
+    SELECT MAX("viewed_at")
+    FROM "insight_view_history"
+    WHERE
+      "insight_view_history"."insight_id" = "insight_weights"."insight_id"
+      AND "insight_view_history"."user_id" = "insight_weights"."user_id"
+  );

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -190,6 +190,13 @@
                         "when": 1774100000000,
                         "tag": "0097_add_character_system_type",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx": 27,
+                        "version": "7",
+                        "when": 1774200000000,
+                        "tag": "0098_add_insight_access_frequency",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/apps/web/lib/db/migrations/0098_add_insight_access_frequency.sql
+++ b/apps/web/lib/db/migrations/0098_add_insight_access_frequency.sql
@@ -1,0 +1,42 @@
+ALTER TABLE "insight_weights"
+ADD COLUMN IF NOT EXISTS "access_count_total" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN IF NOT EXISTS "access_count_7d" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN IF NOT EXISTS "access_count_30d" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "insight_weights"
+ADD COLUMN IF NOT EXISTS "last_accessed_at" timestamp with time zone;
+
+CREATE INDEX IF NOT EXISTS "weights_access_count_30d_idx"
+ON "insight_weights" ("user_id", "access_count_30d");
+
+CREATE INDEX IF NOT EXISTS "weights_last_accessed_idx"
+ON "insight_weights" ("user_id", "last_accessed_at");
+
+UPDATE "insight_weights" AS weights
+SET
+  "access_count_total" = stats.total_count,
+  "access_count_7d" = stats.count_7d,
+  "access_count_30d" = stats.count_30d,
+  "last_accessed_at" = stats.last_accessed_at
+FROM (
+  SELECT
+    "insight_id",
+    "user_id",
+    COUNT(*)::integer AS total_count,
+    COUNT(*) FILTER (
+      WHERE "viewed_at" >= now() - interval '7 days'
+    )::integer AS count_7d,
+    COUNT(*) FILTER (
+      WHERE "viewed_at" >= now() - interval '30 days'
+    )::integer AS count_30d,
+    MAX("viewed_at") AS last_accessed_at
+  FROM "insight_view_history"
+  GROUP BY "insight_id", "user_id"
+) AS stats
+WHERE
+  weights."insight_id" = stats."insight_id"
+  AND weights."user_id" = stats."user_id";

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1774100000000,
       "tag": "0097_add_character_system_type",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1774200000000,
+      "tag": "0098_add_insight_access_frequency",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema-sqlite.ts
+++ b/apps/web/lib/db/schema-sqlite.ts
@@ -2345,6 +2345,10 @@ export const insightWeights = sqliteTable(
       mode: "timestamp",
     }).notNull(),
     currentEventRank: integer("current_event_rank").notNull().default(0),
+    accessCountTotal: integer("access_count_total").notNull().default(0),
+    accessCount7d: integer("access_count_7d").notNull().default(0),
+    accessCount30d: integer("access_count_30d").notNull().default(0),
+    lastAccessedAt: integer("last_accessed_at", { mode: "timestamp" }),
     lastWeightAdjustmentReason: text("last_weight_adjustment_reason"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
@@ -2357,6 +2361,14 @@ export const insightWeights = sqliteTable(
     insightIdx: index("weights_insight_idx").on(table.insightId),
     userIdx: index("weights_user_idx").on(table.userId),
     lastViewedIdx: index("weights_last_viewed_idx").on(table.lastViewedAt),
+    accessCount30dIdx: index("weights_access_count_30d_idx").on(
+      table.userId,
+      table.accessCount30d,
+    ),
+    lastAccessedIdx: index("weights_last_accessed_idx").on(
+      table.userId,
+      table.lastAccessedAt,
+    ),
   }),
 );
 

--- a/apps/web/lib/db/schema.pg.ts
+++ b/apps/web/lib/db/schema.pg.ts
@@ -2235,6 +2235,10 @@ export const insightWeights = pgTable(
       .$type<number>()
       .notNull()
       .default(0),
+    accessCountTotal: integer("access_count_total").notNull().default(0),
+    accessCount7d: integer("access_count_7d").notNull().default(0),
+    accessCount30d: integer("access_count_30d").notNull().default(0),
+    lastAccessedAt: timestamp("last_accessed_at", { withTimezone: true }),
     lastWeightAdjustmentReason: text("last_weight_adjustment_reason"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
@@ -2251,6 +2255,14 @@ export const insightWeights = pgTable(
     insightIdx: index("weights_insight_idx").on(table.insightId),
     userIdx: index("weights_user_idx").on(table.userId),
     lastViewedIdx: index("weights_last_viewed_idx").on(table.lastViewedAt),
+    accessCount30dIdx: index("weights_access_count_30d_idx").on(
+      table.userId,
+      table.accessCount30d,
+    ),
+    lastAccessedIdx: index("weights_last_accessed_idx").on(
+      table.userId,
+      table.lastAccessedAt,
+    ),
   }),
 );
 

--- a/apps/web/lib/insights/analytics.ts
+++ b/apps/web/lib/insights/analytics.ts
@@ -1,0 +1,603 @@
+import { db as defaultDb } from "@/lib/db/queries";
+import {
+  chat,
+  chatInsights,
+  bot,
+  insight,
+  insightViewHistory,
+  insightWeights,
+} from "@/lib/db/schema";
+import type { DrizzleDB } from "@/lib/db/types";
+import { and, eq, gte, inArray, isNull } from "drizzle-orm";
+
+export type InsightAccessTrend = "rising" | "falling" | "stable";
+export type InsightOrganizationAction = "keep" | "archive" | "delete";
+
+export type InsightAnalyticsInsight = {
+  id: string;
+  title: string;
+  description: string;
+  taskLabel: string;
+  platform: string | null;
+  account: string | null;
+  importance: string;
+  urgency: string;
+  isFavorited: boolean;
+  isArchived: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  time: Date;
+  accessCountTotal: number;
+  accessCount7d: number;
+  accessCount30d: number;
+  lastAccessedAt: Date | null;
+  trend: InsightAccessTrend;
+  recent7dAccessCount: number;
+  previous7dAccessCount: number;
+  valueScore: number;
+  recommendation: InsightOrganizationRecommendation;
+};
+
+export type InsightOrganizationRecommendation = {
+  action: InsightOrganizationAction;
+  reason: string;
+};
+
+export type InsightAnalyticsSummary = {
+  totalInsights: number;
+  activeInsights: number;
+  dormantInsights: number;
+  totalAccesses30d: number;
+  averageValueScore: number;
+  risingInsights: number;
+  fallingInsights: number;
+  stableInsights: number;
+};
+
+export type InsightRelationship = {
+  insightId: string;
+  insightTitle: string;
+  relatedInsightId: string;
+  relatedInsightTitle: string;
+  sharedConversationCount: number;
+  combinedAccessCount30d: number;
+  combinedValueScore: number;
+};
+
+export type InsightUsageAnalytics = {
+  generatedAt: string;
+  summary: InsightAnalyticsSummary;
+  topInsights: InsightAnalyticsInsight[];
+  bottomInsights: InsightAnalyticsInsight[];
+  relationships: InsightRelationship[];
+  insights: InsightAnalyticsInsight[];
+};
+
+export type GetInsightUsageAnalyticsInput = {
+  userId: string;
+  limit?: number;
+  includeArchived?: boolean;
+  now?: Date;
+  db?: DrizzleDB;
+};
+
+type InsightAnalyticsRow = {
+  id: string;
+  title: string;
+  description: string;
+  taskLabel: string;
+  platform: string | null;
+  account: string | null;
+  importance: string;
+  urgency: string;
+  isFavorited: boolean | null;
+  isArchived: boolean | null;
+  createdAt: Date;
+  updatedAt: Date;
+  time: Date;
+  accessCountTotal: number | null;
+  accessCount7d: number | null;
+  accessCount30d: number | null;
+  lastAccessedAt: Date | null;
+};
+
+type TrendCounts = {
+  recent7d: number;
+  previous7d: number;
+};
+
+type ConversationInsightLink = {
+  chatId: string | null;
+  insightId: string | null;
+};
+
+const DEFAULT_LIMIT = 10;
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeLabel(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function daysBetween(later: Date, earlier: Date) {
+  return Math.max(0, (later.getTime() - earlier.getTime()) / 86_400_000);
+}
+
+function coerceDate(value: Date | string | number | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function calculateInsightTrend(
+  recent7dAccessCount: number,
+  previous7dAccessCount: number,
+): InsightAccessTrend {
+  if (recent7dAccessCount === 0 && previous7dAccessCount === 0) {
+    return "stable";
+  }
+
+  if (previous7dAccessCount === 0) {
+    return recent7dAccessCount > 0 ? "rising" : "stable";
+  }
+
+  const threshold = Math.max(1, Math.ceil(previous7dAccessCount * 0.25));
+  if (recent7dAccessCount >= previous7dAccessCount + threshold) {
+    return "rising";
+  }
+  if (previous7dAccessCount >= recent7dAccessCount + threshold) {
+    return "falling";
+  }
+  return "stable";
+}
+
+export function calculateInsightValueScore(input: {
+  accessCount30d: number;
+  maxAccessCount30d: number;
+  lastAccessedAt: Date | null;
+  createdAt: Date;
+  importance: string;
+  urgency: string;
+  isFavorited: boolean;
+  now: Date;
+}) {
+  const frequencyScore =
+    input.maxAccessCount30d > 0
+      ? Math.log1p(input.accessCount30d) / Math.log1p(input.maxAccessCount30d)
+      : 0;
+
+  const freshnessDate = input.lastAccessedAt ?? input.createdAt;
+  const ageDays = daysBetween(input.now, freshnessDate);
+  const freshnessScore =
+    ageDays <= 1
+      ? 1
+      : ageDays <= 7
+        ? 0.8
+        : ageDays <= 30
+          ? 0.45
+          : ageDays <= 90
+            ? 0.2
+            : 0.08;
+
+  const importance = normalizeLabel(input.importance);
+  const importanceScore = ["critical", "urgent", "high", "important"].includes(
+    importance,
+  )
+    ? 1
+    : ["medium", "general", "normal"].includes(importance)
+      ? 0.6
+      : 0.25;
+
+  const urgency = normalizeLabel(input.urgency);
+  const urgencyScore = ["immediate", "urgent", "24h", "high"].includes(urgency)
+    ? 1
+    : ["medium", "soon"].includes(urgency)
+      ? 0.6
+      : 0.3;
+
+  const relevanceScore = importanceScore * 0.7 + urgencyScore * 0.3;
+  const favoriteScore = input.isFavorited ? 1 : 0;
+
+  return Math.round(
+    clamp(
+      frequencyScore * 0.45 +
+        freshnessScore * 0.25 +
+        relevanceScore * 0.2 +
+        favoriteScore * 0.1,
+    ) * 100,
+  );
+}
+
+export function recommendInsightOrganization(input: {
+  accessCount30d: number;
+  lastAccessedAt: Date | null;
+  createdAt: Date;
+  importance: string;
+  isFavorited: boolean;
+  trend: InsightAccessTrend;
+  valueScore: number;
+  now: Date;
+}): InsightOrganizationRecommendation {
+  if (input.isFavorited) {
+    return {
+      action: "keep",
+      reason: "Favorited insights are treated as intentionally retained.",
+    };
+  }
+
+  const lastMeaningfulActivity = input.lastAccessedAt ?? input.createdAt;
+  const inactiveDays = daysBetween(input.now, lastMeaningfulActivity);
+  const importance = normalizeLabel(input.importance);
+  const isHighImportance = ["critical", "urgent", "high", "important"].includes(
+    importance,
+  );
+
+  if (
+    input.accessCount30d === 0 &&
+    inactiveDays >= 90 &&
+    input.valueScore < 35 &&
+    !isHighImportance
+  ) {
+    return {
+      action: "delete",
+      reason: "No recent usage and low value score for more than 90 days.",
+    };
+  }
+
+  if (
+    input.accessCount30d === 0 &&
+    inactiveDays >= 30 &&
+    input.valueScore < 55 &&
+    !isHighImportance
+  ) {
+    return {
+      action: "archive",
+      reason: "Dormant for at least 30 days with low recent value.",
+    };
+  }
+
+  if (input.trend === "falling" && input.valueScore < 45) {
+    return {
+      action: "archive",
+      reason: "Usage is falling and value score is below the active threshold.",
+    };
+  }
+
+  return {
+    action: "keep",
+    reason: "Usage, freshness, or relevance still supports keeping it active.",
+  };
+}
+
+function compareTopInsights(
+  left: InsightAnalyticsInsight,
+  right: InsightAnalyticsInsight,
+) {
+  return (
+    right.accessCount30d - left.accessCount30d ||
+    right.accessCountTotal - left.accessCountTotal ||
+    right.valueScore - left.valueScore ||
+    (right.lastAccessedAt?.getTime() ?? 0) -
+      (left.lastAccessedAt?.getTime() ?? 0)
+  );
+}
+
+function compareBottomInsights(
+  left: InsightAnalyticsInsight,
+  right: InsightAnalyticsInsight,
+) {
+  const leftLastAccessed = left.lastAccessedAt?.getTime() ?? 0;
+  const rightLastAccessed = right.lastAccessedAt?.getTime() ?? 0;
+
+  return (
+    left.accessCount30d - right.accessCount30d ||
+    left.valueScore - right.valueScore ||
+    leftLastAccessed - rightLastAccessed ||
+    left.createdAt.getTime() - right.createdAt.getTime()
+  );
+}
+
+function buildSummary(
+  insights: InsightAnalyticsInsight[],
+): InsightAnalyticsSummary {
+  const totalValueScore = insights.reduce(
+    (total, item) => total + item.valueScore,
+    0,
+  );
+
+  return {
+    totalInsights: insights.length,
+    activeInsights: insights.filter((item) => item.accessCount30d > 0).length,
+    dormantInsights: insights.filter((item) => item.accessCount30d === 0)
+      .length,
+    totalAccesses30d: insights.reduce(
+      (total, item) => total + item.accessCount30d,
+      0,
+    ),
+    averageValueScore:
+      insights.length > 0 ? Math.round(totalValueScore / insights.length) : 0,
+    risingInsights: insights.filter((item) => item.trend === "rising").length,
+    fallingInsights: insights.filter((item) => item.trend === "falling").length,
+    stableInsights: insights.filter((item) => item.trend === "stable").length,
+  };
+}
+
+function buildTrendCountMap(
+  views: Array<{ insightId: string | null; viewedAt: Date | string | number }>,
+  now: Date,
+) {
+  const sevenDaysAgo = now.getTime() - 7 * 86_400_000;
+  const fourteenDaysAgo = now.getTime() - 14 * 86_400_000;
+  const trendCounts = new Map<string, TrendCounts>();
+
+  for (const view of views) {
+    if (!view.insightId) continue;
+
+    const viewedAt = coerceDate(view.viewedAt);
+    if (!viewedAt) continue;
+
+    const timestamp = viewedAt.getTime();
+    if (timestamp < fourteenDaysAgo || timestamp > now.getTime()) continue;
+
+    const current = trendCounts.get(view.insightId) ?? {
+      recent7d: 0,
+      previous7d: 0,
+    };
+
+    if (timestamp >= sevenDaysAgo) {
+      current.recent7d += 1;
+    } else {
+      current.previous7d += 1;
+    }
+
+    trendCounts.set(view.insightId, current);
+  }
+
+  return trendCounts;
+}
+
+function buildRelationshipAnalytics(
+  insights: InsightAnalyticsInsight[],
+  conversationLinks: ConversationInsightLink[],
+  limit: number,
+): InsightRelationship[] {
+  const insightsById = new Map(insights.map((item) => [item.id, item]));
+  const insightIdsByChatId = new Map<string, Set<string>>();
+
+  for (const link of conversationLinks) {
+    if (!link.chatId || !link.insightId || !insightsById.has(link.insightId)) {
+      continue;
+    }
+
+    const insightIds = insightIdsByChatId.get(link.chatId) ?? new Set<string>();
+    insightIds.add(link.insightId);
+    insightIdsByChatId.set(link.chatId, insightIds);
+  }
+
+  const pairCounts = new Map<string, number>();
+  for (const insightIds of insightIdsByChatId.values()) {
+    const sortedInsightIds = [...insightIds].sort();
+    for (let leftIndex = 0; leftIndex < sortedInsightIds.length; leftIndex++) {
+      for (
+        let rightIndex = leftIndex + 1;
+        rightIndex < sortedInsightIds.length;
+        rightIndex++
+      ) {
+        const pairKey = `${sortedInsightIds[leftIndex]}:${sortedInsightIds[rightIndex]}`;
+        pairCounts.set(pairKey, (pairCounts.get(pairKey) ?? 0) + 1);
+      }
+    }
+  }
+
+  return [...pairCounts.entries()]
+    .map(([pairKey, sharedConversationCount]) => {
+      const [insightId, relatedInsightId] = pairKey.split(":");
+      const first = insightsById.get(insightId);
+      const second = insightsById.get(relatedInsightId);
+
+      if (!first || !second) return null;
+
+      return {
+        insightId,
+        insightTitle: first.title,
+        relatedInsightId,
+        relatedInsightTitle: second.title,
+        sharedConversationCount,
+        combinedAccessCount30d: first.accessCount30d + second.accessCount30d,
+        combinedValueScore: Math.round(
+          (first.valueScore + second.valueScore) / 2,
+        ),
+      };
+    })
+    .filter((item): item is InsightRelationship => item !== null)
+    .sort(
+      (left, right) =>
+        right.sharedConversationCount - left.sharedConversationCount ||
+        right.combinedAccessCount30d - left.combinedAccessCount30d ||
+        right.combinedValueScore - left.combinedValueScore,
+    )
+    .slice(0, limit);
+}
+
+export function buildInsightUsageAnalytics(input: {
+  rows: InsightAnalyticsRow[];
+  views: Array<{ insightId: string | null; viewedAt: Date | string | number }>;
+  conversationLinks?: ConversationInsightLink[];
+  now: Date;
+  limit?: number;
+}): InsightUsageAnalytics {
+  const limit = input.limit ?? DEFAULT_LIMIT;
+  const maxAccessCount30d = Math.max(
+    0,
+    ...input.rows.map((row) => Number(row.accessCount30d ?? 0)),
+  );
+  const trendCountMap = buildTrendCountMap(input.views, input.now);
+
+  const insights = input.rows.map((row): InsightAnalyticsInsight => {
+    const createdAt = coerceDate(row.createdAt) ?? input.now;
+    const updatedAt = coerceDate(row.updatedAt) ?? createdAt;
+    const time = coerceDate(row.time) ?? createdAt;
+    const lastAccessedAt = coerceDate(row.lastAccessedAt);
+    const accessCount30d = Number(row.accessCount30d ?? 0);
+    const trendCounts = trendCountMap.get(row.id) ?? {
+      recent7d: 0,
+      previous7d: 0,
+    };
+    const trend = calculateInsightTrend(
+      trendCounts.recent7d,
+      trendCounts.previous7d,
+    );
+    const valueScore = calculateInsightValueScore({
+      accessCount30d,
+      maxAccessCount30d,
+      lastAccessedAt,
+      createdAt,
+      importance: row.importance,
+      urgency: row.urgency,
+      isFavorited: Boolean(row.isFavorited),
+      now: input.now,
+    });
+
+    const recommendation = recommendInsightOrganization({
+      accessCount30d,
+      lastAccessedAt,
+      createdAt,
+      importance: row.importance,
+      isFavorited: Boolean(row.isFavorited),
+      trend,
+      valueScore,
+      now: input.now,
+    });
+
+    return {
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      taskLabel: row.taskLabel,
+      platform: row.platform,
+      account: row.account,
+      importance: row.importance,
+      urgency: row.urgency,
+      isFavorited: Boolean(row.isFavorited),
+      isArchived: Boolean(row.isArchived),
+      createdAt,
+      updatedAt,
+      time,
+      accessCountTotal: Number(row.accessCountTotal ?? 0),
+      accessCount7d: Number(row.accessCount7d ?? 0),
+      accessCount30d,
+      lastAccessedAt,
+      trend,
+      recent7dAccessCount: trendCounts.recent7d,
+      previous7dAccessCount: trendCounts.previous7d,
+      valueScore,
+      recommendation,
+    };
+  });
+
+  return {
+    generatedAt: input.now.toISOString(),
+    summary: buildSummary(insights),
+    topInsights: [...insights].sort(compareTopInsights).slice(0, limit),
+    bottomInsights: [...insights].sort(compareBottomInsights).slice(0, limit),
+    relationships: buildRelationshipAnalytics(
+      insights,
+      input.conversationLinks ?? [],
+      limit,
+    ),
+    insights,
+  };
+}
+
+export async function getInsightUsageAnalytics(
+  input: GetInsightUsageAnalyticsInput,
+): Promise<InsightUsageAnalytics> {
+  const db = input.db ?? defaultDb;
+  const now = input.now ?? new Date();
+  const fourteenDaysAgo = new Date(now.getTime() - 14 * 86_400_000);
+  const whereConditions = [eq(bot.userId, input.userId)];
+
+  if (!input.includeArchived) {
+    whereConditions.push(eq(insight.isArchived, false));
+    whereConditions.push(isNull(insight.pendingDeletionAt));
+  }
+
+  const rows = (await db
+    .select({
+      id: insight.id,
+      title: insight.title,
+      description: insight.description,
+      taskLabel: insight.taskLabel,
+      platform: insight.platform,
+      account: insight.account,
+      importance: insight.importance,
+      urgency: insight.urgency,
+      isFavorited: insight.isFavorited,
+      isArchived: insight.isArchived,
+      createdAt: insight.createdAt,
+      updatedAt: insight.updatedAt,
+      time: insight.time,
+      accessCountTotal: insightWeights.accessCountTotal,
+      accessCount7d: insightWeights.accessCount7d,
+      accessCount30d: insightWeights.accessCount30d,
+      lastAccessedAt: insightWeights.lastAccessedAt,
+    })
+    .from(insight)
+    .innerJoin(bot, eq(insight.botId, bot.id))
+    .leftJoin(
+      insightWeights,
+      and(
+        eq(insightWeights.insightId, insight.id),
+        eq(insightWeights.userId, input.userId),
+      ),
+    )
+    .where(and(...whereConditions))) as InsightAnalyticsRow[];
+
+  const insightIds = rows.map((row) => row.id);
+  const views =
+    insightIds.length === 0
+      ? []
+      : ((await db
+          .select({
+            insightId: insightViewHistory.insightId,
+            viewedAt: insightViewHistory.viewedAt,
+          })
+          .from(insightViewHistory)
+          .where(
+            and(
+              eq(insightViewHistory.userId, input.userId),
+              gte(insightViewHistory.viewedAt, fourteenDaysAgo),
+              inArray(insightViewHistory.insightId, insightIds),
+            ),
+          )) as Array<{
+          insightId: string | null;
+          viewedAt: Date | string | number;
+        }>);
+
+  const conversationLinks =
+    insightIds.length === 0
+      ? []
+      : ((await db
+          .select({
+            chatId: chatInsights.chatId,
+            insightId: chatInsights.insightId,
+          })
+          .from(chatInsights)
+          .innerJoin(chat, eq(chatInsights.chatId, chat.id))
+          .where(
+            and(
+              eq(chat.userId, input.userId),
+              inArray(chatInsights.insightId, insightIds),
+            ),
+          )) as ConversationInsightLink[]);
+
+  return buildInsightUsageAnalytics({
+    rows,
+    views,
+    conversationLinks,
+    now,
+    limit: input.limit,
+  });
+}

--- a/apps/web/lib/insights/maintenance.ts
+++ b/apps/web/lib/insights/maintenance.ts
@@ -1,6 +1,6 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db/queries";
-import { bot } from "@/lib/db/schema";
+import { bot, insight, insightWeights } from "@/lib/db/schema";
 import {
   deleteExpiredPendingDeletionInsights,
   runInsightCompaction,
@@ -11,6 +11,7 @@ import {
   getInsightCompactionPlatform,
   type InsightCompactionPlatform,
 } from "@/lib/insights/compaction-profile";
+import { refreshInsightAccessSummary } from "@/lib/insights/weight-adjustment";
 
 export type WeeklyInsightMaintenanceInput = {
   platform?: InsightCompactionPlatform;
@@ -29,6 +30,18 @@ export type WeeklyInsightMaintenanceResult = {
   platform: InsightCompactionPlatform;
   processedUserCount: number;
   users: WeeklyInsightMaintenanceUserResult[];
+};
+
+export type DailyInsightAnalyticsMaintenanceInput = {
+  userId?: string;
+  botId?: string;
+  now?: Date;
+};
+
+export type DailyInsightAnalyticsMaintenanceResult = {
+  processedWeightCount: number;
+  processedUserCount: number;
+  users: string[];
 };
 
 // Weekly maintenance runs per user so compaction and cleanup stay scoped to one owner's insights at a time.
@@ -85,5 +98,58 @@ export async function runWeeklyInsightMaintenance(
     platform,
     processedUserCount: results.length,
     users: results,
+  };
+}
+
+async function loadInsightWeightsForAnalyticsMaintenance(
+  input: DailyInsightAnalyticsMaintenanceInput,
+) {
+  const query = db
+    .select({
+      insightId: insightWeights.insightId,
+      userId: insightWeights.userId,
+    })
+    .from(insightWeights)
+    .innerJoin(insight, eq(insightWeights.insightId, insight.id))
+    .innerJoin(bot, eq(insight.botId, bot.id));
+
+  if (input.userId && input.botId) {
+    return query.where(
+      and(
+        eq(insightWeights.userId, input.userId),
+        eq(insight.botId, input.botId),
+      ),
+    );
+  }
+
+  if (input.userId) {
+    return query.where(eq(insightWeights.userId, input.userId));
+  }
+
+  if (input.botId) {
+    return query.where(eq(insight.botId, input.botId));
+  }
+
+  return query;
+}
+
+export async function runDailyInsightAnalyticsMaintenance(
+  input: DailyInsightAnalyticsMaintenanceInput = {},
+): Promise<DailyInsightAnalyticsMaintenanceResult> {
+  const now = input.now ?? new Date();
+  const rows = await loadInsightWeightsForAnalyticsMaintenance(input);
+  const userIds = new Set<string>();
+
+  for (const row of rows) {
+    if (!row.insightId || !row.userId) continue;
+
+    userIds.add(row.userId);
+    await refreshInsightAccessSummary(row.insightId, row.userId, now, db);
+  }
+
+  return {
+    processedWeightCount: rows.length,
+    processedUserCount: userIds.size,
+    users: Array.from(userIds).sort(),
   };
 }

--- a/apps/web/lib/insights/weight-adjustment.ts
+++ b/apps/web/lib/insights/weight-adjustment.ts
@@ -18,7 +18,7 @@ import {
   type InsertInsightWeightHistory,
   type InsertInsightViewHistory,
 } from "@/lib/db/schema";
-import { eq, and, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, sql } from "drizzle-orm";
 import type { DrizzleDB } from "@/lib/db/types";
 
 // ============================================================================
@@ -70,7 +70,7 @@ export async function getWeightConfig(
     return getDefaultConfig(configKey);
   }
 
-  return configs[0].configValue as WeightConfig;
+  return parseStoredConfig(configs[0].configValue);
 }
 
 /**
@@ -95,6 +95,132 @@ function getDefaultConfig(configKey: string): WeightConfig {
   };
 
   return defaults[configKey] || {};
+}
+
+function isSqliteSchemaMode(): boolean {
+  return process.env.TAURI_MODE === "true" || process.env.IS_TAURI === "true";
+}
+
+function parseStoredConfig(value: unknown): WeightConfig {
+  if (!value) return {};
+  if (typeof value !== "string") return value as WeightConfig;
+
+  try {
+    return JSON.parse(value) as WeightConfig;
+  } catch {
+    return {};
+  }
+}
+
+function serializeJsonForStorage(
+  value: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | string | null {
+  if (!value) return null;
+  return isSqliteSchemaMode() ? JSON.stringify(value) : value;
+}
+
+function getRollingAccessCutoffs(now: Date) {
+  return {
+    sevenDaysAgo: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+    thirtyDaysAgo: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+  };
+}
+
+function readCount(row: { value: unknown } | undefined): number {
+  return Number(row?.value ?? 0);
+}
+
+async function getInsightAccessCounts(
+  insightId: string,
+  userId: string,
+  now: Date,
+  db: DrizzleDB,
+) {
+  const { sevenDaysAgo, thirtyDaysAgo } = getRollingAccessCutoffs(now);
+
+  const [totalRows, sevenDayRows, thirtyDayRows] = await Promise.all([
+    db
+      .select({ value: count() })
+      .from(insightViewHistory)
+      .where(
+        and(
+          eq(insightViewHistory.insightId, insightId),
+          eq(insightViewHistory.userId, userId),
+        ),
+      ),
+    db
+      .select({ value: count() })
+      .from(insightViewHistory)
+      .where(
+        and(
+          eq(insightViewHistory.insightId, insightId),
+          eq(insightViewHistory.userId, userId),
+          gte(insightViewHistory.viewedAt, sevenDaysAgo),
+        ),
+      ),
+    db
+      .select({ value: count() })
+      .from(insightViewHistory)
+      .where(
+        and(
+          eq(insightViewHistory.insightId, insightId),
+          eq(insightViewHistory.userId, userId),
+          gte(insightViewHistory.viewedAt, thirtyDaysAgo),
+        ),
+      ),
+  ]);
+
+  return {
+    total: readCount(totalRows[0]),
+    sevenDays: readCount(sevenDayRows[0]),
+    thirtyDays: readCount(thirtyDayRows[0]),
+  };
+}
+
+async function getLastInsightAccessedAt(
+  insightId: string,
+  userId: string,
+  db: DrizzleDB,
+) {
+  const rows = await db
+    .select({ viewedAt: insightViewHistory.viewedAt })
+    .from(insightViewHistory)
+    .where(
+      and(
+        eq(insightViewHistory.insightId, insightId),
+        eq(insightViewHistory.userId, userId),
+      ),
+    )
+    .orderBy(desc(insightViewHistory.viewedAt))
+    .limit(1);
+
+  return rows[0]?.viewedAt ?? null;
+}
+
+export async function refreshInsightAccessSummary(
+  insightId: string,
+  userId: string,
+  now: Date,
+  db: DrizzleDB,
+): Promise<void> {
+  const accessCounts = await getInsightAccessCounts(insightId, userId, now, db);
+  const lastAccessedAt = await getLastInsightAccessedAt(insightId, userId, db);
+
+  await db
+    .update(insightWeights)
+    .set({
+      accessCountTotal: accessCounts.total,
+      accessCount7d: accessCounts.sevenDays,
+      accessCount30d: accessCounts.thirtyDays,
+      lastAccessedAt,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(insightWeights.insightId, insightId),
+        eq(insightWeights.userId, userId),
+      ),
+    );
 }
 
 // ============================================================================
@@ -391,12 +517,21 @@ export async function recordInsightView(
     if (weightRecord.length === 0) {
       // Create new weight record
       const newWeight: InsertInsightWeight = {
+        id: crypto.randomUUID(),
         insightId,
         userId,
         customWeightMultiplier: 1.0,
         lastViewedAt: now,
+        lastRankCalculatedAt: now,
+        currentEventRank: 0,
+        accessCountTotal: 0,
+        accessCount7d: 0,
+        accessCount30d: 0,
+        lastAccessedAt: now,
+        lastWeightAdjustmentReason: "view_recorded",
+        createdAt: now,
         updatedAt: now,
-      };
+      } as InsertInsightWeight;
       await db.insert(insightWeights).values(newWeight);
     } else {
       // Update existing weight record
@@ -423,6 +558,7 @@ export async function recordInsightView(
 
         // Record weight adjustment history
         const history: InsertInsightWeightHistory = {
+          id: crypto.randomUUID(),
           insightId,
           userId,
           adjustmentType: "view",
@@ -432,13 +568,14 @@ export async function recordInsightView(
           customMultiplierBefore: currentMultiplier,
           customMultiplierAfter: newMultiplier,
           reason: `Viewed after ${Math.floor(daysSinceView)} days, applying ${multiplier}x boost`,
-          context: {
+          context: serializeJsonForStorage({
             source: "api",
             viewSource,
             daysSinceView: Math.floor(daysSinceView),
             durationHours: duration_hours,
-          },
-        };
+          }) as any,
+          createdAt: now,
+        } as InsertInsightWeightHistory;
 
         await db.insert(insightWeightHistory).values(history);
       } else {
@@ -456,12 +593,13 @@ export async function recordInsightView(
     // Record view history (try to insert, ignore duplicate constraint violations)
     try {
       const viewRecord: InsertInsightViewHistory = {
+        id: crypto.randomUUID(),
         insightId,
         userId,
         viewSource,
-        viewContext: viewContext as any,
+        viewContext: serializeJsonForStorage(viewContext) as any,
         viewedAt: now,
-      };
+      } as InsertInsightViewHistory;
       await db.insert(insightViewHistory).values(viewRecord);
     } catch (error: any) {
       // Ignore unique constraint violations (duplicate view records)
@@ -472,6 +610,8 @@ export async function recordInsightView(
         throw error;
       }
     }
+
+    await refreshInsightAccessSummary(insightId, userId, now, db);
   } catch (error) {
     console.error("[WeightAdjustment] Failed to record insight view:", error);
     throw error;

--- a/apps/web/tests/api/insight-analytics-export.route.test.ts
+++ b/apps/web/tests/api/insight-analytics-export.route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type AuthUser = { id: string; type: "regular" };
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: "user-export",
+    type: "regular" as const,
+  } as AuthUser | null,
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: async () => (authState.user ? { user: authState.user } : null),
+  __setUser: (user: AuthUser | null) => {
+    authState.user = user;
+  },
+}));
+
+const analyticsState = vi.hoisted(() => ({
+  result: {
+    generatedAt: "2026-05-09T00:00:00.000Z",
+    summary: {
+      totalInsights: 1,
+      activeInsights: 1,
+      dormantInsights: 0,
+      totalAccesses30d: 3,
+      averageValueScore: 81,
+      risingInsights: 1,
+      fallingInsights: 0,
+      stableInsights: 0,
+    },
+    topInsights: [],
+    bottomInsights: [],
+    insights: [
+      {
+        id: "insight-1",
+        title: 'Launch, "Alpha"',
+        description: "Important\nmulti-line note",
+        platform: "slack",
+        account: "team",
+        taskLabel: "launch",
+        importance: "high",
+        urgency: "urgent",
+        accessCountTotal: 5,
+        accessCount7d: 2,
+        accessCount30d: 3,
+        lastAccessedAt: new Date("2026-05-08T10:00:00.000Z"),
+        trend: "rising",
+        recent7dAccessCount: 2,
+        previous7dAccessCount: 0,
+        valueScore: 81,
+        recommendation: {
+          action: "keep",
+          reason:
+            "Usage, freshness, or relevance still supports keeping it active.",
+        },
+        isFavorited: true,
+        isArchived: false,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T12:00:00.000Z"),
+        time: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ],
+  },
+}));
+
+vi.mock("@/lib/insights/analytics", () => ({
+  getInsightUsageAnalytics: vi.fn(async () => analyticsState.result),
+}));
+
+const authModulePromise = import("@/app/(auth)/auth");
+const analyticsModulePromise = import("@/lib/insights/analytics");
+
+async function invokeExport(
+  path = "http://localhost/api/insights/analytics/export",
+) {
+  const request = new Request(path, { method: "GET" }) as any;
+  request.nextUrl = new URL(path);
+  const { GET } =
+    await import("@/app/(chat)/api/insights/analytics/export/route");
+  return GET(request);
+}
+
+describe("Insight analytics CSV export API", () => {
+  let authModule: any;
+  let analyticsModule: any;
+
+  beforeEach(async () => {
+    authModule = await authModulePromise;
+    analyticsModule = await analyticsModulePromise;
+
+    authModule.__setUser({ id: "user-export", type: "regular" });
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockClear();
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockImplementation(
+      async () => analyticsState.result,
+    );
+  });
+
+  test("rejects anonymous requests", async () => {
+    authModule.__setUser(null);
+
+    const response = await invokeExport();
+
+    expect(response.status).toBe(401);
+    expect(analyticsModule.getInsightUsageAnalytics).not.toHaveBeenCalled();
+  });
+
+  test("exports analytics as CSV", async () => {
+    const response = await invokeExport(
+      "http://localhost/api/insights/analytics/export?includeArchived=1",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/csv");
+    expect(response.headers.get("content-disposition")).toContain(
+      "attachment; filename=",
+    );
+    expect(analyticsModule.getInsightUsageAnalytics).toHaveBeenCalledWith({
+      userId: "user-export",
+      includeArchived: true,
+    });
+
+    const csv = await response.text();
+    expect(csv).toContain(
+      "id,title,description,platform,account,task_label,importance,urgency",
+    );
+    expect(csv).toContain('"Launch, ""Alpha"""');
+    expect(csv).toContain('"Important\nmulti-line note"');
+    expect(csv).toContain("2026-05-08T10:00:00.000Z");
+    expect(csv).toContain(",rising,2,0,81,keep,");
+  });
+
+  test("returns database error when analytics export fails", async () => {
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+
+    const response = await invokeExport();
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toHaveProperty("message");
+  });
+});

--- a/apps/web/tests/api/insight-analytics.route.test.ts
+++ b/apps/web/tests/api/insight-analytics.route.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type AuthUser = { id: string; type: "regular" };
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: "user-analytics",
+    type: "regular" as const,
+  } as AuthUser | null,
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: async () => (authState.user ? { user: authState.user } : null),
+  __setUser: (user: AuthUser | null) => {
+    authState.user = user;
+  },
+}));
+
+const analyticsState = vi.hoisted(() => ({
+  result: {
+    generatedAt: "2026-05-09T00:00:00.000Z",
+    summary: {
+      totalInsights: 0,
+      activeInsights: 0,
+      dormantInsights: 0,
+      totalAccesses30d: 0,
+      averageValueScore: 0,
+      risingInsights: 0,
+      fallingInsights: 0,
+      stableInsights: 0,
+    },
+    topInsights: [],
+    bottomInsights: [],
+    insights: [],
+  },
+}));
+
+vi.mock("@/lib/insights/analytics", () => ({
+  getInsightUsageAnalytics: vi.fn(async () => analyticsState.result),
+  __setAnalyticsResult: (result: unknown) => {
+    analyticsState.result = result as typeof analyticsState.result;
+  },
+}));
+
+const authModulePromise = import("@/app/(auth)/auth");
+const analyticsModulePromise = import("@/lib/insights/analytics");
+
+async function invokeAnalytics(
+  path = "http://localhost/api/insights/analytics",
+) {
+  const request = new Request(path, { method: "GET" }) as any;
+  request.nextUrl = new URL(path);
+  const { GET } = await import("@/app/(chat)/api/insights/analytics/route");
+  return GET(request);
+}
+
+describe("Insight analytics API", () => {
+  let authModule: any;
+  let analyticsModule: any;
+
+  beforeEach(async () => {
+    authModule = await authModulePromise;
+    analyticsModule = await analyticsModulePromise;
+
+    authModule.__setUser({ id: "user-analytics", type: "regular" });
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockClear();
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockImplementation(
+      async () => analyticsState.result,
+    );
+  });
+
+  test("rejects anonymous requests", async () => {
+    authModule.__setUser(null);
+
+    const response = await invokeAnalytics();
+
+    expect(response.status).toBe(401);
+    expect(analyticsModule.getInsightUsageAnalytics).not.toHaveBeenCalled();
+  });
+
+  test("loads analytics with default options", async () => {
+    const response = await invokeAnalytics();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(analyticsState.result);
+    expect(analyticsModule.getInsightUsageAnalytics).toHaveBeenCalledWith({
+      userId: "user-analytics",
+      limit: 10,
+      includeArchived: false,
+    });
+  });
+
+  test("parses limit and includeArchived query params", async () => {
+    const response = await invokeAnalytics(
+      "http://localhost/api/insights/analytics?limit=250&includeArchived=true",
+    );
+
+    expect(response.status).toBe(200);
+    expect(analyticsModule.getInsightUsageAnalytics).toHaveBeenCalledWith({
+      userId: "user-analytics",
+      limit: 100,
+      includeArchived: true,
+    });
+  });
+
+  test("falls back to default limit for invalid values", async () => {
+    const response = await invokeAnalytics(
+      "http://localhost/api/insights/analytics?limit=-10&includeArchived=0",
+    );
+
+    expect(response.status).toBe(200);
+    expect(analyticsModule.getInsightUsageAnalytics).toHaveBeenCalledWith({
+      userId: "user-analytics",
+      limit: 10,
+      includeArchived: false,
+    });
+  });
+
+  test("returns database error when analytics loading fails", async () => {
+    vi.mocked(analyticsModule.getInsightUsageAnalytics).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+
+    const response = await invokeAnalytics();
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toHaveProperty("message");
+  });
+});

--- a/apps/web/tests/api/insight-daily-analytics-maintenance.route.test.ts
+++ b/apps/web/tests/api/insight-daily-analytics-maintenance.route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  authorized: true,
+}));
+
+vi.mock("@/lib/auth/remote-auth-utils", () => ({
+  verifyCronAuth: vi.fn(() => authState.authorized),
+}));
+
+const maintenanceState = vi.hoisted(() => ({
+  result: {
+    processedWeightCount: 2,
+    processedUserCount: 1,
+    users: ["user-1"],
+  },
+}));
+
+vi.mock("@/lib/insights/maintenance", () => ({
+  runDailyInsightAnalyticsMaintenance: vi.fn(
+    async () => maintenanceState.result,
+  ),
+}));
+
+const authUtilsPromise = import("@/lib/auth/remote-auth-utils");
+const maintenanceModulePromise = import("@/lib/insights/maintenance");
+
+async function invokeDailyMaintenance(method: "GET" | "POST" = "GET") {
+  const request = new Request(
+    "http://localhost/api/insights/maintenance/daily-analytics",
+    {
+      method,
+      headers: { authorization: "Bearer secret" },
+    },
+  );
+  const route =
+    await import("@/app/api/insights/maintenance/daily-analytics/route");
+
+  return method === "POST" ? route.POST(request) : route.GET(request);
+}
+
+describe("daily insight analytics maintenance API", () => {
+  let authUtils: any;
+  let maintenanceModule: any;
+
+  beforeEach(async () => {
+    authUtils = await authUtilsPromise;
+    maintenanceModule = await maintenanceModulePromise;
+
+    vi.stubEnv("CRON_SECRET", "secret");
+    authState.authorized = true;
+    vi.mocked(authUtils.verifyCronAuth).mockClear();
+    vi.mocked(
+      maintenanceModule.runDailyInsightAnalyticsMaintenance,
+    ).mockClear();
+    vi.mocked(
+      maintenanceModule.runDailyInsightAnalyticsMaintenance,
+    ).mockImplementation(async () => maintenanceState.result);
+  });
+
+  test("returns 500 when CRON_SECRET is missing", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+
+    const response = await invokeDailyMaintenance();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "CRON_SECRET is not configured",
+    });
+    expect(
+      maintenanceModule.runDailyInsightAnalyticsMaintenance,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("rejects unauthorized cron requests", async () => {
+    authState.authorized = false;
+
+    const response = await invokeDailyMaintenance();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+    expect(
+      maintenanceModule.runDailyInsightAnalyticsMaintenance,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("runs daily analytics maintenance for GET and POST", async () => {
+    const getResponse = await invokeDailyMaintenance("GET");
+    const postResponse = await invokeDailyMaintenance("POST");
+
+    expect(getResponse.status).toBe(200);
+    expect(await getResponse.json()).toEqual({
+      ok: true,
+      ...maintenanceState.result,
+    });
+    expect(postResponse.status).toBe(200);
+    expect(await postResponse.json()).toEqual({
+      ok: true,
+      ...maintenanceState.result,
+    });
+    expect(
+      maintenanceModule.runDailyInsightAnalyticsMaintenance,
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/api/insight-view.route.test.ts
+++ b/apps/web/tests/api/insight-view.route.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type AuthUser = { id: string; type: "regular" };
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: "user-view",
+    type: "regular" as const,
+  } as AuthUser | null,
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: async () => (authState.user ? { user: authState.user } : null),
+  __setUser: (user: AuthUser | null) => {
+    authState.user = user;
+  },
+}));
+
+const dbState = vi.hoisted(() => ({
+  ownedRows: [{ id: "insight-1" }],
+  query: {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  db: {
+    select: vi.fn(() => dbState.query),
+  },
+  __setOwnedRows: (rows: Array<{ id: string }>) => {
+    dbState.ownedRows = rows;
+  },
+  __resetDbMock: () => {
+    dbState.ownedRows = [{ id: "insight-1" }];
+    dbState.query.from.mockClear();
+    dbState.query.innerJoin.mockClear();
+    dbState.query.where.mockClear();
+    dbState.query.limit.mockClear();
+    dbState.query.from.mockReturnValue(dbState.query);
+    dbState.query.innerJoin.mockReturnValue(dbState.query);
+    dbState.query.where.mockReturnValue(dbState.query);
+    dbState.query.limit.mockImplementation(async () => dbState.ownedRows);
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  bot: {
+    id: "bot.id",
+    userId: "bot.userId",
+  },
+  insight: {
+    id: "insight.id",
+    botId: "insight.botId",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ type: "eq", left, right })),
+}));
+
+vi.mock("@/lib/insights/weight-adjustment", () => ({
+  recordInsightView: vi.fn(async () => undefined),
+}));
+
+const authModulePromise = import("@/app/(auth)/auth");
+const queriesModulePromise = import("@/lib/db/queries");
+const weightModulePromise = import("@/lib/insights/weight-adjustment");
+
+async function invokeRecordView(body?: unknown) {
+  const request = new Request("http://localhost/api/insights/insight-1/view", {
+    method: "POST",
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as any;
+  const { POST } = await import("@/app/(chat)/api/insights/[id]/view/route");
+  return POST(request, { params: Promise.resolve({ id: "insight-1" }) });
+}
+
+describe("Insight view tracking API", () => {
+  let authModule: any;
+  let queriesModule: any;
+  let weightModule: any;
+
+  beforeEach(async () => {
+    authModule = await authModulePromise;
+    queriesModule = await queriesModulePromise;
+    weightModule = await weightModulePromise;
+
+    authModule.__setUser({ id: "user-view", type: "regular" });
+    queriesModule.__resetDbMock();
+    vi.mocked(weightModule.recordInsightView).mockClear();
+  });
+
+  test("rejects anonymous requests", async () => {
+    authModule.__setUser(null);
+
+    const response = await invokeRecordView();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+    expect(weightModule.recordInsightView).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when the insight does not belong to the user", async () => {
+    queriesModule.__setOwnedRows([]);
+
+    const response = await invokeRecordView();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Insight not found" });
+    expect(weightModule.recordInsightView).not.toHaveBeenCalled();
+  });
+
+  test("records a detail view with sanitized context", async () => {
+    const response = await invokeRecordView({
+      viewSource: "detail",
+      viewContext: {
+        surface: "drawer",
+        initialTab: "sources",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(weightModule.recordInsightView).toHaveBeenCalledWith(
+      "insight-1",
+      "user-view",
+      "detail",
+      {
+        surface: "drawer",
+        initialTab: "sources",
+      },
+      expect.any(Object),
+    );
+  });
+
+  test("falls back to detail source for invalid payloads", async () => {
+    const response = await invokeRecordView({
+      viewSource: "unknown",
+      viewContext: ["not", "an", "object"],
+    });
+
+    expect(response.status).toBe(200);
+    expect(weightModule.recordInsightView).toHaveBeenCalledWith(
+      "insight-1",
+      "user-view",
+      "detail",
+      null,
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/web/tests/unit/cron-insight-maintenance.test.ts
+++ b/apps/web/tests/unit/cron-insight-maintenance.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getUserInsightSettingsMock,
+  updateUserInsightSettingsMock,
+  runDailyInsightAnalyticsMaintenanceMock,
+  runWeeklyInsightMaintenanceMock,
+} = vi.hoisted(() => ({
+  getUserInsightSettingsMock: vi.fn(),
+  updateUserInsightSettingsMock: vi.fn(),
+  runDailyInsightAnalyticsMaintenanceMock: vi.fn(),
+  runWeeklyInsightMaintenanceMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  getUserInsightSettings: getUserInsightSettingsMock,
+  updateUserInsightSettings: updateUserInsightSettingsMock,
+}));
+
+vi.mock("@/lib/insights/maintenance", () => ({
+  runDailyInsightAnalyticsMaintenance: runDailyInsightAnalyticsMaintenanceMock,
+  runWeeklyInsightMaintenance: runWeeklyInsightMaintenanceMock,
+}));
+
+import {
+  runDailyInsightAnalyticsMaintenanceIfDue,
+  runInsightMaintenanceIfDue,
+  setLastInsightAnalyticsMaintenanceRunAt,
+  setLastInsightMaintenanceRunAt,
+} from "@/lib/cron/insight-maintenance";
+
+describe("cron insight maintenance", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-09T02:17:00.000Z"));
+    setLastInsightAnalyticsMaintenanceRunAt(null);
+    setLastInsightMaintenanceRunAt(null);
+    getUserInsightSettingsMock.mockReset();
+    updateUserInsightSettingsMock.mockReset();
+    runDailyInsightAnalyticsMaintenanceMock.mockReset();
+    runWeeklyInsightMaintenanceMock.mockReset();
+    runDailyInsightAnalyticsMaintenanceMock.mockResolvedValue({
+      processedWeightCount: 0,
+      processedUserCount: 0,
+      users: [],
+    });
+    runWeeklyInsightMaintenanceMock.mockResolvedValue({
+      platform: "desktop",
+      processedUserCount: 0,
+      users: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs daily analytics once per local scheduler interval window", async () => {
+    await runDailyInsightAnalyticsMaintenanceIfDue("user-1");
+    await runDailyInsightAnalyticsMaintenanceIfDue("user-1");
+
+    expect(runDailyInsightAnalyticsMaintenanceMock).toHaveBeenCalledTimes(1);
+    expect(runDailyInsightAnalyticsMaintenanceMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      now: new Date("2026-05-09T02:17:00.000Z"),
+    });
+
+    vi.setSystemTime(new Date("2026-05-10T02:17:01.000Z"));
+    await runDailyInsightAnalyticsMaintenanceIfDue("user-1");
+
+    expect(runDailyInsightAnalyticsMaintenanceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs weekly maintenance when persisted checkpoint is due", async () => {
+    getUserInsightSettingsMock.mockResolvedValue({
+      lastInsightMaintenanceRunAt: new Date("2026-05-01T02:17:00.000Z"),
+    });
+
+    await runInsightMaintenanceIfDue("user-1");
+
+    expect(runWeeklyInsightMaintenanceMock).toHaveBeenCalledWith({
+      platform: "desktop",
+      userId: "user-1",
+    });
+    expect(updateUserInsightSettingsMock).toHaveBeenCalledWith("user-1", {
+      lastInsightMaintenanceRunAt: new Date("2026-05-09T02:17:00.000Z"),
+    });
+  });
+
+  it("skips maintenance without a scheduler user", async () => {
+    await runDailyInsightAnalyticsMaintenanceIfDue(undefined);
+    await runInsightMaintenanceIfDue(undefined);
+
+    expect(runDailyInsightAnalyticsMaintenanceMock).not.toHaveBeenCalled();
+    expect(runWeeklyInsightMaintenanceMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/insight-access-counts.test.ts
+++ b/apps/web/tests/unit/insight-access-counts.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const schema = vi.hoisted(() => ({
+  insightWeights: {
+    _name: "insight_weights",
+    id: "weights.id",
+    insightId: "weights.insightId",
+    userId: "weights.userId",
+    lastViewedAt: "weights.lastViewedAt",
+    createdAt: "weights.createdAt",
+  },
+  insightWeightHistory: {
+    _name: "insight_weight_history",
+  },
+  insightViewHistory: {
+    _name: "insight_view_history",
+    insightId: "view.insightId",
+    userId: "view.userId",
+    viewedAt: "view.viewedAt",
+  },
+  insightWeightConfig: {
+    _name: "insight_weight_config",
+    configKey: "config.configKey",
+    configValue: "config.configValue",
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => schema);
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
+  count: vi.fn(() => "count"),
+  desc: vi.fn((column: unknown) => ({ type: "desc", column })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ type: "eq", left, right })),
+  gte: vi.fn((left: unknown, right: unknown) => ({
+    type: "gte",
+    left,
+    right,
+  })),
+  sql: vi.fn(() => "sql"),
+}));
+
+type TableName =
+  | "insight_weights"
+  | "insight_weight_config"
+  | "insight_view_history";
+
+function createMockDb() {
+  const state = {
+    weightRows: [] as any[],
+    configRows: [] as any[],
+    countRows: [[{ value: 4 }], [{ value: 2 }], [{ value: 3 }]],
+    lastAccessRows: [{ viewedAt: new Date("2026-05-09T10:00:00.000Z") }],
+    inserts: [] as Array<{ table: string; value: any }>,
+    updates: [] as Array<{ table: string; value: any }>,
+    countSelects: [] as Array<{ table?: TableName; where?: unknown }>,
+  };
+
+  class SelectBuilder {
+    private table?: { _name: TableName };
+    private whereClause?: unknown;
+
+    constructor(private readonly selection?: unknown) {}
+
+    from(table: { _name: TableName }) {
+      this.table = table;
+      return this;
+    }
+
+    where(whereClause: unknown) {
+      this.whereClause = whereClause;
+      return this;
+    }
+
+    orderBy() {
+      return this;
+    }
+
+    limit() {
+      if (this.table?._name === "insight_weights") {
+        return Promise.resolve(state.weightRows);
+      }
+      if (this.table?._name === "insight_weight_config") {
+        return Promise.resolve(state.configRows);
+      }
+      if (this.table?._name === "insight_view_history") {
+        return Promise.resolve(state.lastAccessRows);
+      }
+      return Promise.resolve([]);
+    }
+
+    then(
+      resolve: (value: any[]) => unknown,
+      reject?: (reason: unknown) => unknown,
+    ) {
+      if ((this.selection as any)?.value === "count") {
+        state.countSelects.push({
+          table: this.table?._name,
+          where: this.whereClause,
+        });
+        return Promise.resolve(state.countRows.shift() ?? [{ value: 0 }]).then(
+          resolve,
+          reject,
+        );
+      }
+
+      return Promise.resolve([]).then(resolve, reject);
+    }
+  }
+
+  class InsertBuilder {
+    constructor(private readonly table: { _name: string }) {}
+
+    values(value: any) {
+      state.inserts.push({ table: this.table._name, value });
+      return Promise.resolve([]);
+    }
+  }
+
+  class UpdateBuilder {
+    private value: any;
+
+    constructor(private readonly table: { _name: string }) {}
+
+    set(value: any) {
+      this.value = value;
+      return this;
+    }
+
+    where() {
+      state.updates.push({ table: this.table._name, value: this.value });
+      return Promise.resolve([]);
+    }
+  }
+
+  return {
+    state,
+    db: {
+      select: vi.fn((selection?: unknown) => new SelectBuilder(selection)),
+      insert: vi.fn((table: { _name: string }) => new InsertBuilder(table)),
+      update: vi.fn((table: { _name: string }) => new UpdateBuilder(table)),
+    },
+  };
+}
+
+describe("recordInsightView access counts", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("creates a weight record and syncs rolling access counts", async () => {
+    const { recordInsightView } =
+      await import("@/lib/insights/weight-adjustment");
+    const { db, state } = createMockDb();
+
+    await recordInsightView(
+      "insight-1",
+      "user-1",
+      "detail",
+      { surface: "drawer" },
+      db as any,
+    );
+
+    expect(state.inserts[0]).toMatchObject({
+      table: "insight_weights",
+      value: {
+        insightId: "insight-1",
+        userId: "user-1",
+        accessCountTotal: 0,
+        accessCount7d: 0,
+        accessCount30d: 0,
+      },
+    });
+    expect(state.inserts[1]).toMatchObject({
+      table: "insight_view_history",
+      value: {
+        insightId: "insight-1",
+        userId: "user-1",
+        viewSource: "detail",
+        viewContext: { surface: "drawer" },
+      },
+    });
+    expect(state.updates.at(-1)).toMatchObject({
+      table: "insight_weights",
+      value: {
+        accessCountTotal: 4,
+        accessCount7d: 2,
+        accessCount30d: 3,
+      },
+    });
+    expect(state.updates.at(-1)?.value.lastAccessedAt).toBeInstanceOf(Date);
+    expect(state.updates.at(-1)?.value.lastAccessedAt.toISOString()).toBe(
+      "2026-05-09T10:00:00.000Z",
+    );
+  });
+
+  test("serializes view context when running against the SQLite schema", async () => {
+    vi.stubEnv("IS_TAURI", "true");
+
+    const { recordInsightView } =
+      await import("@/lib/insights/weight-adjustment");
+    const { db, state } = createMockDb();
+
+    await recordInsightView(
+      "insight-1",
+      "user-1",
+      "detail",
+      { surface: "drawer" },
+      db as any,
+    );
+
+    expect(state.inserts[1]).toMatchObject({
+      table: "insight_view_history",
+      value: {
+        viewContext: JSON.stringify({ surface: "drawer" }),
+      },
+    });
+  });
+});

--- a/apps/web/tests/unit/insight-analytics.test.ts
+++ b/apps/web/tests/unit/insight-analytics.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildInsightUsageAnalytics,
+  calculateInsightTrend,
+  calculateInsightValueScore,
+  recommendInsightOrganization,
+} from "@/lib/insights/analytics";
+
+const NOW = new Date("2026-05-09T12:00:00.000Z");
+
+function daysAgo(days: number) {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function makeRow(overrides: Partial<any> = {}) {
+  return {
+    id: overrides.id ?? "insight-1",
+    title: overrides.title ?? "Insight",
+    description: overrides.description ?? "Description",
+    taskLabel: overrides.taskLabel ?? "general",
+    platform: overrides.platform ?? "slack",
+    account: overrides.account ?? null,
+    importance: overrides.importance ?? "medium",
+    urgency: overrides.urgency ?? "medium",
+    isFavorited: overrides.isFavorited ?? false,
+    isArchived: overrides.isArchived ?? false,
+    createdAt: overrides.createdAt ?? daysAgo(10),
+    updatedAt: overrides.updatedAt ?? daysAgo(2),
+    time: overrides.time ?? daysAgo(10),
+    accessCountTotal: overrides.accessCountTotal ?? 0,
+    accessCount7d: overrides.accessCount7d ?? 0,
+    accessCount30d: overrides.accessCount30d ?? 0,
+    lastAccessedAt: overrides.lastAccessedAt ?? null,
+  };
+}
+
+describe("insight analytics calculations", () => {
+  test("calculates trend from recent and previous 7-day windows", () => {
+    expect(calculateInsightTrend(5, 1)).toBe("rising");
+    expect(calculateInsightTrend(1, 5)).toBe("falling");
+    expect(calculateInsightTrend(4, 4)).toBe("stable");
+    expect(calculateInsightTrend(0, 0)).toBe("stable");
+  });
+
+  test("scores frequently accessed, fresh, important insights higher", () => {
+    const highScore = calculateInsightValueScore({
+      accessCount30d: 10,
+      maxAccessCount30d: 10,
+      lastAccessedAt: daysAgo(1),
+      createdAt: daysAgo(90),
+      importance: "high",
+      urgency: "urgent",
+      isFavorited: true,
+      now: NOW,
+    });
+    const lowScore = calculateInsightValueScore({
+      accessCount30d: 0,
+      maxAccessCount30d: 10,
+      lastAccessedAt: daysAgo(120),
+      createdAt: daysAgo(180),
+      importance: "low",
+      urgency: "low",
+      isFavorited: false,
+      now: NOW,
+    });
+
+    expect(highScore).toBeGreaterThan(90);
+    expect(lowScore).toBeLessThan(25);
+  });
+
+  test("recommends archive/delete for dormant low-value insights", () => {
+    expect(
+      recommendInsightOrganization({
+        accessCount30d: 0,
+        lastAccessedAt: daysAgo(120),
+        createdAt: daysAgo(150),
+        importance: "low",
+        isFavorited: false,
+        trend: "stable",
+        valueScore: 20,
+        now: NOW,
+      }).action,
+    ).toBe("delete");
+
+    expect(
+      recommendInsightOrganization({
+        accessCount30d: 0,
+        lastAccessedAt: daysAgo(45),
+        createdAt: daysAgo(70),
+        importance: "medium",
+        isFavorited: false,
+        trend: "stable",
+        valueScore: 40,
+        now: NOW,
+      }).action,
+    ).toBe("archive");
+
+    expect(
+      recommendInsightOrganization({
+        accessCount30d: 0,
+        lastAccessedAt: daysAgo(200),
+        createdAt: daysAgo(250),
+        importance: "low",
+        isFavorited: true,
+        trend: "falling",
+        valueScore: 10,
+        now: NOW,
+      }).action,
+    ).toBe("keep");
+  });
+
+  test("builds top, bottom, trend, and summary analytics", () => {
+    const analytics = buildInsightUsageAnalytics({
+      now: NOW,
+      limit: 2,
+      rows: [
+        makeRow({
+          id: "top",
+          title: "Top insight",
+          importance: "high",
+          urgency: "urgent",
+          accessCountTotal: 20,
+          accessCount7d: 5,
+          accessCount30d: 12,
+          lastAccessedAt: daysAgo(1),
+        }),
+        makeRow({
+          id: "dormant",
+          title: "Dormant insight",
+          importance: "low",
+          urgency: "low",
+          createdAt: daysAgo(160),
+          accessCountTotal: 1,
+          accessCount7d: 0,
+          accessCount30d: 0,
+          lastAccessedAt: daysAgo(120),
+        }),
+        makeRow({
+          id: "falling",
+          title: "Falling insight",
+          accessCountTotal: 10,
+          accessCount7d: 1,
+          accessCount30d: 4,
+          lastAccessedAt: daysAgo(4),
+        }),
+      ],
+      views: [
+        { insightId: "top", viewedAt: daysAgo(1) },
+        { insightId: "top", viewedAt: daysAgo(2) },
+        { insightId: "top", viewedAt: daysAgo(8) },
+        { insightId: "falling", viewedAt: daysAgo(1) },
+        { insightId: "falling", viewedAt: daysAgo(8) },
+        { insightId: "falling", viewedAt: daysAgo(9) },
+        { insightId: "falling", viewedAt: daysAgo(10) },
+      ],
+      conversationLinks: [
+        { chatId: "chat-1", insightId: "top" },
+        { chatId: "chat-1", insightId: "falling" },
+        { chatId: "chat-2", insightId: "top" },
+        { chatId: "chat-2", insightId: "falling" },
+        { chatId: "chat-3", insightId: "top" },
+        { chatId: "chat-3", insightId: "dormant" },
+      ],
+    });
+
+    expect(analytics.summary).toMatchObject({
+      totalInsights: 3,
+      activeInsights: 2,
+      dormantInsights: 1,
+      totalAccesses30d: 16,
+      risingInsights: 1,
+      fallingInsights: 1,
+      stableInsights: 1,
+    });
+    expect(analytics.topInsights.map((item) => item.id)).toEqual([
+      "top",
+      "falling",
+    ]);
+    expect(analytics.bottomInsights[0].id).toBe("dormant");
+    expect(
+      analytics.insights.find((item) => item.id === "dormant")?.recommendation
+        .action,
+    ).toBe("delete");
+    expect(analytics.insights.find((item) => item.id === "top")?.trend).toBe(
+      "rising",
+    );
+    expect(
+      analytics.insights.find((item) => item.id === "falling")?.trend,
+    ).toBe("falling");
+    expect(analytics.relationships[0]).toMatchObject({
+      insightId: "falling",
+      relatedInsightId: "top",
+      sharedConversationCount: 2,
+    });
+  });
+});

--- a/apps/web/tests/unit/insight-maintenance.test.ts
+++ b/apps/web/tests/unit/insight-maintenance.test.ts
@@ -10,6 +10,10 @@ const { deleteExpiredPendingDeletionInsightsMock, runInsightCompactionMock } =
     runInsightCompactionMock: vi.fn(),
   }));
 
+const { refreshInsightAccessSummaryMock } = vi.hoisted(() => ({
+  refreshInsightAccessSummaryMock: vi.fn(),
+}));
+
 vi.mock("@/lib/db/queries", () => ({
   db: {
     select: selectMock,
@@ -22,7 +26,14 @@ vi.mock("@/lib/insights/compaction", () => ({
   runInsightCompaction: runInsightCompactionMock,
 }));
 
-import { runWeeklyInsightMaintenance } from "@/lib/insights/maintenance";
+vi.mock("@/lib/insights/weight-adjustment", () => ({
+  refreshInsightAccessSummary: refreshInsightAccessSummaryMock,
+}));
+
+import {
+  runDailyInsightAnalyticsMaintenance,
+  runWeeklyInsightMaintenance,
+} from "@/lib/insights/maintenance";
 
 function makeBotSelectBuilder(response: unknown) {
   return {
@@ -35,11 +46,27 @@ function makeBotSelectBuilder(response: unknown) {
   };
 }
 
+function makeWeightSelectBuilder(response: unknown) {
+  const resolved = Promise.resolve(response);
+  const builder = {
+    innerJoin: vi.fn(),
+    where: vi.fn().mockReturnValue(resolved),
+    then: resolved.then.bind(resolved),
+  };
+
+  builder.innerJoin.mockReturnValue(builder);
+
+  return {
+    from: vi.fn().mockReturnValue(builder),
+  };
+}
+
 describe("weekly insight maintenance", () => {
   beforeEach(() => {
     selectMock.mockReset();
     runInsightCompactionMock.mockReset();
     deleteExpiredPendingDeletionInsightsMock.mockReset();
+    refreshInsightAccessSummaryMock.mockReset();
   });
 
   it("runs compaction and cleanup per user for the selected platform", async () => {
@@ -130,6 +157,47 @@ describe("weekly insight maintenance", () => {
           deletedInsightIds: [],
         },
       ],
+    });
+  });
+
+  it("refreshes rolling access counts for every tracked insight weight", async () => {
+    const now = new Date("2026-05-09T00:00:00.000Z");
+    selectMock.mockImplementationOnce(() =>
+      makeWeightSelectBuilder([
+        { insightId: "insight-1", userId: "user-1" },
+        { insightId: "insight-2", userId: "user-1" },
+        { insightId: "insight-3", userId: "user-2" },
+      ]),
+    );
+
+    const result = await runDailyInsightAnalyticsMaintenance({ now });
+
+    expect(refreshInsightAccessSummaryMock).toHaveBeenNthCalledWith(
+      1,
+      "insight-1",
+      "user-1",
+      now,
+      expect.any(Object),
+    );
+    expect(refreshInsightAccessSummaryMock).toHaveBeenNthCalledWith(
+      2,
+      "insight-2",
+      "user-1",
+      now,
+      expect.any(Object),
+    );
+    expect(refreshInsightAccessSummaryMock).toHaveBeenNthCalledWith(
+      3,
+      "insight-3",
+      "user-2",
+      now,
+      expect.any(Object),
+    );
+
+    expect(result).toEqual({
+      processedWeightCount: 3,
+      processedUserCount: 2,
+      users: ["user-1", "user-2"],
     });
   });
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,12 @@
+{
+  "crons": [
+    {
+      "path": "/api/insights/maintenance/daily-analytics",
+      "schedule": "17 2 * * *"
+    },
+    {
+      "path": "/api/insights/maintenance/weekly",
+      "schedule": "43 3 * * 0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `lib/db/schema.pg.ts`, `lib/db/schema-sqlite.ts`, migrations `0098_add_insight_access_frequency.sql`: added insight access counters and `lastAccessedAt` storage.
- `app/(chat)/api/insights/[id]/view/route.ts`, `lib/insights/weight-adjustment.ts`: record insight view events and refresh access frequency summaries.
- `lib/insights/analytics.ts`: added analytics calculation for top/dormant insights, trends, value score, relationships, and organization recommendations.
- `app/(chat)/api/insights/analytics/route.ts`, `app/(chat)/api/insights/analytics/export/route.ts`: expose analytics JSON and CSV export APIs.
- `lib/insights/maintenance.ts`, `lib/cron/insight-maintenance.ts`, `lib/cron/local-scheduler.ts`, `app/api/insights/maintenance/daily-analytics/route.ts`: add daily analytics maintenance pipeline.
- `components/agent/insight-analytics-panel.tsx`, `components/agent/events-panel.tsx`, `components/app-sidebar.tsx`: add Insight Tracking sidebar entry and Analytics dashboard tab.
- `i18n/locales/en-US.ts`, `i18n/locales/zh-Hans.ts`: localize the new Insight Tracking and Analytics UI.
- Added tests for view tracking, analytics APIs, CSV export, access counts, and daily maintenance.

## Tests
- `pnpm --filter web exec tsc --noEmit`
- Unit tests for insight analytics, access counts, and maintenance

re#48