### PR TITLE
fix: release workflow VERSION env var, cask filename, and add release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -855,6 +855,7 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/}"
           VERSION="${VERSION#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Version: $VERSION"
 
       - name: Download all artifacts
@@ -883,6 +884,7 @@ jobs:
           draft: false
           prerelease: false
           overwrite_files: true
+          generate_release_notes: true
           files: |
             artifacts/openloomi_${{ steps.version.outputs.version }}_aarch64.dmg
             artifacts/openloomi_${{ steps.version.outputs.version }}_amd64.dmg

--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Calculate SHA256 for Intel DMG
         id: sha_intel
         run: |
-          URL="https://github.com/melandlabs/openloomi/releases/download/v${{ steps.version.outputs.version }}/openloomi_${{ steps.version.outputs.version }}_x64.dmg"
+          URL="https://github.com/melandlabs/openloomi/releases/download/v${{ steps.version.outputs.version }}/openloomi_${{ steps.version.outputs.version }}_amd64.dmg"
           echo "Downloading from: $URL"
           SHA=$(curl -sfL "$URL" | shasum -a 256 | cut -d ' ' -f 1)
           if [ -z "$SHA" ]; then


### PR DESCRIPTION
## Summary

Three issues fixed:

1. **Missing `VERSION` env var** (`release.yml`) — The `Extract version from tag` step writes `VERSION` to `$GITHUB_OUTPUT` but never exports it as an env var. When the `Rename artifacts` step runs `mv openloomi_${VERSION}_aarch64.dmg`, `${VERSION}` is empty, producing files like `openloomi__aarch64.dmg` (double underscore). This caused `softprops/action-gh-release` to fail to attach files.

2. **Cask downloads wrong Intel filename** (`update-cask.yml:52`) — Looking for `openloomi_VERSION_x64.dmg` but release creates `openloomi_VERSION_amd64.dmg`.

3. **No release notes generated** — Added `generate_release_notes: true`.

## Root cause

`$GITHUB_OUTPUT` only sets output variables for interpolation in later steps (`${{ steps.version.outputs.version }}`), not shell env vars. The shell `${VERSION}` variable was never persisted between steps.

## Test plan

- [ ] Push a test tag and verify artifacts are named correctly (e.g., `openloomi_0.5.0_aarch64.dmg`)
- [ ] Verify release notes are auto-generated
- [ ] Verify Homebrew cask workflow downloads succeed

## Impact

The v0.5.0 release has no attached assets due to issue #1. A new release will need to be cut after merging this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)