### PR TITLE
chore: update GitHub repo URLs from melandlabs/release to melandlabs/openloomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ Requires Node.js 22+ and pnpm 9+.
 
 <table>
 <tr>
+<td><img src="screenshots/connector-01.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-02.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-03.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-04.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-05.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-06.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-07.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-08.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-09.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-10.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-11.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/connector-12.png" alt="Connector" width="100%"></td>
+</tr>
+<tr>
+<td><img src="screenshots/connector-13.png" alt="Connector" width="100%"></td>
+<td><img src="screenshots/index-loop.png" alt="Intelligence Loop" width="100%"></td>
+</tr>
+</table>
+
+## App Screenshots
+
+<table>
+<tr>
 <td><img src="screenshots/app/docx.gif" alt="Document preview" width="100%"></td>
 <td><img src="screenshots/app/excel.gif" alt="Spreadsheet preview" width="100%"></td>
 </tr>

--- a/apps/marketing/app/home-client.jsx
+++ b/apps/marketing/app/home-client.jsx
@@ -21,22 +21,22 @@ const data = {
   downloadLinks: {
     macOS: {
       arm64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg",
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg",
     },
     linux: {
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb",
       arm64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb",
     },
     windows: {
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe",
       arm64: null,
     },
-    github: "https://github.com/melandlabs/release/releases",
+    github: "https://github.com/melandlabs/openloomi/releases",
   },
   hero: {
     title: "You focus on what matters. OpenLoomi closes the loop.",

--- a/apps/marketing/components/footer.tsx
+++ b/apps/marketing/components/footer.tsx
@@ -71,22 +71,22 @@ export function Footer({
   const downloadLinks = {
     macOS: {
       arm64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg",
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg",
     },
     linux: {
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb",
       arm64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb",
     },
     windows: {
       amd64:
-        "https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe",
       arm64: null,
     },
-    github: "https://github.com/melandlabs/release/releases",
+    github: "https://github.com/melandlabs/openloomi/releases",
   };
 
   const detectPlatform = () => {

--- a/apps/marketing/content/openloomi/connectors.mdx
+++ b/apps/marketing/content/openloomi/connectors.mdx
@@ -141,6 +141,60 @@ These platforms connect to a **user's personal account** via QR code or phone ve
   <img src="/img/openloomi/connectors-dialog.png" />
 </div>
 
+## Connector Screenshots
+
+<div align="center">
+  <img src="/img/openloomi/connector-01.png" alt="Connector 01" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-02.png" alt="Connector 02" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-03.png" alt="Connector 03" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-04.png" alt="Connector 04" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-05.png" alt="Connector 05" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-06.png" alt="Connector 06" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-07.png" alt="Connector 07" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-08.png" alt="Connector 08" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-09.png" alt="Connector 09" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-10.png" alt="Connector 10" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-11.png" alt="Connector 11" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-12.png" alt="Connector 12" style="max-width: 100%; height: auto;" />
+</div>
+
+<div align="center">
+  <img src="/img/openloomi/connector-13.png" alt="Connector 13" style="max-width: 100%; height: auto;" />
+</div>
+
 ## Platform Setup Details
 
 ### Telegram

--- a/apps/marketing/content/openloomi/connectors.mdx
+++ b/apps/marketing/content/openloomi/connectors.mdx
@@ -144,55 +144,107 @@ These platforms connect to a **user's personal account** via QR code or phone ve
 ## Connector Screenshots
 
 <div align="center">
-  <img src="/img/openloomi/connector-01.png" alt="Connector 01" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-01.png"
+    alt="Connector 01"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-02.png" alt="Connector 02" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-02.png"
+    alt="Connector 02"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-03.png" alt="Connector 03" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-03.png"
+    alt="Connector 03"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-04.png" alt="Connector 04" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-04.png"
+    alt="Connector 04"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-05.png" alt="Connector 05" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-05.png"
+    alt="Connector 05"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-06.png" alt="Connector 06" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-06.png"
+    alt="Connector 06"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-07.png" alt="Connector 07" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-07.png"
+    alt="Connector 07"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-08.png" alt="Connector 08" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-08.png"
+    alt="Connector 08"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-09.png" alt="Connector 09" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-09.png"
+    alt="Connector 09"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-10.png" alt="Connector 10" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-10.png"
+    alt="Connector 10"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-11.png" alt="Connector 11" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-11.png"
+    alt="Connector 11"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-12.png" alt="Connector 12" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-12.png"
+    alt="Connector 12"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 <div align="center">
-  <img src="/img/openloomi/connector-13.png" alt="Connector 13" style="max-width: 100%; height: auto;" />
+  <img
+    src="/img/openloomi/connector-13.png"
+    alt="Connector 13"
+    style="max-width: 100%; height: auto;"
+  />
 </div>
 
 ## Platform Setup Details

--- a/apps/marketing/content/openloomi/getting-started.mdx
+++ b/apps/marketing/content/openloomi/getting-started.mdx
@@ -34,8 +34,8 @@ Visit [https://openloomi.ai](https://openloomi.ai) to download, or use the direc
 
 | Option                                                                                                                                      | Notes                                                      |
 | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| [Download .dmg installer (Apple Silicon)](https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg) | Recommended for M1/M2/M3/M4 Macs — double-click to install |
-| [Download .dmg installer (Intel)](https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg)           | For Intel Macs                                             |
+| [Download .dmg installer (Apple Silicon)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg) | Recommended for M1/M2/M3/M4 Macs — double-click to install |
+| [Download .dmg installer (Intel)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg)           | For Intel Macs                                             |
 | Homebrew                                                                                                                                    | For developers — see command below                         |
 
 ```bash
@@ -48,8 +48,8 @@ brew install --cask openloomi
 
 | Option                                                                                                                            | Notes                                               |
 | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Download .deb package (x86_64)](https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb)  | For x86_64 / AMD64 systems                          |
-| [Download .deb package (ARM64)](https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb) | For ARM64 systems (e.g., Raspberry Pi, ARM servers) |
+| [Download .deb package (x86_64)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb)  | For x86_64 / AMD64 systems                          |
+| [Download .deb package (ARM64)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb) | For ARM64 systems (e.g., Raspberry Pi, ARM servers) |
 
 ```bash
 sudo dpkg -i openloomi_0.4.2_linux_amd64.deb
@@ -68,14 +68,14 @@ openloomi
 
 | Option                                                                                                                      | Notes                                               |
 | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Download .exe installer](https://github.com/melandlabs/release/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe) | Recommended — run the installer to set up OpenLoomi |
+| [Download .exe installer](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe) | Recommended — run the installer to set up OpenLoomi |
 | Winget                                                                                                                      | Coming Soon                                         |
 
 > **Windows SmartScreen:** If Windows shows a warning when running the installer, click **"More info"** then **"Run anyway"**. This is normal — OpenLoomi is open-source and the code is publicly verifiable. You only need to do this once per machine.
 >
 > **"Unable to Find Entry Point" / GetSystemTimePreciseAsFileTime error:** If you see an error about `GetSystemTimePreciseAsFileTime` not being found in `kernel32.dll`, your Windows version is too old. OpenLoomi requires **Windows 10 (build 1607 or later)** or **Windows 11**. Windows XP, Vista, 7, and 8/8.1 are not supported. To check your version, press `Win + R`, type `winver`, and press Enter — or go to **Settings > System > About**.
 
-[View all releases →](https://github.com/melandlabs/release/releases)
+[View all releases →](https://github.com/melandlabs/openloomi/releases)
 
 ---
 

--- a/apps/marketing/content/openloomi/getting-started.mdx
+++ b/apps/marketing/content/openloomi/getting-started.mdx
@@ -32,11 +32,11 @@ Visit [https://openloomi.ai](https://openloomi.ai) to download, or use the direc
 
 **macOS**
 
-| Option                                                                                                                                      | Notes                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Option                                                                                                                                        | Notes                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | [Download .dmg installer (Apple Silicon)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_aarch64.dmg) | Recommended for M1/M2/M3/M4 Macs — double-click to install |
 | [Download .dmg installer (Intel)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_macOS_amd64.dmg)           | For Intel Macs                                             |
-| Homebrew                                                                                                                                    | For developers — see command below                         |
+| Homebrew                                                                                                                                      | For developers — see command below                         |
 
 ```bash
 # Install via Homebrew
@@ -46,8 +46,8 @@ brew install --cask openloomi
 
 **Linux (Ubuntu/Debian)**
 
-| Option                                                                                                                            | Notes                                               |
-| --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Option                                                                                                                              | Notes                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | [Download .deb package (x86_64)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_amd64.deb)  | For x86_64 / AMD64 systems                          |
 | [Download .deb package (ARM64)](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_linux_aarch64.deb) | For ARM64 systems (e.g., Raspberry Pi, ARM servers) |
 
@@ -66,10 +66,10 @@ openloomi
 
 **Windows**
 
-| Option                                                                                                                      | Notes                                               |
-| --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Option                                                                                                                        | Notes                                               |
+| ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | [Download .exe installer](https://github.com/melandlabs/openloomi/releases/download/v0.4.2/openloomi_0.4.2_windows_amd64.exe) | Recommended — run the installer to set up OpenLoomi |
-| Winget                                                                                                                      | Coming Soon                                         |
+| Winget                                                                                                                        | Coming Soon                                         |
 
 > **Windows SmartScreen:** If Windows shows a warning when running the installer, click **"More info"** then **"Run anyway"**. This is normal — OpenLoomi is open-source and the code is publicly verifiable. You only need to do this once per machine.
 >

--- a/apps/web/src-tauri/src/update.rs
+++ b/apps/web/src-tauri/src/update.rs
@@ -296,7 +296,7 @@ pub async fn do_check_for_update() -> Result<UpdateCheckResult, String> {
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
     let mut req = client
-        .get("https://api.github.com/repos/melandlabs/release/tags")
+        .get("https://api.github.com/repos/melandlabs/openloomi/tags")
         .header("Accept", "application/vnd.github+json");
     if let Ok(token) = std::env::var("GITHUB_TOKEN") {
         if !token.is_empty() {
@@ -337,7 +337,7 @@ pub async fn do_check_for_update() -> Result<UpdateCheckResult, String> {
 
     // Check if a release exists for this tag before showing update
     let release_url = format!(
-        "https://api.github.com/repos/melandlabs/release/releases/tags/{}",
+        "https://api.github.com/repos/melandlabs/openloomi/releases/tags/{}",
         latest_tag
     );
     let mut release_req = client
@@ -385,7 +385,7 @@ pub async fn do_check_for_update() -> Result<UpdateCheckResult, String> {
 
     let download_url = if !download_filename.is_empty() {
         format!(
-            "https://github.com/melandlabs/release/releases/download/{}/{}",
+            "https://github.com/melandlabs/openloomi/releases/download/{}/{}",
             latest_tag, download_filename
         )
     } else {
@@ -398,7 +398,7 @@ pub async fn do_check_for_update() -> Result<UpdateCheckResult, String> {
         current_version: current_version.to_string(),
         download_url,
         release_url: format!(
-            "https://github.com/melandlabs/release/releases/tag/{}",
+            "https://github.com/melandlabs/openloomi/releases/tag/{}",
             latest_tag
         ),
         file_size,

--- a/skills/openloomi-feature-guide/SKILL.md
+++ b/skills/openloomi-feature-guide/SKILL.md
@@ -278,7 +278,7 @@ openloomi also offers a **desktop app** (macOS, Linux, and Windows) that provide
 
 **Windows:**
 
-1. Download the latest `.exe` installer from [GitHub Releases](https://github.com/melandlabs/release/releases/latest)
+1. Download the latest `.exe` installer from [GitHub Releases](https://github.com/melandlabs/openloomi/releases/latest)
 2. Run the installer — if Windows SmartScreen shows a warning, click **"More info"** then **"Run anyway"**. This is normal for new applications without a long code-signing reputation; openloomi is open-source and the code is publicly verifiable
 3. After the first run, SmartScreen typically bypasses automatically on subsequent updates
 
@@ -292,11 +292,11 @@ winget install openloomi.openloomi
 
 **macOS:**
 
-Download the latest `.dmg` from [GitHub Releases](https://github.com/melandlabs/release/releases/latest) and drag openloomi to your Applications folder.
+Download the latest `.dmg` from [GitHub Releases](https://github.com/melandlabs/openloomi/releases/latest) and drag openloomi to your Applications folder.
 
 **Linux:**
 
-Download the latest `.AppImage` or `.deb` from [GitHub Releases](https://github.com/melandlabs/release/releases/latest).
+Download the latest `.AppImage` or `.deb` from [GitHub Releases](https://github.com/melandlabs/openloomi/releases/latest).
 
 | Platform | Status | Installer |
 |----------|--------|----------|


### PR DESCRIPTION
## Summary

- Update all GitHub release/download URLs from `melandlabs/release` to `melandlabs/openloomi`
- Add connector screenshots to README.md and connectors documentation
- Update Tauri update checker to use correct GitHub repository API endpoints

## Test plan

- [ ] Verify download links work for macOS, Linux, and Windows
- [ ] Verify update check works in desktop app
- [ ] Verify connector screenshots render correctly in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)