### PR TITLE
chore: update repo name from alloomi to openloomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br>
 
-[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-4B4B4B?logo=linux&logoColor=white)](https://alloomi.ai) 
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-4B4B4B?logo=linux&logoColor=white)](https://alloomi.ai)
 [![License](https://img.shields.io/badge/License-Apache%202.0-F8D52A?logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/xkJaJyWcsv)
 [![X](https://img.shields.io/badge/X-Follow-000000?logo=x&logoColor=white)](https://x.com/AlloomiAI)
@@ -24,32 +24,30 @@
 Alloomi is an open-source AI workspace that runs on your desktop. It connects to the tools you already use — messaging apps, email, calendar, documents, project trackers — and builds a working memory of your people, projects, and decisions.
 
 ### Download to Try
+
  <a href="https://github.com/melandlabs/release">
     <img src="https://img.shields.io/github/v/tag/melandlabs/release?logo=github&label=Download&color=24C8D5" alt="Download" height="30" style="transform:scale(1);">
   </a>
 
-
-
 ## Features
 
-| | Capability | What it does |
-|---|---|---|
-| 🔌 | **18 Platform Connectors** | Telegram, WhatsApp, WeChat, DingTalk, Feishu, Gmail, Google Calendar, Outlook, Google Docs, X/Twitter, Instagram, LinkedIn, Facebook Messenger, Jira, HubSpot, Asana, iMessage, QQ, RSS — messages, emails, calendar events, documents, and project updates flow in continuously |
-| 🧠 | **Working Memory** | Short → mid → long-term memory with a progressive forgetting engine — scores by access frequency, recency, and importance, summarizes and archives over time, recalls context from months ago |
-| 📄 | **Document Skills** | Create and edit DOCX, XLSX, PPTX, PDF — with formulas, formatting, tracked changes, OCR, and merge/split |
-| ⏰ | **Automation** | Scheduled jobs with cron expressions, intervals, or one-time triggers — agent-driven execution with timeout recovery and history |
-| 🖥️ | **Desktop App** | Native app for Windows, macOS, Linux via Tauri — local-first storage with IndexedDB + SQLite, AES-256 encryption, no data leaves your machine |
+|     | Capability                 | What it does                                                                                                                                                                                                                                                                     |
+| --- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🔌  | **18 Platform Connectors** | Telegram, WhatsApp, WeChat, DingTalk, Feishu, Gmail, Google Calendar, Outlook, Google Docs, X/Twitter, Instagram, LinkedIn, Facebook Messenger, Jira, HubSpot, Asana, iMessage, QQ, RSS — messages, emails, calendar events, documents, and project updates flow in continuously |
+| 🧠  | **Working Memory**         | Short → mid → long-term memory with a progressive forgetting engine — scores by access frequency, recency, and importance, summarizes and archives over time, recalls context from months ago                                                                                    |
+| 📄  | **Document Skills**        | Create and edit DOCX, XLSX, PPTX, PDF — with formulas, formatting, tracked changes, OCR, and merge/split                                                                                                                                                                         |
+| ⏰  | **Automation**             | Scheduled jobs with cron expressions, intervals, or one-time triggers — agent-driven execution with timeout recovery and history                                                                                                                                                 |
+| 🖥️  | **Desktop App**            | Native app for Windows, macOS, Linux via Tauri — local-first storage with IndexedDB + SQLite, AES-256 encryption, no data leaves your machine                                                                                                                                    |
 
 <p align="center">
   <img src="screenshots/components.png" alt="Architecture" width="100%">
 </p>
 
-
 ## Quick Start
 
 ```bash
-git clone https://github.com/melandlabs/alloomi.git
-cd alloomi
+git clone https://github.com/melandlabs/openloomi.git
+cd openloomi
 
 cp apps/web/.env.example apps/web/.env
 
@@ -102,13 +100,13 @@ alloomi/
 
 This is early-stage software. We're looking for people who'll actually install it, connect their tools, and tell us what's broken.
 
-- [GitHub Issues](https://github.com/melandlabs/alloomi/issues) — bugs, install problems, feature requests
+- [GitHub Issues](https://github.com/melandlabs/openloomi/issues) — bugs, install problems, feature requests
 - [Discord](https://discord.com/invite/xkJaJyWcsv) — discussion, questions, help
 - [Email](mailto:developer@alloomi.ai) — anything else
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md). Look for [`good first issue`](https://github.com/melandlabs/alloomi/labels/good%20first%20issue) labels.
+See [CONTRIBUTING.md](./CONTRIBUTING.md). Look for [`good first issue`](https://github.com/melandlabs/openloomi/labels/good%20first%20issue) labels.
 
 ## License
 

--- a/apps/marketing/components/footer.tsx
+++ b/apps/marketing/components/footer.tsx
@@ -166,7 +166,7 @@ export function Footer({
         },
         {
           name: "GitHub",
-          href: "https://github.com/melandlabs/alloomi",
+          href: "https://github.com/melandlabs/openloomi",
           icon: <RemixIcon name="github" variant="line" size="size-4" />,
         },
         {

--- a/apps/marketing/content/alloomi/getting-started.mdx
+++ b/apps/marketing/content/alloomi/getting-started.mdx
@@ -40,8 +40,8 @@ Visit [https://alloomi.ai](https://alloomi.ai) to download, or use the direct li
 
 ```bash
 # Install via Homebrew
-brew tap melandlabs/alloomi https://github.com/melandlabs/release
-brew install --cask alloomi
+brew tap melandlabs/release https://github.com/melandlabs/release
+brew install --cask openloomi
 ```
 
 **Linux (Ubuntu/Debian)**

--- a/apps/marketing/content/alloomi/use-cases/engineering-daily-sync.mdx
+++ b/apps/marketing/content/alloomi/use-cases/engineering-daily-sync.mdx
@@ -14,7 +14,7 @@ Engineering teams waste hours every week pulling commit logs, writing status rep
 
 | Step           | Action                                                      |
 | -------------- | ----------------------------------------------------------- |
-| 🌙 Every 10 PM | Pull all commits from `melandlabs/Alloomi` on GitHub        |
+| 🌙 Every 10 PM | Pull all commits from `melandlabs/openloomi` on GitHub      |
 | 📝 Compile     | Generate a structured daily dev report                      |
 | 📧 Email       | Send the report to the engineering team                     |
 | 🐛 New Issues  | Fetch all issues created that day, rewrite with full detail |
@@ -82,7 +82,7 @@ Alloomi's tracking panel shows exactly how many times each task has run, against
 Open Alloomi and paste this:
 
 ```
-Please pull all commits from melandlabs/Alloomi every night at 10 PM, compile a report, and send it to my email. Also, monitor all new issues created that day, rewrite them in detail, and sync them to Linear.
+Please pull all commits from melandlabs/openloomi every night at 10 PM, compile a report, and send it to my email. Also, monitor all new issues created that day, rewrite them in detail, and sync them to Linear.
 ```
 
 Alloomi will automatically create the scheduled tasks for you!
@@ -94,11 +94,11 @@ Alloomi will automatically create the scheduled tasks for you!
 1. Go to the **Agent** page, then select **Automation** → **New Task**
 2. Create the first task:
 
-| Field            | Input                                                                                                                                                                                                                                                                |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task Name        | `PD Daily Sync`                                                                                                                                                                                                                                                      |
-| Task Description | `1. Fetch all commits from your GitHub repo (e.g. melandlabs/Alloomi)\n2. Compile a structured daily dev report\n3. Email the report to your team\n4. Fetch all issues created that day\n5. Rewrite each issue with full detail\n6. Sync rewritten issues to Linear` |
-| Schedule         | `0 22 * * *` (every day at 10 PM)                                                                                                                                                                                                                                    |
+| Field            | Input                                                                                                                                                                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `PD Daily Sync`                                                                                                                                                                                                                                                        |
+| Task Description | `1. Fetch all commits from your GitHub repo (e.g. melandlabs/openloomi)\n2. Compile a structured daily dev report\n3. Email the report to your team\n4. Fetch all issues created that day\n5. Rewrite each issue with full detail\n6. Sync rewritten issues to Linear` |
+| Schedule         | `0 22 * * *` (every day at 10 PM)                                                                                                                                                                                                                                      |
 
 3. Create the second task:
 


### PR DESCRIPTION
## Summary
- Update all GitHub URLs from `melandlabs/alloomi` to `melandlabs/openloomi`
- Update Homebrew tap command from `melandlabs/alloomi` to `melandlabs/release`
- Update brew install command from `alloomi` to `openloomi`
- Update all documentation references to use the new repo name

## Files Changed
- `README.md` - Links and references
- `apps/marketing/components/footer.tsx` - GitHub link
- `apps/marketing/content/alloomi/getting-started.mdx` - Homebrew commands
- `apps/marketing/content/alloomi/use-cases/engineering-daily-sync.mdx` - Repo references

🤖 Generated with [Claude Code](https://claude.com/claude-code)