### PR TITLE
feat: add OpenRouter models and memory update support

### DIFF
--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -2178,9 +2178,6 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
           "listKnowledgeBaseDocuments",
           "downloadInsightAttachment",
           "time",
-          ...(options?.executionReport?.enabled
-            ? ["submitExecutionReport"]
-            : []),
         ];
       } catch (error) {
         logger.error(
@@ -3157,9 +3154,6 @@ If you need to create any files during planning, use this directory.
           "listKnowledgeBaseDocuments",
           "downloadInsightAttachment",
           "time",
-          ...(options.executionReport?.enabled
-            ? ["submitExecutionReport"]
-            : []),
         ];
         logger.info(
           `[Claude ${session.id}] Execute: Business tools MCP server loaded with user session`,

--- a/apps/web/lib/cron/executor.ts
+++ b/apps/web/lib/cron/executor.ts
@@ -51,7 +51,6 @@ import { DEFAULT_AI_MODEL, AI_PROXY_BASE_URL } from "@/lib/env/constants";
 
 const MAX_JOB_HISTORY_TOKENS = 20_000;
 const JOB_HISTORY_LIMIT = 100;
-const SUBMIT_EXECUTION_REPORT_TOOL = "submitExecutionReport";
 
 // Reason passed to AbortController.abort() to distinguish between user stop and client disconnect
 export const REASON_USER_STOPPED = "user_stopped";
@@ -859,12 +858,6 @@ ${characterContextSection}`,
           : (userSettings?.aiSoulPrompt ?? null),
         language: userSettings?.language ?? null,
         timezone: context.timezone ?? null,
-        executionReport: {
-          enabled: true,
-          onSubmit: (report) => {
-            submittedStructuredData = report as StructuredExecutionOutput;
-          },
-        },
         abortController: options?.abortController,
       });
 

--- a/packages/ai/src/agent/billing/model-pricing.ts
+++ b/packages/ai/src/agent/billing/model-pricing.ts
@@ -37,7 +37,14 @@ export type ModelType =
   | "qwen/qwen3.6-flash"
   | "xiaomi/mimo-v2.5"
   | "xiaomi/mimo-v2.5-pro"
-  | "stepfun/step-3.5-flash";
+  | "stepfun/step-3.5-flash"
+  | "openrouter/auto"
+  | "openrouter/fusion";
+
+/**
+ * Routing mode type for OpenRouter Auto Route and Fusion
+ */
+export type RoutingMode = "direct" | "auto-route" | "fusion";
 
 export interface ModelPricing {
   inputPricePerMillion: number;
@@ -209,6 +216,16 @@ export const MODEL_PRICING: Record<ModelType, ModelPricing> = {
   "qwen/qwen3.6-plus": {
     inputPricePerMillion: 0.3,
     outputPricePerMillion: 1,
+    supportsVision: true,
+  },
+  "openrouter/auto": {
+    inputPricePerMillion: 2.5, // Weighted average for auto-selected models
+    outputPricePerMillion: 10,
+    supportsVision: true,
+  },
+  "openrouter/fusion": {
+    inputPricePerMillion: 8, // 2-3x due to multi-model calls
+    outputPricePerMillion: 30,
     supportsVision: true,
   },
 };

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -55,7 +55,8 @@ export type AgentMessageType =
   | "permission_request"
   | "password_input"
   | "reasoning"
-  | "preferenceUpdate";
+  | "preferenceUpdate"
+  | "memoryUpdate";
 
 export interface AgentMessage {
   type: AgentMessageType;
@@ -87,6 +88,20 @@ export interface AgentMessage {
     preferenceType: string;
     value: string;
     displayLabel: string;
+  };
+  /**
+   * Memory update fields — fired when the agent writes a user-fact markdown
+   * file under the memory directory (people / projects / notes / strategy).
+   * The UI surfaces this as a notification card so the user can see which
+   * pieces of their information the agent just updated.
+   */
+  memoryUpdate?: {
+    category: string;
+    fileName: string;
+    displayLabel: string;
+    action: "create" | "update";
+    description?: string;
+    filePath?: string;
   };
   /** Permission request fields */
   permissionRequest?: {
@@ -309,6 +324,31 @@ export interface AgentOptions {
     value: string;
     displayLabel: string;
   }) => void;
+  /**
+   * Called when the agent SDK has fully resolved a tool call's input — i.e.
+   * after streaming `input_json_delta` finishes and the assistant message
+   * is materialized. Hosts use this to inspect tool inputs that aren't
+   * available at the initial `tool_use` emission (which fires at
+   * `content_block_start` with empty/partial input under Anthropic's
+   * streaming protocol). Fires at most once per `toolUseId`.
+   */
+  onToolUseSeen?: (data: {
+    toolUseId: string;
+    toolName: string;
+    input: unknown;
+  }) => void;
+  /**
+   * Called after a first-party memory tool successfully persists a durable
+   * user fact. The host surfaces this as a chat notification card.
+   */
+  onMemoryUpdate?: (data: {
+    category: string;
+    fileName: string;
+    displayLabel: string;
+    action: "create" | "update";
+    description?: string;
+    filePath?: string;
+  }) => void;
   /** Callback for handling permission requests from SDK */
   onPermissionRequest?: (request: {
     toolName: string;
@@ -329,11 +369,6 @@ export interface AgentOptions {
   language?: string | null;
   /** User timezone for date/time operations */
   timezone?: string | null;
-  /** Internal scheduled-job execution report submission hook */
-  executionReport?: {
-    enabled: boolean;
-    onSubmit: (report: unknown) => void;
-  };
 }
 
 export interface PlanOptions extends AgentOptions {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -371,6 +371,23 @@ export type CustomUIDataTypes = {
       };
     }>;
   };
+  taskExecutionStep: {
+    stepId: string;
+    title: string;
+    status:
+      | "started"
+      | "running"
+      | "completed"
+      | "reused"
+      | "skipped"
+      | "blocked"
+      | "error";
+    detail?: string;
+    characterId?: string;
+    characterName?: string;
+    childExecutionId?: string;
+    timestamp?: string;
+  };
 };
 
 export type ChatMessage = UIMessage<MessageMetadata, CustomUIDataTypes>;


### PR DESCRIPTION
## Summary

- Add `openrouter/auto` and `openrouter/fusion` model types with pricing info
- Add `RoutingMode` type (`direct`, `auto-route`, `fusion`) for routing modes
- Add `memoryUpdate` message type and `onMemoryUpdate` / `onToolUseSeen` callbacks to agent options
- Remove deprecated `executionReport` from `AgentOptions` and `submitExecutionReport` tool references
- Add `taskExecutionStep` to `CustomUIDataTypes` for UI step tracking

## Changes

- `packages/ai/src/agent/billing/model-pricing.ts` - added OpenRouter model pricing entries and `RoutingMode` type
- `packages/ai/src/agent/types.ts` - added `memoryUpdate` message type, `onToolUseSeen`/`onMemoryUpdate` callbacks, removed `executionReport`
- `packages/shared/src/types.ts` - added `taskExecutionStep` to `CustomUIDataTypes`
- `apps/web/lib/cron/executor.ts` - removed `SUBMIT_EXECUTION_REPORT_TOOL` constant and `executionReport` option
- `apps/web/lib/ai/extensions/agent/claude/index.ts` - removed `submitExecutionReport` from tool lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)