### PR TITLE
feat(memory): migrate raw messages to local sqlite backend

### DIFF
--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -1,0 +1,326 @@
+import { auth } from "@/app/(auth)/auth";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+} from "@/lib/memory/sqlite-raw-message-store";
+import { AppError } from "@openloomi/shared/errors";
+import {
+  queryMemoryWithFallback,
+  runMemoryForgettingCycle,
+} from "@openloomi/indexeddb/forgetting";
+import type {
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageQuery,
+} from "@openloomi/indexeddb";
+import type { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+
+function normalizeTimestampToMs(value: number | undefined): number | undefined {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  if ((value as number) < 1e11) {
+    return Math.floor((value as number) * 1000);
+  }
+  return Math.floor(value as number);
+}
+
+function toRawSourceItem(message: RawMessage): RawMessage & {
+  sourceType: "raw";
+} {
+  return {
+    ...message,
+    sourceType: "raw",
+  };
+}
+
+function toSummarySourceItem(
+  summary: MemorySummaryRecord,
+): MemorySummaryRecord & {
+  sourceType: "summary";
+} {
+  return {
+    ...summary,
+    sourceType: "summary",
+  };
+}
+
+function scopedQuery(query: RawMessageQuery | undefined, userId: string) {
+  return {
+    ...(query ?? {}),
+    userId,
+  };
+}
+
+async function queryRawMessagesWithFallback(
+  query: RawMessageQuery,
+  userId: string,
+) {
+  const manager = await getSQLiteRawMessageManager();
+  const pageSize = query.pageSize ?? query.limit ?? 50;
+  const minRaw =
+    query.minRawResultsWithoutFallback ?? query.pageSize ?? query.limit ?? 50;
+
+  const result = await queryMemoryWithFallback(manager as any, {
+    userId,
+    keywords: query.keywords,
+    startTime: normalizeTimestampToMs(query.startTime),
+    endTime: normalizeTimestampToMs(query.endTime),
+    limit: pageSize,
+    pageSize,
+    offset: query.offset,
+    reverse: query.reverse ?? true,
+    tiers: query.memoryStages,
+    dimensions: {
+      platform: query.platform,
+      channel: query.channel,
+      person: query.person,
+      botId: query.botId,
+    },
+    minRawResultsWithoutFallback: minRaw,
+  });
+
+  return result.items
+    .map((item) => {
+      if (item.sourceType === "summary") {
+        return toSummarySourceItem({
+          summaryId: item.summary.summaryId,
+          userId: item.summary.userId,
+          summaryTier: item.summary.summaryTier,
+          sourceTier: item.summary.sourceTier,
+          startTimestamp: item.summary.startTimestamp,
+          endTimestamp: item.summary.endTimestamp,
+          messageCount: item.summary.messageCount,
+          sourceRecordIds: item.summary.sourceRecordIds,
+          keyPoints: item.summary.keyPoints,
+          keywords: item.summary.keywords,
+          keywordsText: item.summary.keywords.join(" "),
+          summaryText: item.summary.summaryText,
+          dimensions: item.summary.dimensions,
+          qualityScore: item.summary.qualityScore,
+          createdAt: item.summary.createdAt,
+          updatedAt: item.summary.updatedAt,
+        });
+      }
+
+      const rawMaybe = (
+        item.record.metadata as Record<string, unknown> | undefined
+      )?.__rawMessage;
+      if (rawMaybe && typeof rawMaybe === "object") {
+        return toRawSourceItem(rawMaybe as RawMessage);
+      }
+
+      return toRawSourceItem({
+        messageId: item.record.id,
+        platform:
+          typeof item.record.dimensions?.platform === "string"
+            ? String(item.record.dimensions.platform)
+            : "unknown",
+        botId:
+          typeof item.record.dimensions?.botId === "string"
+            ? String(item.record.dimensions.botId)
+            : "unknown",
+        userId: item.record.userId,
+        channel:
+          typeof item.record.dimensions?.channel === "string"
+            ? String(item.record.dimensions.channel)
+            : undefined,
+        person:
+          typeof item.record.dimensions?.person === "string"
+            ? String(item.record.dimensions.person)
+            : undefined,
+        timestamp: Math.floor(item.record.timestamp / 1000),
+        content: item.record.text ?? "",
+        attachments: [],
+        embedding: item.record.embedding,
+        embeddingModel: item.record.embeddingModel,
+        embeddingContentHash: item.record.embeddingContentHash,
+        embeddingDimensions: item.record.embeddingDimensions,
+        embeddingUpdatedAt: item.record.embeddingUpdatedAt,
+        metadata:
+          (item.record.metadata as Record<string, any> | undefined) ??
+          undefined,
+        createdAt: item.record.timestamp,
+        memoryStage: item.record.tier,
+        accessCount: item.record.accessCount,
+        lastAccessAt: item.record.lastAccessAt,
+        importanceScore: item.record.importanceScore,
+        archivedAt: item.record.archivedAt,
+        isPinned: item.record.isPinned,
+      });
+    })
+    .slice(0, pageSize);
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return new AppError("unauthorized:api").toResponse();
+  }
+
+  if (!isSQLiteRawMessageStorageAvailable()) {
+    return Response.json({
+      available: false,
+      reason: "not_tauri",
+    });
+  }
+
+  const manager = await getSQLiteRawMessageManager();
+  return Response.json({
+    available: true,
+    stats: await manager.getStats(),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new AppError("unauthorized:api").toResponse();
+  }
+
+  if (!isSQLiteRawMessageStorageAvailable()) {
+    return Response.json(
+      {
+        success: false,
+        reason: "not_tauri",
+        message: "SQLite raw message storage is only available in Tauri mode.",
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const action = typeof body.action === "string" ? body.action : "";
+    const userId = session.user.id;
+    const manager = await getSQLiteRawMessageManager();
+
+    switch (action) {
+      case "store": {
+        const messages = Array.isArray(body.messages) ? body.messages : [];
+        if (messages.length === 0) {
+          return new AppError(
+            "bad_request:api",
+            "messages array is required and must not be empty",
+          ).toResponse();
+        }
+
+        const now = Math.floor(Date.now() / 1000);
+        const normalized = messages.map((message: Partial<RawMessage>) => ({
+          ...message,
+          userId,
+          createdAt: message.createdAt ?? now,
+        })) as RawMessage[];
+        const ids = await manager.storeMessages(normalized);
+        return Response.json({
+          success: true,
+          stored: ids.length,
+          errors: 0,
+        });
+      }
+
+      case "query": {
+        const query = scopedQuery(body.query, userId);
+        if (query.includeSummaryFallback) {
+          return Response.json({
+            success: true,
+            items: await queryRawMessagesWithFallback(query, userId),
+          });
+        }
+
+        const messages = await manager.queryMessages(query);
+        return Response.json({
+          success: true,
+          items: messages.map(toRawSourceItem),
+        });
+      }
+
+      case "queryGrouped": {
+        const grouped = await manager.queryMessagesGrouped(
+          scopedQuery(body.query, userId),
+        );
+        return Response.json({ success: true, grouped });
+      }
+
+      case "stats": {
+        return Response.json({
+          success: true,
+          stats: await manager.getStats(),
+        });
+      }
+
+      case "clearOld": {
+        const olderThan = Number(body.olderThan);
+        if (!Number.isFinite(olderThan)) {
+          return new AppError(
+            "bad_request:api",
+            "olderThan must be a finite timestamp",
+          ).toResponse();
+        }
+        const deleted = await manager.deleteOldMessages(olderThan, userId);
+        return Response.json({ success: true, deleted });
+      }
+
+      case "updateEmbeddings": {
+        const updates = Array.isArray(body.updates) ? body.updates : [];
+        const updated = await manager.updateMessageEmbeddings(updates, userId);
+        return Response.json({ success: true, updated });
+      }
+
+      case "semanticSearch": {
+        const queryEmbedding = Array.isArray(body.queryEmbedding)
+          ? body.queryEmbedding
+          : [];
+        if (queryEmbedding.length === 0) {
+          return Response.json({ success: true, items: [] });
+        }
+
+        const items =
+          typeof (manager as any).searchMessagesSemantically === "function"
+            ? await (manager as any).searchMessagesSemantically({
+                ...(body.options ?? {}),
+                userId,
+                queryEmbedding,
+              })
+            : [];
+        return Response.json({ success: true, items });
+      }
+
+      case "upsertSummaries": {
+        const summaries = Array.isArray(body.summaries) ? body.summaries : [];
+        await manager.upsertSummaries(
+          summaries.map((summary: Partial<MemorySummaryRecord>) => ({
+            ...summary,
+            userId,
+          })) as MemorySummaryRecord[],
+        );
+        return Response.json({ success: true, stored: summaries.length });
+      }
+
+      case "forgettingCycle": {
+        const result = await runMemoryForgettingCycle(manager as any, userId, {
+          dryRun: body.options?.dryRun === true,
+          hardDeleteArchivedOlderThan:
+            typeof body.options?.hardDeleteArchivedOlderThan === "number"
+              ? body.options.hardDeleteArchivedOlderThan
+              : undefined,
+        });
+        return Response.json({ success: true, result });
+      }
+
+      default:
+        return new AppError(
+          "bad_request:api",
+          `Unsupported raw message action: ${action || "(missing)"}`,
+        ).toResponse();
+    }
+  } catch (error) {
+    console.error("[SQLite Raw Messages API] Error:", error);
+    return new AppError(
+      "bad_request:database",
+      error instanceof Error ? error.message : String(error),
+    ).toResponse();
+  }
+}

--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -1,8 +1,9 @@
 import { auth } from "@/app/(auth)/auth";
 import {
-  getSQLiteRawMessageManager,
-  isSQLiteRawMessageStorageAvailable,
-} from "@/lib/memory/sqlite-raw-message-store";
+  getRawMessageManager,
+  getRawMessageStorageBackend,
+  isRawMessageStorageAvailable,
+} from "@/lib/memory/raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 import {
   queryMemoryWithFallback,
@@ -58,7 +59,7 @@ async function queryRawMessagesWithFallback(
   query: RawMessageQuery,
   userId: string,
 ) {
-  const manager = await getSQLiteRawMessageManager();
+  const manager = await getRawMessageManager();
   const pageSize = query.pageSize ?? query.limit ?? 50;
   const minRaw =
     query.minRawResultsWithoutFallback ?? query.pageSize ?? query.limit ?? 50;
@@ -160,16 +161,17 @@ export async function GET() {
     return new AppError("unauthorized:api").toResponse();
   }
 
-  if (!isSQLiteRawMessageStorageAvailable()) {
+  if (!isRawMessageStorageAvailable()) {
     return Response.json({
       available: false,
-      reason: "not_tauri",
+      reason: "not_available",
     });
   }
 
-  const manager = await getSQLiteRawMessageManager();
+  const manager = await getRawMessageManager();
   return Response.json({
     available: true,
+    storage: getRawMessageStorageBackend(),
     stats: await manager.getStats(),
   });
 }
@@ -180,12 +182,12 @@ export async function POST(request: NextRequest) {
     return new AppError("unauthorized:api").toResponse();
   }
 
-  if (!isSQLiteRawMessageStorageAvailable()) {
+  if (!isRawMessageStorageAvailable()) {
     return Response.json(
       {
         success: false,
-        reason: "not_tauri",
-        message: "SQLite raw message storage is only available in Tauri mode.",
+        reason: "not_available",
+        message: "Raw message storage is not available in this environment.",
       },
       { status: 409 },
     );
@@ -195,7 +197,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const action = typeof body.action === "string" ? body.action : "";
     const userId = session.user.id;
-    const manager = await getSQLiteRawMessageManager();
+    const manager = await getRawMessageManager();
 
     switch (action) {
       case "store": {
@@ -278,8 +280,8 @@ export async function POST(request: NextRequest) {
         }
 
         const items =
-          typeof (manager as any).searchMessagesSemantically === "function"
-            ? await (manager as any).searchMessagesSemantically({
+          typeof manager.searchMessagesSemantically === "function"
+            ? await manager.searchMessagesSemantically({
                 ...(body.options ?? {}),
                 userId,
                 queryEmbedding,
@@ -317,7 +319,7 @@ export async function POST(request: NextRequest) {
         ).toResponse();
     }
   } catch (error) {
-    console.error("[SQLite Raw Messages API] Error:", error);
+    console.error("[Raw Messages API] Error:", error);
     return new AppError(
       "bad_request:database",
       error instanceof Error ? error.message : String(error),

--- a/apps/web/app/api/messages/check/route.ts
+++ b/apps/web/app/api/messages/check/route.ts
@@ -1,4 +1,8 @@
 import { auth } from "@/app/(auth)/auth";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+} from "@/lib/memory/sqlite-raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 
 /**
@@ -12,13 +16,19 @@ export async function GET() {
   }
 
   try {
-    // This endpoint can be used to check if raw messages are available
-    // The actual messages are stored in IndexedDB on the client side
-    // This endpoint could potentially fetch from server-side storage if implemented
+    if (isSQLiteRawMessageStorageAvailable()) {
+      const manager = await getSQLiteRawMessageManager();
+      return Response.json({
+        success: true,
+        storage: "sqlite",
+        stats: await manager.getStats(),
+      });
+    }
 
     return Response.json({
       success: true,
-      message: "Raw messages are stored in client-side IndexedDB",
+      storage: "browser",
+      message: "Raw messages are stored in client-side browser storage",
       info: "Please refresh insights to sync latest raw messages",
     });
   } catch (error) {

--- a/apps/web/app/api/messages/check/route.ts
+++ b/apps/web/app/api/messages/check/route.ts
@@ -1,8 +1,8 @@
 import { auth } from "@/app/(auth)/auth";
 import {
-  getSQLiteRawMessageManager,
-  isSQLiteRawMessageStorageAvailable,
-} from "@/lib/memory/sqlite-raw-message-store";
+  getRawMessageManager,
+  getRawMessageStorageBackend,
+} from "@/lib/memory/raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 
 /**
@@ -16,20 +16,11 @@ export async function GET() {
   }
 
   try {
-    if (isSQLiteRawMessageStorageAvailable()) {
-      const manager = await getSQLiteRawMessageManager();
-      return Response.json({
-        success: true,
-        storage: "sqlite",
-        stats: await manager.getStats(),
-      });
-    }
-
+    const manager = await getRawMessageManager();
     return Response.json({
       success: true,
-      storage: "browser",
-      message: "Raw messages are stored in client-side browser storage",
-      info: "Please refresh insights to sync latest raw messages",
+      storage: getRawMessageStorageBackend(),
+      stats: await manager.getStats(),
     });
   } catch (error) {
     console.error("[Raw Messages Check] Error:", error);

--- a/apps/web/app/api/messages/raw/route.ts
+++ b/apps/web/app/api/messages/raw/route.ts
@@ -1,4 +1,8 @@
 import { auth } from "@/app/(auth)/auth";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+} from "@/lib/memory/sqlite-raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 import type { NextRequest } from "next/server";
 
@@ -56,10 +60,21 @@ export async function POST(request: NextRequest) {
     const messagesWithUserId = messages.map((message) => ({
       ...message,
       userId: session.user.id,
+      createdAt: Math.floor(Date.now() / 1000),
     }));
 
-    // Return messages to client for IndexedDB storage
-    // Note: We're returning the data because IndexedDB operations must happen on the client side
+    if (isSQLiteRawMessageStorageAvailable()) {
+      const manager = await getSQLiteRawMessageManager();
+      const ids = await manager.storeMessages(messagesWithUserId as any);
+      return Response.json({
+        success: true,
+        message: "Messages stored in SQLite",
+        stored: ids.length,
+        count: ids.length,
+      });
+    }
+
+    // Return messages to the client for browser-side fallback storage.
     return Response.json({
       success: true,
       message: "Messages prepared for client-side storage",
@@ -86,12 +101,23 @@ export async function GET(request: NextRequest) {
   const botId = searchParams.get("botId");
   const platform = searchParams.get("platform");
 
+  if (isSQLiteRawMessageStorageAvailable()) {
+    const manager = await getSQLiteRawMessageManager();
+    return Response.json({
+      userId: session.user.id,
+      botId: botId || undefined,
+      platform: platform || undefined,
+      storage: "sqlite",
+      stats: await manager.getStats(),
+    });
+  }
+
   // This endpoint returns configuration for querying
   return Response.json({
     userId: session.user.id,
     botId: botId || undefined,
     platform: platform || undefined,
-    message:
-      "Use client-side IndexedDB to query raw messages. Check browser console for stats.",
+    storage: "browser",
+    message: "Use client-side raw message storage for queries.",
   });
 }

--- a/apps/web/app/api/messages/raw/route.ts
+++ b/apps/web/app/api/messages/raw/route.ts
@@ -1,8 +1,8 @@
 import { auth } from "@/app/(auth)/auth";
 import {
-  getSQLiteRawMessageManager,
-  isSQLiteRawMessageStorageAvailable,
-} from "@/lib/memory/sqlite-raw-message-store";
+  getRawMessageManager,
+  getRawMessageStorageBackend,
+} from "@/lib/memory/raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 import type { NextRequest } from "next/server";
 
@@ -63,23 +63,15 @@ export async function POST(request: NextRequest) {
       createdAt: Math.floor(Date.now() / 1000),
     }));
 
-    if (isSQLiteRawMessageStorageAvailable()) {
-      const manager = await getSQLiteRawMessageManager();
-      const ids = await manager.storeMessages(messagesWithUserId as any);
-      return Response.json({
-        success: true,
-        message: "Messages stored in SQLite",
-        stored: ids.length,
-        count: ids.length,
-      });
-    }
-
-    // Return messages to the client for browser-side fallback storage.
+    const manager = await getRawMessageManager();
+    const storage = getRawMessageStorageBackend();
+    const ids = await manager.storeMessages(messagesWithUserId as any);
     return Response.json({
       success: true,
-      message: "Messages prepared for client-side storage",
-      data: messagesWithUserId,
-      count: messagesWithUserId.length,
+      message: `Messages stored in ${storage}`,
+      storage,
+      stored: ids.length,
+      count: ids.length,
     });
   } catch (error) {
     console.error("[Raw Messages API] Error:", error);
@@ -101,23 +93,13 @@ export async function GET(request: NextRequest) {
   const botId = searchParams.get("botId");
   const platform = searchParams.get("platform");
 
-  if (isSQLiteRawMessageStorageAvailable()) {
-    const manager = await getSQLiteRawMessageManager();
-    return Response.json({
-      userId: session.user.id,
-      botId: botId || undefined,
-      platform: platform || undefined,
-      storage: "sqlite",
-      stats: await manager.getStats(),
-    });
-  }
-
-  // This endpoint returns configuration for querying
+  const manager = await getRawMessageManager();
+  const storage = getRawMessageStorageBackend();
   return Response.json({
     userId: session.user.id,
     botId: botId || undefined,
     platform: platform || undefined,
-    storage: "browser",
-    message: "Use client-side raw message storage for queries.",
+    storage,
+    stats: await manager.getStats(),
   });
 }

--- a/apps/web/app/api/messages/sync/route.ts
+++ b/apps/web/app/api/messages/sync/route.ts
@@ -4,7 +4,8 @@ import { AppError } from "@openloomi/shared/errors";
 
 /**
  * POST endpoint to fetch and return raw messages for all bots
- * This endpoint is called after insights are refreshed to sync raw messages to IndexedDB
+ * This endpoint is called after insights are refreshed to sync raw messages to
+ * the active local raw-message backend.
  */
 export async function POST() {
   const session = await auth();

--- a/apps/web/components/app-providers.tsx
+++ b/apps/web/components/app-providers.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/feishu-listener-init";
 import { CloudSyncInit } from "@/components/cloud-sync-init";
 import { InsightRefreshInit } from "@/components/insight-refresh-init";
+import { RawMessagesMigrationInit } from "@/components/raw-messages-migration-init";
 import { TelegramTokenFormProvider } from "@/components/platform-integrations";
 
 // Lazy load initialization components - use Suspense boundaries to avoid blocking initial render
@@ -36,6 +37,7 @@ const IntegrationInitComponents = memo(() => (
     <WeixinListenerInit />
     <CloudSyncInit />
     <InsightRefreshInit />
+    <RawMessagesMigrationInit />
   </Suspense>
 ));
 

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -965,12 +965,11 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               }, chatIdForMessages);
             } else if (data.type === "tool_result") {
               // Tool execution result - update corresponding tool use part
-              // Check if it is an indexeddb_query type tool result
+              // Check if it is a raw-message query tool result.
               if (data.output && typeof data.output === "string") {
                 try {
                   const outputObj = JSON.parse(data.output);
                   if (outputObj.method === "indexeddb_query") {
-                    // Import IndexedDB query function
                     const {
                       queryRawMessages,
                       queryRawMessagesGrouped,

--- a/apps/web/components/global-search-dialog.tsx
+++ b/apps/web/components/global-search-dialog.tsx
@@ -24,7 +24,7 @@ import {
 import { getRecentInsights, type RecentInsight } from "@/lib/insights/recent";
 import { fetcher } from "@/lib/utils";
 import useSWR from "swr";
-import { getIndexedDBManager } from "@openloomi/indexeddb/manager";
+import { queryRawMessages } from "@openloomi/indexeddb/client";
 import { useSession } from "next-auth/react";
 
 /**
@@ -105,11 +105,11 @@ export function GlobalSearchDialog({
     };
   }, [searchQuery]);
 
-  // Fetch search results (excluding rawMessages as it's client-side search)
+  // Fetch search results (excluding rawMessages as local raw-message search)
   const searchUrl = useMemo(() => {
     if (!debouncedQuery.trim() || !open) return null;
 
-    // Exclude rawMessages as it's client-side IndexedDB search
+    // Exclude rawMessages because it is queried through the raw-message client API.
     const serverSearchTypes = SEARCH_TYPES.filter((t) => t !== "rawMessages");
     const typesArray =
       selectedType === "all" ? serverSearchTypes : [selectedType];
@@ -139,7 +139,8 @@ export function GlobalSearchDialog({
     }
   }, [open]);
 
-  // Search raw messages (IndexedDB client-side query)
+  // Search raw messages through the public client API, which uses SQLite in
+  // Tauri mode and IndexedDB as the browser fallback.
   useEffect(() => {
     const searchRawMessages = async () => {
       if (
@@ -153,14 +154,11 @@ export function GlobalSearchDialog({
       }
 
       try {
-        const manager = getIndexedDBManager();
-        await manager.init();
-
-        const messages = await manager.queryMessages({
+        const messages = await queryRawMessages({
           userId: session.user.id,
           keywords: [debouncedQuery],
           limit: 20,
-        });
+        }).then((items) => items.filter((item) => item.sourceType === "raw"));
 
         const results: SearchResultItem[] = messages.map((msg) => ({
           id: msg.messageId,

--- a/apps/web/components/insight-detail-source-info.tsx
+++ b/apps/web/components/insight-detail-source-info.tsx
@@ -32,17 +32,18 @@ import { coerceDate } from "@openloomi/shared";
 import { ReplyWorkspace } from "@/components/insight-detail-footer";
 
 /**
- * IndexedDB stores second-level timestamps, DetailData.time expects millisecond-level timestamps
+ * Raw messages store second-level timestamps, DetailData.time expects millisecond-level timestamps
  * Returns timestamp number after conversion using coerceDate
  */
-function convertIndexedDBTimestamp(secondsTimestamp: number): number {
+function convertRawMessageTimestamp(secondsTimestamp: number): number {
   return coerceDate(secondsTimestamp).getTime();
 }
 
 import { useIntegrations, type IntegrationId } from "@/hooks/use-integrations";
 import { useSendInsightReply } from "@/components/insight-detail-footer/hooks";
 import { cn, normalizeTimestamp } from "@/lib/utils";
-import { IndexedDBManager } from "@openloomi/indexeddb/manager";
+import { queryRawMessages } from "@openloomi/indexeddb/client";
+import type { RawMessage } from "@openloomi/indexeddb";
 import { toast } from "sonner";
 import { useInsightOptimisticUpdates } from "@/components/insight-optimistic-context";
 
@@ -191,7 +192,7 @@ export function InsightDetailSourceInfo({
   }, [mergedDetails]);
 
   /**
-   * Get channel messages (supports pagination, query from IndexedDB)
+   * Get channel messages (supports pagination through raw message storage)
    * First load gets latest messages (reverse order), load more gets older messages (forward order)
    * @param loadMore Whether it's load more mode (append data instead of replace)
    */
@@ -203,8 +204,6 @@ export function InsightDetailSourceInfo({
       if (isLoadingChannelMessages || isLoadingMore) return;
       loadingStateSetter(true);
       try {
-        const idbManager = new IndexedDBManager();
-
         // Get channel name - use insight.platform or insight.taskLabel as fallback when groups is empty
         const channelName =
           (insight.groups?.[0] as string | undefined) ||
@@ -232,22 +231,26 @@ export function InsightDetailSourceInfo({
           ? allChannelMessages.length + PAGE_SIZE
           : PAGE_SIZE;
 
-        const rawMessages = await idbManager.queryMessages({
+        const rawMessageItems = await queryRawMessages({
           userId: session?.user?.id,
           platform,
           channel: channelName,
           reverse: true, // Always fetch in reverse order, newest first
           limit: fetchLimit,
         });
+        const rawMessages = rawMessageItems.filter(
+          (item): item is RawMessage & { sourceType: "raw" } =>
+            item.sourceType === "raw",
+        );
 
         // Determine if there are more messages (if returned count equals loaded count, no more messages)
         const hasMore = rawMessages.length >= fetchLimit;
         setHasMoreMessages(hasMore);
 
         // Convert to DetailData format
-        // Note: msg.timestamp in IndexedDB is second-level timestamp, needs to be converted to millisecond-level
+        // Note: raw message timestamps are second-level and need conversion.
         const messages: DetailData[] = rawMessages.map((msg) => ({
-          time: convertIndexedDBTimestamp(msg.timestamp),
+          time: convertRawMessageTimestamp(msg.timestamp),
           person: msg.person,
           platform: msg.platform,
           channel: msg.channel,
@@ -300,10 +303,7 @@ export function InsightDetailSourceInfo({
           setLoadedTimestamps(timestampSet);
         }
       } catch (error) {
-        console.error(
-          "Failed to fetch channel messages from IndexedDB:",
-          error,
-        );
+        console.error("Failed to fetch channel messages:", error);
       } finally {
         loadingStateSetter(false);
       }

--- a/apps/web/components/raw-messages-migration-init.tsx
+++ b/apps/web/components/raw-messages-migration-init.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import {
+  ensureRawMessagesSQLiteMigration,
+  shouldUseSQLiteRawMessageStorage,
+} from "@openloomi/indexeddb/client";
+
+export function RawMessagesMigrationInit() {
+  const { data: session, status } = useSession();
+  const userId = session?.user?.id;
+
+  useEffect(() => {
+    if (status !== "authenticated" || !userId) {
+      return;
+    }
+    if (!shouldUseSQLiteRawMessageStorage()) {
+      return;
+    }
+
+    let cancelled = false;
+
+    ensureRawMessagesSQLiteMigration({
+      userId,
+      batchSize: 200,
+      includeArchived: true,
+      includeSummaries: true,
+      onProgress: (state) => {
+        if (cancelled || state.status !== "running") {
+          return;
+        }
+        console.log(
+          `[Raw Messages] SQLite migration progress: ${state.migratedMessages} messages, ${state.migratedSummaries} summaries`,
+        );
+      },
+    })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        if (result.status === "completed") {
+          console.log(
+            `[Raw Messages] SQLite migration completed: ${result.migratedMessages} messages, ${result.migratedSummaries} summaries`,
+          );
+        } else if (result.status === "failed") {
+          console.warn("[Raw Messages] SQLite migration failed:", result.error);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn("[Raw Messages] SQLite migration failed:", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [status, userId]);
+
+  return null;
+}

--- a/apps/web/hooks/use-insight-refresh.ts
+++ b/apps/web/hooks/use-insight-refresh.ts
@@ -495,7 +495,7 @@ export function useInsightRefresh(
         }
       }
 
-      // Store raw messages to IndexedDB
+      // Store raw messages in the active local backend.
       if (
         refreshResult.rawMessages &&
         Array.isArray(refreshResult.rawMessages)
@@ -510,7 +510,7 @@ export function useInsightRefresh(
               refreshResult.rawMessages,
             );
             console.log(
-              `[Raw Messages] Stored ${result.stored} raw messages to IndexedDB for userId: ${userId}`,
+              `[Raw Messages] Stored ${result.stored} raw messages for userId: ${userId}`,
             );
             // Auto-cleanup old messages based on user entitlements
             await autoCleanupOldMessages(userId);

--- a/apps/web/lib/ai/mcp/tools/raw-messages.ts
+++ b/apps/web/lib/ai/mcp/tools/raw-messages.ts
@@ -15,7 +15,7 @@ export function createRawMessagesTools(session: Session) {
     tool(
       "getRawMessages",
       [
-        "Search and retrieve ORIGINAL MESSAGE CONTENT stored in browser's IndexedDB.",
+        "Search and retrieve ORIGINAL MESSAGE CONTENT stored in local raw-message storage.",
         "",
         "**⭐ SEARCH STRATEGY - IMPORTANT:**",
         "- When searching, use MULTIPLE SEPARATE keywords instead of a single long phrase",
@@ -26,7 +26,7 @@ export function createRawMessagesTools(session: Session) {
         "",
         "**CRITICAL: Use this tool whenever the user asks to search, find, or query their STORED MESSAGES, CHAT HISTORY, or CONVERSATIONS.**",
         "",
-        "This tool searches through messages that were previously collected and stored in the browser's IndexedDB.",
+        "This tool searches through messages that were previously collected and stored locally.",
         "Users often refer to these as: 'my messages', 'chat history', 'conversations', 'stored information', etc.",
         "",
         "**PAGINATION:** To handle large result sets efficiently:",
@@ -195,7 +195,7 @@ export function createRawMessagesTools(session: Session) {
         "  ❌ BAD: keywords=['openloomi PR feature'] (too specific, won't match)",
         "  ✅ GOOD: Try keywords=['PR'], then keywords=['openloomi'], then keywords=['feature'] (multiple searches)",
         "",
-        "Search the user's raw messages data stored in browser's IndexedDB.",
+        "Search the user's locally stored raw messages data.",
         "This includes original message content from all platforms (Telegram, Slack, Discord, etc.).",
         "",
         "**CRITICAL: This tool provides ADDITIONAL search results to complement chatInsight results.**",

--- a/apps/web/lib/db/migrations/0102_add_raw_message_storage.sql
+++ b/apps/web/lib/db/migrations/0102_add_raw_message_storage.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS "raw_messages" (
+  "id" bigserial PRIMARY KEY,
+  "message_id" text NOT NULL,
+  "platform" text NOT NULL,
+  "bot_id" uuid NOT NULL REFERENCES "public"."Bot"("id") ON DELETE cascade,
+  "user_id" uuid NOT NULL REFERENCES "public"."User"("id") ON DELETE cascade,
+  "channel" text,
+  "person" text,
+  "timestamp" bigint NOT NULL,
+  "content" text NOT NULL,
+  "attachments" jsonb DEFAULT NULL,
+  "embedding" text,
+  "embedding_model" text,
+  "embedding_content_hash" text,
+  "embedding_dimensions" integer,
+  "embedding_updated_at" bigint,
+  "metadata" jsonb,
+  "created_at" bigint NOT NULL,
+  "memory_stage" varchar(16) DEFAULT 'short',
+  "access_count" integer DEFAULT 0,
+  "last_access_at" bigint,
+  "importance_score" real DEFAULT 0,
+  "archived_at" bigint,
+  "is_pinned" boolean DEFAULT false,
+  "summary_ref_id" text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "raw_messages_message_id_idx"
+  ON "raw_messages" ("message_id");
+CREATE INDEX IF NOT EXISTS "raw_messages_user_timestamp_idx"
+  ON "raw_messages" ("user_id", "timestamp");
+CREATE INDEX IF NOT EXISTS "raw_messages_user_memory_stage_idx"
+  ON "raw_messages" ("user_id", "memory_stage");
+CREATE INDEX IF NOT EXISTS "raw_messages_platform_idx"
+  ON "raw_messages" ("platform");
+CREATE INDEX IF NOT EXISTS "raw_messages_bot_id_idx"
+  ON "raw_messages" ("bot_id");
+CREATE INDEX IF NOT EXISTS "raw_messages_archived_at_idx"
+  ON "raw_messages" ("archived_at");
+CREATE INDEX IF NOT EXISTS "raw_messages_created_at_idx"
+  ON "raw_messages" ("created_at");
+CREATE INDEX IF NOT EXISTS "raw_messages_fts_idx"
+  ON "raw_messages"
+  USING gin (
+    to_tsvector(
+      'simple',
+      coalesce("content", '') || ' ' || coalesce("channel", '') || ' ' || coalesce("person", '')
+    )
+  );
+
+CREATE TABLE IF NOT EXISTS "memory_summaries" (
+  "summary_id" text PRIMARY KEY,
+  "user_id" uuid NOT NULL REFERENCES "public"."User"("id") ON DELETE cascade,
+  "summary_tier" varchar(8) NOT NULL,
+  "source_tier" varchar(16) NOT NULL,
+  "start_timestamp" bigint NOT NULL,
+  "end_timestamp" bigint NOT NULL,
+  "message_count" integer NOT NULL,
+  "source_record_ids" jsonb DEFAULT NULL,
+  "key_points" jsonb DEFAULT NULL,
+  "keywords" jsonb DEFAULT NULL,
+  "keywords_text" text,
+  "summary_text" text NOT NULL,
+  "dimensions" jsonb DEFAULT NULL,
+  "quality_score" real,
+  "created_at" bigint NOT NULL,
+  "updated_at" bigint NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "memory_summaries_user_time_idx"
+  ON "memory_summaries" ("user_id", "end_timestamp");
+CREATE INDEX IF NOT EXISTS "memory_summaries_user_tier_idx"
+  ON "memory_summaries" ("user_id", "summary_tier");

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -638,6 +638,13 @@
       "when": 1774500000000,
       "tag": "0101_persist_insight_embedding_dream_checkpoint",
       "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1778847858000,
+      "tag": "0102_add_raw_message_storage",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.pg.ts
+++ b/apps/web/lib/db/schema.pg.ts
@@ -15,6 +15,8 @@ import {
   numeric,
   index,
   bigint,
+  bigserial,
+  real,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import type { DetailData, TimelineData } from "../ai/subagents/insights";
@@ -759,6 +761,108 @@ export const insightEmbeddings = pgTable(
 
 export type InsightEmbedding = InferSelectModel<typeof insightEmbeddings>;
 export type InsertInsightEmbedding = InferInsertModel<typeof insightEmbeddings>;
+
+export const rawMessages = pgTable(
+  "raw_messages",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    messageId: text("message_id").notNull(),
+    platform: text("platform").notNull(),
+    botId: uuid("bot_id")
+      .notNull()
+      .references(() => bot.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    channel: text("channel"),
+    person: text("person"),
+    timestamp: bigint("timestamp", { mode: "number" }).notNull(),
+    content: text("content").notNull(),
+    attachments: jsonb("attachments")
+      .$type<Array<{
+        name: string;
+        url: string;
+        contentType?: string;
+        sizeBytes?: number;
+      }> | null>()
+      .default(null),
+    embedding: text("embedding"),
+    embeddingModel: text("embedding_model"),
+    embeddingContentHash: text("embedding_content_hash"),
+    embeddingDimensions: integer("embedding_dimensions"),
+    embeddingUpdatedAt: bigint("embedding_updated_at", { mode: "number" }),
+    metadata: jsonb("metadata").$type<Record<string, unknown> | null>(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    memoryStage: varchar("memory_stage", { length: 16 }).default("short"),
+    accessCount: integer("access_count").default(0),
+    lastAccessAt: bigint("last_access_at", { mode: "number" }),
+    importanceScore: real("importance_score").default(0),
+    archivedAt: bigint("archived_at", { mode: "number" }),
+    isPinned: boolean("is_pinned").default(false),
+    summaryRefId: text("summary_ref_id"),
+  },
+  (table) => ({
+    messageIdUnique: uniqueIndex("raw_messages_message_id_idx").on(
+      table.messageId,
+    ),
+    userTimestampIdx: index("raw_messages_user_timestamp_idx").on(
+      table.userId,
+      table.timestamp,
+    ),
+    userMemoryStageIdx: index("raw_messages_user_memory_stage_idx").on(
+      table.userId,
+      table.memoryStage,
+    ),
+    platformIdx: index("raw_messages_platform_idx").on(table.platform),
+    botIdx: index("raw_messages_bot_id_idx").on(table.botId),
+    archivedAtIdx: index("raw_messages_archived_at_idx").on(table.archivedAt),
+    createdAtIdx: index("raw_messages_created_at_idx").on(table.createdAt),
+  }),
+);
+
+export type RawMessageRow = InferSelectModel<typeof rawMessages>;
+export type InsertRawMessageRow = InferInsertModel<typeof rawMessages>;
+
+export const memorySummaries = pgTable(
+  "memory_summaries",
+  {
+    summaryId: text("summary_id").primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    summaryTier: varchar("summary_tier", { length: 8 }).notNull(),
+    sourceTier: varchar("source_tier", { length: 16 }).notNull(),
+    startTimestamp: bigint("start_timestamp", { mode: "number" }).notNull(),
+    endTimestamp: bigint("end_timestamp", { mode: "number" }).notNull(),
+    messageCount: integer("message_count").notNull(),
+    sourceRecordIds: jsonb("source_record_ids")
+      .$type<string[] | null>()
+      .default(null),
+    keyPoints: jsonb("key_points").$type<string[] | null>().default(null),
+    keywords: jsonb("keywords").$type<string[] | null>().default(null),
+    keywordsText: text("keywords_text"),
+    summaryText: text("summary_text").notNull(),
+    dimensions: jsonb("dimensions")
+      .$type<Record<string, string | number | boolean | undefined> | null>()
+      .default(null),
+    qualityScore: real("quality_score"),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
+  },
+  (table) => ({
+    userTimeIdx: index("memory_summaries_user_time_idx").on(
+      table.userId,
+      table.endTimestamp,
+    ),
+    userTierIdx: index("memory_summaries_user_tier_idx").on(
+      table.userId,
+      table.summaryTier,
+    ),
+  }),
+);
+
+export type MemorySummaryRow = InferSelectModel<typeof memorySummaries>;
+export type InsertMemorySummaryRow = InferInsertModel<typeof memorySummaries>;
 
 export const insightCompactionLinks = pgTable(
   "insight_compaction_links",

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -30,6 +30,8 @@ export const stream = (currentSchema as any).stream;
 export const bot = (currentSchema as any).bot;
 export const insight = (currentSchema as any).insight;
 export const insightEmbeddings = (currentSchema as any).insightEmbeddings;
+export const rawMessages = (currentSchema as any).rawMessages;
+export const memorySummaries = (currentSchema as any).memorySummaries;
 export const userInsightSettings = (currentSchema as any).userInsightSettings;
 export const userContacts = (currentSchema as any).userContacts;
 export const dingtalkBotInsightMessages = (currentSchema as any)
@@ -131,6 +133,10 @@ export type {
   InsertInsight,
   InsightEmbedding,
   InsertInsightEmbedding,
+  RawMessageRow,
+  InsertRawMessageRow,
+  MemorySummaryRow,
+  InsertMemorySummaryRow,
   InsightSettings,
   DBInsightSettings,
   DBInsertInsightSettings,

--- a/apps/web/lib/env/tauri-paths.ts
+++ b/apps/web/lib/env/tauri-paths.ts
@@ -45,6 +45,9 @@ export function getTauriDataDir(): string {
  * Get database path
  */
 export function getTauriDbPath(): string {
+  if (process.env.TAURI_DB_PATH) {
+    return process.env.TAURI_DB_PATH;
+  }
   return `${getTauriDataDir()}/data.db`;
 }
 

--- a/apps/web/lib/memory/postgres-raw-message-store.ts
+++ b/apps/web/lib/memory/postgres-raw-message-store.ts
@@ -1,0 +1,844 @@
+import "server-only";
+
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  max,
+  min,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import { getDb, initDb, isDbInitialized } from "@/lib/db/adapters";
+import {
+  memorySummaries,
+  rawMessages,
+  type MemorySummaryRow,
+  type RawMessageRow,
+} from "@/lib/db/schema.pg";
+import { isTauriMode } from "@/lib/env/constants";
+import type {
+  MemoryStage,
+  MemorySummaryQuery,
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+  RawMessageStats,
+  RawMessageStorageManager,
+} from "@openloomi/indexeddb/storage";
+
+interface PostgresRawMessageSemanticSearchInput {
+  userId: string;
+  queryEmbedding: number[];
+  embeddingModel?: string;
+  limit?: number;
+  scanLimit?: number;
+  threshold?: number;
+  includeArchived?: boolean;
+  platform?: string;
+  botId?: string;
+  channel?: string;
+  person?: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+interface PostgresRawMessageSemanticSearchResult {
+  type: "memory";
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: {
+    userId: string;
+    platform: string;
+    botId: string;
+    channel?: string;
+    person?: string;
+    timestamp: number;
+    memoryStage?: string;
+    embeddingModel?: string;
+  };
+  message: RawMessage;
+}
+
+function currentUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function normalizeTimestampToMs(timestamp: number): number {
+  return timestamp < 1e11 ? timestamp * 1000 : timestamp;
+}
+
+function embeddingToText(embedding: number[] | undefined): string | null {
+  if (!embedding || embedding.length === 0) {
+    return null;
+  }
+  return `[${embedding.join(",")}]`;
+}
+
+function parseEmbedding(value: string | null): number[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+    const vector = parsed.map((item) => Number(item));
+    return vector.every((item) => Number.isFinite(item)) ? vector : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toRawMessage(row: RawMessageRow): RawMessage {
+  return {
+    id: row.id,
+    messageId: row.messageId,
+    platform: row.platform,
+    botId: row.botId,
+    userId: row.userId,
+    channel: row.channel ?? undefined,
+    person: row.person ?? undefined,
+    timestamp: row.timestamp,
+    content: row.content,
+    attachments: row.attachments ?? undefined,
+    embedding: parseEmbedding(row.embedding),
+    embeddingModel: row.embeddingModel ?? undefined,
+    embeddingContentHash: row.embeddingContentHash ?? undefined,
+    embeddingDimensions: row.embeddingDimensions ?? undefined,
+    embeddingUpdatedAt: row.embeddingUpdatedAt ?? undefined,
+    metadata: row.metadata ?? undefined,
+    createdAt: row.createdAt,
+    memoryStage: (row.memoryStage ?? "short") as MemoryStage,
+    accessCount: row.accessCount ?? 0,
+    lastAccessAt: row.lastAccessAt ?? undefined,
+    importanceScore: row.importanceScore ?? 0,
+    archivedAt: row.archivedAt ?? undefined,
+    isPinned: row.isPinned ?? false,
+    summaryRefId: row.summaryRefId ?? undefined,
+  };
+}
+
+function toSummaryRecord(row: MemorySummaryRow): MemorySummaryRecord {
+  return {
+    summaryId: row.summaryId,
+    userId: row.userId,
+    summaryTier: row.summaryTier as MemorySummaryRecord["summaryTier"],
+    sourceTier: row.sourceTier as MemoryStage,
+    startTimestamp: row.startTimestamp,
+    endTimestamp: row.endTimestamp,
+    messageCount: row.messageCount,
+    sourceRecordIds: row.sourceRecordIds ?? [],
+    keyPoints: row.keyPoints ?? [],
+    keywords: row.keywords ?? [],
+    keywordsText: row.keywordsText ?? undefined,
+    summaryText: row.summaryText,
+    dimensions: row.dimensions ?? undefined,
+    qualityScore: row.qualityScore ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function buildKeywordCondition(keywords: string[]): SQL | undefined {
+  const trimmed = keywords.map((keyword) => keyword.trim()).filter(Boolean);
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const query = trimmed.join(" | ");
+  const fallbackConditions = trimmed.map((keyword) => {
+    const pattern = `%${escapeLike(keyword.toLowerCase())}%`;
+    return sql`lower(${rawMessages.content}) LIKE ${pattern} ESCAPE '\\'
+      OR lower(coalesce(${rawMessages.channel}, '')) LIKE ${pattern} ESCAPE '\\'
+      OR lower(coalesce(${rawMessages.person}, '')) LIKE ${pattern} ESCAPE '\\'`;
+  });
+
+  return or(
+    sql`to_tsvector('simple', coalesce(${rawMessages.content}, '') || ' ' || coalesce(${rawMessages.channel}, '') || ' ' || coalesce(${rawMessages.person}, '')) @@ plainto_tsquery('simple', ${query})`,
+    ...fallbackConditions,
+  );
+}
+
+function buildMessageConditions(query: RawMessageQuery): SQL[] {
+  const conditions: SQL[] = [];
+
+  if (query.userId) {
+    conditions.push(eq(rawMessages.userId, query.userId));
+  }
+  if (query.platform) {
+    conditions.push(eq(rawMessages.platform, query.platform));
+  }
+  if (query.botId) {
+    conditions.push(eq(rawMessages.botId, query.botId));
+  }
+  if (query.channel) {
+    conditions.push(
+      sql`lower(coalesce(${rawMessages.channel}, '')) LIKE ${`%${escapeLike(query.channel.toLowerCase())}%`} ESCAPE '\\'`,
+    );
+  }
+  if (query.person) {
+    conditions.push(
+      sql`lower(coalesce(${rawMessages.person}, '')) LIKE ${`%${escapeLike(query.person.toLowerCase())}%`} ESCAPE '\\'`,
+    );
+  }
+  if (query.startTime !== undefined) {
+    conditions.push(gte(rawMessages.timestamp, query.startTime));
+  }
+  if (query.endTime !== undefined) {
+    conditions.push(lt(rawMessages.timestamp, query.endTime));
+  }
+  if (query.memoryStages?.length) {
+    conditions.push(inArray(rawMessages.memoryStage, query.memoryStages));
+  }
+  if (!query.includeArchived) {
+    conditions.push(isNull(rawMessages.archivedAt));
+  }
+  if (query.keywords?.length) {
+    const keywordCondition = buildKeywordCondition(query.keywords);
+    if (keywordCondition) {
+      conditions.push(keywordCondition);
+    }
+  }
+
+  return conditions;
+}
+
+function buildSummaryConditions(query: MemorySummaryQuery): SQL[] {
+  const conditions: SQL[] = [eq(memorySummaries.userId, query.userId)];
+
+  if (query.summaryTiers?.length) {
+    conditions.push(inArray(memorySummaries.summaryTier, query.summaryTiers));
+  }
+  if (query.startTime !== undefined) {
+    conditions.push(gte(memorySummaries.endTimestamp, query.startTime));
+  }
+  if (query.endTime !== undefined) {
+    conditions.push(lt(memorySummaries.startTimestamp, query.endTime));
+  }
+  if (query.keywords?.length) {
+    const keywordConditions = query.keywords
+      .map((keyword) => keyword.trim())
+      .filter(Boolean)
+      .map((keyword) => {
+        const pattern = `%${escapeLike(keyword.toLowerCase())}%`;
+        return sql`lower(coalesce(${memorySummaries.keywordsText}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR lower(${memorySummaries.summaryText}) LIKE ${pattern} ESCAPE '\\'`;
+      });
+    if (keywordConditions.length > 0) {
+      conditions.push(or(...keywordConditions) as SQL);
+    }
+  }
+
+  return conditions;
+}
+
+function matchesSummaryDimensions(
+  summary: MemorySummaryRecord,
+  dimensions: MemorySummaryQuery["dimensions"],
+): boolean {
+  if (!dimensions) {
+    return true;
+  }
+  const values = summary.dimensions ?? {};
+  return Object.entries(dimensions).every(
+    ([key, value]) => value === undefined || values[key] === value,
+  );
+}
+
+export class PostgresRawMessageManager implements RawMessageStorageManager {
+  private initialized = false;
+  private db?: ReturnType<typeof getDb>;
+
+  constructor(db?: ReturnType<typeof getDb>) {
+    this.db = db;
+  }
+
+  async init(): Promise<void> {
+    if (isTauriMode()) {
+      throw new Error(
+        "Postgres raw message storage is only available in server mode.",
+      );
+    }
+    if (!this.db) {
+      if (!isDbInitialized()) {
+        initDb();
+      }
+      this.db = getDb();
+    }
+    this.initialized = true;
+  }
+
+  async close(): Promise<void> {
+    this.initialized = false;
+  }
+
+  private async getDatabase() {
+    if (!this.initialized || !this.db) {
+      await this.init();
+    }
+    return this.db ?? getDb();
+  }
+
+  async storeMessage(message: RawMessage): Promise<number> {
+    const ids = await this.storeMessages([message]);
+    return ids[0] ?? 0;
+  }
+
+  async storeMessages(messages: RawMessage[]): Promise<number[]> {
+    if (messages.length === 0) {
+      return [];
+    }
+
+    const db = await this.getDatabase();
+    const rows = messages.map((message) => {
+      const normalized = {
+        ...message,
+        memoryStage: message.memoryStage ?? "short",
+        accessCount: message.accessCount ?? 0,
+        importanceScore: message.importanceScore ?? 0,
+        isPinned: message.isPinned ?? false,
+        createdAt: message.createdAt ?? currentUnixSeconds(),
+      };
+      return {
+        messageId: normalized.messageId,
+        platform: normalized.platform,
+        botId: normalized.botId,
+        userId: normalized.userId,
+        channel: normalized.channel ?? null,
+        person: normalized.person ?? null,
+        timestamp: normalized.timestamp,
+        content: normalized.content,
+        attachments: normalized.attachments ?? null,
+        embedding: embeddingToText(normalized.embedding),
+        embeddingModel: normalized.embeddingModel ?? null,
+        embeddingContentHash: normalized.embeddingContentHash ?? null,
+        embeddingDimensions:
+          normalized.embeddingDimensions ??
+          normalized.embedding?.length ??
+          null,
+        embeddingUpdatedAt: normalized.embeddingUpdatedAt ?? null,
+        metadata: normalized.metadata ?? null,
+        createdAt: normalized.createdAt,
+        memoryStage: normalized.memoryStage,
+        accessCount: normalized.accessCount,
+        lastAccessAt: normalized.lastAccessAt ?? null,
+        importanceScore: normalized.importanceScore,
+        archivedAt: normalized.archivedAt ?? null,
+        isPinned: normalized.isPinned,
+        summaryRefId: normalized.summaryRefId ?? null,
+      };
+    });
+
+    const inserted = await db
+      .insert(rawMessages)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: rawMessages.messageId,
+        set: {
+          platform: sql`excluded.platform`,
+          botId: sql`excluded.bot_id`,
+          userId: sql`excluded.user_id`,
+          channel: sql`excluded.channel`,
+          person: sql`excluded.person`,
+          timestamp: sql`excluded.timestamp`,
+          content: sql`excluded.content`,
+          attachments: sql`excluded.attachments`,
+          embedding: sql`excluded.embedding`,
+          embeddingModel: sql`excluded.embedding_model`,
+          embeddingContentHash: sql`excluded.embedding_content_hash`,
+          embeddingDimensions: sql`excluded.embedding_dimensions`,
+          embeddingUpdatedAt: sql`excluded.embedding_updated_at`,
+          metadata: sql`excluded.metadata`,
+          createdAt: sql`excluded.created_at`,
+          memoryStage: sql`excluded.memory_stage`,
+          accessCount: sql`excluded.access_count`,
+          lastAccessAt: sql`excluded.last_access_at`,
+          importanceScore: sql`excluded.importance_score`,
+          archivedAt: sql`excluded.archived_at`,
+          isPinned: sql`excluded.is_pinned`,
+          summaryRefId: sql`excluded.summary_ref_id`,
+        },
+      })
+      .returning({ id: rawMessages.id });
+
+    return inserted.map((row: { id: number }) => row.id);
+  }
+
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    const db = await this.getDatabase();
+    const conditions = buildMessageConditions(query);
+    const order = query.reverse ? desc : asc;
+    const rows = (await db
+      .select()
+      .from(rawMessages)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(order(rawMessages.timestamp), order(rawMessages.id))
+      .limit(query.pageSize ?? query.limit ?? 50)
+      .offset(query.offset ?? 0)) as RawMessageRow[];
+
+    return rows.map(toRawMessage);
+  }
+
+  async queryMessagesGrouped(
+    query: RawMessageQuery,
+  ): Promise<Record<string, RawMessage[]>> {
+    const messages = await this.queryMessages({
+      ...query,
+      limit: query.limit ? query.limit * 10 : 1000,
+    });
+
+    if (messages.length === 0 || query.groupBy === "none" || !query.groupBy) {
+      return { all: messages };
+    }
+
+    const grouped: Record<string, RawMessage[]> = {};
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    for (const message of messages) {
+      const date = new Date(normalizeTimestampToMs(message.timestamp));
+      let key = date.toISOString().split("T")[0];
+
+      if (query.groupBy === "day") {
+        const localDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate(),
+        );
+        if (localDate.getTime() === today.getTime()) {
+          key = "Today";
+        } else if (localDate.getTime() === yesterday.getTime()) {
+          key = "Yesterday";
+        }
+      } else if (query.groupBy === "week") {
+        const dayOfWeek = date.getDay();
+        const monday = new Date(date);
+        monday.setDate(date.getDate() - dayOfWeek + 1);
+        key = `Week of ${monday.toISOString().split("T")[0]}`;
+      } else if (query.groupBy === "month") {
+        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+          2,
+          "0",
+        )}`;
+      }
+
+      grouped[key] = grouped[key] ?? [];
+      grouped[key].push(message);
+    }
+
+    return grouped;
+  }
+
+  async getStats(): Promise<RawMessageStats> {
+    const db = await this.getDatabase();
+    const [totalRow] = await db.select({ value: count() }).from(rawMessages);
+    const platformRows = await db
+      .select({ platform: rawMessages.platform, value: count() })
+      .from(rawMessages)
+      .groupBy(rawMessages.platform);
+    const botRows = await db
+      .select({ botId: rawMessages.botId, value: count() })
+      .from(rawMessages)
+      .groupBy(rawMessages.botId);
+    const [rangeRow] = await db
+      .select({
+        oldest: min(rawMessages.timestamp),
+        newest: max(rawMessages.timestamp),
+      })
+      .from(rawMessages);
+
+    return {
+      totalMessages: Number(totalRow?.value ?? 0),
+      messagesByPlatform: Object.fromEntries(
+        platformRows.map((row: { platform: string; value: number }) => [
+          row.platform,
+          Number(row.value),
+        ]),
+      ),
+      messagesByBot: Object.fromEntries(
+        botRows.map((row: { botId: string; value: number }) => [
+          row.botId,
+          Number(row.value),
+        ]),
+      ),
+      oldestMessage:
+        typeof rangeRow?.oldest === "number" ? rangeRow.oldest : undefined,
+      newestMessage:
+        typeof rangeRow?.newest === "number" ? rangeRow.newest : undefined,
+    };
+  }
+
+  async getMessageById(messageId: string): Promise<RawMessage | null> {
+    const db = await this.getDatabase();
+    const [row] = (await db
+      .select()
+      .from(rawMessages)
+      .where(eq(rawMessages.messageId, messageId))
+      .limit(1)) as RawMessageRow[];
+    return row ? toRawMessage(row) : null;
+  }
+
+  async deleteOldMessages(olderThan: number, userId?: string): Promise<number> {
+    const db = await this.getDatabase();
+    const conditions = [lt(rawMessages.createdAt, olderThan)];
+    if (userId) {
+      conditions.push(eq(rawMessages.userId, userId));
+    }
+    const deleted = await db
+      .delete(rawMessages)
+      .where(and(...conditions))
+      .returning({ id: rawMessages.id });
+    return deleted.length;
+  }
+
+  async clearAll(): Promise<void> {
+    const db = await this.getDatabase();
+    await db.delete(rawMessages);
+    await db.delete(memorySummaries);
+  }
+
+  async upsertSummaries(summaries: MemorySummaryRecord[]): Promise<void> {
+    if (summaries.length === 0) {
+      return;
+    }
+    const db = await this.getDatabase();
+    const rows = summaries.map((summary) => ({
+      summaryId: summary.summaryId,
+      userId: summary.userId,
+      summaryTier: summary.summaryTier,
+      sourceTier: summary.sourceTier,
+      startTimestamp: summary.startTimestamp,
+      endTimestamp: summary.endTimestamp,
+      messageCount: summary.messageCount,
+      sourceRecordIds: summary.sourceRecordIds,
+      keyPoints: summary.keyPoints,
+      keywords: summary.keywords,
+      keywordsText: summary.keywordsText ?? summary.keywords.join(" "),
+      summaryText: summary.summaryText,
+      dimensions: summary.dimensions ?? null,
+      qualityScore: summary.qualityScore ?? null,
+      createdAt: summary.createdAt,
+      updatedAt: summary.updatedAt,
+    }));
+
+    await db
+      .insert(memorySummaries)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: memorySummaries.summaryId,
+        set: {
+          userId: sql`excluded.user_id`,
+          summaryTier: sql`excluded.summary_tier`,
+          sourceTier: sql`excluded.source_tier`,
+          startTimestamp: sql`excluded.start_timestamp`,
+          endTimestamp: sql`excluded.end_timestamp`,
+          messageCount: sql`excluded.message_count`,
+          sourceRecordIds: sql`excluded.source_record_ids`,
+          keyPoints: sql`excluded.key_points`,
+          keywords: sql`excluded.keywords`,
+          keywordsText: sql`excluded.keywords_text`,
+          summaryText: sql`excluded.summary_text`,
+          dimensions: sql`excluded.dimensions`,
+          qualityScore: sql`excluded.quality_score`,
+          createdAt: sql`excluded.created_at`,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
+  }
+
+  async querySummaries(
+    query: MemorySummaryQuery,
+  ): Promise<MemorySummaryRecord[]> {
+    const db = await this.getDatabase();
+    const conditions = buildSummaryConditions(query);
+    const order = (query.reverse ?? true) ? desc : asc;
+    const rows = (await db
+      .select()
+      .from(memorySummaries)
+      .where(and(...conditions))
+      .orderBy(order(memorySummaries.endTimestamp))
+      .limit(query.pageSize ?? query.limit ?? 50)
+      .offset(query.offset ?? 0)) as MemorySummaryRow[];
+
+    return rows.map(toSummaryRecord).filter((summary) => {
+      return matchesSummaryDimensions(summary, query.dimensions);
+    });
+  }
+
+  async markMessagesAccessed(
+    messageIds: string[],
+    at = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    if (messageIds.length === 0) {
+      return 0;
+    }
+    const db = await this.getDatabase();
+    const conditions = [inArray(rawMessages.messageId, messageIds)];
+    if (userId) {
+      conditions.push(eq(rawMessages.userId, userId));
+    }
+    const rows = await db
+      .update(rawMessages)
+      .set({
+        accessCount: sql`coalesce(${rawMessages.accessCount}, 0) + 1`,
+        lastAccessAt: at,
+      })
+      .where(and(...conditions))
+      .returning({ id: rawMessages.id });
+    return rows.length;
+  }
+
+  async promoteMessagesToStage(
+    messageIds: string[],
+    stage: MemoryStage,
+    options?: { userId?: string; summaryRefId?: string; promotedAt?: number },
+  ): Promise<number> {
+    if (messageIds.length === 0) {
+      return 0;
+    }
+    const db = await this.getDatabase();
+    const existing = await this.getRowsByMessageIds(
+      messageIds,
+      options?.userId,
+    );
+    if (existing.length === 0) {
+      return 0;
+    }
+
+    const changed = await Promise.all(
+      existing.map((row) => {
+        const metadata = {
+          ...(row.metadata ?? {}),
+          ...(options?.promotedAt
+            ? { memoryPromotedAt: options.promotedAt }
+            : {}),
+        };
+        return db
+          .update(rawMessages)
+          .set({
+            memoryStage: stage,
+            summaryRefId: options?.summaryRefId ?? row.summaryRefId,
+            metadata,
+          })
+          .where(eq(rawMessages.messageId, row.messageId))
+          .returning({ id: rawMessages.id });
+      }),
+    );
+    return changed.reduce((total, rows) => total + rows.length, 0);
+  }
+
+  async archiveMessages(
+    messageIds: string[],
+    archivedAt = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    if (messageIds.length === 0) {
+      return 0;
+    }
+    const db = await this.getDatabase();
+    const conditions = [inArray(rawMessages.messageId, messageIds)];
+    if (userId) {
+      conditions.push(eq(rawMessages.userId, userId));
+    }
+    const rows = await db
+      .update(rawMessages)
+      .set({ archivedAt })
+      .where(and(...conditions))
+      .returning({ id: rawMessages.id });
+    return rows.length;
+  }
+
+  async hardDeleteArchived(
+    olderThan: number,
+    userId?: string,
+  ): Promise<number> {
+    const db = await this.getDatabase();
+    const conditions = [
+      isNotNull(rawMessages.archivedAt),
+      lt(rawMessages.archivedAt, olderThan),
+    ];
+    if (userId) {
+      conditions.push(eq(rawMessages.userId, userId));
+    }
+    const rows = await db
+      .delete(rawMessages)
+      .where(and(...conditions))
+      .returning({ id: rawMessages.id });
+    return rows.length;
+  }
+
+  async updateMessageEmbeddings(
+    updates: RawMessageEmbeddingUpdate[],
+    userId?: string,
+  ): Promise<number> {
+    if (updates.length === 0) {
+      return 0;
+    }
+    const db = await this.getDatabase();
+    let changed = 0;
+
+    for (const update of updates.filter((item) => item.messageId)) {
+      const conditions = [eq(rawMessages.messageId, update.messageId)];
+      if (userId) {
+        conditions.push(eq(rawMessages.userId, userId));
+      }
+      const rows = await db
+        .update(rawMessages)
+        .set({
+          embedding: embeddingToText(update.embedding),
+          embeddingModel: update.embeddingModel,
+          embeddingContentHash: update.embeddingContentHash,
+          embeddingDimensions:
+            update.embeddingDimensions ?? update.embedding.length,
+          embeddingUpdatedAt: update.embeddingUpdatedAt ?? Date.now(),
+        })
+        .where(and(...conditions))
+        .returning({ id: rawMessages.id });
+      changed += rows.length;
+    }
+
+    return changed;
+  }
+
+  async searchMessagesSemantically(
+    input: PostgresRawMessageSemanticSearchInput,
+  ): Promise<PostgresRawMessageSemanticSearchResult[]> {
+    const db = await this.getDatabase();
+    if (input.queryEmbedding.length === 0) {
+      return [];
+    }
+
+    const limit = Math.max(1, Math.floor(input.limit ?? 10));
+    const threshold = input.threshold ?? 0.7;
+    const queryEmbedding = `[${input.queryEmbedding.join(",")}]`;
+    const distanceSql = sql`${rawMessages.embedding}::vector <=> ${queryEmbedding}::vector`;
+    const similaritySql = sql<number>`1 - (${distanceSql})`;
+    const conditions = buildMessageConditions({
+      userId: input.userId,
+      platform: input.platform,
+      botId: input.botId,
+      channel: input.channel,
+      person: input.person,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      includeArchived: input.includeArchived,
+    });
+    conditions.push(isNotNull(rawMessages.embedding));
+    if (input.embeddingModel) {
+      conditions.push(eq(rawMessages.embeddingModel, input.embeddingModel));
+    }
+
+    const rows = (await db
+      .select({
+        row: rawMessages,
+        similarity: similaritySql,
+      })
+      .from(rawMessages)
+      .where(and(...conditions, sql`${distanceSql} < ${1 - threshold}`))
+      .orderBy(distanceSql)
+      .limit(limit)) as Array<{ row: RawMessageRow; similarity: number }>;
+
+    return rows
+      .map(({ row, similarity }) =>
+        this.toSemanticSearchResult(toRawMessage(row), Number(similarity)),
+      )
+      .filter(
+        (result): result is PostgresRawMessageSemanticSearchResult =>
+          result !== null,
+      );
+  }
+
+  private async getRowsByMessageIds(
+    messageIds: string[],
+    userId?: string,
+  ): Promise<RawMessageRow[]> {
+    const ids = Array.from(new Set(messageIds.filter(Boolean)));
+    if (ids.length === 0) {
+      return [];
+    }
+    const db = await this.getDatabase();
+    const conditions = [inArray(rawMessages.messageId, ids)];
+    if (userId) {
+      conditions.push(eq(rawMessages.userId, userId));
+    }
+    return (await db
+      .select()
+      .from(rawMessages)
+      .where(and(...conditions))) as RawMessageRow[];
+  }
+
+  private toSemanticSearchResult(
+    message: RawMessage,
+    similarity: number,
+  ): PostgresRawMessageSemanticSearchResult | null {
+    if (!Number.isFinite(similarity)) {
+      return null;
+    }
+
+    return {
+      type: "memory",
+      id: message.messageId,
+      content: message.archivedAt ? "" : message.content,
+      similarity,
+      metadata: {
+        userId: message.userId,
+        platform: message.platform,
+        botId: message.botId,
+        channel: message.channel,
+        person: message.person,
+        timestamp: normalizeTimestampToMs(message.timestamp),
+        memoryStage: message.memoryStage,
+        embeddingModel: message.embeddingModel,
+      },
+      message,
+    };
+  }
+}
+
+let manager: PostgresRawMessageManager | null = null;
+
+export function isPostgresRawMessageStorageAvailable(): boolean {
+  return !isTauriMode();
+}
+
+export async function getPostgresRawMessageManager(): Promise<PostgresRawMessageManager> {
+  if (!isPostgresRawMessageStorageAvailable()) {
+    throw new Error(
+      "Postgres raw message storage is only available in server mode.",
+    );
+  }
+
+  if (!manager) {
+    manager = new PostgresRawMessageManager();
+    await manager.init();
+  }
+
+  return manager;
+}
+
+export async function closePostgresRawMessageManager(): Promise<void> {
+  if (!manager) {
+    return;
+  }
+  await manager.close();
+  manager = null;
+}

--- a/apps/web/lib/memory/raw-message-store.ts
+++ b/apps/web/lib/memory/raw-message-store.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import type { RawMessageStorageManager } from "@openloomi/indexeddb/storage";
+import {
+  getPostgresRawMessageManager,
+  isPostgresRawMessageStorageAvailable,
+} from "@/lib/memory/postgres-raw-message-store";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+} from "@/lib/memory/sqlite-raw-message-store";
+
+export type RawMessageStorageBackend = "sqlite" | "postgres";
+
+export type RawMessageStorageManagerWithSearch = RawMessageStorageManager & {
+  searchMessagesSemantically?: (input: {
+    userId: string;
+    queryEmbedding: number[];
+    embeddingModel?: string;
+    limit?: number;
+    scanLimit?: number;
+    threshold?: number;
+    includeArchived?: boolean;
+    platform?: string;
+    botId?: string;
+    channel?: string;
+    person?: string;
+    startTime?: number;
+    endTime?: number;
+  }) => Promise<unknown[]>;
+};
+
+export function getRawMessageStorageBackend(): RawMessageStorageBackend {
+  return isSQLiteRawMessageStorageAvailable() ? "sqlite" : "postgres";
+}
+
+export function isRawMessageStorageAvailable(): boolean {
+  return (
+    isSQLiteRawMessageStorageAvailable() ||
+    isPostgresRawMessageStorageAvailable()
+  );
+}
+
+export async function getRawMessageManager(): Promise<RawMessageStorageManagerWithSearch> {
+  if (isSQLiteRawMessageStorageAvailable()) {
+    return getSQLiteRawMessageManager();
+  }
+  return getPostgresRawMessageManager();
+}

--- a/apps/web/lib/memory/sqlite-raw-message-store.ts
+++ b/apps/web/lib/memory/sqlite-raw-message-store.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { SQLiteRawMessageManager } from "@openloomi/sqlite";
+import { isTauriMode } from "@/lib/env/constants";
+import { getTauriDbPath } from "@/lib/env/tauri-paths";
+
+let manager: SQLiteRawMessageManager | null = null;
+
+export function isSQLiteRawMessageStorageAvailable(): boolean {
+  return isTauriMode();
+}
+
+export async function getSQLiteRawMessageManager(): Promise<SQLiteRawMessageManager> {
+  if (!isSQLiteRawMessageStorageAvailable()) {
+    throw new Error(
+      "SQLite raw message storage is only available in Tauri mode.",
+    );
+  }
+
+  if (!manager) {
+    const dbPath = getTauriDbPath();
+    mkdirSync(dirname(dbPath), { recursive: true });
+    manager = new SQLiteRawMessageManager(dbPath);
+    await manager.init();
+  }
+
+  return manager;
+}
+
+export async function closeSQLiteRawMessageManager(): Promise<void> {
+  if (!manager) {
+    return;
+  }
+  await manager.close();
+  manager = null;
+}

--- a/apps/web/lib/memory/unified-search.ts
+++ b/apps/web/lib/memory/unified-search.ts
@@ -1,9 +1,9 @@
 import { searchSimilarChunks } from "@/lib/ai/rag/langchain-service";
 import { searchInsightsSemantically } from "@/lib/insights/search";
 import {
-  getSQLiteRawMessageManager,
-  isSQLiteRawMessageStorageAvailable,
-} from "@/lib/memory/sqlite-raw-message-store";
+  getRawMessageManager,
+  isRawMessageStorageAvailable,
+} from "@/lib/memory/raw-message-store";
 import type { RawMessage } from "@openloomi/indexeddb";
 
 export type UnifiedMemorySearchSource = "memory" | "insights" | "knowledge";
@@ -167,6 +167,25 @@ function toMemoryResult(result: {
   };
 }
 
+function isRawMemorySemanticResult(result: unknown): result is {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+} {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const item = result as Record<string, unknown>;
+  return (
+    typeof item.id === "string" &&
+    typeof item.content === "string" &&
+    typeof item.similarity === "number" &&
+    Boolean(item.metadata) &&
+    typeof item.metadata === "object"
+  );
+}
+
 function extractRawMemoryKeywords(query: string): string[] {
   const normalized = query.trim().replace(/\s+/g, " ");
   if (!normalized) {
@@ -269,7 +288,7 @@ function mergeMemoryHybridResults(
   return mergeUnifiedMemorySearchResults(Array.from(byId.values()), limit);
 }
 
-async function searchSQLiteRawMemoryHybrid(input: {
+async function searchRawMemoryHybrid(input: {
   userId: string;
   query: string;
   authToken?: string;
@@ -277,7 +296,7 @@ async function searchSQLiteRawMemoryHybrid(input: {
   limit: number;
   threshold: number;
 }): Promise<UnifiedMemorySearchResult[]> {
-  const manager = await getSQLiteRawMessageManager();
+  const manager = await getRawMessageManager();
   const filters =
     input.botIds && input.botIds.length > 0
       ? input.botIds.map((botId) => ({ botId }))
@@ -310,7 +329,7 @@ async function searchSQLiteRawMemoryHybrid(input: {
 
   let semanticResults: UnifiedMemorySearchResult[] = [];
   if (
-    typeof (manager as any).searchMessagesSemantically === "function" &&
+    typeof manager.searchMessagesSemantically === "function" &&
     hasEmbeddingProviderConfig(input.authToken)
   ) {
     const queryEmbedding = await embedQuery(input.query, input.authToken);
@@ -318,7 +337,7 @@ async function searchSQLiteRawMemoryHybrid(input: {
       semanticResults = (
         await Promise.all(
           filters.map((filter) =>
-            (manager as any).searchMessagesSemantically({
+            manager.searchMessagesSemantically?.({
               userId: input.userId,
               queryEmbedding,
               limit: input.limit,
@@ -329,6 +348,7 @@ async function searchSQLiteRawMemoryHybrid(input: {
         )
       )
         .flat()
+        .filter(isRawMemorySemanticResult)
         .map(toMemoryResult);
     }
   }
@@ -357,8 +377,8 @@ export async function searchUnifiedMemory(
   }
 
   if (sources.includes("memory")) {
-    if (isSQLiteRawMessageStorageAvailable()) {
-      const memoryResults = await searchSQLiteRawMemoryHybrid({
+    if (isRawMessageStorageAvailable()) {
+      const memoryResults = await searchRawMemoryHybrid({
         userId: input.userId,
         query,
         authToken: input.authToken,
@@ -370,9 +390,8 @@ export async function searchUnifiedMemory(
     } else {
       warnings.push({
         source: "memory",
-        code: "client_indexeddb_required",
-        message:
-          "Raw memory records are stored in client-side IndexedDB and cannot be searched from this server API.",
+        code: "raw_message_storage_unavailable",
+        message: "Raw memory storage is not available in this environment.",
       });
     }
   }

--- a/apps/web/lib/memory/unified-search.ts
+++ b/apps/web/lib/memory/unified-search.ts
@@ -1,5 +1,10 @@
 import { searchSimilarChunks } from "@/lib/ai/rag/langchain-service";
 import { searchInsightsSemantically } from "@/lib/insights/search";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+} from "@/lib/memory/sqlite-raw-message-store";
+import type { RawMessage } from "@openloomi/indexeddb";
 
 export type UnifiedMemorySearchSource = "memory" | "insights" | "knowledge";
 
@@ -39,6 +44,9 @@ export interface UnifiedMemorySearchOutput {
 
 const DEFAULT_LIMIT = 10;
 const DEFAULT_THRESHOLD = 0.7;
+const MEMORY_KEYWORD_BASE_SCORE = 0.78;
+const MEMORY_KEYWORD_MATCH_BONUS = 0.04;
+const MEMORY_HYBRID_MATCH_BONUS = 0.08;
 const DEFAULT_SOURCES: UnifiedMemorySearchSource[] = [
   "memory",
   "insights",
@@ -121,6 +129,213 @@ function toKnowledgeResult(result: {
   };
 }
 
+function hasEmbeddingProviderConfig(authToken?: string): boolean {
+  return Boolean(
+    authToken ||
+    process.env.OPENAI_EMBEDDINGS_API_KEY ||
+    process.env.OPENROUTER_API_KEY ||
+    process.env.LLM_API_KEY,
+  );
+}
+
+async function embedQuery(
+  query: string,
+  authToken?: string,
+): Promise<number[]> {
+  if (!hasEmbeddingProviderConfig(authToken)) {
+    throw new Error("Embedding provider API key is not configured");
+  }
+
+  const { UniversalEmbeddings } =
+    await import("@openloomi/rag/universal-embeddings");
+  const embeddings = new UniversalEmbeddings(authToken);
+  return embeddings.embedQuery(query);
+}
+
+function toMemoryResult(result: {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+}): UnifiedMemorySearchResult {
+  return {
+    type: "memory",
+    id: result.id,
+    content: result.content,
+    similarity: result.similarity,
+    metadata: result.metadata,
+  };
+}
+
+function extractRawMemoryKeywords(query: string): string[] {
+  const normalized = query.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return [];
+  }
+
+  const tokens = normalized
+    .split(/[\s,.;:!?()[\]{}"'`，。！？、；：]+/u)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1);
+
+  return Array.from(new Set([normalized, ...tokens])).slice(0, 8);
+}
+
+function countKeywordMatches(message: RawMessage, keywords: string[]): number {
+  const haystack = [
+    message.content,
+    message.channel,
+    message.person,
+    message.platform,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return keywords.reduce((count, keyword) => {
+    return haystack.includes(keyword.toLowerCase()) ? count + 1 : count;
+  }, 0);
+}
+
+function toKeywordMemoryResult(
+  message: RawMessage,
+  keywords: string[],
+): UnifiedMemorySearchResult {
+  const matchCount = countKeywordMatches(message, keywords);
+  const similarity = Math.min(
+    0.95,
+    MEMORY_KEYWORD_BASE_SCORE + matchCount * MEMORY_KEYWORD_MATCH_BONUS,
+  );
+
+  return {
+    type: "memory",
+    id: message.messageId,
+    content: message.archivedAt ? "" : message.content,
+    similarity,
+    metadata: {
+      userId: message.userId,
+      platform: message.platform,
+      botId: message.botId,
+      channel: message.channel,
+      person: message.person,
+      timestamp:
+        message.timestamp < 1e11 ? message.timestamp * 1000 : message.timestamp,
+      memoryStage: message.memoryStage,
+      matchType: "keyword",
+      keywordMatches: matchCount,
+    },
+  };
+}
+
+function mergeMemoryHybridResults(
+  semanticResults: UnifiedMemorySearchResult[],
+  keywordResults: UnifiedMemorySearchResult[],
+  limit: number,
+): UnifiedMemorySearchResult[] {
+  const byId = new Map<string, UnifiedMemorySearchResult>();
+
+  for (const result of semanticResults) {
+    byId.set(result.id, {
+      ...result,
+      metadata: {
+        ...result.metadata,
+        matchType: "semantic",
+      },
+    });
+  }
+
+  for (const result of keywordResults) {
+    const existing = byId.get(result.id);
+    if (!existing) {
+      byId.set(result.id, result);
+      continue;
+    }
+
+    byId.set(result.id, {
+      ...existing,
+      similarity: Math.min(
+        1,
+        Math.max(existing.similarity, result.similarity) +
+          MEMORY_HYBRID_MATCH_BONUS,
+      ),
+      metadata: {
+        ...existing.metadata,
+        matchType: "hybrid",
+        keywordMatches: result.metadata.keywordMatches,
+      },
+    });
+  }
+
+  return mergeUnifiedMemorySearchResults(Array.from(byId.values()), limit);
+}
+
+async function searchSQLiteRawMemoryHybrid(input: {
+  userId: string;
+  query: string;
+  authToken?: string;
+  botIds?: string[];
+  limit: number;
+  threshold: number;
+}): Promise<UnifiedMemorySearchResult[]> {
+  const manager = await getSQLiteRawMessageManager();
+  const filters =
+    input.botIds && input.botIds.length > 0
+      ? input.botIds.map((botId) => ({ botId }))
+      : [{}];
+  const keywords = extractRawMemoryKeywords(input.query);
+
+  const keywordResults = (
+    await Promise.all(
+      filters.map(async (filter) => {
+        if (
+          keywords.length === 0 ||
+          typeof manager.queryMessages !== "function"
+        ) {
+          return [];
+        }
+        const messages = await manager.queryMessages({
+          userId: input.userId,
+          keywords,
+          reverse: true,
+          includeArchived: false,
+          pageSize: Math.max(input.limit * 3, input.limit),
+          ...filter,
+        });
+        return messages
+          .map((message) => toKeywordMemoryResult(message, keywords))
+          .filter((result) => result.similarity >= input.threshold);
+      }),
+    )
+  ).flat();
+
+  let semanticResults: UnifiedMemorySearchResult[] = [];
+  if (
+    typeof (manager as any).searchMessagesSemantically === "function" &&
+    hasEmbeddingProviderConfig(input.authToken)
+  ) {
+    const queryEmbedding = await embedQuery(input.query, input.authToken);
+    if (queryEmbedding.length > 0) {
+      semanticResults = (
+        await Promise.all(
+          filters.map((filter) =>
+            (manager as any).searchMessagesSemantically({
+              userId: input.userId,
+              queryEmbedding,
+              limit: input.limit,
+              threshold: input.threshold,
+              ...filter,
+            }),
+          ),
+        )
+      )
+        .flat()
+        .map(toMemoryResult);
+    }
+  }
+
+  return mergeMemoryHybridResults(semanticResults, keywordResults, input.limit);
+}
+
 export async function searchUnifiedMemory(
   input: UnifiedMemorySearchInput,
 ): Promise<UnifiedMemorySearchOutput> {
@@ -142,12 +357,24 @@ export async function searchUnifiedMemory(
   }
 
   if (sources.includes("memory")) {
-    warnings.push({
-      source: "memory",
-      code: "client_indexeddb_required",
-      message:
-        "Raw memory records are stored in client-side IndexedDB and cannot be searched from this server API.",
-    });
+    if (isSQLiteRawMessageStorageAvailable()) {
+      const memoryResults = await searchSQLiteRawMemoryHybrid({
+        userId: input.userId,
+        query,
+        authToken: input.authToken,
+        botIds: input.botIds,
+        limit,
+        threshold,
+      });
+      results.push(...memoryResults);
+    } else {
+      warnings.push({
+        source: "memory",
+        code: "client_indexeddb_required",
+        message:
+          "Raw memory records are stored in client-side IndexedDB and cannot be searched from this server API.",
+      });
+    }
   }
 
   if (sources.includes("insights")) {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -21,6 +21,7 @@ const nextConfig = {
     "@tencent-weixin/openclaw-weixin",
     "@openloomi/shared",
     "@openloomi/indexeddb",
+    "@openloomi/sqlite",
     "@openloomi/insights",
     "@openloomi/ai",
     "@openloomi/integrations",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,6 +56,7 @@
     "@openloomi/rss": "workspace:*",
     "@openloomi/search": "workspace:*",
     "@openloomi/shared": "workspace:*",
+    "@openloomi/sqlite": "workspace:*",
     "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@anthropic-ai/sandbox-runtime": "^0.0.32",
     "@anthropic-ai/sdk": "^0.72.1",

--- a/apps/web/tests/helpers/raw-message-storage-conformance.ts
+++ b/apps/web/tests/helpers/raw-message-storage-conformance.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageStorage,
+} from "../../../../packages/indexeddb/src/storage";
+
+export interface RawMessageStorageConformanceContext {
+  storage: RawMessageStorage;
+  cleanup?: () => Promise<void> | void;
+}
+
+export type RawMessageStorageConformanceFactory = () =>
+  | RawMessageStorageConformanceContext
+  | Promise<RawMessageStorageConformanceContext>;
+
+export function createConformanceRawMessage(
+  overrides: Partial<RawMessage> = {},
+): RawMessage {
+  return {
+    messageId: "msg-1",
+    platform: "slack",
+    botId: "bot-1",
+    userId: "user-1",
+    channel: "general",
+    person: "alice",
+    timestamp: 1774500000,
+    content: "Project launch planning update",
+    attachments: [
+      {
+        name: "brief.txt",
+        url: "https://example.test/brief.txt",
+        contentType: "text/plain",
+        sizeBytes: 128,
+      },
+    ],
+    metadata: { source: "conformance" },
+    createdAt: 1774500000000,
+    memoryStage: "short",
+    accessCount: 0,
+    importanceScore: 0,
+    isPinned: false,
+    ...overrides,
+  };
+}
+
+function createConformanceSummary(
+  overrides: Partial<MemorySummaryRecord> = {},
+): MemorySummaryRecord {
+  return {
+    summaryId: "summary-1",
+    userId: "user-1",
+    summaryTier: "L1",
+    sourceTier: "short",
+    startTimestamp: 1774400000000,
+    endTimestamp: 1774500000000,
+    messageCount: 2,
+    sourceRecordIds: ["msg-1", "msg-2"],
+    keyPoints: ["launch plan"],
+    keywords: ["launch", "planning"],
+    keywordsText: "launch planning",
+    summaryText: "The team discussed launch planning.",
+    dimensions: { platform: "slack", channel: "general" },
+    qualityScore: 0.9,
+    createdAt: 1774500000000,
+    updatedAt: 1774500000000,
+    ...overrides,
+  };
+}
+
+export function createRawMessageStorageConformanceSuite(
+  name: string,
+  factory: RawMessageStorageConformanceFactory,
+): void {
+  describe(`${name} raw message storage contract`, () => {
+    let context: RawMessageStorageConformanceContext;
+    let storage: RawMessageStorage;
+
+    beforeEach(async () => {
+      context = await factory();
+      storage = context.storage;
+      await storage.clearAll();
+    });
+
+    afterEach(async () => {
+      await context.cleanup?.();
+    });
+
+    it("stores, upserts, fetches, and reports stats for raw messages", async () => {
+      const stored = await storage.storeMessages([
+        createConformanceRawMessage({ messageId: "msg-1" }),
+        createConformanceRawMessage({
+          messageId: "msg-2",
+          platform: "discord",
+          botId: "bot-2",
+          content: "Support escalation follow up",
+          timestamp: 1774500060,
+        }),
+      ]);
+      expect(stored).toHaveLength(2);
+
+      await storage.storeMessage(
+        createConformanceRawMessage({
+          messageId: "msg-1",
+          content: "Updated launch planning note",
+          timestamp: 1774500120,
+        }),
+      );
+
+      const msg1 = await storage.getMessageById("msg-1");
+      expect(msg1).toMatchObject({
+        messageId: "msg-1",
+        content: "Updated launch planning note",
+        platform: "slack",
+      });
+      expect(msg1?.attachments?.[0]).toMatchObject({
+        name: "brief.txt",
+        contentType: "text/plain",
+      });
+
+      const all = await storage.queryMessages({
+        userId: "user-1",
+        pageSize: 10,
+      });
+      expect(all.map((item) => item.messageId).sort()).toEqual([
+        "msg-1",
+        "msg-2",
+      ]);
+
+      const stats = await storage.getStats();
+      expect(stats.totalMessages).toBe(2);
+      expect(stats.messagesByPlatform).toMatchObject({ slack: 1, discord: 1 });
+      expect(stats.messagesByBot).toMatchObject({ "bot-1": 1, "bot-2": 1 });
+      expect(stats.oldestMessage).toBe(1774500060);
+      expect(stats.newestMessage).toBe(1774500120);
+    });
+
+    it("applies raw message filters, ordering, pagination, and archive visibility", async () => {
+      await storage.storeMessages([
+        createConformanceRawMessage({
+          messageId: "old-general",
+          timestamp: 1774500000,
+          content: "alpha launch note",
+        }),
+        createConformanceRawMessage({
+          messageId: "new-general",
+          timestamp: 1774500100,
+          person: "bob",
+          content: "beta rollout note",
+        }),
+        createConformanceRawMessage({
+          messageId: "support",
+          timestamp: 1774500200,
+          channel: "support-room",
+          person: "carol",
+          content: "customer support topic",
+          memoryStage: "mid",
+        }),
+        createConformanceRawMessage({
+          messageId: "archived",
+          timestamp: 1774500300,
+          content: "archived topic",
+          archivedAt: 1774600000000,
+        }),
+        createConformanceRawMessage({
+          messageId: "other-user",
+          userId: "user-2",
+          timestamp: 1774500400,
+          content: "other user launch",
+        }),
+      ]);
+
+      const newestPage = await storage.queryMessages({
+        userId: "user-1",
+        reverse: true,
+        pageSize: 2,
+      });
+      expect(newestPage.map((item) => item.messageId)).toEqual([
+        "support",
+        "new-general",
+      ]);
+
+      const keywordHits = await storage.queryMessages({
+        userId: "user-1",
+        keywords: ["support"],
+        pageSize: 10,
+      });
+      expect(keywordHits.map((item) => item.messageId)).toEqual(["support"]);
+
+      const fuzzyHits = await storage.queryMessages({
+        userId: "user-1",
+        channel: "support",
+        person: "car",
+        pageSize: 10,
+      });
+      expect(fuzzyHits.map((item) => item.messageId)).toEqual(["support"]);
+
+      const stagedHits = await storage.queryMessages({
+        userId: "user-1",
+        memoryStages: ["mid"],
+        pageSize: 10,
+      });
+      expect(stagedHits.map((item) => item.messageId)).toEqual(["support"]);
+
+      const timeBoundHits = await storage.queryMessages({
+        userId: "user-1",
+        startTime: 1774500050,
+        endTime: 1774500250,
+        pageSize: 10,
+      });
+      expect(timeBoundHits.map((item) => item.messageId)).toEqual([
+        "new-general",
+        "support",
+      ]);
+
+      const withArchived = await storage.queryMessages({
+        userId: "user-1",
+        includeArchived: true,
+        reverse: true,
+        pageSize: 1,
+      });
+      expect(withArchived.map((item) => item.messageId)).toEqual(["archived"]);
+    });
+
+    it("groups raw messages by calendar buckets", async () => {
+      await storage.storeMessages([
+        createConformanceRawMessage({
+          messageId: "march",
+          timestamp: 1774500000,
+        }),
+        createConformanceRawMessage({
+          messageId: "april",
+          timestamp: 1777092000,
+        }),
+      ]);
+
+      const grouped = await storage.queryMessagesGrouped({
+        userId: "user-1",
+        groupBy: "month",
+        pageSize: 10,
+      });
+
+      expect(
+        Object.values(grouped)
+          .flat()
+          .map((item) => item.messageId),
+      ).toEqual(["april", "march"]);
+    });
+
+    it("upserts and queries memory summaries", async () => {
+      await storage.upsertSummaries([
+        createConformanceSummary({ summaryId: "summary-1" }),
+        createConformanceSummary({
+          summaryId: "summary-2",
+          summaryTier: "L2",
+          sourceTier: "mid",
+          endTimestamp: 1774600000000,
+          keywords: ["support"],
+          keywordsText: "support",
+          summaryText: "Support handoff summary.",
+          dimensions: { platform: "slack", channel: "support-room" },
+        }),
+      ]);
+      await storage.upsertSummaries([
+        createConformanceSummary({
+          summaryId: "summary-1",
+          summaryText: "Updated launch summary.",
+          keywords: ["launch"],
+          keywordsText: "launch",
+        }),
+      ]);
+
+      const summaries = await storage.querySummaries({
+        userId: "user-1",
+        keywords: ["launch"],
+        summaryTiers: ["L1"],
+        dimensions: { platform: "slack", channel: "general" },
+        pageSize: 10,
+      });
+
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]).toMatchObject({
+        summaryId: "summary-1",
+        summaryText: "Updated launch summary.",
+      });
+
+      const reversePage = await storage.querySummaries({
+        userId: "user-1",
+        reverse: true,
+        pageSize: 1,
+      });
+      expect(reversePage.map((item) => item.summaryId)).toEqual(["summary-2"]);
+    });
+
+    it("updates access, lifecycle state, archive cleanup, and embeddings", async () => {
+      await storage.storeMessages([
+        createConformanceRawMessage({ messageId: "msg-1" }),
+        createConformanceRawMessage({ messageId: "msg-2", userId: "user-2" }),
+      ]);
+
+      expect(
+        await storage.markMessagesAccessed(
+          ["msg-1", "msg-2"],
+          1774600000000,
+          "user-1",
+        ),
+      ).toBe(1);
+      expect(
+        await storage.promoteMessagesToStage(["msg-1", "msg-2"], "mid", {
+          userId: "user-1",
+          summaryRefId: "summary-1",
+          promotedAt: 1774600000000,
+        }),
+      ).toBe(1);
+      expect(
+        await storage.updateMessageEmbeddings(
+          [
+            {
+              messageId: "msg-1",
+              embedding: [0.1, 0.2],
+              embeddingModel: "model-a",
+              embeddingContentHash: "hash-a",
+              embeddingDimensions: 2,
+              embeddingUpdatedAt: 1774600000000,
+            },
+          ],
+          "user-1",
+        ),
+      ).toBe(1);
+
+      const updated = await storage.getMessageById("msg-1");
+      expect(updated).toMatchObject({
+        accessCount: 1,
+        lastAccessAt: 1774600000000,
+        memoryStage: "mid",
+        summaryRefId: "summary-1",
+        embeddingModel: "model-a",
+        embeddingContentHash: "hash-a",
+        embeddingDimensions: 2,
+        embeddingUpdatedAt: 1774600000000,
+      });
+      expect(updated?.embedding).toHaveLength(2);
+      expect(updated?.embedding?.[0]).toBeCloseTo(0.1);
+      expect(updated?.embedding?.[1]).toBeCloseTo(0.2);
+
+      expect(
+        await storage.archiveMessages(["msg-1"], 1774700000000, "user-1"),
+      ).toBe(1);
+      expect(await storage.hardDeleteArchived(1774700000001, "user-1")).toBe(1);
+      expect(await storage.getMessageById("msg-1")).toBeNull();
+      expect(await storage.getMessageById("msg-2")).not.toBeNull();
+    });
+
+    it("deletes old messages with optional user scoping", async () => {
+      await storage.storeMessages([
+        createConformanceRawMessage({
+          messageId: "old-user-1",
+          createdAt: 100,
+        }),
+        createConformanceRawMessage({
+          messageId: "new-user-1",
+          createdAt: 300,
+        }),
+        createConformanceRawMessage({
+          messageId: "old-user-2",
+          userId: "user-2",
+          createdAt: 100,
+        }),
+      ]);
+
+      expect(await storage.deleteOldMessages(200, "user-1")).toBe(1);
+      expect(await storage.getMessageById("old-user-1")).toBeNull();
+      expect(await storage.getMessageById("old-user-2")).not.toBeNull();
+
+      expect(await storage.deleteOldMessages(200)).toBe(1);
+      expect(await storage.getMessageById("old-user-2")).toBeNull();
+      expect(await storage.getMessageById("new-user-1")).not.toBeNull();
+    });
+  });
+}

--- a/apps/web/tests/unit/postgres-raw-message-store.test.ts
+++ b/apps/web/tests/unit/postgres-raw-message-store.test.ts
@@ -1,0 +1,202 @@
+import { PostgresRawMessageManager } from "@/lib/memory/postgres-raw-message-store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: () => false,
+}));
+
+vi.mock("@/lib/db/adapters", () => ({
+  getDb: vi.fn(() => ({})),
+  initDb: vi.fn(),
+  isDbInitialized: vi.fn(() => true),
+}));
+
+const userId = "00000000-0000-0000-0000-000000000001";
+const botId = "00000000-0000-0000-0000-000000000002";
+
+function createRawMessageRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    messageId: "msg-1",
+    platform: "slack",
+    botId,
+    userId,
+    channel: "general",
+    person: "alice",
+    timestamp: 1774500000,
+    content: "Project launch planning update",
+    attachments: [
+      {
+        name: "brief.txt",
+        url: "https://example.test/brief.txt",
+        contentType: "text/plain",
+      },
+    ],
+    embedding: "[0.5,0.25]",
+    embeddingModel: "text-embedding-3-small",
+    embeddingContentHash: "hash-1",
+    embeddingDimensions: 2,
+    embeddingUpdatedAt: 1774500000000,
+    metadata: { source: "postgres-test" },
+    createdAt: 1774500000,
+    memoryStage: "short",
+    accessCount: 0,
+    lastAccessAt: null,
+    importanceScore: 0,
+    archivedAt: null,
+    isPinned: false,
+    summaryRefId: null,
+    ...overrides,
+  };
+}
+
+function createInsertDb(returningRows: Array<{ id: number }>) {
+  const insertChain = {
+    values: vi.fn(() => insertChain),
+    onConflictDoUpdate: vi.fn(() => insertChain),
+    returning: vi.fn(async () => returningRows),
+  };
+  const db = {
+    insert: vi.fn(() => insertChain),
+  };
+  return { db, insertChain };
+}
+
+function createSelectDb(rows: unknown[], terminal: "limit" | "offset") {
+  const selectChain = {
+    from: vi.fn(() => selectChain),
+    where: vi.fn(() => selectChain),
+    orderBy: vi.fn(() => selectChain),
+    limit: vi.fn(() => (terminal === "limit" ? rows : selectChain)),
+    offset: vi.fn(async () => rows),
+  };
+  const db = {
+    select: vi.fn(() => selectChain),
+  };
+  return { db, selectChain };
+}
+
+describe("postgres raw message storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts raw messages using pgvector-compatible embedding text", async () => {
+    const { db, insertChain } = createInsertDb([{ id: 42 }]);
+    const storage = new PostgresRawMessageManager(db as never);
+
+    const ids = await storage.storeMessages([
+      {
+        messageId: "msg-1",
+        platform: "slack",
+        botId,
+        userId,
+        timestamp: 1774500000,
+        content: "Project launch planning update",
+        embedding: [1, 0.25],
+        embeddingModel: "text-embedding-3-small",
+        embeddingContentHash: "hash-1",
+        createdAt: 1774500000,
+      },
+    ]);
+
+    expect(ids).toEqual([42]);
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(insertChain.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    expect(insertChain.values).toHaveBeenCalledWith([
+      expect.objectContaining({
+        messageId: "msg-1",
+        userId,
+        botId,
+        embedding: "[1,0.25]",
+        embeddingDimensions: 2,
+        memoryStage: "short",
+        accessCount: 0,
+        importanceScore: 0,
+        isPinned: false,
+      }),
+    ]);
+  });
+
+  it("maps postgres rows back to the shared raw message contract", async () => {
+    const { db, selectChain } = createSelectDb(
+      [createRawMessageRow()],
+      "offset",
+    );
+    const storage = new PostgresRawMessageManager(db as never);
+
+    const messages = await storage.queryMessages({
+      userId,
+      keywords: ["launch"],
+      reverse: true,
+      pageSize: 5,
+      offset: 2,
+    });
+
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(selectChain.limit).toHaveBeenCalledWith(5);
+    expect(selectChain.offset).toHaveBeenCalledWith(2);
+    expect(messages).toEqual([
+      expect.objectContaining({
+        messageId: "msg-1",
+        userId,
+        botId,
+        content: "Project launch planning update",
+        embedding: [0.5, 0.25],
+        metadata: { source: "postgres-test" },
+        memoryStage: "short",
+        isPinned: false,
+      }),
+    ]);
+  });
+
+  it("maps pgvector semantic search rows to memory search results", async () => {
+    const row = createRawMessageRow({
+      messageId: "semantic-1",
+      embedding: "[1,0]",
+      embeddingModel: "text-embedding-3-small",
+      timestamp: 1774500003,
+    });
+    const { db, selectChain } = createSelectDb(
+      [{ row, similarity: "0.91" }],
+      "limit",
+    );
+    const storage = new PostgresRawMessageManager(db as never);
+
+    const results = await storage.searchMessagesSemantically({
+      userId,
+      queryEmbedding: [1, 0],
+      embeddingModel: "text-embedding-3-small",
+      limit: 3,
+      threshold: 0.7,
+    });
+
+    expect(db.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.anything(),
+        similarity: expect.anything(),
+      }),
+    );
+    expect(selectChain.limit).toHaveBeenCalledWith(3);
+    expect(results).toEqual([
+      expect.objectContaining({
+        type: "memory",
+        id: "semantic-1",
+        content: "Project launch planning update",
+        similarity: 0.91,
+        metadata: expect.objectContaining({
+          userId,
+          botId,
+          timestamp: 1774500003000,
+          embeddingModel: "text-embedding-3-small",
+        }),
+        message: expect.objectContaining({
+          messageId: "semantic-1",
+          embedding: [1, 0],
+        }),
+      }),
+    ]);
+  });
+});

--- a/apps/web/tests/unit/raw-message-storage-contract.test.ts
+++ b/apps/web/tests/unit/raw-message-storage-contract.test.ts
@@ -68,10 +68,12 @@ class InMemoryRawMessageStorage implements RawMessageStorage {
       );
     }
     if (query.startTime !== undefined) {
-      items = items.filter((item) => item.timestamp >= query.startTime!);
+      const startTime = query.startTime;
+      items = items.filter((item) => item.timestamp >= startTime);
     }
     if (query.endTime !== undefined) {
-      items = items.filter((item) => item.timestamp < query.endTime!);
+      const endTime = query.endTime;
+      items = items.filter((item) => item.timestamp < endTime);
     }
     if (query.keywords?.length) {
       const keywords = query.keywords.map((item) => item.toLowerCase());
@@ -201,10 +203,12 @@ class InMemoryRawMessageStorage implements RawMessageStorage {
       items = items.filter((item) => tiers.has(item.summaryTier));
     }
     if (query.startTime !== undefined) {
-      items = items.filter((item) => item.endTimestamp >= query.startTime!);
+      const startTime = query.startTime;
+      items = items.filter((item) => item.endTimestamp >= startTime);
     }
     if (query.endTime !== undefined) {
-      items = items.filter((item) => item.startTimestamp < query.endTime!);
+      const endTime = query.endTime;
+      items = items.filter((item) => item.startTimestamp < endTime);
     }
     if (query.keywords?.length) {
       const keywords = query.keywords.map((item) => item.toLowerCase());

--- a/apps/web/tests/unit/raw-message-storage-contract.test.ts
+++ b/apps/web/tests/unit/raw-message-storage-contract.test.ts
@@ -1,0 +1,359 @@
+import type {
+  MemoryStage,
+  MemorySummaryQuery,
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+  RawMessageStats,
+  RawMessageStorage,
+} from "../../../../packages/indexeddb/src/storage";
+import {
+  createConformanceRawMessage,
+  createRawMessageStorageConformanceSuite,
+} from "../helpers/raw-message-storage-conformance";
+
+class InMemoryRawMessageStorage implements RawMessageStorage {
+  private nextId = 1;
+  private messages = new Map<string, RawMessage>();
+  private summaries = new Map<string, MemorySummaryRecord>();
+
+  async storeMessage(message: RawMessage): Promise<number> {
+    const existing = this.messages.get(message.messageId);
+    const normalized: RawMessage = {
+      ...message,
+      id: existing?.id ?? this.nextId++,
+      memoryStage: message.memoryStage ?? "short",
+      accessCount: message.accessCount ?? 0,
+      importanceScore: message.importanceScore ?? 0,
+      isPinned: message.isPinned ?? false,
+    };
+    this.messages.set(
+      message.messageId,
+      existing ? { ...existing, ...normalized } : normalized,
+    );
+    return normalized.id ?? 0;
+  }
+
+  async storeMessages(messages: RawMessage[]): Promise<number[]> {
+    const ids: number[] = [];
+    for (const message of messages) {
+      ids.push(await this.storeMessage(message));
+    }
+    return ids;
+  }
+
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    let items = Array.from(this.messages.values());
+
+    if (query.userId) {
+      items = items.filter((item) => item.userId === query.userId);
+    }
+    if (query.platform) {
+      items = items.filter((item) => item.platform === query.platform);
+    }
+    if (query.botId) {
+      items = items.filter((item) => item.botId === query.botId);
+    }
+    if (query.channel) {
+      const channel = query.channel.toLowerCase();
+      items = items.filter((item) =>
+        item.channel?.toLowerCase().includes(channel),
+      );
+    }
+    if (query.person) {
+      const person = query.person.toLowerCase();
+      items = items.filter((item) =>
+        item.person?.toLowerCase().includes(person),
+      );
+    }
+    if (query.startTime !== undefined) {
+      items = items.filter((item) => item.timestamp >= query.startTime!);
+    }
+    if (query.endTime !== undefined) {
+      items = items.filter((item) => item.timestamp < query.endTime!);
+    }
+    if (query.keywords?.length) {
+      const keywords = query.keywords.map((item) => item.toLowerCase());
+      items = items.filter((item) => {
+        const searchable =
+          `${item.content} ${item.channel ?? ""} ${item.person ?? ""}`.toLowerCase();
+        return keywords.some((keyword) => searchable.includes(keyword));
+      });
+    }
+    if (query.memoryStages?.length) {
+      const stages = new Set(query.memoryStages);
+      items = items.filter((item) => stages.has(item.memoryStage ?? "short"));
+    }
+    if (!query.includeArchived) {
+      items = items.filter((item) => item.archivedAt === undefined);
+    }
+
+    items.sort((a, b) => a.timestamp - b.timestamp);
+    if (query.reverse) {
+      items.reverse();
+    }
+
+    const offset = query.offset ?? 0;
+    const pageSize = query.pageSize ?? query.limit ?? 50;
+    return items.slice(offset, offset + pageSize).map((item) => ({ ...item }));
+  }
+
+  async queryMessagesGrouped(
+    query: RawMessageQuery,
+  ): Promise<Record<string, RawMessage[]>> {
+    const messages = await this.queryMessages({
+      ...query,
+      limit: query.limit ? query.limit * 10 : 1000,
+    });
+
+    if (!query.groupBy || query.groupBy === "none") {
+      return { all: messages };
+    }
+
+    const grouped: Record<string, RawMessage[]> = {};
+    for (const message of messages) {
+      const date = new Date(message.timestamp * 1000);
+      let key = date.toISOString().split("T")[0];
+      if (query.groupBy === "month") {
+        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+      } else if (query.groupBy === "week") {
+        const monday = new Date(date);
+        const day = date.getDay();
+        monday.setDate(date.getDate() - (day === 0 ? 6 : day - 1));
+        key = `Week of ${monday.toISOString().split("T")[0]}`;
+      }
+      grouped[key] = grouped[key] ?? [];
+      grouped[key].push(message);
+    }
+
+    return Object.fromEntries(
+      Object.entries(grouped).sort(([a], [b]) => b.localeCompare(a)),
+    );
+  }
+
+  async getStats(): Promise<RawMessageStats> {
+    const stats: RawMessageStats = {
+      totalMessages: 0,
+      messagesByPlatform: {},
+      messagesByBot: {},
+    };
+
+    for (const message of this.messages.values()) {
+      stats.totalMessages += 1;
+      stats.messagesByPlatform[message.platform] =
+        (stats.messagesByPlatform[message.platform] ?? 0) + 1;
+      stats.messagesByBot[message.botId] =
+        (stats.messagesByBot[message.botId] ?? 0) + 1;
+      stats.oldestMessage =
+        stats.oldestMessage === undefined
+          ? message.timestamp
+          : Math.min(stats.oldestMessage, message.timestamp);
+      stats.newestMessage =
+        stats.newestMessage === undefined
+          ? message.timestamp
+          : Math.max(stats.newestMessage, message.timestamp);
+    }
+
+    return stats;
+  }
+
+  async getMessageById(messageId: string): Promise<RawMessage | null> {
+    const message = this.messages.get(messageId);
+    return message ? { ...message } : null;
+  }
+
+  async deleteOldMessages(olderThan: number, userId?: string): Promise<number> {
+    let deleted = 0;
+    for (const [messageId, message] of this.messages.entries()) {
+      if (userId && message.userId !== userId) {
+        continue;
+      }
+      if (message.createdAt < olderThan) {
+        this.messages.delete(messageId);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  async clearAll(): Promise<void> {
+    this.messages.clear();
+    this.summaries.clear();
+    this.nextId = 1;
+  }
+
+  async upsertSummaries(summaries: MemorySummaryRecord[]): Promise<void> {
+    for (const summary of summaries) {
+      this.summaries.set(summary.summaryId, { ...summary });
+    }
+  }
+
+  async querySummaries(
+    query: MemorySummaryQuery,
+  ): Promise<MemorySummaryRecord[]> {
+    let items = Array.from(this.summaries.values()).filter(
+      (item) => item.userId === query.userId,
+    );
+
+    if (query.summaryTiers?.length) {
+      const tiers = new Set(query.summaryTiers);
+      items = items.filter((item) => tiers.has(item.summaryTier));
+    }
+    if (query.startTime !== undefined) {
+      items = items.filter((item) => item.endTimestamp >= query.startTime!);
+    }
+    if (query.endTime !== undefined) {
+      items = items.filter((item) => item.startTimestamp < query.endTime!);
+    }
+    if (query.keywords?.length) {
+      const keywords = query.keywords.map((item) => item.toLowerCase());
+      items = items.filter((item) => {
+        const searchable =
+          `${item.keywordsText ?? ""} ${item.summaryText}`.toLowerCase();
+        return keywords.some((keyword) => searchable.includes(keyword));
+      });
+    }
+    if (query.dimensions) {
+      items = items.filter((item) => {
+        const dimensions = item.dimensions ?? {};
+        return Object.entries(query.dimensions ?? {}).every(
+          ([key, value]) => value === undefined || dimensions[key] === value,
+        );
+      });
+    }
+
+    items.sort((a, b) => a.endTimestamp - b.endTimestamp);
+    if (query.reverse ?? true) {
+      items.reverse();
+    }
+
+    const offset = query.offset ?? 0;
+    const pageSize = query.pageSize ?? query.limit ?? 50;
+    return items.slice(offset, offset + pageSize).map((item) => ({ ...item }));
+  }
+
+  async markMessagesAccessed(
+    messageIds: string[],
+    at = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    return this.updateMessagesById(messageIds, userId, (message) => ({
+      ...message,
+      accessCount: (message.accessCount ?? 0) + 1,
+      lastAccessAt: at,
+    }));
+  }
+
+  async promoteMessagesToStage(
+    messageIds: string[],
+    stage: MemoryStage,
+    options?: { userId?: string; summaryRefId?: string; promotedAt?: number },
+  ): Promise<number> {
+    return this.updateMessagesById(messageIds, options?.userId, (message) => ({
+      ...message,
+      memoryStage: stage,
+      summaryRefId: options?.summaryRefId ?? message.summaryRefId,
+      metadata: {
+        ...(message.metadata ?? {}),
+        ...(options?.promotedAt
+          ? { memoryPromotedAt: options.promotedAt }
+          : {}),
+      },
+    }));
+  }
+
+  async archiveMessages(
+    messageIds: string[],
+    archivedAt = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    return this.updateMessagesById(messageIds, userId, (message) => ({
+      ...message,
+      archivedAt,
+    }));
+  }
+
+  async hardDeleteArchived(
+    olderThan: number,
+    userId?: string,
+  ): Promise<number> {
+    let deleted = 0;
+    for (const [messageId, message] of this.messages.entries()) {
+      if (userId && message.userId !== userId) {
+        continue;
+      }
+      if (message.archivedAt !== undefined && message.archivedAt < olderThan) {
+        this.messages.delete(messageId);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  async updateMessageEmbeddings(
+    updates: RawMessageEmbeddingUpdate[],
+    userId?: string,
+  ): Promise<number> {
+    const updatesById = new Map(
+      updates.map((update) => [update.messageId, update]),
+    );
+    return this.updateMessagesById(
+      Array.from(updatesById.keys()),
+      userId,
+      (message) => {
+        const update = updatesById.get(message.messageId);
+        if (!update) {
+          return message;
+        }
+        return {
+          ...message,
+          embedding: update.embedding,
+          embeddingModel: update.embeddingModel,
+          embeddingContentHash: update.embeddingContentHash,
+          embeddingDimensions:
+            update.embeddingDimensions ?? update.embedding.length,
+          embeddingUpdatedAt: update.embeddingUpdatedAt,
+        };
+      },
+    );
+  }
+
+  private async updateMessagesById(
+    messageIds: string[],
+    userId: string | undefined,
+    update: (message: RawMessage) => RawMessage,
+  ): Promise<number> {
+    const ids = new Set(messageIds);
+    let updated = 0;
+    for (const [messageId, message] of this.messages.entries()) {
+      if (!ids.has(messageId)) {
+        continue;
+      }
+      if (userId && message.userId !== userId) {
+        continue;
+      }
+      this.messages.set(messageId, update(message));
+      updated += 1;
+    }
+    return updated;
+  }
+}
+
+createRawMessageStorageConformanceSuite("in-memory", () => ({
+  storage: new InMemoryRawMessageStorage(),
+}));
+
+createRawMessageStorageConformanceSuite(
+  "in-memory with prefilled clear",
+  async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storage.storeMessage(
+      createConformanceRawMessage({
+        messageId: "prefilled",
+        content: "clearAll should remove this fixture",
+      }),
+    );
+    return { storage };
+  },
+);

--- a/apps/web/tests/unit/sqlite-raw-message-migration.test.ts
+++ b/apps/web/tests/unit/sqlite-raw-message-migration.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  manager: {
+    init: vi.fn(),
+    queryMessages: vi.fn(),
+    querySummaries: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../packages/indexeddb/src/manager", () => ({
+  getIndexedDBManager: () => mocks.manager,
+}));
+
+import {
+  clearRawMessagesSQLiteMigrationState,
+  ensureRawMessagesSQLiteMigration,
+  getRawMessagesSQLiteMigrationState,
+  getRawMessagesSQLiteMigrationStorageKey,
+} from "../../../../packages/indexeddb/src/sqlite-client";
+
+function createStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    get length() {
+      return store.size;
+    },
+  } as unknown as Storage;
+}
+
+describe("raw message SQLite migration", () => {
+  let storage: Storage;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    storage = createStorage();
+    (globalThis as any).window = {
+      __TAURI__: {},
+      localStorage: storage,
+    };
+
+    mocks.manager.init.mockReset();
+    mocks.manager.queryMessages.mockReset();
+    mocks.manager.querySummaries.mockReset();
+
+    fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body ?? "{}"));
+      if (body.action === "store") {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            stored: Array.isArray(body.messages) ? body.messages.length : 0,
+          }),
+        );
+      }
+      if (body.action === "upsertSummaries") {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            stored: Array.isArray(body.summaries) ? body.summaries.length : 0,
+          }),
+        );
+      }
+      return new Response(JSON.stringify({ success: true }));
+    });
+    (globalThis as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).window;
+    delete (globalThis as any).fetch;
+  });
+
+  it("migrates IndexedDB records in batches and records completion", async () => {
+    const messages = [
+      {
+        messageId: "m1",
+        userId: "u1",
+        platform: "slack",
+        botId: "b1",
+        timestamp: 1,
+        content: "one",
+        createdAt: 1,
+      },
+      {
+        messageId: "m2",
+        userId: "u1",
+        platform: "slack",
+        botId: "b1",
+        timestamp: 2,
+        content: "two",
+        createdAt: 2,
+      },
+      {
+        messageId: "m3",
+        userId: "u1",
+        platform: "slack",
+        botId: "b1",
+        timestamp: 3,
+        content: "three",
+        createdAt: 3,
+      },
+    ];
+    const summaries = [
+      {
+        summaryId: "s1",
+        userId: "u1",
+        summaryTier: "L1",
+        sourceTier: "short",
+        startTimestamp: 1,
+        endTimestamp: 3,
+        messageCount: 3,
+        sourceRecordIds: ["m1", "m2", "m3"],
+        keyPoints: ["summary"],
+        keywords: ["slack"],
+        keywordsText: "slack",
+        summaryText: "summary",
+        dimensions: { platform: "slack" },
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+
+    mocks.manager.queryMessages.mockImplementation(async (query) => {
+      const offset = query.offset ?? 0;
+      return messages.slice(offset, offset + query.pageSize);
+    });
+    mocks.manager.querySummaries.mockImplementation(async (query) => {
+      const offset = query.offset ?? 0;
+      return summaries.slice(offset, offset + query.pageSize);
+    });
+
+    const result = await ensureRawMessagesSQLiteMigration({
+      userId: "u1",
+      batchSize: 2,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.migratedMessages).toBe(3);
+    expect(result.migratedSummaries).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getRawMessagesSQLiteMigrationState("u1")?.status).toBe("completed");
+  });
+
+  it("skips migration when the current version already completed", async () => {
+    storage.setItem(
+      getRawMessagesSQLiteMigrationStorageKey("u1"),
+      JSON.stringify({
+        version: 1,
+        userId: "u1",
+        status: "completed",
+        migratedMessages: 12,
+        migratedSummaries: 2,
+        updatedAt: Date.now(),
+        completedAt: Date.now(),
+      }),
+    );
+
+    const result = await ensureRawMessagesSQLiteMigration({ userId: "u1" });
+
+    expect(result).toMatchObject({
+      status: "skipped",
+      reason: "already_completed",
+      migratedMessages: 12,
+      migratedSummaries: 2,
+    });
+    expect(mocks.manager.init).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    clearRawMessagesSQLiteMigrationState("u1");
+    expect(getRawMessagesSQLiteMigrationState("u1")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/sqlite-raw-message-migration.test.ts
+++ b/apps/web/tests/unit/sqlite-raw-message-migration.test.ts
@@ -79,8 +79,8 @@ describe("raw message SQLite migration", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete (globalThis as any).window;
-    delete (globalThis as any).fetch;
+    (globalThis as any).window = undefined;
+    (globalThis as any).fetch = undefined;
   });
 
   it("migrates IndexedDB records in batches and records completion", async () => {

--- a/apps/web/tests/unit/sqlite-raw-message-storage.test.ts
+++ b/apps/web/tests/unit/sqlite-raw-message-storage.test.ts
@@ -1,0 +1,188 @@
+import { SQLiteRawMessageManager } from "../../../../packages/sqlite/src/raw-message-manager";
+import { createRawMessageStorageConformanceSuite } from "../helpers/raw-message-storage-conformance";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+createRawMessageStorageConformanceSuite("sqlite", async () => {
+  const storage = new SQLiteRawMessageManager(":memory:");
+  await storage.init();
+  return {
+    storage,
+    cleanup: () => storage.close(),
+  };
+});
+
+describe("sqlite raw message search", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defaults createdAt to unix seconds for retention cleanup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T00:00:00.000Z"));
+
+    const storage = new SQLiteRawMessageManager(":memory:");
+    await storage.init();
+    try {
+      await storage.storeMessage({
+        messageId: "default-created-at",
+        platform: "slack",
+        botId: "bot-1",
+        userId: "user-1",
+        timestamp: 1774500000,
+        content: "retention cleanup candidate",
+      } as any);
+
+      const stored = await storage.getMessageById("default-created-at");
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      expect(stored?.createdAt).toBe(nowSeconds);
+      expect(await storage.deleteOldMessages(nowSeconds + 1, "user-1")).toBe(1);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("keeps FTS index in sync across insert, update, and delete", async () => {
+    const storage = new SQLiteRawMessageManager(":memory:");
+    await storage.init();
+    try {
+      await storage.storeMessages([
+        {
+          messageId: "fts-1",
+          platform: "slack",
+          botId: "bot-1",
+          userId: "user-1",
+          channel: "general",
+          person: "alice",
+          timestamp: 1774500000,
+          content: "alpha launch planning",
+          createdAt: 1774500000000,
+        },
+        {
+          messageId: "fts-2",
+          platform: "slack",
+          botId: "bot-1",
+          userId: "user-1",
+          channel: "support-room",
+          person: "bob",
+          timestamp: 1774500010,
+          content: "customer support handoff",
+          createdAt: 1774500000000,
+        },
+      ]);
+
+      await expect(
+        storage.queryMessages({ userId: "user-1", keywords: ["launch"] }),
+      ).resolves.toMatchObject([{ messageId: "fts-1" }]);
+
+      await storage.storeMessage({
+        messageId: "fts-1",
+        platform: "slack",
+        botId: "bot-1",
+        userId: "user-1",
+        channel: "general",
+        person: "alice",
+        timestamp: 1774500000,
+        content: "renamed roadmap planning",
+        createdAt: 1774500000000,
+      });
+
+      await expect(
+        storage.queryMessages({ userId: "user-1", keywords: ["launch"] }),
+      ).resolves.toEqual([]);
+      await expect(
+        storage.queryMessages({ userId: "user-1", keywords: ["roadmap"] }),
+      ).resolves.toMatchObject([{ messageId: "fts-1" }]);
+
+      await storage.deleteOldMessages(1774500000001, "user-1");
+      await expect(
+        storage.queryMessages({ userId: "user-1", keywords: ["roadmap"] }),
+      ).resolves.toEqual([]);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("returns semantic results ordered by vector similarity", async () => {
+    const storage = new SQLiteRawMessageManager({
+      dbPath: ":memory:",
+      vectorDimensions: 2,
+    });
+    await storage.init();
+    try {
+      await storage.storeMessages([
+        {
+          messageId: "near",
+          platform: "slack",
+          botId: "bot-1",
+          userId: "user-1",
+          channel: "product",
+          person: "alice",
+          timestamp: 1774500003,
+          content: "Project feedback was positive.",
+          embedding: [1, 0],
+          embeddingModel: "model-a",
+          embeddingContentHash: "hash-near",
+          embeddingDimensions: 2,
+          embeddingUpdatedAt: 1774500000000,
+          createdAt: 1774500000000,
+        },
+        {
+          messageId: "far",
+          platform: "slack",
+          botId: "bot-1",
+          userId: "user-1",
+          channel: "product",
+          person: "bob",
+          timestamp: 1774500002,
+          content: "Lunch menu discussion.",
+          embedding: [0, 1],
+          embeddingModel: "model-a",
+          embeddingContentHash: "hash-far",
+          embeddingDimensions: 2,
+          embeddingUpdatedAt: 1774500000000,
+          createdAt: 1774500000000,
+        },
+        {
+          messageId: "other-user",
+          platform: "slack",
+          botId: "bot-1",
+          userId: "user-2",
+          channel: "product",
+          person: "carol",
+          timestamp: 1774500001,
+          content: "Other user project note.",
+          embedding: [1, 0],
+          embeddingModel: "model-a",
+          embeddingContentHash: "hash-other",
+          embeddingDimensions: 2,
+          embeddingUpdatedAt: 1774500000000,
+          createdAt: 1774500000000,
+        },
+      ]);
+
+      const results = await storage.searchMessagesSemantically({
+        userId: "user-1",
+        queryEmbedding: [1, 0],
+        embeddingModel: "model-a",
+        limit: 5,
+        threshold: 0.5,
+      });
+
+      expect(results.map((result) => result.id)).toEqual(["near"]);
+      expect(results[0]).toMatchObject({
+        type: "memory",
+        content: "Project feedback was positive.",
+        metadata: {
+          userId: "user-1",
+          platform: "slack",
+          botId: "bot-1",
+          timestamp: 1774500003000,
+          embeddingModel: "model-a",
+        },
+      });
+      expect(results[0]?.similarity).toBeGreaterThan(0.99);
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/apps/web/tests/unit/unified-memory-search.test.ts
+++ b/apps/web/tests/unit/unified-memory-search.test.ts
@@ -1,11 +1,35 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { searchInsightsSemanticallyMock, searchSimilarChunksMock } = vi.hoisted(
-  () => ({
-    searchInsightsSemanticallyMock: vi.fn(),
-    searchSimilarChunksMock: vi.fn(),
+const {
+  getSQLiteRawMessageManagerMock,
+  isSQLiteRawMessageStorageAvailableMock,
+  queryMessagesMock,
+  searchInsightsSemanticallyMock,
+  searchMessagesSemanticallyMock,
+  searchSimilarChunksMock,
+  universalEmbedQueryMock,
+} = vi.hoisted(() => ({
+  getSQLiteRawMessageManagerMock: vi.fn(),
+  isSQLiteRawMessageStorageAvailableMock: vi.fn(),
+  queryMessagesMock: vi.fn(),
+  searchInsightsSemanticallyMock: vi.fn(),
+  searchMessagesSemanticallyMock: vi.fn(),
+  searchSimilarChunksMock: vi.fn(),
+  universalEmbedQueryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/memory/sqlite-raw-message-store", () => ({
+  getSQLiteRawMessageManager: getSQLiteRawMessageManagerMock,
+  isSQLiteRawMessageStorageAvailable: isSQLiteRawMessageStorageAvailableMock,
+}));
+
+vi.mock("@openloomi/rag/universal-embeddings", () => ({
+  UniversalEmbeddings: vi.fn().mockImplementation(function () {
+    return {
+      embedQuery: universalEmbedQueryMock,
+    };
   }),
-);
+}));
 
 vi.mock("@/lib/insights/search", () => ({
   searchInsightsSemantically: searchInsightsSemanticallyMock,
@@ -25,6 +49,27 @@ import {
 } from "@/lib/memory/unified-search";
 
 describe("unified memory search", () => {
+  beforeEach(() => {
+    getSQLiteRawMessageManagerMock.mockReset();
+    isSQLiteRawMessageStorageAvailableMock.mockReset();
+    queryMessagesMock.mockReset();
+    searchInsightsSemanticallyMock.mockReset();
+    searchMessagesSemanticallyMock.mockReset();
+    searchSimilarChunksMock.mockReset();
+    universalEmbedQueryMock.mockReset();
+
+    isSQLiteRawMessageStorageAvailableMock.mockReturnValue(false);
+    getSQLiteRawMessageManagerMock.mockResolvedValue({
+      queryMessages: queryMessagesMock,
+      searchMessagesSemantically: searchMessagesSemanticallyMock,
+    });
+    queryMessagesMock.mockResolvedValue([]);
+    searchInsightsSemanticallyMock.mockResolvedValue([]);
+    searchMessagesSemanticallyMock.mockResolvedValue([]);
+    searchSimilarChunksMock.mockResolvedValue([]);
+    universalEmbedQueryMock.mockResolvedValue([0.1, 0.2]);
+  });
+
   it("normalizes sources and clamps numeric options", () => {
     expect(normalizeUnifiedMemorySearchSources(undefined)).toEqual([
       "memory",
@@ -142,5 +187,103 @@ describe("unified memory search", () => {
           "Raw memory records are stored in client-side IndexedDB and cannot be searched from this server API.",
       },
     ]);
+  });
+
+  it("hybrid searches SQLite raw memory with FTS keywords and semantic vectors", async () => {
+    isSQLiteRawMessageStorageAvailableMock.mockReturnValue(true);
+    queryMessagesMock.mockResolvedValue([
+      {
+        messageId: "message-1",
+        userId: "user-1",
+        platform: "slack",
+        botId: "bot-1",
+        channel: "product",
+        person: "alice",
+        timestamp: 1774500000,
+        content: "Raw project feedback",
+        createdAt: 1774500000,
+        memoryStage: "short",
+      },
+      {
+        messageId: "message-2",
+        userId: "user-1",
+        platform: "slack",
+        botId: "bot-1",
+        channel: "product",
+        person: "bob",
+        timestamp: 1774500010,
+        content: "Project keyword-only note",
+        createdAt: 1774500010,
+        memoryStage: "short",
+      },
+    ]);
+    searchMessagesSemanticallyMock.mockResolvedValue([
+      {
+        type: "memory",
+        id: "message-1",
+        content: "Raw project feedback",
+        similarity: 0.93,
+        metadata: {
+          userId: "user-1",
+          botId: "bot-1",
+          platform: "slack",
+        },
+      },
+    ]);
+
+    const output = await searchUnifiedMemory({
+      userId: "user-1",
+      query: "project feedback",
+      sources: ["memory"],
+      limit: 5,
+      threshold: 0.6,
+      authToken: "token",
+      botIds: ["bot-1"],
+    });
+
+    expect(universalEmbedQueryMock).toHaveBeenCalledWith("project feedback");
+    expect(queryMessagesMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      keywords: ["project feedback", "project", "feedback"],
+      reverse: true,
+      includeArchived: false,
+      pageSize: 15,
+      botId: "bot-1",
+    });
+    expect(searchMessagesSemanticallyMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      queryEmbedding: [0.1, 0.2],
+      limit: 5,
+      threshold: 0.6,
+      botId: "bot-1",
+    });
+    expect(output.warnings).toEqual([]);
+    expect(output.results.map((result) => result.id)).toEqual([
+      "message-1",
+      "message-2",
+    ]);
+    expect(output.results[0]).toMatchObject({
+      type: "memory",
+      id: "message-1",
+      content: "Raw project feedback",
+      metadata: {
+        userId: "user-1",
+        botId: "bot-1",
+        platform: "slack",
+        matchType: "hybrid",
+      },
+    });
+    expect(output.results[0]?.similarity).toBe(1);
+    expect(output.results[1]).toMatchObject({
+      type: "memory",
+      id: "message-2",
+      content: "Project keyword-only note",
+      metadata: {
+        userId: "user-1",
+        botId: "bot-1",
+        platform: "slack",
+        matchType: "keyword",
+      },
+    });
   });
 });

--- a/apps/web/tests/unit/unified-memory-search.test.ts
+++ b/apps/web/tests/unit/unified-memory-search.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  getSQLiteRawMessageManagerMock,
-  isSQLiteRawMessageStorageAvailableMock,
+  getRawMessageManagerMock,
+  isRawMessageStorageAvailableMock,
   queryMessagesMock,
   searchInsightsSemanticallyMock,
   searchMessagesSemanticallyMock,
   searchSimilarChunksMock,
   universalEmbedQueryMock,
 } = vi.hoisted(() => ({
-  getSQLiteRawMessageManagerMock: vi.fn(),
-  isSQLiteRawMessageStorageAvailableMock: vi.fn(),
+  getRawMessageManagerMock: vi.fn(),
+  isRawMessageStorageAvailableMock: vi.fn(),
   queryMessagesMock: vi.fn(),
   searchInsightsSemanticallyMock: vi.fn(),
   searchMessagesSemanticallyMock: vi.fn(),
@@ -18,9 +18,9 @@ const {
   universalEmbedQueryMock: vi.fn(),
 }));
 
-vi.mock("@/lib/memory/sqlite-raw-message-store", () => ({
-  getSQLiteRawMessageManager: getSQLiteRawMessageManagerMock,
-  isSQLiteRawMessageStorageAvailable: isSQLiteRawMessageStorageAvailableMock,
+vi.mock("@/lib/memory/raw-message-store", () => ({
+  getRawMessageManager: getRawMessageManagerMock,
+  isRawMessageStorageAvailable: isRawMessageStorageAvailableMock,
 }));
 
 vi.mock("@openloomi/rag/universal-embeddings", () => ({
@@ -50,16 +50,16 @@ import {
 
 describe("unified memory search", () => {
   beforeEach(() => {
-    getSQLiteRawMessageManagerMock.mockReset();
-    isSQLiteRawMessageStorageAvailableMock.mockReset();
+    getRawMessageManagerMock.mockReset();
+    isRawMessageStorageAvailableMock.mockReset();
     queryMessagesMock.mockReset();
     searchInsightsSemanticallyMock.mockReset();
     searchMessagesSemanticallyMock.mockReset();
     searchSimilarChunksMock.mockReset();
     universalEmbedQueryMock.mockReset();
 
-    isSQLiteRawMessageStorageAvailableMock.mockReturnValue(false);
-    getSQLiteRawMessageManagerMock.mockResolvedValue({
+    isRawMessageStorageAvailableMock.mockReturnValue(false);
+    getRawMessageManagerMock.mockResolvedValue({
       queryMessages: queryMessagesMock,
       searchMessagesSemantically: searchMessagesSemanticallyMock,
     });
@@ -182,15 +182,14 @@ describe("unified memory search", () => {
     expect(output.warnings).toEqual([
       {
         source: "memory",
-        code: "client_indexeddb_required",
-        message:
-          "Raw memory records are stored in client-side IndexedDB and cannot be searched from this server API.",
+        code: "raw_message_storage_unavailable",
+        message: "Raw memory storage is not available in this environment.",
       },
     ]);
   });
 
-  it("hybrid searches SQLite raw memory with FTS keywords and semantic vectors", async () => {
-    isSQLiteRawMessageStorageAvailableMock.mockReturnValue(true);
+  it("hybrid searches raw memory with FTS keywords and semantic vectors", async () => {
+    isRawMessageStorageAvailableMock.mockReturnValue(true);
     queryMessagesMock.mockResolvedValue([
       {
         messageId: "message-1",

--- a/apps/web/tests/unit/unified-memory-search.test.ts
+++ b/apps/web/tests/unit/unified-memory-search.test.ts
@@ -24,10 +24,10 @@ vi.mock("@/lib/memory/sqlite-raw-message-store", () => ({
 }));
 
 vi.mock("@openloomi/rag/universal-embeddings", () => ({
-  UniversalEmbeddings: vi.fn().mockImplementation(function () {
-    return {
-      embedQuery: universalEmbedQueryMock,
-    };
+  UniversalEmbeddings: vi.fn().mockImplementation(function (this: {
+    embedQuery: typeof universalEmbedQueryMock;
+  }) {
+    this.embedQuery = universalEmbedQueryMock;
   }),
 }));
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,6 +27,8 @@
       "@openloomi/ui/*": ["./components/ui/*"],
       "@openloomi/shared": ["../../packages/shared/src/index.ts"],
       "@openloomi/indexeddb": ["../../packages/indexeddb/src/index.ts"],
+      "@openloomi/sqlite": ["../../packages/sqlite/src/index.ts"],
+      "@openloomi/sqlite/*": ["../../packages/sqlite/src/*"],
       "@openloomi/insights": ["../../packages/insights/src/index.ts"],
       "@openloomi/agent": ["../../packages/ai/src/agent/index.ts"],
       "@openloomi/agent/*": ["../../packages/ai/src/agent/*"],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -199,6 +199,14 @@ export default defineConfig({
         replacement: alias("../../packages/indexeddb/src/index.ts"),
       },
       {
+        find: "@openloomi/sqlite/*",
+        replacement: alias("../../packages/sqlite/src/*"),
+      },
+      {
+        find: "@openloomi/sqlite",
+        replacement: alias("../../packages/sqlite/src/index.ts"),
+      },
+      {
         find: "@openloomi/integrations/imessage",
         replacement: alias("../../packages/integrations/imessage/src/index.ts"),
       },

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -9,9 +9,27 @@ import type {
   GroupByType,
   MemorySummaryRecord,
 } from "./manager";
+import {
+  ensureRawMessagesSQLiteMigration,
+  migrateIndexedDBRawMessagesToSQLite,
+  shouldUseSQLiteRawMessageStorage,
+  sqliteClearOldRawMessages,
+  sqliteGetRawMessagesStats,
+  sqliteQueryRawMessages,
+  sqliteQueryRawMessagesGrouped,
+  sqliteRunMemoryForgettingCycleForUser,
+  sqliteRunRawMessageEmbeddingDreamForUser,
+  sqliteSearchRawMessagesSemanticallyForUser,
+  sqliteStoreRawMessagesFromInsight,
+} from "./sqlite-client";
 
 // Re-export types for external use
 export type { RawMessage, RawMessageQuery, GroupByType, MemorySummaryRecord };
+export {
+  ensureRawMessagesSQLiteMigration,
+  migrateIndexedDBRawMessagesToSQLite,
+  shouldUseSQLiteRawMessageStorage,
+};
 
 export type RawMessageSourceType = "raw" | "summary";
 
@@ -94,6 +112,17 @@ export async function storeRawMessagesFromInsight(
     metadata?: Record<string, any>;
   }>,
 ): Promise<{ success: boolean; stored: number; errors: number }> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteStoreRawMessagesFromInsight(userId, messages);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to store messages, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   try {
     const manager = await getManager();
 
@@ -126,6 +155,19 @@ export async function storeRawMessagesFromInsight(
 export async function queryRawMessages(
   query: RawMessageQuery,
 ): Promise<RawMessageQueryResultItem[]> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return (await sqliteQueryRawMessages(
+        query,
+      )) as RawMessageQueryResultItem[];
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to query messages, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   // Opt-in switch to keep old behavior stable unless caller requests fallback.
   if (query.includeSummaryFallback) {
     return queryRawMessagesWithFallback(query);
@@ -274,6 +316,17 @@ export async function queryRawMessagesWithFallback(
 export async function queryRawMessagesGrouped(
   query: RawMessageQuery,
 ): Promise<Record<string, RawMessage[]>> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteQueryRawMessagesGrouped(query);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to query grouped messages, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   // Normal IndexedDB query
   try {
     const manager = await getManager();
@@ -297,6 +350,17 @@ export async function getRawMessagesStats(): Promise<{
   oldestMessage?: number;
   newestMessage?: number;
 }> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteGetRawMessagesStats();
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to get stats, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   // Normal IndexedDB query
   try {
     const manager = await getManager();
@@ -318,6 +382,17 @@ export async function clearOldRawMessages(
   olderThan: number,
   userId?: string,
 ): Promise<{ success: boolean; deleted: number }> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteClearOldRawMessages(olderThan, userId);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to clear old messages, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   try {
     const manager = await getManager();
     const deleted = await manager.deleteOldMessages(olderThan, userId);
@@ -349,6 +424,17 @@ export async function runMemoryForgettingCycleForUser(
   hardDeletedRecords?: number;
   error?: string;
 }> {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteRunMemoryForgettingCycleForUser(userId, options);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to run forgetting cycle, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   try {
     const manager = await getManager();
     const { runMemoryForgettingCycle } = await import("./forgetting");
@@ -384,6 +470,17 @@ export async function runRawMessageEmbeddingDreamForUser(
     dryRun?: boolean;
   },
 ) {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteRunRawMessageEmbeddingDreamForUser(userId, options);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to run embedding dream, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   const manager = await getManager();
   const { runRawMessageEmbeddingDream } = await import("./embedding");
   return await runRawMessageEmbeddingDream(manager, {
@@ -410,6 +507,17 @@ export async function searchRawMessagesSemanticallyForUser(
     endTime?: number;
   },
 ) {
+  if (shouldUseSQLiteRawMessageStorage()) {
+    try {
+      return await sqliteSearchRawMessagesSemanticallyForUser(userId, options);
+    } catch (error) {
+      console.warn(
+        "[Client SQLite] Failed to search semantically, falling back to IndexedDB:",
+        error,
+      );
+    }
+  }
+
   const manager = await getManager();
   const { searchRawMessagesSemantically } = await import("./embedding");
   return await searchRawMessagesSemantically(manager, {
@@ -472,16 +580,18 @@ export async function clearOldMessagesByUserEntitlements(
     const cutoffTimestamp =
       Math.floor(Date.now() / 1000) - historyDays * 24 * 60 * 60;
 
-    // Delete messages older than the cutoff (only for current user)
-    const manager = await getManager();
-    const deleted = await manager.deleteOldMessages(cutoffTimestamp, userId);
+    // Delete messages older than the cutoff (only for current user).
+    // Route through the public helper so Tauri/SQLite mode uses the server-side
+    // SQLite bridge while browser builds keep the IndexedDB path.
+    const cleanup = await clearOldRawMessages(cutoffTimestamp, userId);
+    const deleted = cleanup.deleted;
 
     console.log(
-      `[Client IndexedDB] Cleaned up ${deleted} messages older than ${historyDays} days (user type: ${entitlements.userType})`,
+      `[Client Raw Messages] Cleaned up ${deleted} messages older than ${historyDays} days (user type: ${entitlements.userType})`,
     );
 
     return {
-      success: true,
+      success: cleanup.success,
       deleted,
       historyDays,
       userType: entitlements.userType,
@@ -618,11 +728,13 @@ export async function sendRawMessagesToServer(
 }
 
 /**
- * Initialize IndexedDB and load initial data
- * Call this on app startup to prepare IndexedDB
+ * Initialize raw message storage and load initial data.
+ * Tauri builds use SQLite with a one-time IndexedDB migration; browser builds
+ * keep the IndexedDB backend.
  */
-export async function initializeRawMessagesStorage(): Promise<{
+export async function initializeRawMessagesStorage(userId?: string): Promise<{
   success: boolean;
+  migration?: Awaited<ReturnType<typeof ensureRawMessagesSQLiteMigration>>;
   stats?: {
     totalMessages: number;
     messagesByPlatform: Record<string, number>;
@@ -632,6 +744,23 @@ export async function initializeRawMessagesStorage(): Promise<{
   try {
     if (typeof window === "undefined") {
       return { success: false };
+    }
+
+    if (shouldUseSQLiteRawMessageStorage()) {
+      const migration = userId
+        ? await ensureRawMessagesSQLiteMigration({ userId })
+        : undefined;
+      const stats = await sqliteGetRawMessagesStats();
+      console.log("[Client SQLite] Initialized with stats:", stats);
+      return {
+        success: true,
+        migration,
+        stats: {
+          totalMessages: stats.totalMessages,
+          messagesByPlatform: stats.messagesByPlatform,
+          messagesByBot: stats.messagesByBot,
+        },
+      };
     }
 
     const manager = await getManager();
@@ -684,8 +813,7 @@ export async function useRawMessages() {
   const loadStats = react.useCallback(async () => {
     setLoading(true);
     try {
-      const manager = await getManager();
-      const stats = await manager.getStats();
+      const stats = await getRawMessagesStats();
       setStats({
         totalMessages: stats.totalMessages,
         messagesByPlatform: stats.messagesByPlatform,

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -12,6 +12,7 @@ import type {
 import {
   ensureRawMessagesSQLiteMigration,
   migrateIndexedDBRawMessagesToSQLite,
+  shouldUseRawMessageApiStorage,
   shouldUseSQLiteRawMessageStorage,
   sqliteClearOldRawMessages,
   sqliteGetRawMessagesStats,
@@ -28,6 +29,7 @@ export type { RawMessage, RawMessageQuery, GroupByType, MemorySummaryRecord };
 export {
   ensureRawMessagesSQLiteMigration,
   migrateIndexedDBRawMessagesToSQLite,
+  shouldUseRawMessageApiStorage,
   shouldUseSQLiteRawMessageStorage,
 };
 
@@ -112,12 +114,12 @@ export async function storeRawMessagesFromInsight(
     metadata?: Record<string, any>;
   }>,
 ): Promise<{ success: boolean; stored: number; errors: number }> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteStoreRawMessagesFromInsight(userId, messages);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to store messages, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to store messages, falling back to IndexedDB:",
         error,
       );
     }
@@ -155,14 +157,14 @@ export async function storeRawMessagesFromInsight(
 export async function queryRawMessages(
   query: RawMessageQuery,
 ): Promise<RawMessageQueryResultItem[]> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return (await sqliteQueryRawMessages(
         query,
       )) as RawMessageQueryResultItem[];
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to query messages, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to query messages, falling back to IndexedDB:",
         error,
       );
     }
@@ -316,12 +318,12 @@ export async function queryRawMessagesWithFallback(
 export async function queryRawMessagesGrouped(
   query: RawMessageQuery,
 ): Promise<Record<string, RawMessage[]>> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteQueryRawMessagesGrouped(query);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to query grouped messages, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to query grouped messages, falling back to IndexedDB:",
         error,
       );
     }
@@ -350,12 +352,12 @@ export async function getRawMessagesStats(): Promise<{
   oldestMessage?: number;
   newestMessage?: number;
 }> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteGetRawMessagesStats();
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to get stats, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to get stats, falling back to IndexedDB:",
         error,
       );
     }
@@ -382,12 +384,12 @@ export async function clearOldRawMessages(
   olderThan: number,
   userId?: string,
 ): Promise<{ success: boolean; deleted: number }> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteClearOldRawMessages(olderThan, userId);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to clear old messages, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to clear old messages, falling back to IndexedDB:",
         error,
       );
     }
@@ -424,12 +426,12 @@ export async function runMemoryForgettingCycleForUser(
   hardDeletedRecords?: number;
   error?: string;
 }> {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteRunMemoryForgettingCycleForUser(userId, options);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to run forgetting cycle, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to run forgetting cycle, falling back to IndexedDB:",
         error,
       );
     }
@@ -470,12 +472,12 @@ export async function runRawMessageEmbeddingDreamForUser(
     dryRun?: boolean;
   },
 ) {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteRunRawMessageEmbeddingDreamForUser(userId, options);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to run embedding dream, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to run embedding dream, falling back to IndexedDB:",
         error,
       );
     }
@@ -507,12 +509,12 @@ export async function searchRawMessagesSemanticallyForUser(
     endTime?: number;
   },
 ) {
-  if (shouldUseSQLiteRawMessageStorage()) {
+  if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteSearchRawMessagesSemanticallyForUser(userId, options);
     } catch (error) {
       console.warn(
-        "[Client SQLite] Failed to search semantically, falling back to IndexedDB:",
+        "[Client Raw Messages API] Failed to search semantically, falling back to IndexedDB:",
         error,
       );
     }
@@ -746,12 +748,13 @@ export async function initializeRawMessagesStorage(userId?: string): Promise<{
       return { success: false };
     }
 
-    if (shouldUseSQLiteRawMessageStorage()) {
-      const migration = userId
-        ? await ensureRawMessagesSQLiteMigration({ userId })
-        : undefined;
+    if (shouldUseRawMessageApiStorage()) {
+      const migration =
+        shouldUseSQLiteRawMessageStorage() && userId
+          ? await ensureRawMessagesSQLiteMigration({ userId })
+          : undefined;
       const stats = await sqliteGetRawMessagesStats();
-      console.log("[Client SQLite] Initialized with stats:", stats);
+      console.log("[Client Raw Messages API] Initialized with stats:", stats);
       return {
         success: true,
         migration,

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -3,3 +3,5 @@ export * from "./embedding";
 export * from "./extractor";
 export * from "./forgetting";
 export * from "./manager";
+export * from "./sqlite-client";
+export * from "./storage";

--- a/packages/indexeddb/src/manager.ts
+++ b/packages/indexeddb/src/manager.ts
@@ -3,110 +3,37 @@
  * This allows AI tools to query original message content during insight generation
  */
 
+import type {
+  GroupByType,
+  MemoryStage,
+  MemorySummaryQuery,
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+  RawMessageStorageManager,
+} from "./storage";
+
 const DB_NAME = "openloomi_messages_db";
 const DB_VERSION = 3; // Incremented to add memory stage fields and summaries store
 const STORE_NAME = "raw_messages";
 const SUMMARY_STORE_NAME = "memory_summaries";
 
-export type MemoryStage = "short" | "mid" | "long";
-export type MemorySummaryTier = "L1" | "L2" | "L3";
+export type {
+  GroupByType,
+  MemoryStage,
+  MemorySummaryQuery,
+  MemorySummaryRecord,
+  MemorySummaryTier,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+  RawMessageStats,
+  RawMessageStorage,
+  RawMessageStorageManager,
+} from "./storage";
 
-export interface RawMessage {
-  id?: number; // Auto-increment key
-  messageId: string; // Unique message ID from platform
-  platform: string; // slack, discord, telegram, etc.
-  botId: string; // Bot ID
-  userId: string; // User ID
-  channel?: string; // Channel or chat name
-  person?: string; // Sender name
-  timestamp: number; // Unix timestamp
-  content: string; // Message content
-  attachments?: Array<{
-    name: string;
-    url: string;
-    contentType?: string;
-    sizeBytes?: number;
-  }>;
-  embedding?: number[];
-  embeddingModel?: string;
-  embeddingContentHash?: string;
-  embeddingDimensions?: number;
-  embeddingUpdatedAt?: number;
-  metadata?: Record<string, any>; // Additional platform-specific data
-  createdAt: number; // When stored in IndexedDB
-  memoryStage?: MemoryStage;
-  accessCount?: number;
-  lastAccessAt?: number;
-  importanceScore?: number;
-  archivedAt?: number;
-  isPinned?: boolean;
-  summaryRefId?: string;
-}
-
-export type GroupByType = "none" | "day" | "week" | "month";
-
-export interface RawMessageQuery {
-  userId?: string; // User ID to filter messages
-  platform?: string;
-  botId?: string;
-  channel?: string;
-  person?: string;
-  startTime?: number;
-  endTime?: number;
-  keywords?: string[];
-  limit?: number; // Deprecated: Use offset + pageSize instead
-  offset?: number; // Number of messages to skip for pagination
-  pageSize?: number; // Number of messages per page
-  groupBy?: GroupByType; // Group results by time period
-  reverse?: boolean; // Return results in reverse order (newest first)
-  includeSummaryFallback?: boolean;
-  minRawResultsWithoutFallback?: number;
-  memoryStages?: MemoryStage[];
-  includeArchived?: boolean;
-}
-
-export interface MemorySummaryRecord {
-  summaryId: string;
-  userId: string;
-  summaryTier: MemorySummaryTier;
-  sourceTier: MemoryStage;
-  startTimestamp: number;
-  endTimestamp: number;
-  messageCount: number;
-  sourceRecordIds: string[];
-  keyPoints: string[];
-  keywords: string[];
-  keywordsText?: string;
-  summaryText: string;
-  dimensions?: Record<string, string | number | boolean | undefined>;
-  qualityScore?: number;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface MemorySummaryQuery {
-  userId: string;
-  keywords?: string[];
-  startTime?: number;
-  endTime?: number;
-  reverse?: boolean;
-  summaryTiers?: MemorySummaryTier[];
-  pageSize?: number;
-  limit?: number;
-  offset?: number;
-  dimensions?: Record<string, string | number | boolean | undefined>;
-}
-
-export interface RawMessageEmbeddingUpdate {
-  messageId: string;
-  embedding: number[];
-  embeddingModel: string;
-  embeddingContentHash: string;
-  embeddingDimensions?: number;
-  embeddingUpdatedAt?: number;
-}
-
-class IndexedDBManager {
+class IndexedDBManager implements RawMessageStorageManager {
   private db: IDBDatabase | null = null;
 
   /**

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -1,0 +1,632 @@
+import type {
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+} from "./manager";
+import type {
+  RunRawMessageEmbeddingDreamInput,
+  RawMessageSemanticSearchInput,
+} from "./embedding";
+
+export type SQLiteRawMessageQueryResultItem =
+  | (RawMessage & { sourceType: "raw" })
+  | (MemorySummaryRecord & { sourceType: "summary" });
+
+const SQLITE_RAW_MESSAGES_API = "/api/memory/raw-messages";
+const SQLITE_RAW_MESSAGES_MIGRATION_VERSION = 1;
+const SQLITE_RAW_MESSAGES_MIGRATION_STALE_MS = 10 * 60 * 1000;
+
+export type RawMessagesSQLiteMigrationStatus =
+  | "not_started"
+  | "running"
+  | "completed"
+  | "failed";
+
+export interface RawMessagesSQLiteMigrationState {
+  version: number;
+  userId: string;
+  status: RawMessagesSQLiteMigrationStatus;
+  migratedMessages: number;
+  migratedSummaries: number;
+  startedAt?: number;
+  completedAt?: number;
+  updatedAt: number;
+  error?: string;
+}
+
+export type RawMessagesSQLiteMigrationResult =
+  | {
+      status: "completed";
+      migratedMessages: number;
+      migratedSummaries: number;
+      state: RawMessagesSQLiteMigrationState;
+    }
+  | {
+      status: "skipped";
+      reason: "not_available" | "already_completed" | "already_running";
+      migratedMessages: number;
+      migratedSummaries: number;
+      state?: RawMessagesSQLiteMigrationState;
+    }
+  | {
+      status: "failed";
+      migratedMessages: number;
+      migratedSummaries: number;
+      error: string;
+      state: RawMessagesSQLiteMigrationState;
+    };
+
+const migrationPromises = new Map<
+  string,
+  Promise<RawMessagesSQLiteMigrationResult>
+>();
+
+function hasTauriGlobal(): boolean {
+  return typeof window !== "undefined" && "__TAURI__" in window;
+}
+
+function currentUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function shouldUseSQLiteRawMessageStorage(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  if (hasTauriGlobal()) {
+    return true;
+  }
+  return (
+    typeof process !== "undefined" &&
+    (process.env.TAURI_MODE === "tauri" || process.env.IS_TAURI === "true")
+  );
+}
+
+export function getRawMessagesSQLiteMigrationStorageKey(
+  userId: string,
+): string {
+  return `openloomi:raw-messages-sqlite-migration:v${SQLITE_RAW_MESSAGES_MIGRATION_VERSION}:${userId}`;
+}
+
+function getMigrationStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getRawMessagesSQLiteMigrationState(
+  userId: string,
+): RawMessagesSQLiteMigrationState | null {
+  const storage = getMigrationStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const raw = storage.getItem(
+      getRawMessagesSQLiteMigrationStorageKey(userId),
+    );
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<RawMessagesSQLiteMigrationState>;
+    if (
+      parsed.version !== SQLITE_RAW_MESSAGES_MIGRATION_VERSION ||
+      parsed.userId !== userId ||
+      typeof parsed.status !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      version: SQLITE_RAW_MESSAGES_MIGRATION_VERSION,
+      userId,
+      status: parsed.status as RawMessagesSQLiteMigrationStatus,
+      migratedMessages: Number(parsed.migratedMessages ?? 0),
+      migratedSummaries: Number(parsed.migratedSummaries ?? 0),
+      startedAt:
+        typeof parsed.startedAt === "number" ? parsed.startedAt : undefined,
+      completedAt:
+        typeof parsed.completedAt === "number" ? parsed.completedAt : undefined,
+      updatedAt:
+        typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      error: typeof parsed.error === "string" ? parsed.error : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function setRawMessagesSQLiteMigrationState(
+  state: RawMessagesSQLiteMigrationState,
+): void {
+  const storage = getMigrationStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      getRawMessagesSQLiteMigrationStorageKey(state.userId),
+      JSON.stringify(state),
+    );
+  } catch {
+    // Migration status is an optimization; storage failures should not block use.
+  }
+}
+
+export function clearRawMessagesSQLiteMigrationState(userId: string): void {
+  const storage = getMigrationStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.removeItem(getRawMessagesSQLiteMigrationStorageKey(userId));
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
+function isFreshRunningMigration(
+  state: RawMessagesSQLiteMigrationState | null,
+): boolean {
+  return (
+    state?.status === "running" &&
+    Date.now() - state.updatedAt < SQLITE_RAW_MESSAGES_MIGRATION_STALE_MS
+  );
+}
+
+async function requestSQLiteRawMessages<T>(
+  action: string,
+  payload: Record<string, unknown> = {},
+): Promise<T> {
+  const response = await fetch(SQLITE_RAW_MESSAGES_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      action,
+      ...payload,
+    }),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || data?.success === false) {
+    throw new Error(
+      typeof data?.message === "string"
+        ? data.message
+        : `SQLite raw message API failed: ${response.status}`,
+    );
+  }
+  return data as T;
+}
+
+export async function sqliteStoreRawMessagesFromInsight(
+  userId: string,
+  messages: Array<{
+    messageId: string;
+    platform: string;
+    botId: string;
+    channel?: string;
+    person?: string;
+    timestamp: number;
+    content: string;
+    attachments?: Array<{
+      name: string;
+      url: string;
+      contentType?: string;
+      sizeBytes?: number;
+    }>;
+    embedding?: number[];
+    embeddingModel?: string;
+    embeddingContentHash?: string;
+    embeddingDimensions?: number;
+    embeddingUpdatedAt?: number;
+    metadata?: Record<string, any>;
+  }>,
+): Promise<{ success: boolean; stored: number; errors: number }> {
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    stored: number;
+    errors: number;
+  }>("store", {
+    messages: messages.map((message) => ({
+      ...message,
+      userId,
+      createdAt: currentUnixSeconds(),
+    })),
+  });
+  return response;
+}
+
+export async function sqliteQueryRawMessages(
+  query: RawMessageQuery,
+): Promise<SQLiteRawMessageQueryResultItem[]> {
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    items: SQLiteRawMessageQueryResultItem[];
+  }>("query", { query });
+  return response.items ?? [];
+}
+
+export async function sqliteQueryRawMessagesGrouped(
+  query: RawMessageQuery,
+): Promise<Record<string, RawMessage[]>> {
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    grouped: Record<string, RawMessage[]>;
+  }>("queryGrouped", { query });
+  return response.grouped ?? {};
+}
+
+export async function sqliteGetRawMessagesStats(): Promise<{
+  totalMessages: number;
+  messagesByPlatform: Record<string, number>;
+  messagesByBot: Record<string, number>;
+  oldestMessage?: number;
+  newestMessage?: number;
+}> {
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    stats: {
+      totalMessages: number;
+      messagesByPlatform: Record<string, number>;
+      messagesByBot: Record<string, number>;
+      oldestMessage?: number;
+      newestMessage?: number;
+    };
+  }>("stats");
+  return response.stats;
+}
+
+export async function sqliteClearOldRawMessages(
+  olderThan: number,
+  _userId?: string,
+): Promise<{ success: boolean; deleted: number }> {
+  return requestSQLiteRawMessages("clearOld", { olderThan });
+}
+
+export async function sqliteRunMemoryForgettingCycleForUser(
+  _userId: string,
+  options?: {
+    dryRun?: boolean;
+    hardDeleteArchivedOlderThan?: number;
+  },
+): Promise<{
+  success: boolean;
+  status?: "success" | "skipped_locked";
+  createdSummaries?: number;
+  transitionedRecords?: number;
+  archivedDetailRecords?: number;
+  hardDeletedRecords?: number;
+  error?: string;
+}> {
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    result: {
+      status: "success" | "skipped_locked";
+      createdSummaries: number;
+      transitionedRecords: number;
+      archivedDetailRecords: number;
+      hardDeletedRecords: number;
+    };
+  }>("forgettingCycle", { options });
+  return {
+    success: true,
+    status: response.result.status,
+    createdSummaries: response.result.createdSummaries,
+    transitionedRecords: response.result.transitionedRecords,
+    archivedDetailRecords: response.result.archivedDetailRecords,
+    hardDeletedRecords: response.result.hardDeletedRecords,
+  };
+}
+
+class SQLiteApiRawMessageManager {
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    const items = await sqliteQueryRawMessages(query);
+    return items.filter(
+      (item): item is RawMessage & { sourceType: "raw" } =>
+        item.sourceType === "raw",
+    );
+  }
+
+  async updateMessageEmbeddings(
+    updates: RawMessageEmbeddingUpdate[],
+    userId?: string,
+  ): Promise<number> {
+    const response = await requestSQLiteRawMessages<{
+      success: boolean;
+      updated: number;
+    }>("updateEmbeddings", {
+      updates,
+      userId,
+    });
+    return response.updated;
+  }
+}
+
+export async function sqliteRunRawMessageEmbeddingDreamForUser(
+  userId: string,
+  options: Omit<RunRawMessageEmbeddingDreamInput, "userId">,
+) {
+  const { runRawMessageEmbeddingDream } = await import("./embedding");
+  return runRawMessageEmbeddingDream(new SQLiteApiRawMessageManager(), {
+    userId,
+    ...options,
+  });
+}
+
+export async function sqliteSearchRawMessagesSemanticallyForUser(
+  userId: string,
+  options: Omit<RawMessageSemanticSearchInput, "userId">,
+) {
+  const query = options.query.trim();
+  if (!query) {
+    return [];
+  }
+
+  const queryEmbedding = await options.embedQuery(query);
+  if (queryEmbedding.length === 0) {
+    return [];
+  }
+
+  const response = await requestSQLiteRawMessages<{
+    success: boolean;
+    items: unknown[];
+  }>("semanticSearch", {
+    queryEmbedding,
+    options: {
+      embeddingModel: options.embeddingModel,
+      limit: options.limit,
+      scanLimit: options.scanLimit,
+      threshold: options.threshold,
+      includeArchived: options.includeArchived,
+      platform: options.platform,
+      botId: options.botId,
+      channel: options.channel,
+      person: options.person,
+      startTime: options.startTime,
+      endTime: options.endTime,
+    },
+  });
+  return response.items ?? [];
+}
+
+export async function migrateIndexedDBRawMessagesToSQLite(options: {
+  userId: string;
+  batchSize?: number;
+  includeArchived?: boolean;
+  includeSummaries?: boolean;
+  onProgress?: (progress: {
+    migratedMessages: number;
+    migratedSummaries: number;
+    done: boolean;
+  }) => void;
+}): Promise<{
+  success: boolean;
+  migratedMessages: number;
+  migratedSummaries: number;
+}> {
+  if (!shouldUseSQLiteRawMessageStorage()) {
+    return {
+      success: false,
+      migratedMessages: 0,
+      migratedSummaries: 0,
+    };
+  }
+
+  const { getIndexedDBManager } = await import("./manager");
+  const manager = getIndexedDBManager();
+  await manager.init();
+
+  const batchSize = Math.max(1, Math.min(500, options.batchSize ?? 100));
+  let offset = 0;
+  let migratedMessages = 0;
+  let migratedSummaries = 0;
+
+  while (true) {
+    const messages = await manager.queryMessages({
+      userId: options.userId,
+      includeArchived: options.includeArchived ?? true,
+      reverse: false,
+      offset,
+      pageSize: batchSize,
+    });
+    if (messages.length === 0) {
+      break;
+    }
+
+    const response = await requestSQLiteRawMessages<{
+      success: boolean;
+      stored: number;
+    }>("store", { messages });
+    migratedMessages += response.stored ?? messages.length;
+    offset += messages.length;
+    options.onProgress?.({
+      migratedMessages,
+      migratedSummaries,
+      done: false,
+    });
+
+    if (messages.length < batchSize) {
+      break;
+    }
+  }
+
+  if (options.includeSummaries !== false) {
+    offset = 0;
+    while (typeof (manager as any).querySummaries === "function") {
+      const summaries = await (manager as any).querySummaries({
+        userId: options.userId,
+        reverse: false,
+        offset,
+        pageSize: batchSize,
+      });
+      if (!Array.isArray(summaries) || summaries.length === 0) {
+        break;
+      }
+
+      await requestSQLiteRawMessages("upsertSummaries", { summaries });
+      migratedSummaries += summaries.length;
+      offset += summaries.length;
+      options.onProgress?.({
+        migratedMessages,
+        migratedSummaries,
+        done: false,
+      });
+
+      if (summaries.length < batchSize) {
+        break;
+      }
+    }
+  }
+
+  options.onProgress?.({
+    migratedMessages,
+    migratedSummaries,
+    done: true,
+  });
+
+  return {
+    success: true,
+    migratedMessages,
+    migratedSummaries,
+  };
+}
+
+export async function ensureRawMessagesSQLiteMigration(options: {
+  userId: string;
+  batchSize?: number;
+  includeArchived?: boolean;
+  includeSummaries?: boolean;
+  onProgress?: (state: RawMessagesSQLiteMigrationState) => void;
+}): Promise<RawMessagesSQLiteMigrationResult> {
+  if (!shouldUseSQLiteRawMessageStorage()) {
+    return {
+      status: "skipped",
+      reason: "not_available",
+      migratedMessages: 0,
+      migratedSummaries: 0,
+    };
+  }
+
+  const existing = getRawMessagesSQLiteMigrationState(options.userId);
+  if (existing?.status === "completed") {
+    return {
+      status: "skipped",
+      reason: "already_completed",
+      migratedMessages: existing.migratedMessages,
+      migratedSummaries: existing.migratedSummaries,
+      state: existing,
+    };
+  }
+
+  const inFlight = migrationPromises.get(options.userId);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  if (isFreshRunningMigration(existing)) {
+    return {
+      status: "skipped",
+      reason: "already_running",
+      migratedMessages: existing?.migratedMessages ?? 0,
+      migratedSummaries: existing?.migratedSummaries ?? 0,
+      state: existing ?? undefined,
+    };
+  }
+
+  const promise = runRawMessagesSQLiteMigration(options);
+  migrationPromises.set(options.userId, promise);
+
+  try {
+    return await promise;
+  } finally {
+    migrationPromises.delete(options.userId);
+  }
+}
+
+async function runRawMessagesSQLiteMigration(options: {
+  userId: string;
+  batchSize?: number;
+  includeArchived?: boolean;
+  includeSummaries?: boolean;
+  onProgress?: (state: RawMessagesSQLiteMigrationState) => void;
+}): Promise<RawMessagesSQLiteMigrationResult> {
+  const now = Date.now();
+  let state: RawMessagesSQLiteMigrationState = {
+    version: SQLITE_RAW_MESSAGES_MIGRATION_VERSION,
+    userId: options.userId,
+    status: "running",
+    migratedMessages: 0,
+    migratedSummaries: 0,
+    startedAt: now,
+    updatedAt: now,
+  };
+
+  const updateState = (patch: Partial<RawMessagesSQLiteMigrationState>) => {
+    state = {
+      ...state,
+      ...patch,
+      updatedAt: Date.now(),
+    };
+    setRawMessagesSQLiteMigrationState(state);
+    options.onProgress?.(state);
+  };
+
+  updateState({});
+
+  try {
+    const result = await migrateIndexedDBRawMessagesToSQLite({
+      userId: options.userId,
+      batchSize: options.batchSize,
+      includeArchived: options.includeArchived,
+      includeSummaries: options.includeSummaries,
+      onProgress: (progress) => {
+        updateState({
+          migratedMessages: progress.migratedMessages,
+          migratedSummaries: progress.migratedSummaries,
+        });
+      },
+    });
+
+    updateState({
+      status: "completed",
+      migratedMessages: result.migratedMessages,
+      migratedSummaries: result.migratedSummaries,
+      completedAt: Date.now(),
+      error: undefined,
+    });
+
+    return {
+      status: "completed",
+      migratedMessages: result.migratedMessages,
+      migratedSummaries: result.migratedSummaries,
+      state,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    updateState({
+      status: "failed",
+      error: message,
+    });
+
+    return {
+      status: "failed",
+      migratedMessages: state.migratedMessages,
+      migratedSummaries: state.migratedSummaries,
+      error: message,
+      state,
+    };
+  }
+}

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -83,6 +83,10 @@ export function shouldUseSQLiteRawMessageStorage(): boolean {
   );
 }
 
+export function shouldUseRawMessageApiStorage(): boolean {
+  return typeof window !== "undefined";
+}
+
 export function getRawMessagesSQLiteMigrationStorageKey(
   userId: string,
 ): string {
@@ -205,7 +209,7 @@ async function requestSQLiteRawMessages<T>(
     throw new Error(
       typeof data?.message === "string"
         ? data.message
-        : `SQLite raw message API failed: ${response.status}`,
+        : `Raw message API failed: ${response.status}`,
     );
   }
   return data as T;

--- a/packages/indexeddb/src/storage.ts
+++ b/packages/indexeddb/src/storage.ts
@@ -1,0 +1,159 @@
+/**
+ * Storage contract for local raw message persistence.
+ *
+ * The current browser implementation lives in `manager.ts`, while the desktop
+ * SQLite implementation can implement this same shape without leaking storage
+ * details into client code.
+ */
+
+export type MemoryStage = "short" | "mid" | "long";
+export type MemorySummaryTier = "L1" | "L2" | "L3";
+
+export interface RawMessage {
+  id?: number;
+  messageId: string;
+  platform: string;
+  botId: string;
+  userId: string;
+  channel?: string;
+  person?: string;
+  timestamp: number;
+  content: string;
+  attachments?: Array<{
+    name: string;
+    url: string;
+    contentType?: string;
+    sizeBytes?: number;
+  }>;
+  embedding?: number[];
+  embeddingModel?: string;
+  embeddingContentHash?: string;
+  embeddingDimensions?: number;
+  embeddingUpdatedAt?: number;
+  metadata?: Record<string, any>;
+  createdAt: number;
+  memoryStage?: MemoryStage;
+  accessCount?: number;
+  lastAccessAt?: number;
+  importanceScore?: number;
+  archivedAt?: number;
+  isPinned?: boolean;
+  summaryRefId?: string;
+}
+
+export type GroupByType = "none" | "day" | "week" | "month";
+
+export interface RawMessageQuery {
+  userId?: string;
+  platform?: string;
+  botId?: string;
+  channel?: string;
+  person?: string;
+  startTime?: number;
+  endTime?: number;
+  keywords?: string[];
+  limit?: number;
+  offset?: number;
+  pageSize?: number;
+  groupBy?: GroupByType;
+  reverse?: boolean;
+  includeSummaryFallback?: boolean;
+  minRawResultsWithoutFallback?: number;
+  memoryStages?: MemoryStage[];
+  includeArchived?: boolean;
+}
+
+export interface MemorySummaryRecord {
+  summaryId: string;
+  userId: string;
+  summaryTier: MemorySummaryTier;
+  sourceTier: MemoryStage;
+  startTimestamp: number;
+  endTimestamp: number;
+  messageCount: number;
+  sourceRecordIds: string[];
+  keyPoints: string[];
+  keywords: string[];
+  keywordsText?: string;
+  summaryText: string;
+  dimensions?: Record<string, string | number | boolean | undefined>;
+  qualityScore?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface MemorySummaryQuery {
+  userId: string;
+  keywords?: string[];
+  startTime?: number;
+  endTime?: number;
+  reverse?: boolean;
+  summaryTiers?: MemorySummaryTier[];
+  pageSize?: number;
+  limit?: number;
+  offset?: number;
+  dimensions?: Record<string, string | number | boolean | undefined>;
+}
+
+export interface RawMessageEmbeddingUpdate {
+  messageId: string;
+  embedding: number[];
+  embeddingModel: string;
+  embeddingContentHash: string;
+  embeddingDimensions?: number;
+  embeddingUpdatedAt?: number;
+}
+
+export interface RawMessageStats {
+  totalMessages: number;
+  messagesByPlatform: Record<string, number>;
+  messagesByBot: Record<string, number>;
+  oldestMessage?: number;
+  newestMessage?: number;
+}
+
+export interface RawMessageStorage {
+  storeMessage(message: RawMessage): Promise<number>;
+  storeMessages(messages: RawMessage[]): Promise<number[]>;
+  queryMessages(query: RawMessageQuery): Promise<RawMessage[]>;
+  queryMessagesGrouped(
+    query: RawMessageQuery,
+  ): Promise<Record<string, RawMessage[]>>;
+  getStats(): Promise<RawMessageStats>;
+  getMessageById(messageId: string): Promise<RawMessage | null>;
+  deleteOldMessages(olderThan: number, userId?: string): Promise<number>;
+  clearAll(): Promise<void>;
+
+  upsertSummaries(summaries: MemorySummaryRecord[]): Promise<void>;
+  querySummaries(query: MemorySummaryQuery): Promise<MemorySummaryRecord[]>;
+
+  markMessagesAccessed(
+    messageIds: string[],
+    at?: number,
+    userId?: string,
+  ): Promise<number>;
+  promoteMessagesToStage(
+    messageIds: string[],
+    stage: MemoryStage,
+    options?: {
+      userId?: string;
+      summaryRefId?: string;
+      promotedAt?: number;
+    },
+  ): Promise<number>;
+  archiveMessages(
+    messageIds: string[],
+    archivedAt?: number,
+    userId?: string,
+  ): Promise<number>;
+  hardDeleteArchived(olderThan: number, userId?: string): Promise<number>;
+  updateMessageEmbeddings(
+    updates: RawMessageEmbeddingUpdate[],
+    userId?: string,
+  ): Promise<number>;
+}
+
+export interface RawMessageStorageManager extends RawMessageStorage {
+  init(): Promise<void>;
+  close(): Promise<void>;
+}

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openloomi/sqlite",
+  "version": "0.5.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./raw-message-manager": "./src/raw-message-manager.ts",
+    "./schema": "./src/schema.ts"
+  },
+  "dependencies": {
+    "@openloomi/indexeddb": "workspace:*",
+    "better-sqlite3": "^11.10.0",
+    "sqlite-vec": "0.1.7-alpha.2"
+  },
+  "devDependencies": {
+    "@openloomi/config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.13",
+    "typescript": "^5.6.3"
+  },
+  "scripts": {
+    "build": "echo no build needed"
+  }
+}

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./raw-message-manager";
+export * from "./schema";

--- a/packages/sqlite/src/raw-message-manager.ts
+++ b/packages/sqlite/src/raw-message-manager.ts
@@ -1,0 +1,1314 @@
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+import type {
+  MemoryStage,
+  MemorySummaryQuery,
+  MemorySummaryRecord,
+  RawMessage,
+  RawMessageEmbeddingUpdate,
+  RawMessageQuery,
+  RawMessageStats,
+  RawMessageStorageManager,
+} from "../../indexeddb/src/storage";
+import { initializeRawMessageSchema } from "./schema";
+
+type DatabaseLike = Database.Database;
+
+interface RawMessageRow {
+  id: number;
+  message_id: string;
+  platform: string;
+  bot_id: string;
+  user_id: string;
+  channel: string | null;
+  person: string | null;
+  timestamp: number;
+  content: string;
+  attachments: string | null;
+  embedding: Buffer | null;
+  embedding_model: string | null;
+  embedding_content_hash: string | null;
+  embedding_dimensions: number | null;
+  embedding_updated_at: number | null;
+  metadata: string | null;
+  created_at: number;
+  memory_stage: MemoryStage | null;
+  access_count: number | null;
+  last_access_at: number | null;
+  importance_score: number | null;
+  archived_at: number | null;
+  is_pinned: number | null;
+  summary_ref_id: string | null;
+}
+
+interface MemorySummaryRow {
+  summary_id: string;
+  user_id: string;
+  summary_tier: "L1" | "L2" | "L3";
+  source_tier: MemoryStage;
+  start_timestamp: number;
+  end_timestamp: number;
+  message_count: number;
+  source_record_ids: string | null;
+  key_points: string | null;
+  keywords: string | null;
+  keywords_text: string | null;
+  summary_text: string;
+  dimensions: string | null;
+  quality_score: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface SQLiteRawMessageManagerOptions {
+  dbPath?: string;
+  db?: DatabaseLike;
+  vectorDimensions?: number;
+  enableVectorSearch?: boolean;
+}
+
+export interface SQLiteRawMessageSemanticSearchInput {
+  userId: string;
+  queryEmbedding: number[];
+  embeddingModel?: string;
+  limit?: number;
+  scanLimit?: number;
+  threshold?: number;
+  includeArchived?: boolean;
+  platform?: string;
+  botId?: string;
+  channel?: string;
+  person?: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+export interface SQLiteRawMessageSemanticSearchResult {
+  type: "memory";
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: {
+    userId: string;
+    platform: string;
+    botId: string;
+    channel?: string;
+    person?: string;
+    timestamp: number;
+    memoryStage?: string;
+    embeddingModel?: string;
+  };
+  message: RawMessage;
+}
+
+function stringifyJson(value: unknown): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  return JSON.stringify(value);
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function floatArrayToBuffer(
+  values: number[] | undefined,
+): Buffer | null {
+  if (!values || values.length === 0) {
+    return null;
+  }
+  const buffer = Buffer.allocUnsafe(values.length * 4);
+  for (let index = 0; index < values.length; index += 1) {
+    buffer.writeFloatLE(values[index], index * 4);
+  }
+  return buffer;
+}
+
+export function bufferToFloatArray(
+  buffer: Buffer | null,
+): number[] | undefined {
+  if (!buffer || buffer.length === 0) {
+    return undefined;
+  }
+  const values: number[] = [];
+  for (let offset = 0; offset < buffer.length; offset += 4) {
+    values.push(buffer.readFloatLE(offset));
+  }
+  return values;
+}
+
+function toRawMessage(row: RawMessageRow): RawMessage {
+  return {
+    id: row.id,
+    messageId: row.message_id,
+    platform: row.platform,
+    botId: row.bot_id,
+    userId: row.user_id,
+    channel: row.channel ?? undefined,
+    person: row.person ?? undefined,
+    timestamp: row.timestamp,
+    content: row.content,
+    attachments: parseJson(row.attachments, undefined),
+    embedding: bufferToFloatArray(row.embedding),
+    embeddingModel: row.embedding_model ?? undefined,
+    embeddingContentHash: row.embedding_content_hash ?? undefined,
+    embeddingDimensions: row.embedding_dimensions ?? undefined,
+    embeddingUpdatedAt: row.embedding_updated_at ?? undefined,
+    metadata: parseJson(row.metadata, undefined),
+    createdAt: row.created_at,
+    memoryStage: row.memory_stage ?? "short",
+    accessCount: row.access_count ?? 0,
+    lastAccessAt: row.last_access_at ?? undefined,
+    importanceScore: row.importance_score ?? 0,
+    archivedAt: row.archived_at ?? undefined,
+    isPinned: Boolean(row.is_pinned ?? 0),
+    summaryRefId: row.summary_ref_id ?? undefined,
+  };
+}
+
+function toSummaryRecord(row: MemorySummaryRow): MemorySummaryRecord {
+  return {
+    summaryId: row.summary_id,
+    userId: row.user_id,
+    summaryTier: row.summary_tier,
+    sourceTier: row.source_tier,
+    startTimestamp: row.start_timestamp,
+    endTimestamp: row.end_timestamp,
+    messageCount: row.message_count,
+    sourceRecordIds: parseJson(row.source_record_ids, []),
+    keyPoints: parseJson(row.key_points, []),
+    keywords: parseJson(row.keywords, []),
+    keywordsText: row.keywords_text ?? undefined,
+    summaryText: row.summary_text,
+    dimensions: parseJson(row.dimensions, undefined),
+    qualityScore: row.quality_score ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function buildFtsQuery(keywords: string[]): string {
+  return keywords
+    .map((keyword) => keyword.trim())
+    .filter(Boolean)
+    .map((keyword) => `"${keyword.replace(/"/g, '""')}"`)
+    .join(" OR ");
+}
+
+function cosineSimilarity(vecA: number[], vecB: number[]): number {
+  if (vecA.length === 0 || vecA.length !== vecB.length) {
+    return Number.NaN;
+  }
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let index = 0; index < vecA.length; index += 1) {
+    dot += vecA[index] * vecB[index];
+    normA += vecA[index] * vecA[index];
+    normB += vecB[index] * vecB[index];
+  }
+
+  if (normA === 0 || normB === 0) {
+    return Number.NaN;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function normalizeTimestampToMs(value: number): number {
+  if (value < 1e11) {
+    return Math.floor(value * 1000);
+  }
+  return Math.floor(value);
+}
+
+function currentUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export class SQLiteRawMessageManager implements RawMessageStorageManager {
+  private readonly db: DatabaseLike;
+  private readonly ownsConnection: boolean;
+  private readonly vectorDimensions: number;
+  private readonly enableVectorSearch: boolean;
+  private initialized = false;
+  private vectorSearchAvailable = false;
+
+  constructor(options: SQLiteRawMessageManagerOptions | string = ":memory:") {
+    if (typeof options === "string") {
+      this.db = new Database(options);
+      this.ownsConnection = true;
+      this.vectorDimensions = 1536;
+      this.enableVectorSearch = true;
+      return;
+    }
+
+    if (options.db) {
+      this.db = options.db;
+      this.ownsConnection = false;
+      this.vectorDimensions = options.vectorDimensions ?? 1536;
+      this.enableVectorSearch = options.enableVectorSearch ?? true;
+      return;
+    }
+
+    this.db = new Database(options.dbPath ?? ":memory:");
+    this.ownsConnection = true;
+    this.vectorDimensions = options.vectorDimensions ?? 1536;
+    this.enableVectorSearch = options.enableVectorSearch ?? true;
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    initializeRawMessageSchema(this.db);
+    this.initializeVectorSearch();
+    this.initialized = true;
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsConnection) {
+      this.db.close();
+    }
+    this.initialized = false;
+  }
+
+  async storeMessage(message: RawMessage): Promise<number> {
+    await this.init();
+
+    const normalized = {
+      ...message,
+      memoryStage: message.memoryStage ?? "short",
+      accessCount: message.accessCount ?? 0,
+      importanceScore: message.importanceScore ?? 0,
+      isPinned: message.isPinned ?? false,
+      createdAt: message.createdAt ?? currentUnixSeconds(),
+    };
+
+    this.db
+      .prepare(
+        `
+          INSERT INTO raw_messages (
+            message_id, platform, bot_id, user_id, channel, person, timestamp,
+            content, attachments, embedding, embedding_model,
+            embedding_content_hash, embedding_dimensions, embedding_updated_at,
+            metadata, created_at, memory_stage, access_count, last_access_at,
+            importance_score, archived_at, is_pinned, summary_ref_id
+          )
+          VALUES (
+            @messageId, @platform, @botId, @userId, @channel, @person,
+            @timestamp, @content, @attachments, @embedding, @embeddingModel,
+            @embeddingContentHash, @embeddingDimensions, @embeddingUpdatedAt,
+            @metadata, @createdAt, @memoryStage, @accessCount, @lastAccessAt,
+            @importanceScore, @archivedAt, @isPinned, @summaryRefId
+          )
+          ON CONFLICT(message_id) DO UPDATE SET
+            platform = excluded.platform,
+            bot_id = excluded.bot_id,
+            user_id = excluded.user_id,
+            channel = excluded.channel,
+            person = excluded.person,
+            timestamp = excluded.timestamp,
+            content = excluded.content,
+            attachments = excluded.attachments,
+            embedding = excluded.embedding,
+            embedding_model = excluded.embedding_model,
+            embedding_content_hash = excluded.embedding_content_hash,
+            embedding_dimensions = excluded.embedding_dimensions,
+            embedding_updated_at = excluded.embedding_updated_at,
+            metadata = excluded.metadata,
+            created_at = excluded.created_at,
+            memory_stage = excluded.memory_stage,
+            access_count = excluded.access_count,
+            last_access_at = excluded.last_access_at,
+            importance_score = excluded.importance_score,
+            archived_at = excluded.archived_at,
+            is_pinned = excluded.is_pinned,
+            summary_ref_id = excluded.summary_ref_id
+        `,
+      )
+      .run({
+        messageId: normalized.messageId,
+        platform: normalized.platform,
+        botId: normalized.botId,
+        userId: normalized.userId,
+        channel: normalized.channel ?? null,
+        person: normalized.person ?? null,
+        timestamp: normalized.timestamp,
+        content: normalized.content,
+        attachments: stringifyJson(normalized.attachments),
+        embedding: floatArrayToBuffer(normalized.embedding),
+        embeddingModel: normalized.embeddingModel ?? null,
+        embeddingContentHash: normalized.embeddingContentHash ?? null,
+        embeddingDimensions:
+          normalized.embeddingDimensions ??
+          normalized.embedding?.length ??
+          null,
+        embeddingUpdatedAt: normalized.embeddingUpdatedAt ?? null,
+        metadata: stringifyJson(normalized.metadata),
+        createdAt: normalized.createdAt,
+        memoryStage: normalized.memoryStage,
+        accessCount: normalized.accessCount,
+        lastAccessAt: normalized.lastAccessAt ?? null,
+        importanceScore: normalized.importanceScore,
+        archivedAt: normalized.archivedAt ?? null,
+        isPinned: normalized.isPinned ? 1 : 0,
+        summaryRefId: normalized.summaryRefId ?? null,
+      });
+
+    const row = this.db
+      .prepare("SELECT id FROM raw_messages WHERE message_id = ?")
+      .get(normalized.messageId) as { id: number };
+    this.upsertVectorForMessage(normalized.messageId, normalized.embedding);
+    return row.id;
+  }
+
+  async storeMessages(messages: RawMessage[]): Promise<number[]> {
+    await this.init();
+    const ids: number[] = [];
+    const insertMany = this.db.transaction((items: RawMessage[]) => {
+      for (const message of items) {
+        const existing = this.storeMessageSync(message);
+        ids.push(existing);
+      }
+    });
+    insertMany(messages);
+    return ids;
+  }
+
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    await this.init();
+
+    const where: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (query.userId) {
+      where.push("user_id = @userId");
+      params.userId = query.userId;
+    }
+    if (query.platform) {
+      where.push("platform = @platform");
+      params.platform = query.platform;
+    }
+    if (query.botId) {
+      where.push("bot_id = @botId");
+      params.botId = query.botId;
+    }
+    if (query.channel) {
+      where.push("lower(coalesce(channel, '')) LIKE @channel ESCAPE '\\'");
+      params.channel = `%${escapeLike(query.channel.toLowerCase())}%`;
+    }
+    if (query.person) {
+      where.push("lower(coalesce(person, '')) LIKE @person ESCAPE '\\'");
+      params.person = `%${escapeLike(query.person.toLowerCase())}%`;
+    }
+    if (query.startTime !== undefined) {
+      where.push("timestamp >= @startTime");
+      params.startTime = query.startTime;
+    }
+    if (query.endTime !== undefined) {
+      where.push("timestamp < @endTime");
+      params.endTime = query.endTime;
+    }
+    if (query.memoryStages?.length) {
+      where.push(
+        `coalesce(memory_stage, 'short') IN (${query.memoryStages
+          .map((_, index) => `@memoryStage${index}`)
+          .join(", ")})`,
+      );
+      query.memoryStages.forEach((stage, index) => {
+        params[`memoryStage${index}`] = stage;
+      });
+    }
+    if (!query.includeArchived) {
+      where.push("archived_at IS NULL");
+    }
+    if (query.keywords?.length) {
+      const ftsQuery = buildFtsQuery(query.keywords);
+      if (ftsQuery) {
+        where.push(
+          "id IN (SELECT rowid FROM raw_messages_fts WHERE raw_messages_fts MATCH @ftsQuery)",
+        );
+        params.ftsQuery = ftsQuery;
+      }
+    }
+
+    const order = query.reverse ? "DESC" : "ASC";
+    params.limit = query.pageSize ?? query.limit ?? 50;
+    params.offset = query.offset ?? 0;
+
+    const sql = `
+      SELECT *
+      FROM raw_messages
+      ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY timestamp ${order}, id ${order}
+      LIMIT @limit OFFSET @offset
+    `;
+
+    return (this.db.prepare(sql).all(params) as RawMessageRow[]).map(
+      toRawMessage,
+    );
+  }
+
+  async queryMessagesGrouped(
+    query: RawMessageQuery,
+  ): Promise<Record<string, RawMessage[]>> {
+    const messages = await this.queryMessages({
+      ...query,
+      limit: query.limit ? query.limit * 10 : 1000,
+    });
+
+    if (messages.length === 0 || query.groupBy === "none" || !query.groupBy) {
+      return { all: messages };
+    }
+
+    const grouped: Record<string, RawMessage[]> = {};
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    for (const message of messages) {
+      const date = new Date(message.timestamp * 1000);
+      let key = date.toISOString().split("T")[0];
+
+      if (query.groupBy === "day") {
+        const localDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate(),
+        );
+        if (localDate.getTime() === today.getTime()) {
+          key = "Today";
+        } else if (localDate.getTime() === yesterday.getTime()) {
+          key = "Yesterday";
+        }
+      } else if (query.groupBy === "week") {
+        const dayOfWeek = date.getDay();
+        const monday = new Date(date);
+        monday.setDate(date.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1));
+        key = `Week of ${monday.toISOString().split("T")[0]}`;
+      } else if (query.groupBy === "month") {
+        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+          2,
+          "0",
+        )}`;
+      }
+
+      grouped[key] = grouped[key] ?? [];
+      grouped[key].push(message);
+    }
+
+    const sorted: Record<string, RawMessage[]> = {};
+    for (const key of Object.keys(grouped).sort((a, b) => {
+      if (a === "Today") return -1;
+      if (b === "Today") return 1;
+      if (a === "Yesterday") return -1;
+      if (b === "Yesterday") return 1;
+      return b.localeCompare(a);
+    })) {
+      sorted[key] = grouped[key];
+    }
+    return sorted;
+  }
+
+  async getStats(): Promise<RawMessageStats> {
+    await this.init();
+    const total = this.db
+      .prepare("SELECT COUNT(*) AS count FROM raw_messages")
+      .get() as { count: number };
+    const platforms = this.db
+      .prepare(
+        "SELECT platform, COUNT(*) AS count FROM raw_messages GROUP BY platform",
+      )
+      .all() as Array<{ platform: string; count: number }>;
+    const bots = this.db
+      .prepare(
+        "SELECT bot_id, COUNT(*) AS count FROM raw_messages GROUP BY bot_id",
+      )
+      .all() as Array<{ bot_id: string; count: number }>;
+    const times = this.db
+      .prepare(
+        "SELECT MIN(timestamp) AS oldest, MAX(timestamp) AS newest FROM raw_messages",
+      )
+      .get() as { oldest: number | null; newest: number | null };
+
+    return {
+      totalMessages: total.count,
+      messagesByPlatform: Object.fromEntries(
+        platforms.map((row) => [row.platform, row.count]),
+      ),
+      messagesByBot: Object.fromEntries(
+        bots.map((row) => [row.bot_id, row.count]),
+      ),
+      oldestMessage: times.oldest ?? undefined,
+      newestMessage: times.newest ?? undefined,
+    };
+  }
+
+  async getMessageById(messageId: string): Promise<RawMessage | null> {
+    await this.init();
+    const row = this.db
+      .prepare("SELECT * FROM raw_messages WHERE message_id = ?")
+      .get(messageId) as RawMessageRow | undefined;
+    return row ? toRawMessage(row) : null;
+  }
+
+  async deleteOldMessages(olderThan: number, userId?: string): Promise<number> {
+    await this.init();
+    const result = userId
+      ? this.db
+          .prepare(
+            "DELETE FROM raw_messages WHERE created_at < ? AND user_id = ?",
+          )
+          .run(olderThan, userId)
+      : this.db
+          .prepare("DELETE FROM raw_messages WHERE created_at < ?")
+          .run(olderThan);
+    return result.changes;
+  }
+
+  async clearAll(): Promise<void> {
+    await this.init();
+    this.db.exec(`
+      DELETE FROM raw_messages;
+      DELETE FROM memory_summaries;
+      INSERT INTO raw_messages_fts(raw_messages_fts) VALUES('rebuild');
+    `);
+    this.clearVectorTable();
+  }
+
+  async upsertSummaries(summaries: MemorySummaryRecord[]): Promise<void> {
+    await this.init();
+    const stmt = this.db.prepare(`
+      INSERT INTO memory_summaries (
+        summary_id, user_id, summary_tier, source_tier, start_timestamp,
+        end_timestamp, message_count, source_record_ids, key_points, keywords,
+        keywords_text, summary_text, dimensions, quality_score, created_at,
+        updated_at
+      )
+      VALUES (
+        @summaryId, @userId, @summaryTier, @sourceTier, @startTimestamp,
+        @endTimestamp, @messageCount, @sourceRecordIds, @keyPoints, @keywords,
+        @keywordsText, @summaryText, @dimensions, @qualityScore, @createdAt,
+        @updatedAt
+      )
+      ON CONFLICT(summary_id) DO UPDATE SET
+        user_id = excluded.user_id,
+        summary_tier = excluded.summary_tier,
+        source_tier = excluded.source_tier,
+        start_timestamp = excluded.start_timestamp,
+        end_timestamp = excluded.end_timestamp,
+        message_count = excluded.message_count,
+        source_record_ids = excluded.source_record_ids,
+        key_points = excluded.key_points,
+        keywords = excluded.keywords,
+        keywords_text = excluded.keywords_text,
+        summary_text = excluded.summary_text,
+        dimensions = excluded.dimensions,
+        quality_score = excluded.quality_score,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `);
+
+    const upsertMany = this.db.transaction((items: MemorySummaryRecord[]) => {
+      for (const summary of items) {
+        stmt.run({
+          summaryId: summary.summaryId,
+          userId: summary.userId,
+          summaryTier: summary.summaryTier,
+          sourceTier: summary.sourceTier,
+          startTimestamp: summary.startTimestamp,
+          endTimestamp: summary.endTimestamp,
+          messageCount: summary.messageCount,
+          sourceRecordIds: stringifyJson(summary.sourceRecordIds),
+          keyPoints: stringifyJson(summary.keyPoints),
+          keywords: stringifyJson(summary.keywords),
+          keywordsText: summary.keywordsText ?? summary.keywords.join(" "),
+          summaryText: summary.summaryText,
+          dimensions: stringifyJson(summary.dimensions),
+          qualityScore: summary.qualityScore ?? null,
+          createdAt: summary.createdAt,
+          updatedAt: summary.updatedAt,
+        });
+      }
+    });
+    upsertMany(summaries);
+  }
+
+  async querySummaries(
+    query: MemorySummaryQuery,
+  ): Promise<MemorySummaryRecord[]> {
+    await this.init();
+
+    const where: string[] = ["user_id = @userId"];
+    const params: Record<string, unknown> = { userId: query.userId };
+
+    if (query.summaryTiers?.length) {
+      where.push(
+        `summary_tier IN (${query.summaryTiers
+          .map((_, index) => `@summaryTier${index}`)
+          .join(", ")})`,
+      );
+      query.summaryTiers.forEach((tier, index) => {
+        params[`summaryTier${index}`] = tier;
+      });
+    }
+    if (query.startTime !== undefined) {
+      where.push("end_timestamp >= @startTime");
+      params.startTime = query.startTime;
+    }
+    if (query.endTime !== undefined) {
+      where.push("start_timestamp < @endTime");
+      params.endTime = query.endTime;
+    }
+    if (query.keywords?.length) {
+      query.keywords.forEach((keyword, index) => {
+        where.push(
+          `(lower(coalesce(keywords_text, '')) LIKE @keyword${index} ESCAPE '\\' OR lower(summary_text) LIKE @keyword${index} ESCAPE '\\')`,
+        );
+        params[`keyword${index}`] = `%${escapeLike(keyword.toLowerCase())}%`;
+      });
+    }
+
+    const order = (query.reverse ?? true) ? "DESC" : "ASC";
+    const rows = this.db
+      .prepare(
+        `
+          SELECT *
+          FROM memory_summaries
+          WHERE ${where.join(" AND ")}
+          ORDER BY end_timestamp ${order}
+        `,
+      )
+      .all(params) as MemorySummaryRow[];
+
+    let summaries = rows.map(toSummaryRecord);
+    if (query.dimensions) {
+      summaries = summaries.filter((summary) => {
+        const dimensions = summary.dimensions ?? {};
+        return Object.entries(query.dimensions ?? {}).every(
+          ([key, value]) => value === undefined || dimensions[key] === value,
+        );
+      });
+    }
+
+    const offset = query.offset ?? 0;
+    const pageSize = query.pageSize ?? query.limit ?? 50;
+    return summaries.slice(offset, offset + pageSize);
+  }
+
+  async markMessagesAccessed(
+    messageIds: string[],
+    at = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    await this.init();
+    return this.updateMessagesByMessageIds(
+      messageIds,
+      `
+        access_count = coalesce(access_count, 0) + 1,
+        last_access_at = @at
+      `,
+      { at },
+      userId,
+    );
+  }
+
+  async promoteMessagesToStage(
+    messageIds: string[],
+    stage: MemoryStage,
+    options?: { userId?: string; summaryRefId?: string; promotedAt?: number },
+  ): Promise<number> {
+    await this.init();
+    const existingRows = this.getRowsByMessageIds(messageIds, options?.userId);
+    let changed = 0;
+    const stmt = this.db.prepare(`
+      UPDATE raw_messages
+      SET memory_stage = @stage,
+          summary_ref_id = @summaryRefId,
+          metadata = @metadata
+      WHERE message_id = @messageId
+    `);
+    const updateMany = this.db.transaction((rows: RawMessageRow[]) => {
+      for (const row of rows) {
+        const metadata = {
+          ...parseJson<Record<string, unknown>>(row.metadata, {}),
+          ...(options?.promotedAt
+            ? { memoryPromotedAt: options.promotedAt }
+            : {}),
+        };
+        changed += stmt.run({
+          stage,
+          summaryRefId: options?.summaryRefId ?? row.summary_ref_id,
+          metadata: stringifyJson(metadata),
+          messageId: row.message_id,
+        }).changes;
+      }
+    });
+    updateMany(existingRows);
+    return changed;
+  }
+
+  async archiveMessages(
+    messageIds: string[],
+    archivedAt = Date.now(),
+    userId?: string,
+  ): Promise<number> {
+    await this.init();
+    return this.updateMessagesByMessageIds(
+      messageIds,
+      "archived_at = @archivedAt",
+      { archivedAt },
+      userId,
+    );
+  }
+
+  async hardDeleteArchived(
+    olderThan: number,
+    userId?: string,
+  ): Promise<number> {
+    await this.init();
+    const result = userId
+      ? this.db
+          .prepare(
+            "DELETE FROM raw_messages WHERE archived_at IS NOT NULL AND archived_at < ? AND user_id = ?",
+          )
+          .run(olderThan, userId)
+      : this.db
+          .prepare(
+            "DELETE FROM raw_messages WHERE archived_at IS NOT NULL AND archived_at < ?",
+          )
+          .run(olderThan);
+    return result.changes;
+  }
+
+  async updateMessageEmbeddings(
+    updates: RawMessageEmbeddingUpdate[],
+    userId?: string,
+  ): Promise<number> {
+    await this.init();
+    const stmt = this.db.prepare(`
+      UPDATE raw_messages
+      SET embedding = @embedding,
+          embedding_model = @embeddingModel,
+          embedding_content_hash = @embeddingContentHash,
+          embedding_dimensions = @embeddingDimensions,
+          embedding_updated_at = @embeddingUpdatedAt
+      WHERE message_id = @messageId
+      ${userId ? "AND user_id = @userId" : ""}
+    `);
+    let changed = 0;
+    const updateMany = this.db.transaction(
+      (items: RawMessageEmbeddingUpdate[]) => {
+        for (const update of items) {
+          changed += stmt.run({
+            messageId: update.messageId,
+            embedding: floatArrayToBuffer(update.embedding),
+            embeddingModel: update.embeddingModel,
+            embeddingContentHash: update.embeddingContentHash,
+            embeddingDimensions:
+              update.embeddingDimensions ?? update.embedding.length,
+            embeddingUpdatedAt: update.embeddingUpdatedAt ?? Date.now(),
+            userId,
+          }).changes;
+          this.upsertVectorForMessage(update.messageId, update.embedding);
+        }
+      },
+    );
+    updateMany(updates.filter((update) => update.messageId));
+    return changed;
+  }
+
+  private storeMessageSync(message: RawMessage): number {
+    const normalized = {
+      ...message,
+      memoryStage: message.memoryStage ?? "short",
+      accessCount: message.accessCount ?? 0,
+      importanceScore: message.importanceScore ?? 0,
+      isPinned: message.isPinned ?? false,
+      createdAt: message.createdAt ?? currentUnixSeconds(),
+    };
+
+    this.db
+      .prepare(
+        `
+          INSERT INTO raw_messages (
+            message_id, platform, bot_id, user_id, channel, person, timestamp,
+            content, attachments, embedding, embedding_model,
+            embedding_content_hash, embedding_dimensions, embedding_updated_at,
+            metadata, created_at, memory_stage, access_count, last_access_at,
+            importance_score, archived_at, is_pinned, summary_ref_id
+          )
+          VALUES (
+            @messageId, @platform, @botId, @userId, @channel, @person,
+            @timestamp, @content, @attachments, @embedding, @embeddingModel,
+            @embeddingContentHash, @embeddingDimensions, @embeddingUpdatedAt,
+            @metadata, @createdAt, @memoryStage, @accessCount, @lastAccessAt,
+            @importanceScore, @archivedAt, @isPinned, @summaryRefId
+          )
+          ON CONFLICT(message_id) DO UPDATE SET
+            platform = excluded.platform,
+            bot_id = excluded.bot_id,
+            user_id = excluded.user_id,
+            channel = excluded.channel,
+            person = excluded.person,
+            timestamp = excluded.timestamp,
+            content = excluded.content,
+            attachments = excluded.attachments,
+            embedding = excluded.embedding,
+            embedding_model = excluded.embedding_model,
+            embedding_content_hash = excluded.embedding_content_hash,
+            embedding_dimensions = excluded.embedding_dimensions,
+            embedding_updated_at = excluded.embedding_updated_at,
+            metadata = excluded.metadata,
+            created_at = excluded.created_at,
+            memory_stage = excluded.memory_stage,
+            access_count = excluded.access_count,
+            last_access_at = excluded.last_access_at,
+            importance_score = excluded.importance_score,
+            archived_at = excluded.archived_at,
+            is_pinned = excluded.is_pinned,
+            summary_ref_id = excluded.summary_ref_id
+        `,
+      )
+      .run({
+        messageId: normalized.messageId,
+        platform: normalized.platform,
+        botId: normalized.botId,
+        userId: normalized.userId,
+        channel: normalized.channel ?? null,
+        person: normalized.person ?? null,
+        timestamp: normalized.timestamp,
+        content: normalized.content,
+        attachments: stringifyJson(normalized.attachments),
+        embedding: floatArrayToBuffer(normalized.embedding),
+        embeddingModel: normalized.embeddingModel ?? null,
+        embeddingContentHash: normalized.embeddingContentHash ?? null,
+        embeddingDimensions:
+          normalized.embeddingDimensions ??
+          normalized.embedding?.length ??
+          null,
+        embeddingUpdatedAt: normalized.embeddingUpdatedAt ?? null,
+        metadata: stringifyJson(normalized.metadata),
+        createdAt: normalized.createdAt,
+        memoryStage: normalized.memoryStage,
+        accessCount: normalized.accessCount,
+        lastAccessAt: normalized.lastAccessAt ?? null,
+        importanceScore: normalized.importanceScore,
+        archivedAt: normalized.archivedAt ?? null,
+        isPinned: normalized.isPinned ? 1 : 0,
+        summaryRefId: normalized.summaryRefId ?? null,
+      });
+
+    const row = this.db
+      .prepare("SELECT id FROM raw_messages WHERE message_id = ?")
+      .get(normalized.messageId) as { id: number };
+    this.upsertVectorForMessage(normalized.messageId, normalized.embedding);
+    return row.id;
+  }
+
+  async searchMessagesSemantically(
+    input: SQLiteRawMessageSemanticSearchInput,
+  ): Promise<SQLiteRawMessageSemanticSearchResult[]> {
+    await this.init();
+
+    if (input.queryEmbedding.length === 0) {
+      return [];
+    }
+
+    if (
+      this.vectorSearchAvailable &&
+      input.queryEmbedding.length === this.vectorDimensions
+    ) {
+      return this.searchMessagesWithVectorTable(input);
+    }
+
+    return this.searchMessagesWithStoredEmbeddings(input);
+  }
+
+  private initializeVectorSearch(): void {
+    if (!this.enableVectorSearch) {
+      return;
+    }
+
+    try {
+      (sqliteVec as any).load(this.db);
+      this.db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS raw_messages_vec
+        USING vec0(
+          embedding float[${this.vectorDimensions}],
+          message_id TEXT PRIMARY KEY
+        )
+      `);
+      this.vectorSearchAvailable = true;
+      this.rebuildVectorTable();
+    } catch (error) {
+      this.vectorSearchAvailable = false;
+      console.warn("[SQLite Raw Messages] sqlite-vec unavailable:", error);
+    }
+  }
+
+  private upsertVectorForMessage(
+    messageId: string,
+    embedding: number[] | undefined,
+  ): void {
+    if (!this.vectorSearchAvailable) {
+      return;
+    }
+
+    const deleteStmt = this.db.prepare(
+      "DELETE FROM raw_messages_vec WHERE message_id = ?",
+    );
+    deleteStmt.run(messageId);
+
+    if (!embedding || embedding.length !== this.vectorDimensions) {
+      return;
+    }
+
+    this.db
+      .prepare(
+        `
+          INSERT INTO raw_messages_vec (embedding, message_id)
+          VALUES (?, ?)
+        `,
+      )
+      .run(floatArrayToBuffer(embedding), messageId);
+  }
+
+  private rebuildVectorTable(): void {
+    if (!this.vectorSearchAvailable) {
+      return;
+    }
+
+    this.clearVectorTable();
+    const rows = this.db
+      .prepare(
+        `
+          SELECT message_id, embedding, embedding_dimensions
+          FROM raw_messages
+          WHERE embedding IS NOT NULL
+            AND embedding_dimensions = ?
+        `,
+      )
+      .all(this.vectorDimensions) as Array<{
+      message_id: string;
+      embedding: Buffer;
+      embedding_dimensions: number;
+    }>;
+
+    const stmt = this.db.prepare(
+      "INSERT INTO raw_messages_vec (embedding, message_id) VALUES (?, ?)",
+    );
+    const insertMany = this.db.transaction(
+      (items: Array<{ message_id: string; embedding: Buffer }>) => {
+        for (const row of items) {
+          stmt.run(row.embedding, row.message_id);
+        }
+      },
+    );
+    insertMany(rows);
+  }
+
+  private clearVectorTable(): void {
+    if (!this.vectorSearchAvailable) {
+      return;
+    }
+    this.db.prepare("DELETE FROM raw_messages_vec").run();
+  }
+
+  private searchMessagesWithVectorTable(
+    input: SQLiteRawMessageSemanticSearchInput,
+  ): SQLiteRawMessageSemanticSearchResult[] {
+    const limit = Math.max(1, Math.floor(input.limit ?? 10));
+    const scanLimit = Math.max(
+      limit,
+      Math.floor(input.scanLimit ?? limit * 10),
+    );
+    const threshold = input.threshold ?? 0.7;
+    const rows = this.db
+      .prepare(
+        `
+          SELECT message_id, distance
+          FROM raw_messages_vec
+          WHERE embedding MATCH ?
+          ORDER BY distance
+          LIMIT ?
+        `,
+      )
+      .all(floatArrayToBuffer(input.queryEmbedding), scanLimit) as Array<{
+      message_id: string;
+      distance: number;
+    }>;
+
+    const byDistance = new Map(
+      rows.map((row) => [row.message_id, row.distance]),
+    );
+    const messages = this.getRowsByMessageIds(rows.map((row) => row.message_id))
+      .map(toRawMessage)
+      .filter((message) => this.matchesSemanticFilters(message, input));
+
+    return messages
+      .map((message) =>
+        this.toSemanticSearchResult(
+          message,
+          1 - (byDistance.get(message.messageId) ?? Number.POSITIVE_INFINITY),
+        ),
+      )
+      .filter(
+        (result): result is SQLiteRawMessageSemanticSearchResult =>
+          result !== null && result.similarity >= threshold,
+      )
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, limit);
+  }
+
+  private searchMessagesWithStoredEmbeddings(
+    input: SQLiteRawMessageSemanticSearchInput,
+  ): SQLiteRawMessageSemanticSearchResult[] {
+    const limit = Math.max(1, Math.floor(input.limit ?? 10));
+    const scanLimit = Math.max(
+      limit,
+      Math.floor(input.scanLimit ?? limit * 10),
+    );
+    const threshold = input.threshold ?? 0.7;
+
+    return this.queryMessagesSync({
+      userId: input.userId,
+      includeArchived: input.includeArchived ?? false,
+      reverse: true,
+      pageSize: scanLimit,
+      platform: input.platform,
+      botId: input.botId,
+      channel: input.channel,
+      person: input.person,
+      startTime: input.startTime,
+      endTime: input.endTime,
+    })
+      .map((message) => {
+        if (!message.embedding || message.embedding.length === 0) {
+          return null;
+        }
+        if (
+          input.embeddingModel &&
+          message.embeddingModel &&
+          message.embeddingModel !== input.embeddingModel
+        ) {
+          return null;
+        }
+        const similarity = cosineSimilarity(
+          input.queryEmbedding,
+          message.embedding,
+        );
+        return this.toSemanticSearchResult(message, similarity);
+      })
+      .filter(
+        (result): result is SQLiteRawMessageSemanticSearchResult =>
+          result !== null &&
+          Number.isFinite(result.similarity) &&
+          result.similarity >= threshold,
+      )
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, limit);
+  }
+
+  private matchesSemanticFilters(
+    message: RawMessage,
+    input: SQLiteRawMessageSemanticSearchInput,
+  ): boolean {
+    if (message.userId !== input.userId) {
+      return false;
+    }
+    if (!input.includeArchived && message.archivedAt !== undefined) {
+      return false;
+    }
+    if (
+      input.embeddingModel &&
+      message.embeddingModel !== input.embeddingModel
+    ) {
+      return false;
+    }
+    if (input.platform && message.platform !== input.platform) {
+      return false;
+    }
+    if (input.botId && message.botId !== input.botId) {
+      return false;
+    }
+    if (
+      input.channel &&
+      !message.channel?.toLowerCase().includes(input.channel.toLowerCase())
+    ) {
+      return false;
+    }
+    if (
+      input.person &&
+      !message.person?.toLowerCase().includes(input.person.toLowerCase())
+    ) {
+      return false;
+    }
+    if (input.startTime !== undefined && message.timestamp < input.startTime) {
+      return false;
+    }
+    if (input.endTime !== undefined && message.timestamp >= input.endTime) {
+      return false;
+    }
+    return true;
+  }
+
+  private toSemanticSearchResult(
+    message: RawMessage,
+    similarity: number,
+  ): SQLiteRawMessageSemanticSearchResult | null {
+    if (!Number.isFinite(similarity)) {
+      return null;
+    }
+
+    return {
+      type: "memory",
+      id: message.messageId,
+      content: message.archivedAt ? "" : message.content,
+      similarity,
+      metadata: {
+        userId: message.userId,
+        platform: message.platform,
+        botId: message.botId,
+        channel: message.channel,
+        person: message.person,
+        timestamp: normalizeTimestampToMs(message.timestamp),
+        memoryStage: message.memoryStage,
+        embeddingModel: message.embeddingModel,
+      },
+      message,
+    };
+  }
+
+  private queryMessagesSync(query: RawMessageQuery): RawMessage[] {
+    const where: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (query.userId) {
+      where.push("user_id = @userId");
+      params.userId = query.userId;
+    }
+    if (query.platform) {
+      where.push("platform = @platform");
+      params.platform = query.platform;
+    }
+    if (query.botId) {
+      where.push("bot_id = @botId");
+      params.botId = query.botId;
+    }
+    if (query.channel) {
+      where.push("lower(coalesce(channel, '')) LIKE @channel ESCAPE '\\'");
+      params.channel = `%${escapeLike(query.channel.toLowerCase())}%`;
+    }
+    if (query.person) {
+      where.push("lower(coalesce(person, '')) LIKE @person ESCAPE '\\'");
+      params.person = `%${escapeLike(query.person.toLowerCase())}%`;
+    }
+    if (query.startTime !== undefined) {
+      where.push("timestamp >= @startTime");
+      params.startTime = query.startTime;
+    }
+    if (query.endTime !== undefined) {
+      where.push("timestamp < @endTime");
+      params.endTime = query.endTime;
+    }
+    if (!query.includeArchived) {
+      where.push("archived_at IS NULL");
+    }
+
+    const order = query.reverse ? "DESC" : "ASC";
+    params.limit = query.pageSize ?? query.limit ?? 50;
+    params.offset = query.offset ?? 0;
+
+    return (
+      this.db
+        .prepare(
+          `
+            SELECT *
+            FROM raw_messages
+            ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+            ORDER BY timestamp ${order}, id ${order}
+            LIMIT @limit OFFSET @offset
+          `,
+        )
+        .all(params) as RawMessageRow[]
+    ).map(toRawMessage);
+  }
+
+  private getRowsByMessageIds(
+    messageIds: string[],
+    userId?: string,
+  ): RawMessageRow[] {
+    const ids = Array.from(new Set(messageIds.filter(Boolean)));
+    if (ids.length === 0) {
+      return [];
+    }
+    const params: Record<string, unknown> = {};
+    const placeholders = ids
+      .map((id, index) => {
+        params[`id${index}`] = id;
+        return `@id${index}`;
+      })
+      .join(", ");
+    if (userId) {
+      params.userId = userId;
+    }
+    return this.db
+      .prepare(
+        `
+          SELECT *
+          FROM raw_messages
+          WHERE message_id IN (${placeholders})
+          ${userId ? "AND user_id = @userId" : ""}
+        `,
+      )
+      .all(params) as RawMessageRow[];
+  }
+
+  private updateMessagesByMessageIds(
+    messageIds: string[],
+    setSql: string,
+    params: Record<string, unknown>,
+    userId?: string,
+  ): number {
+    const ids = Array.from(new Set(messageIds.filter(Boolean)));
+    if (ids.length === 0) {
+      return 0;
+    }
+    const queryParams = { ...params } as Record<string, unknown>;
+    const placeholders = ids
+      .map((id, index) => {
+        queryParams[`id${index}`] = id;
+        return `@id${index}`;
+      })
+      .join(", ");
+    if (userId) {
+      queryParams.userId = userId;
+    }
+    const result = this.db
+      .prepare(
+        `
+          UPDATE raw_messages
+          SET ${setSql}
+          WHERE message_id IN (${placeholders})
+          ${userId ? "AND user_id = @userId" : ""}
+        `,
+      )
+      .run(queryParams);
+    return result.changes;
+  }
+}

--- a/packages/sqlite/src/schema.ts
+++ b/packages/sqlite/src/schema.ts
@@ -1,0 +1,99 @@
+import type Database from "better-sqlite3";
+
+export const RAW_MESSAGES_SCHEMA_VERSION = 1;
+
+export function initializeRawMessageSchema(db: Database.Database): void {
+  db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 30000");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS raw_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      message_id TEXT UNIQUE NOT NULL,
+      platform TEXT NOT NULL,
+      bot_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      channel TEXT,
+      person TEXT,
+      timestamp INTEGER NOT NULL,
+      content TEXT NOT NULL,
+      attachments TEXT,
+      embedding BLOB,
+      embedding_model TEXT,
+      embedding_content_hash TEXT,
+      embedding_dimensions INTEGER,
+      embedding_updated_at INTEGER,
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      memory_stage TEXT DEFAULT 'short',
+      access_count INTEGER DEFAULT 0,
+      last_access_at INTEGER,
+      importance_score REAL DEFAULT 0,
+      archived_at INTEGER,
+      is_pinned INTEGER DEFAULT 0,
+      summary_ref_id TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_user_timestamp
+      ON raw_messages(user_id, timestamp);
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_user_memory_stage
+      ON raw_messages(user_id, memory_stage);
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_platform
+      ON raw_messages(platform);
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_bot_id
+      ON raw_messages(bot_id);
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_archived_at
+      ON raw_messages(archived_at);
+    CREATE INDEX IF NOT EXISTS idx_raw_messages_created_at
+      ON raw_messages(created_at);
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS raw_messages_fts USING fts5(
+      content,
+      channel,
+      person,
+      content='raw_messages',
+      content_rowid='id'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS raw_messages_ai AFTER INSERT ON raw_messages BEGIN
+      INSERT INTO raw_messages_fts(rowid, content, channel, person)
+      VALUES (new.id, new.content, new.channel, new.person);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS raw_messages_ad AFTER DELETE ON raw_messages BEGIN
+      INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content, channel, person)
+      VALUES('delete', old.id, old.content, old.channel, old.person);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS raw_messages_au AFTER UPDATE ON raw_messages BEGIN
+      INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content, channel, person)
+      VALUES('delete', old.id, old.content, old.channel, old.person);
+      INSERT INTO raw_messages_fts(rowid, content, channel, person)
+      VALUES (new.id, new.content, new.channel, new.person);
+    END;
+
+    CREATE TABLE IF NOT EXISTS memory_summaries (
+      summary_id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      summary_tier TEXT NOT NULL,
+      source_tier TEXT NOT NULL,
+      start_timestamp INTEGER NOT NULL,
+      end_timestamp INTEGER NOT NULL,
+      message_count INTEGER NOT NULL,
+      source_record_ids TEXT,
+      key_points TEXT,
+      keywords TEXT,
+      keywords_text TEXT,
+      summary_text TEXT NOT NULL,
+      dimensions TEXT,
+      quality_score REAL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_user_time
+      ON memory_summaries(user_id, end_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_user_tier
+      ON memory_summaries(user_id, summary_tier);
+  `);
+}

--- a/packages/sqlite/tsconfig.json
+++ b/packages/sqlite/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../config/src/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "..",
+    "incremental": false,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "noEmit": false
+  },
+  "include": ["src", "../indexeddb/src/storage.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@openloomi/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@openloomi/sqlite':
+        specifier: workspace:*
+        version: link:../../packages/sqlite
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -1130,6 +1133,28 @@ importers:
       '@openloomi/config':
         specifier: workspace:*
         version: link:../config
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/sqlite:
+    dependencies:
+      '@openloomi/indexeddb':
+        specifier: workspace:*
+        version: link:../indexeddb
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      sqlite-vec:
+        specifier: 0.1.7-alpha.2
+        version: 0.1.7-alpha.2
+    devDependencies:
+      '@openloomi/config':
+        specifier: workspace:*
+        version: link:../config
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Add `@openloomi/sqlite` raw message backend with SQLite schema, FTS5 search, and sqlite-vec semantic search
- Extract shared raw message storage contracts from `@openloomi/indexeddb`
- Add Tauri raw message API bridge backed by local SQLite
- Add IndexedDB -> SQLite migration with local migration state tracking
- Add PostgreSQL raw message and memory summary schema for web/server mode
- Add a unified raw message storage selector that uses SQLite in Tauri mode and PostgreSQL in web/server mode
- Route existing `@openloomi/indexeddb/client` APIs through the raw message API, with IndexedDB fallback on API failure
- Enable `/api/memory/search` to retrieve raw messages from the active backend using hybrid keyword + vector semantic search
- Add unit coverage for SQLite storage, PostgreSQL storage, migration, storage contract, and unified memory search

## Tests

- `pnpm --filter web tsc`
- `pnpm exec tsc -p packages/sqlite/tsconfig.json --noEmit`
- `pnpm exec prettier --check <changed code files>`
- Related unit tests
re #90