### PR TITLE
fix: update remaining GitHub URLs from alloomi to openloomi

### DIFF
--- a/apps/marketing/app/home-client.jsx
+++ b/apps/marketing/app/home-client.jsx
@@ -352,7 +352,7 @@ const MarketingPage = () => {
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <a
-                  href="https://github.com/melandlabs/alloomi"
+                  href="https://github.com/melandlabs/openloomi"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bg-primary-gradient text-primary-foreground px-8 py-4 rounded-lg shadow-sm font-medium transition-all transform flex items-center gap-2 relative z-20 hover:brightness-95"
@@ -534,7 +534,7 @@ const MarketingPage = () => {
             </div>
             <div className="flex flex-col sm:flex-row items-center gap-4">
               <a
-                href="https://github.com/melandlabs/alloomi"
+                href="https://github.com/melandlabs/openloomi"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-primary-gradient text-primary-foreground px-8 py-4 rounded-lg shadow-sm font-medium transition-all transform flex items-center gap-2 hover:brightness-95"

--- a/apps/marketing/components/footer.tsx
+++ b/apps/marketing/components/footer.tsx
@@ -166,7 +166,7 @@ export function Footer({
         },
         {
           name: "GitHub",
-          href: "https://github.com/melandlabs/alloomi",
+          href: "https://github.com/melandlabs/openloomi",
           icon: <RemixIcon name="github" variant="line" size="size-4" />,
         },
         {

--- a/apps/marketing/components/landing-footer-cta-section.tsx
+++ b/apps/marketing/components/landing-footer-cta-section.tsx
@@ -27,7 +27,7 @@ export function LandingFooterCtaSection() {
         </p>
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <a
-            href="https://github.com/melandlabs/alloomi"
+            href="https://github.com/melandlabs/openloomi"
             target="_blank"
             rel="noopener noreferrer"
             className="bg-primary-gradient text-primary-foreground px-8 py-4 rounded-lg shadow-sm font-medium transition-all transform flex items-center gap-2 relative z-20 hover:brightness-95 min-w-[180px] justify-center"

--- a/apps/marketing/components/navbar.tsx
+++ b/apps/marketing/components/navbar.tsx
@@ -61,7 +61,7 @@ export function Navbar({
     if (onSignInClick) {
       onSignInClick();
     } else {
-      window.open("https://github.com/melandlabs/alloomi", "_blank");
+      window.open("https://github.com/melandlabs/openloomi", "_blank");
     }
   };
 
@@ -69,7 +69,7 @@ export function Navbar({
     if (onGetStartedClick) {
       onGetStartedClick();
     } else {
-      window.open("https://github.com/melandlabs/alloomi", "_blank");
+      window.open("https://github.com/melandlabs/openloomi", "_blank");
     }
   };
 
@@ -83,7 +83,7 @@ export function Navbar({
     return { backgroundColor: "var(--color-background)" };
   };
 
-  const githubUrl = "https://github.com/melandlabs/alloomi";
+  const githubUrl = "https://github.com/melandlabs/openloomi";
 
   // Nav padding tuned to match the design preview.
   // Move: <md shows Logo.svg only; Desktop: shows Logo-full-light.

--- a/apps/marketing/content/alloomi/getting-started.mdx
+++ b/apps/marketing/content/alloomi/getting-started.mdx
@@ -40,8 +40,8 @@ Visit [https://alloomi.ai](https://alloomi.ai) to download, or use the direct li
 
 ```bash
 # Install via Homebrew
-brew tap melandlabs/alloomi https://github.com/melandlabs/release
-brew install --cask alloomi
+brew tap melandlabs/openloomi https://github.com/melandlabs/release
+brew install --cask openloomi
 ```
 
 **Linux (Ubuntu/Debian)**

--- a/apps/marketing/i18n/en.ts
+++ b/apps/marketing/i18n/en.ts
@@ -147,7 +147,7 @@ export const en = {
     title: "Open-source. Local-first. Yours.",
     subtitle:
       "OpenLoomi is open-source under Apache 2.0. Self-host on your machine — your data never leaves. Clone, build, and run in under 5 minutes.",
-    cloneCommand: "git clone https://github.com/melandlabs/alloomi.git",
+    cloneCommand: "git clone https://github.com/melandlabs/openloomi.git",
     cta: "GitHub",
     community: "Join the community on Discord",
   },

--- a/apps/marketing/i18n/zh-Hans.ts
+++ b/apps/marketing/i18n/zh-Hans.ts
@@ -144,7 +144,7 @@ export const zhHans = {
     title: "开源。本地优先。属于你。",
     subtitle:
       "OpenLoomi 在 Apache 2.0 下开源。在你的机器上自托管——你的数据永远不会离开。五分钟内 clone、build、运行。",
-    cloneCommand: "git clone https://github.com/melandlabs/alloomi.git",
+    cloneCommand: "git clone https://github.com/melandlabs/openloomi.git",
     cta: "GitHub",
     community: "加入 Discord 社区",
   },


### PR DESCRIPTION
## Summary
- Update GitHub repository URLs across marketing files that were missed during the initial Alloomi to OpenLoomi rebrand
- Affects: homepage, navbar, footer, landing CTA section, getting started docs, and i18n files

🤖 Generated with [Claude Code](https://claude.com/claude-code)