### PR TITLE
fix: update GitHub badge to point to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@
 
 OpenLoomi is an open-source AI workspace that runs on your desktop. It connects to the tools you already use — messaging apps, email, calendar, documents, project trackers — and builds a working memory of your people, projects, and decisions.
 
-### Download to Try
-
  <a href="https://openloomi.ai/docs/getting-started">
-    <img src="https://img.shields.io/github/v/tag/melandlabs/release?logo=github&label=Download&color=24C8D5" alt="Download" height="30" style="transform:scale(1);">
+    <img src="https://img.shields.io/github/v/tag/melandlabs/openloomi?logo=github&label=Download&color=24C8D5" alt="Download to Try" height="30" style="transform:scale(1);">
   </a>
 
 ## Features


### PR DESCRIPTION
## Summary
- Fix GitHub badge link from `melandlabs/release` to `melandlabs/openloomi`

## Test plan
- [ ] Verify badge renders correctly on the README
- [ ] Click badge to confirm it links to the correct GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)