### PR TITLE
chore: remove personalization UI components from user menu

### DIFF
--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -394,9 +394,6 @@ export function AppSidebar() {
     i18n.changeLanguage(code);
   };
 
-  /** Open "Contact Us" dialog from user dropdown menu (entry when sidebar is collapsed) */
-  const onOpenContactUs = () => setContactDialogOpen(true);
-
   const handleLogout = async () => {
     if (status === "loading") {
       toast({
@@ -1300,7 +1297,6 @@ export function AppSidebar() {
                           onLanguageChange={handleLanguageChange}
                           onLogin={handleLogin}
                           onCloseSidebar={() => setIsCollapsed(true)}
-                          onOpenContactUs={onOpenContactUs}
                         />
                       </>
                     ) : (
@@ -1313,7 +1309,6 @@ export function AppSidebar() {
                         onLanguageChange={handleLanguageChange}
                         onLogin={handleLogin}
                         onCloseSidebar={() => setIsCollapsed(true)}
-                        onOpenContactUs={onOpenContactUs}
                       >
                         <DropdownMenuTrigger asChild>
                           <Button
@@ -1347,45 +1342,6 @@ export function AppSidebar() {
                           : "flex-row items-center",
                       )}
                     >
-                      {/* When collapsed: personalization above avatar */}
-                      {isCollapsed && (
-                        <Tooltip open={false}>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-8 shrink-0 text-sidebar-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground"
-                              aria-label={t(
-                                "nav.personalization",
-                                "Personalization",
-                              )}
-                              onClick={() => {
-                                window.dispatchEvent(
-                                  new CustomEvent(
-                                    "openloomi:open-personalization",
-                                  ),
-                                );
-                                setIsCollapsed(true);
-                                window.dispatchEvent(
-                                  new CustomEvent("openloomi:close-sidebar"),
-                                );
-                              }}
-                            >
-                              <RemixIcon
-                                name="brain_ai_3"
-                                size={SIDEBAR_NAV_ICON_SIZE}
-                                className="shrink-0"
-                              />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent
-                            side="right"
-                            className="border border-border bg-card text-card-foreground z-[9999]"
-                          >
-                            <p>{t("nav.personalization", "Personalization")}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
                       <div
                         className={cn(
                           "flex w-full items-center gap-0",
@@ -1420,51 +1376,6 @@ export function AppSidebar() {
                             <p>{t("nav.myAccount")}</p>
                           </TooltipContent>
                         </Tooltip>
-                        {/* When expanded: personalization right-aligned */}
-                        {!isCollapsed && (
-                          <div className="ml-auto flex items-center gap-1 shrink-0">
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="size-8 shrink-0 text-sidebar-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground"
-                                  aria-label={t(
-                                    "nav.personalization",
-                                    "Personalization",
-                                  )}
-                                  onClick={() => {
-                                    window.dispatchEvent(
-                                      new CustomEvent(
-                                        "openloomi:open-personalization",
-                                      ),
-                                    );
-                                    setIsCollapsed(true);
-                                    window.dispatchEvent(
-                                      new CustomEvent(
-                                        "openloomi:close-sidebar",
-                                      ),
-                                    );
-                                  }}
-                                >
-                                  <RemixIcon
-                                    name="brain_ai_3"
-                                    size={SIDEBAR_NAV_ICON_SIZE}
-                                    className="shrink-0"
-                                  />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent
-                                side="right"
-                                className="border border-border bg-card text-card-foreground z-[9999]"
-                              >
-                                <p>
-                                  {t("nav.personalization", "Personalization")}
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </div>
-                        )}
                       </div>
                     </div>
                     <UserMenuFullscreen
@@ -1493,7 +1404,6 @@ export function AppSidebar() {
                       onLanguageChange={handleLanguageChange}
                       onLogin={handleLogin}
                       onCloseSidebar={() => setIsCollapsed(true)}
-                      onOpenContactUs={onOpenContactUs}
                     />
                   </>
                 ) : (
@@ -1505,41 +1415,6 @@ export function AppSidebar() {
                         : "flex-row items-center",
                     )}
                   >
-                    {/* When collapsed: personalization above avatar */}
-                    {isCollapsed && (
-                      <Tooltip open={false}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-8 shrink-0 text-sidebar-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground"
-                            aria-label={t(
-                              "nav.personalization",
-                              "Personalization",
-                            )}
-                            onClick={() => {
-                              window.dispatchEvent(
-                                new CustomEvent(
-                                  "openloomi:open-personalization",
-                                ),
-                              );
-                            }}
-                          >
-                            <RemixIcon
-                              name="brain_ai_3"
-                              size={SIDEBAR_NAV_ICON_SIZE}
-                              className="shrink-0"
-                            />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="right"
-                          className="border border-border bg-card text-card-foreground z-[9999]"
-                        >
-                          <p>{t("nav.personalization", "Personalization")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
                     <div
                       className={cn(
                         "flex w-full items-center gap-0",
@@ -1555,7 +1430,6 @@ export function AppSidebar() {
                         onLanguageChange={handleLanguageChange}
                         onLogin={handleLogin}
                         onCloseSidebar={() => setIsCollapsed(true)}
-                        onOpenContactUs={onOpenContactUs}
                       >
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -1613,41 +1487,6 @@ export function AppSidebar() {
                               className="border border-border bg-card text-card-foreground z-[9999]"
                             >
                               <p>{t("settings.menuSettings", "Settings")}</p>
-                            </TooltipContent>
-                          </Tooltip>
-
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="size-8 shrink-0 text-sidebar-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground"
-                                aria-label={t(
-                                  "nav.personalization",
-                                  "Personalization",
-                                )}
-                                onClick={() => {
-                                  window.dispatchEvent(
-                                    new CustomEvent(
-                                      "openloomi:open-personalization",
-                                    ),
-                                  );
-                                }}
-                              >
-                                <RemixIcon
-                                  name="brain_ai_3"
-                                  size={SIDEBAR_NAV_ICON_SIZE}
-                                  className="shrink-0"
-                                />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent
-                              side="right"
-                              className="border border-border bg-card text-card-foreground z-[9999]"
-                            >
-                              <p>
-                                {t("nav.personalization", "Personalization")}
-                              </p>
                             </TooltipContent>
                           </Tooltip>
                         </div>

--- a/apps/web/components/user-menu-content.tsx
+++ b/apps/web/components/user-menu-content.tsx
@@ -8,7 +8,6 @@ import type { Session } from "next-auth";
 import { RemixIcon } from "@/components/remix-icon";
 import { cn } from "@/lib/utils";
 import { guestRegex } from "@/lib/env/constants";
-import { isTauri, openUrl } from "@/lib/tauri";
 import {
   LanguageSettingsMenu,
   languages,
@@ -49,8 +48,6 @@ interface UserMenuContentProps {
   onLogin: () => void;
   /** Menu item click handler */
   onMenuItemClick: () => void;
-  /** Opens the "Contact Us" dialog (entry from menu when sidebar is collapsed) */
-  onOpenContactUs?: () => void;
   /** Callback when clicking the "Personal Settings" icon on the user card (navigates to personal settings page) */
   onPersonalSettingsClick?: () => void;
   /** Callback when clicking the user card to navigate to subscription management page */
@@ -76,7 +73,6 @@ export function UserMenuContent({
   onLanguageChange,
   onLogin,
   onMenuItemClick,
-  onOpenContactUs,
   onPersonalSettingsClick,
   onGoToSubscriptionManagement,
 }: UserMenuContentProps) {
@@ -330,162 +326,6 @@ export function UserMenuContent({
         <RemixIcon name="settings_line" size={styles.iconSize} />
         <span>{t("settings.menuSettings", "Settings")}</span>
       </Link>
-
-      <Link
-        href={
-          isFullscreen
-            ? "/?page=profile-soul&fromUserMenu=true"
-            : "/?page=profile-soul"
-        }
-        onClick={onMenuItemClick}
-        className={cn(
-          "flex items-center w-full rounded-sm text-foreground",
-          styles.itemGap,
-          styles.itemPadding,
-          styles.itemTextSize,
-          styles.itemHover,
-        )}
-      >
-        <RemixIcon name="brain_ai_3" size={styles.iconSize} />
-        <span>{t("settings.personalization")}</span>
-      </Link>
-
-      {/* Divider */}
-      <div className={cn("border-t border-border", styles.dividerMargin)} />
-
-      {/* Help */}
-      {isTauri() ? (
-        <>
-          <button
-            type="button"
-            onClick={() => {
-              onMenuItemClick();
-              openUrl("https://openloomi.ai/docs");
-            }}
-            className={cn(
-              "flex items-center w-full rounded-sm text-foreground cursor-pointer bg-transparent border-none",
-              styles.itemGap,
-              styles.itemPadding,
-              styles.itemTextSize,
-              styles.itemHover,
-            )}
-          >
-            <RemixIcon name="question" size={styles.iconSize} />
-            <span>{t("nav.help")}</span>
-          </button>
-        </>
-      ) : (
-        <button
-          type="button"
-          onClick={() => {
-            onMenuItemClick?.();
-            openUrl("https://openloomi.ai/docs");
-          }}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="question" size={styles.iconSize} />
-          <span>{t("nav.help")}</span>
-        </button>
-      )}
-
-      {/* Contact us - opened from this entry when sidebar is collapsed */}
-      {onOpenContactUs && (
-        <button
-          type="button"
-          onClick={() => {
-            onMenuItemClick();
-            onOpenContactUs();
-          }}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="message_3" size={styles.iconSize} />
-          <span>{t("common.contactUs")}</span>
-        </button>
-      )}
-
-      {/* Privacy policy */}
-      {isTauri() ? (
-        <button
-          type="button"
-          onClick={() => {
-            onMenuItemClick();
-            openUrl("https://app.openloomi.ai/privacy");
-          }}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground cursor-pointer bg-transparent border-none",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="shield_check" size={styles.iconSize} />
-          <span>{t("common.privacy")}</span>
-        </button>
-      ) : (
-        <Link
-          href="/privacy"
-          onClick={onMenuItemClick}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="shield_check" size={styles.iconSize} />
-          <span>{t("common.privacy")}</span>
-        </Link>
-      )}
-
-      {/* Terms of service */}
-      {isTauri() ? (
-        <button
-          type="button"
-          onClick={() => {
-            onMenuItemClick();
-            openUrl("https://app.openloomi.ai/terms");
-          }}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground cursor-pointer bg-transparent border-none",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="file_text" size={styles.iconSize} />
-          <span>{t("common.terms")}</span>
-        </button>
-      ) : (
-        <Link
-          href="/terms"
-          onClick={onMenuItemClick}
-          className={cn(
-            "flex items-center w-full rounded-sm text-foreground",
-            styles.itemGap,
-            styles.itemPadding,
-            styles.itemTextSize,
-            styles.itemHover,
-          )}
-        >
-          <RemixIcon name="file_text" size={styles.iconSize} />
-          <span>{t("common.terms")}</span>
-        </Link>
-      )}
     </>
   );
 

--- a/apps/web/components/user-menu-dropdown.tsx
+++ b/apps/web/components/user-menu-dropdown.tsx
@@ -36,8 +36,6 @@ interface UserMenuDropdownProps {
   onLogin: () => void;
   /** Mobile sidebar close callback */
   onCloseSidebar?: () => void;
-  /** Open "Contact Us" dialog (accessed from menu when sidebar is collapsed) */
-  onOpenContactUs?: () => void;
   /** Child elements (trigger) */
   children: React.ReactNode;
 }
@@ -59,7 +57,6 @@ export function UserMenuDropdown({
   onLanguageChange,
   onLogin,
   onCloseSidebar,
-  onOpenContactUs,
   children,
 }: UserMenuDropdownProps) {
   const { t } = useTranslation();
@@ -195,7 +192,6 @@ export function UserMenuDropdown({
             onLanguageChange={onLanguageChange}
             onLogin={onLogin}
             onMenuItemClick={handleMenuItemClick}
-            onOpenContactUs={onOpenContactUs}
             onPersonalSettingsClick={handlePersonalSettingsClick}
           />
         </DropdownMenuContent>

--- a/apps/web/components/user-menu-fullscreen.tsx
+++ b/apps/web/components/user-menu-fullscreen.tsx
@@ -40,8 +40,6 @@ interface UserMenuFullscreenProps {
   onLogin: () => void;
   /** Callback for closing sidebar on mobile */
   onCloseSidebar?: () => void;
-  /** Opens the "Contact Us" dialog */
-  onOpenContactUs?: () => void;
 }
 
 /**
@@ -60,7 +58,6 @@ export function UserMenuFullscreen({
   onLanguageChange,
   onLogin,
   onCloseSidebar,
-  onOpenContactUs,
 }: UserMenuFullscreenProps) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -98,77 +95,6 @@ export function UserMenuFullscreen({
     onClose();
     router.push("/?page=profile&fromUserMenu=true");
   };
-
-  /**
-   * Listen for open personalization settings event.
-   */
-  useEffect(() => {
-    const handleOpenPersonalization = (event: Event) => {
-      const customEvent = event as CustomEvent<{
-        targetPage?: "profile-soul";
-        tab?: "basic" | "contexts" | "roles" | "people" | "linkedAccounts";
-        addPlatform?: boolean;
-      }>;
-
-      if (customEvent.detail?.targetPage === "profile-soul") {
-        onClose();
-        router.push("/?page=profile-soul");
-        return;
-      }
-
-      if (
-        customEvent.detail?.tab === "roles" ||
-        customEvent.detail?.tab === "people"
-      ) {
-        onClose();
-        router.push("/?page=profile-soul");
-        return;
-      }
-
-      if (customEvent.detail?.tab === "linkedAccounts") {
-        onClose();
-        const q = customEvent.detail?.addPlatform ? "?addPlatform=true" : "";
-        router.push(`/connectors${q}`);
-        return;
-      }
-
-      if (customEvent.detail?.tab === "basic") {
-        onClose();
-        router.push("/?page=openloomi-soul");
-        return;
-      }
-      if (customEvent.detail?.tab === "contexts") {
-        onClose();
-        router.push("/?page=profile-soul");
-        return;
-      }
-
-      onClose();
-      router.push("/?page=openloomi-soul");
-    };
-
-    window.addEventListener(
-      "openloomi:open-personalization",
-      handleOpenPersonalization as EventListener,
-    );
-
-    // Backwards compatibility with old event name
-    window.addEventListener(
-      "openloomi:open-user-settings",
-      handleOpenPersonalization as EventListener,
-    );
-
-    return () => {
-      window.removeEventListener(
-        "openloomi:open-personalization",
-        handleOpenPersonalization as EventListener,
-      );
-      window.removeEventListener(
-        "openloomi:open-user-settings",
-        handleOpenPersonalization as EventListener,
-      );
-    };
-  }, [onClose, router]);
 
   // When opening/closing, set data attribute on body to hide the bottom menu
   useEffect(() => {
@@ -258,7 +184,6 @@ export function UserMenuFullscreen({
               onLanguageChange={onLanguageChange}
               onLogin={onLogin}
               onMenuItemClick={handleMenuItemClick}
-              onOpenContactUs={onOpenContactUs}
               onPersonalSettingsClick={handlePersonalSettingsClick}
             />
           </div>

--- a/apps/web/components/user-profile-settings.tsx
+++ b/apps/web/components/user-profile-settings.tsx
@@ -24,8 +24,6 @@ import {
 import { toast } from "@/components/toast";
 import { fetchWithAuth } from "@/lib/utils";
 import { useUserProfile } from "@/hooks/use-user-profile";
-import { PersonalizationSwrBoundary } from "@/components/personalization/personalization-swr-boundary";
-import { PersonalizationBasicSettings } from "@/components/personalization/personalization-basic-settings";
 
 type ProfileResponse = {
   user: {
@@ -546,15 +544,6 @@ export function UserProfileSettings() {
         </div>
 
         <Separator className="mb-8" />
-
-        <div className="w-full mt-0">
-          <p className="mb-6 px-0 pb-0 text-base font-semibold text-foreground-secondary">
-            {t("settings.openloomiSettings")}
-          </p>
-          <PersonalizationSwrBoundary>
-            <PersonalizationBasicSettings open />
-          </PersonalizationSwrBoundary>
-        </div>
       </div>
 
       {/* Change full name */}

--- a/skills/openloomi-feature-guide/SKILL.md
+++ b/skills/openloomi-feature-guide/SKILL.md
@@ -594,55 +594,9 @@ After uploading documents, you can ask AI questions about them directly.
 2. **Ask questions** - Ask AI "What's in the document about XXX?"
 3. **Get full content** - View the complete document when needed
 
----
-
-## Subscription & Pricing
-
-openloomi offers flexible plans to suit different needs.
-
-### Plans
-
-| Plan | Description |
-|------|-------------|
-| **Free** | Limited credits and features to get started |
-| **Basic** | Higher limits and more features |
-| **Pro** | Full features, highest limits, and priority support |
-
-### How to Upgrade
-
-1. Click your profile icon in the top right
-2. Select **"Upgrade"** or **"Manage Plan"**
-3. Choose your preferred plan
-4. Complete the payment
-
-Your upgrade takes effect immediately.
-
-### Credits System
-
-Credits are used to power AI tasks such as message analysis, insight generation, and skill execution.
-
-**How to top up credits:**
-1. Click your profile icon → **"Upgrade"** or **"Manage Plan"**
-2. Select **"Top Up Credits"**
-3. Choose a credit package and complete payment
-
-Credits do not expire and can be purchased anytime without upgrading to Pro.
-
----
-
-## Legal
-
-### Terms of Service
-
-By using openloomi, you agree to our Terms of Service. These terms outline the rules, guidelines, and legal obligations governing your use of openloomi — including acceptable use, account responsibilities, and limitations of liability.
-
-📄 **[Read Terms of Service](https://app.openloomi.ai/terms)**
-
 ### Privacy Policy
 
 Your privacy matters. Our Privacy Policy explains in detail how we collect, use, store, and protect your data — including what data we access, how it's encrypted, how long we retain it, and your rights to access, export, or delete it at any time.
-
-📄 **[Read Privacy Policy](https://app.openloomi.ai/privacy)**
 
 ### Privacy & Security
 


### PR DESCRIPTION
## Summary
- Remove personalization-related UI elements from user menu and sidebar components
- Remove `onOpenContactUs` prop from UserMenuDropdown and UserMenuFullscreen
- Remove personalization event listener from UserMenuFullscreen
- Remove personalization settings section from UserProfileSettings
- Remove Subscription, Terms, and Privacy Policy sections from SKILL.md

## Test plan
- [ ] Verify sidebar renders correctly in both collapsed and expanded states
- [ ] Verify user menu dropdown renders without personalization items
- [ ] Verify user profile settings page renders without personalization section
- [ ] Verify no console errors related to removed components