### PR TITLE
feat: add use cases page with industry-specific content

### DIFF
--- a/apps/marketing/content/meta.json
+++ b/apps/marketing/content/meta.json
@@ -13,6 +13,7 @@
     "memory",
     "privacy-security",
     "glossary",
+    "use-cases",
     "changelog"
   ]
 }

--- a/apps/marketing/content/use-cases/engineering-daily-sync.mdx
+++ b/apps/marketing/content/use-cases/engineering-daily-sync.mdx
@@ -1,0 +1,131 @@
+---
+title: "Engineering Daily Sync"
+description: "Automated dev reports and issue sync to Linear — every night at 10 PM"
+icon: "FaLightbulb"
+---
+
+# Engineering Daily Sync
+
+## Automated Dev Reports + Issue Sync to Linear — Every Night
+
+Engineering teams waste hours every week pulling commit logs, writing status reports, and triaging GitHub issues. What if every night at 10 PM, AI automatically fetched all commits, compiled a dev report, emailed it to the team, and synced new issues directly to Linear?
+
+**What it does:**
+
+| Step           | Action                                                      |
+| -------------- | ----------------------------------------------------------- |
+| 🌙 Every 10 PM | Pull all commits from your GitHub repo                      |
+| 📝 Compile     | Generate a structured daily dev report                      |
+| 📧 Email       | Send the report to the engineering team                    |
+| 🐛 New Issues  | Fetch all issues created that day, rewrite with full detail |
+| 🔄 Linear Sync | Sync rewritten issues to Linear for prioritization          |
+
+---
+
+## The Setup
+
+### Configure the PD Prompt
+
+Paste the automation prompt into OpenLoomi. It defines the nightly workflow: commit fetching, report compilation, email delivery, and Linear sync.
+
+---
+
+### Create the Automation Tasks
+
+Two scheduled tasks handle the full workflow:
+
+| Task              | Schedule           | Purpose                                      |
+| ----------------- | ------------------ | -------------------------------------------- |
+| **PD Daily Sync** | Every day at 10 PM | Fetch commits, compile report, email to team |
+| **PD Issue Sync** | Every 1 hour       | Monitor new issues, rewrite, sync to Linear   |
+
+Both tasks are created with tracking enabled for full observability.
+
+---
+
+## The Operation
+
+### Every 10 PM: PD Daily Sync Runs
+
+OpenLoomi executes the full pipeline — fetching commits, compiling the report, and syncing issues — then generates structured artifacts for each output.
+
+### Execution Complete
+
+After a few minutes, the task finishes with two artifacts: the daily dev report and the issue sync summary.
+
+The sync produces two structured artifacts — the daily dev report and the issue migration summary — each ready to share or archive.
+
+---
+
+## Tracking Every Execution
+
+OpenLoomi's tracking panel shows exactly how many times each task has run, against which repositories:
+
+---
+
+## What Changed
+
+| Aspect                 | Before                        | After                          |
+| ---------------------- | ----------------------------- | ------------------------------ |
+| Dev report compilation | Manual, weekly or never       | Automated, every night         |
+| Commit review          | Developer pulls logs manually | AI fetches and summarizes      |
+| Issue triaging         | Often delayed or missed       | Real-time, every hour          |
+| Linear sync            | Manual copy-paste             | Fully automated rewrite & sync |
+| Engineering time saved | ~2 hrs/week                   | Near-zero, review only         |
+
+---
+
+## How to Set Up
+
+**Option 1: Copy & Paste (Easiest)**
+
+Open OpenLoomi and paste this:
+
+```
+Please pull all commits from my GitHub repo every night at 10 PM, compile a report, and send it to my email. Also, monitor all new issues created that day, rewrite them in detail, and sync them to Linear.
+```
+
+OpenLoomi will automatically create the scheduled tasks for you!
+
+---
+
+**Option 2: Manual Setup**
+
+1. Go to the **Agent** page, then select **Automation** → **New Task**
+2. Create the first task:
+
+| Field            | Input                                                                                                                                                                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `PD Daily Sync`                                                                                                                                                                                                                                                      |
+| Task Description | `1. Fetch all commits from your GitHub repo\n2. Compile a structured daily dev report\n3. Email the report to your team\n4. Fetch all issues created that day\n5. Rewrite each issue with full detail\n6. Sync rewritten issues to Linear` |
+| Schedule         | `0 22 * * *` (every day at 10 PM)                                                                                                                                                                                                                                    |
+
+3. Create the second task:
+
+| Field            | Input                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| Task Name        | `PD Issue Sync`                                                                                          |
+| Task Description | `Fetch new GitHub issues created today, rewrite each with full detail and context, then sync to Linear.` |
+| Schedule         | `Every 1 hour`                                                                                           |
+
+---
+
+## Why This Works
+
+**📊 Reporting Without the Effort**
+
+- Every night at 10 PM, a full dev report lands in the team's inbox
+- No developer time spent on status updates
+- Reports are structured, consistent, and always on time
+
+**🔄 Linear Stays in Sync**
+
+- New GitHub issues are automatically rewritten with full context
+- Linear is always up to date, ready for sprint planning
+- No manual issue copy-pasting between platforms
+
+**⏱️ Tracking Shows the Truth**
+
+- See exactly how many syncs have run
+- Know which repositories are being tracked
+- Identify gaps in the engineering workflow at a glance

--- a/apps/marketing/content/use-cases/engineering-daily-sync.mdx
+++ b/apps/marketing/content/use-cases/engineering-daily-sync.mdx
@@ -16,7 +16,7 @@ Engineering teams waste hours every week pulling commit logs, writing status rep
 | -------------- | ----------------------------------------------------------- |
 | 🌙 Every 10 PM | Pull all commits from your GitHub repo                      |
 | 📝 Compile     | Generate a structured daily dev report                      |
-| 📧 Email       | Send the report to the engineering team                    |
+| 📧 Email       | Send the report to the engineering team                     |
 | 🐛 New Issues  | Fetch all issues created that day, rewrite with full detail |
 | 🔄 Linear Sync | Sync rewritten issues to Linear for prioritization          |
 
@@ -37,7 +37,7 @@ Two scheduled tasks handle the full workflow:
 | Task              | Schedule           | Purpose                                      |
 | ----------------- | ------------------ | -------------------------------------------- |
 | **PD Daily Sync** | Every day at 10 PM | Fetch commits, compile report, email to team |
-| **PD Issue Sync** | Every 1 hour       | Monitor new issues, rewrite, sync to Linear   |
+| **PD Issue Sync** | Every 1 hour       | Monitor new issues, rewrite, sync to Linear  |
 
 Both tasks are created with tracking enabled for full observability.
 
@@ -94,11 +94,11 @@ OpenLoomi will automatically create the scheduled tasks for you!
 1. Go to the **Agent** page, then select **Automation** → **New Task**
 2. Create the first task:
 
-| Field            | Input                                                                                                                                                                                                                                                                |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task Name        | `PD Daily Sync`                                                                                                                                                                                                                                                      |
+| Field            | Input                                                                                                                                                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Task Name        | `PD Daily Sync`                                                                                                                                                                                                                            |
 | Task Description | `1. Fetch all commits from your GitHub repo\n2. Compile a structured daily dev report\n3. Email the report to your team\n4. Fetch all issues created that day\n5. Rewrite each issue with full detail\n6. Sync rewritten issues to Linear` |
-| Schedule         | `0 22 * * *` (every day at 10 PM)                                                                                                                                                                                                                                    |
+| Schedule         | `0 22 * * *` (every day at 10 PM)                                                                                                                                                                                                          |
 
 3. Create the second task:
 

--- a/apps/marketing/content/use-cases/founders-salespeople.mdx
+++ b/apps/marketing/content/use-cases/founders-salespeople.mdx
@@ -1,0 +1,173 @@
+---
+title: "Founders & Salespeople"
+description: "One person does the work of many, at scale"
+icon: "FaLightbulb"
+---
+
+# Founders & Salespeople
+
+## One Person Does the Work of Many, at Scale
+
+OpenLoomi learns your communication style, automatically maintains hundreds of client relationships, follows up on leads, and generates personalized proposals — never burns out.
+
+**What it does:**
+
+| Step                  | Action                                                           |
+| --------------------- | ---------------------------------------------------------------- |
+| 🧠 Learn your style   | Read past messages to mirror your tone and phrasing              |
+| 📊 Track all leads    | HubSpot/Salesforce sync — auto-updated pipeline with deal stages |
+| ✉️ Follow-up at scale | Personalized outreach sequences across email, Telegram, LinkedIn |
+| 📄 Generate proposals | Auto-draft proposals from conversation context and CRM data      |
+
+> "I can now manage what used to require a full sales team. OpenLoomi handles the follow-ups, the personalized outreach, the proposal generation — while I focus on closing deals."
+
+---
+
+## See It in Action
+
+### HubSpot Pipeline Sync
+
+Connect HubSpot in **Settings → Connectors** to sync your full pipeline. OpenLoomi reads deal stages, owner assignments, and close dates — keeping your pipeline view always current without manual updates.
+
+---
+
+### Personalized Outreach Draft
+
+OpenLoomi reads your past messages and communication patterns to draft follow-ups that sound like you — not generic AI output. Use the **cold-email** and **revops** skills to generate personalized sequences at scale.
+
+---
+
+### Follow-Up Sequence Automation
+
+Set up scheduled tasks for your outreach sequences. OpenLoomi manages the cadence — weekly check-ins, post-demo follow-ups, competitive intel alerts — and drafts each message for your approval.
+
+---
+
+### Auto-Generated Proposal Draft
+
+OpenLoomi compiles context from past conversations, HubSpot deal data, and your notes into structured proposal drafts. Save hours of manual writing and ensure every proposal reflects what the client actually discussed.
+
+---
+
+## Tracking Your Pipeline
+
+OpenLoomi's tracking panel shows pipeline sync executions, outreach messages sent, and proposal drafts generated — giving you full visibility into your AI-powered sales operations.
+
+---
+
+## What Changed
+
+| Aspect              | Before                        | After                                   |
+| ------------------- | ----------------------------- | --------------------------------------- |
+| Client management   | 50 clients managed manually   | 500+ with AI assistance                 |
+| Outreach quality    | Generic mass emails           | Personalized at scale                   |
+| Proposal writing    | Hours per proposal            | Auto-drafted from context               |
+| Follow-up cadence   | Dropped leads after one touch | 5-touch sequences, automated            |
+| Pipeline visibility | Stale CRM, manual updates    | Live HubSpot sync, always current       |
+| Competitive intel   | Missed competitor mentions    | Real-time alerts via Interests settings |
+
+---
+
+## Reference Case Studies
+
+Companies running AI sales agents report significant pipeline acceleration:
+
+- **Gumloop / Gusto**: 31% higher win rate, $1.5M+ ARR in 3 months from AI sales agents
+- **11x AI / Checkr**: 1.5x increase in qualified meetings
+- **11x AI / canibuild**: $1M+ pipeline generated in first 3 months
+
+---
+
+## How to Set Up
+
+**Option 1: Copy & Paste (Easiest)**
+
+Open OpenLoomi and paste this:
+
+```
+Please help me set up my sales automation workflow.
+
+1. Connect HubSpot in Settings → Connectors so OpenLoomi can read my pipeline (deals, stages, owners, close dates)
+
+2. Set up a personalized outreach system:
+   - Read my past emails to learn my communication style (tone, formality, phrasing)
+   - When I flag a lead in HubSpot, draft a personalized first outreach using the cold-email skill
+   - Schedule a 5-touch follow-up sequence: day 1, day 3, day 7, day 14, day 21
+   - Each touch should add new value (not just "checking in")
+   - Draft everything — I approve before anything goes out
+
+3. Set up proposal generation:
+   - When a deal reaches the "Proposal" stage in HubSpot, compile context from conversation history, deal data, and notes
+   - Generate a structured proposal draft in my template format
+   - Create the proposal artifact and notify me for review
+
+4. Track everything: log each outreach, follow-up, and proposal draft to my timeline
+```
+
+OpenLoomi will automatically create the scheduled tasks for you!
+
+---
+
+**Option 2: Manual Setup**
+
+### Step 1: Connect HubSpot
+
+1. Go to **Settings → Connectors**
+2. Find HubSpot in the connector list and click **Connect**
+3. Complete the OAuth flow to authorize OpenLoomi access
+
+### Step 2: Configure Personalization
+
+1. Go to **Settings → Personalization → My Interests**
+2. Add your priority keywords: client names, deal stages, competitors to track
+3. Add communication preferences: formal/informal, preferred phrasing
+
+### Step 3: Create Automation Tasks
+
+1. Go to the **Agent** page, then select **Automation** → **New Task**
+2. Create the first task:
+
+| Field            | Input                                                                                                                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `Pipeline Sync & Lead Monitoring`                                                                                                                                                                                          |
+| Task Description | `1. Sync with HubSpot — read all deals, stages, owners, and close dates\n2. Monitor for deals entering "Proposal" stage\n3. Generate proposal draft from conversation context and deal data\n4. Log sync runs to timeline` |
+| Schedule         | `Every 1 hour`                                                                                                                                                                                                             |
+
+3. Create the second task:
+
+| Field            | Input                                                                                                                                                                                                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `Outreach Sequence Manager`                                                                                                                                                                                                                                                                       |
+| Task Description | `1. Check for new leads flagged in HubSpot\n2. Draft personalized first outreach using cold-email skill, mirroring user's communication style\n3. Schedule 5-touch follow-up sequence (day 1, 3, 7, 14, 21)\n4. Draft each touch — user approves before sending\n5. Log all outreach to timeline` |
+| Schedule         | `Every 4 hours`                                                                                                                                                                                                                                                                                   |
+
+### Step 4: Use the Right Skills
+
+| Use Case            | Skill to Invoke        | What It Does                                          |
+| ------------------- | ---------------------- | ----------------------------------------------------- |
+| Personalized emails | **cold-email**         | Writes B2B outreach that sounds human, not templated  |
+| Pipeline management | **revops**             | Lead scoring, lifecycle stages, routing rules         |
+| HubSpot automation  | **hubspot-automation** | Contact/deal creation, pipeline search, property sync |
+| Notion proposals    | **notion-api**         | Create and manage proposal documents from templates   |
+
+---
+
+## Why This Works
+
+**🧠 It Sounds Like You, Not AI**
+
+- OpenLoomi reads your communication patterns and mirrors your tone in every draft
+- Prospects get personalized outreach, not mass-sent templates
+- The more you use it, the more it learns your style
+
+**📈 Pipeline Without the Admin Work**
+
+- HubSpot sync keeps your CRM always current — no manual updates
+- Deals auto-advance in OpenLoomi's Focus view as they progress in HubSpot
+- Never lose a lead because you forgot to log an interaction
+
+**⚡ Scale Without Burnout**
+
+- 5-touch sequences that actually add value on each touch
+- Proposal drafts in minutes, not hours
+- AI handles the cadence; you focus on closing deals

--- a/apps/marketing/content/use-cases/founders-salespeople.mdx
+++ b/apps/marketing/content/use-cases/founders-salespeople.mdx
@@ -63,7 +63,7 @@ OpenLoomi's tracking panel shows pipeline sync executions, outreach messages sen
 | Outreach quality    | Generic mass emails           | Personalized at scale                   |
 | Proposal writing    | Hours per proposal            | Auto-drafted from context               |
 | Follow-up cadence   | Dropped leads after one touch | 5-touch sequences, automated            |
-| Pipeline visibility | Stale CRM, manual updates    | Live HubSpot sync, always current       |
+| Pipeline visibility | Stale CRM, manual updates     | Live HubSpot sync, always current       |
 | Competitive intel   | Missed competitor mentions    | Real-time alerts via Interests settings |
 
 ---

--- a/apps/marketing/content/use-cases/global-managers.mdx
+++ b/apps/marketing/content/use-cases/global-managers.mdx
@@ -1,0 +1,131 @@
+---
+title: "Global Managers"
+description: "Never miss a critical signal across time zones"
+icon: "FaLightbulb"
+---
+
+# Global Managers
+
+## Never Miss a Critical Signal Across Time Zones
+
+Business runs 24/7 globally. OpenLoomi filters time zone and language noise, capturing high-value opportunities while you sleep — wake up to a refined action list.
+
+**What it does:**
+
+| Step                | Action                                                         |
+| ------------------- | -------------------------------------------------------------- |
+| ☀️ Morning briefing | Pull updates from Slack, Telegram, Gmail                       |
+| 🎯 Prioritize       | Rank by urgency and your Interests settings                    |
+| 📋 Action list      | Deliver a 3-item morning briefing to your Telegram or WhatsApp |
+| 📊 Track            | Log every briefing run and what was captured in your timeline  |
+
+---
+
+## See It in Action
+
+### Connect All Platforms
+
+Start by connecting every platform your global team uses. In **Settings → Connectors**, add Slack, Telegram and Gmail. OpenLoomi reads across all of them, regardless of language or time zone.
+
+---
+
+### Configure the Briefing Prompt
+
+Paste the automation prompt into OpenLoomi's agent chat. It defines the morning briefing workflow: multi-platform pull, prioritization by urgency, and delivery to your preferred channel.
+
+---
+
+### Create the Automation Tasks
+
+Two scheduled tasks handle the full briefing workflow:
+
+| Task                 | Schedule  | Purpose                                                     |
+| -------------------- | --------- | ----------------------------------------------------------- |
+| **Morning Briefing** | Every day | Pull from all platforms, rank, deliver to Telegram/WhatsApp |
+| **Context Tabs**     | Always on | Real-time signal routing by keyword and topic               |
+
+---
+
+### Briefing Delivered
+
+Every morning at 8 AM, OpenLoomi delivers a prioritized 3-item briefing directly to your Telegram — ranked by urgency, filtered by your Interests settings.
+
+---
+
+## Tracking Every Run
+
+OpenLoomi records every briefing execution in your personal timeline. Review past briefings, see what signals were captured, and track how your Focus view improves over time.
+
+---
+
+## What Changed
+
+| Aspect             | Before                              | After                                  |
+| ------------------ | ----------------------------------- | -------------------------------------- |
+| Morning routine    | 2 hrs scanning messages             | 3-item prioritized action list         |
+| Escalations        | Missed across time zones            | Keyword-triggered alerts 24/7          |
+| Context gathering  | Manual aggregation across platforms | Automatic multi-platform pull          |
+| Language barriers  | Important updates missed            | Translated and prioritized in Focus    |
+| Time zone coverage | Gaps overnight                      | 24/7 signal monitoring while you sleep |
+
+---
+
+## How to Set Up
+
+**Option 1: Copy & Paste (Easiest)**
+
+Open OpenLoomi and paste this:
+
+```
+Please help me set up a morning briefing automation.
+
+Every day at 8 AM:
+1. Pull updates from Slack, Telegram and Gmail from the past 24 hours
+2. Filter for signals relevant to enterprise deals, product launches and competitive updates
+3. Prioritize items by urgency using my Interests settings
+4. Deliver a 3-item morning briefing to my Telegram, formatted as:
+• [URGENT] Item 1 — why it matters
+• [ACTION] Item 2 — what to do
+• [INFO] Item 3 — worth knowing
+5. Log the briefing run to my timeline with a summary of what was captured in the event "My Tasks"
+```
+
+OpenLoomi will automatically create the scheduled task for you!
+
+---
+
+**Option 2: Manual Setup**
+
+1. Go to the **Agent** page, then select **Automation** → **New Task**
+2. Fill in:
+
+| Field            | Input                                                                                                                                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Task Name        | `Morning Briefing`                                                                                                                                                                                                                                                 |
+| Task Description | `1. Pull updates from Slack, Telegram and Gmail from the past 24 hours\n2. Filter for signals relevant to your key topics\n3. Prioritize items by urgency using Interests settings\n4. Deliver a 3-item briefing to Telegram\n5. Log the briefing run to timeline` |
+| Schedule         | `0 8 * * *` (every day at 8 AM)                                                                                                                                                                                                                                    |
+
+3. Go to **Settings → Connectors** and connect your platforms (Slack, Telegram, Gmail)
+4. Go to **Settings → Personalization → Interests** and add your priority keywords (e.g., "enterprise deal," "competitor," "launch," "escalation")
+
+---
+
+## Why This Works
+
+**⏰ Wake Up Ready, Not Overwhelmed**
+
+- Every morning you get 3 prioritized items, not 500 unread messages
+- OpenLoomi filters the noise so you can act on what actually matters
+- Time zone gaps are covered — signals from APAC and EMEA arrive while you sleep
+
+**🎯 Interests Settings Make It Personal**
+
+- The more you use OpenLoomi, the sharper the prioritization becomes
+- Your Interests settings tune both the briefing and all Context tabs toward exactly what matters to you
+- Context tabs (Escalations, APAC, EMEA, VIP) give you on-demand views without re-running the briefing
+
+**📊 Tracking Closes the Loop**
+
+- Every briefing run is logged with a summary
+- Ask: "What did I miss last Tuesday?"
+- Review past runs to see how your priorities have shifted over time

--- a/apps/marketing/content/use-cases/industry-intelligence.mdx
+++ b/apps/marketing/content/use-cases/industry-intelligence.mdx
@@ -1,0 +1,109 @@
+---
+title: "Industry Intelligence Automation"
+description: "Stay ahead of AI product trends 24/7 — set up once, runs forever"
+icon: "FaLightbulb"
+---
+
+# Industry Intelligence Automation
+
+## Stay Ahead of AI Product Trends 24/7
+
+Never miss important product launches, trending discussions, or competitive updates. Set up once, runs forever.
+
+**What it does:**
+
+| Step          | Action                                                               |
+| ------------- | -------------------------------------------------------------------- |
+| ☀️ Daily 9 AM | Automatically scrapes X, Reddit, Product Hunt                        |
+| 📝 Summarizes | Creates daily briefing with top 10 stories                           |
+| 📆 Timeline   | Records to "AI Product Daily Updates" event                          |
+| 📱 Notifies   | Visual dashboards pushes to your Telegram or share it with your team |
+
+---
+
+## See It in Action
+
+### Set Up Your Automation
+
+Create a scheduled task in seconds. Configure when and how often your automation runs — daily, weekly, or custom intervals.
+
+Watch OpenLoomi analyze the task and break it down into actionable steps. The AI understands your requirements and creates a structured plan.
+
+---
+
+### Automation Tracking and Updates
+
+Once triggered, OpenLoomi automatically executes each step using built-in skills: fetching data from X, Reddit, Product Hunt, and more.
+
+---
+
+### Track Results in Timeline
+
+Every automation run is recorded in your personal timeline. Review past executions, see what data was collected, and track how your insights evolve over time.
+
+---
+
+### Auto-Generated Dashboard
+
+OpenLoomi automatically builds a website to showcase your collected intelligence. Each update adds new data, and the site visualizes trends, launches, and insights — all without writing code.
+
+---
+
+### Get Notified via Telegram
+
+Get instant updates delivered to your Telegram. Each notification includes a summary of what was collected and a screenshot of the generated website — stay informed wherever you are.
+
+Receive your daily briefing directly on Telegram with the generated website screenshot and summary.
+
+---
+
+## How to Set Up
+
+**Option 1: Copy & Paste (Easiest)**
+
+Open OpenLoomi and paste this:
+
+```
+Please help me set up an industry intelligence automation at every morning at 9 AM using English with following tasks:
+1. Automatically scrape X, Reddit, Product Hunt for AI product news with skills all you need
+2. Summarize the results into a briefing, record to timeline
+3. Send the briefing to me, generate/modify the insight named "AI Product Daily Digest" and generate/modify the website to show the results and use the git tool to log the code and result diff.
+4. Share the brief message and the website figure to the telegram group named "Saved Messages"
+```
+
+OpenLoomi will automatically create the scheduled task for you!
+
+---
+
+**Option 2: Manual Setup**
+
+1. Go to the **Agent** page, then select **Automation** → **New Task**
+2. Fill in:
+
+| Field            | Input                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `AI Product Daily Digest`                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Task Description | `1. Automatically scrape X, Reddit, Product Hunt for AI product news with skills all you need\n2. Summarize the results into a briefing, record to timeline\n3. Send the briefing to me, generate/modify the insight named "AI Product Daily Digest" and generate/modify the website to show the results and use the git tool to log the code and result diff.\n4. Share the brief message and the website figure to the telegram group named "Saved Messages"` |
+| Schedule         | `0 9 * * *` (daily 9 AM)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+
+---
+
+## Why This Works
+
+**🧠 Long-term Memory**
+
+- OpenLoomi remembers what you tracked last week, last month
+- Ask: "What was the top product two weeks ago?"
+- Context persists across sessions
+
+**⚡ One-time Setup**
+
+- Configure once, runs forever
+- No manual intervention needed
+- Automatically adapts and improves
+
+**🔄 Continuous Learning**
+
+- Each day improves understanding of your interests
+- More relevant results over time
+- Learns what you care about

--- a/apps/marketing/content/use-cases/meta.json
+++ b/apps/marketing/content/use-cases/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Use Cases",
+  "pages": [
+    "industry-intelligence",
+    "x-content-automation",
+    "engineering-daily-sync",
+    "global-managers",
+    "founders-salespeople"
+  ]
+}

--- a/apps/marketing/content/use-cases/x-content-automation.mdx
+++ b/apps/marketing/content/use-cases/x-content-automation.mdx
@@ -1,0 +1,104 @@
+---
+title: "X Content Automation"
+description: "Run your X account on autopilot — 24/7 posting, engagement, and tracking"
+icon: "FaLightbulb"
+---
+
+# X Content Automation
+
+## Run Your X Account on Autopilot — 24/7
+
+Building an engaged following on X (Twitter) is time-consuming. What if AI could handle posting, liking, retweeting, and replying every 4 hours — while you simply approve before anything goes live?
+
+This is exactly how the @OpenLoomi X account runs: fully autonomous, around the clock.
+
+**What it does:**
+
+| Step            | Action                                                              |
+| --------------- | ------------------------------------------------------------------- |
+| 🕐 Every 4 hrs  | Research trending AI topics, like & retweet relevant content        |
+| 📝 Post         | Publish pre-approved AI content — trends, products, user guides     |
+| 💬 Reply        | Engage with AI discussions to build visibility                      |
+| 📊 Daily Review | Summarize the day's ops, prepare tomorrow's plan, optimize strategy |
+| 🔍 Track        | Log every action — likes, retweets, replies, follower changes       |
+
+---
+
+## The Setup
+
+### Connect X Account in OpenLoomi
+
+Before setting up automation, connect your X account in **Settings → Connectors** and authenticate with X:
+
+---
+
+### Configure the X Ops Mate
+
+Paste a detailed prompt into OpenLoomi's agent chat covering objectives, persona, operation frequency, content boundaries, approval workflow, and growth phasing:
+
+---
+
+### Create the Automation Tasks
+
+Two scheduled tasks handle the full operation:
+
+| Task            | Schedule      | Purpose                                                        |
+| --------------- | ------------- | -------------------------------------------------------------- |
+| **X Ops Agent** | Every 4 hours | Execute posting, engagement, tracking and summarize operations |
+
+---
+
+## The Operation
+
+### Every 4 Hours: X Ops Agent Runs
+
+OpenLoomi researches trending topics, engages with AI accounts, posts approved content, and tracks every action — then generates a structured operation summary.
+
+### Daily Review: Evening Optimization
+
+Once a day, the review task logs the full day's operations and optimizes the strategy:
+
+## Tracking Every Action
+
+OpenLoomi's tracking shows the full picture — execution volume, operation artifacts, and tracked accounts:
+
+---
+
+## What Changed
+
+| Aspect                   | Before           | After                                  |
+| ------------------------ | ---------------- | -------------------------------------- |
+| Posting frequency        | Manual, sporadic | Every 4 hours, 24/7                    |
+| Community engagement     | Neglected        | Automated liking, retweeting, replying |
+| Daily review             | None             | Automated evening summary              |
+| Strategy iteration       | Rare             | Continuous, daily optimization         |
+| Manual time required     | 2–3 hrs/day      | ~10 min/day (approval only)            |
+| Total executions tracked | None             | 100+ with full detail in one event     |
+
+---
+
+## Why This Works
+
+**⏰ Automation Eliminates the Grind**
+
+- Every 4 hours, OpenLoomi handles likes, retweets, posts, and replies
+- No manual effort between approval steps
+- 24/7 presence without burning out
+
+**🔍 Tracking Closes the Loop**
+
+- Every action is logged with full detail
+- Operation artifacts show exactly what was done
+- Easy to spot what's working and optimize
+
+**🛡️ Approval Gates Keep the Brand Safe**
+
+- The agent prepares, the human approves
+- Fully automated execution, human-controlled strategy
+- No off-brand content slips through
+
+**📈 Value First, Monetize Later**
+
+- The prompt instructs minimizing ads early
+- Focus on genuine engagement to build followers
+- Promote once there's an audience that trusts you


### PR DESCRIPTION
## Summary
- Add `use-cases` section to sidebar navigation in `meta.json`
- Add new `use-cases/` directory with MDX content covering 5 use case scenarios:
  - Engineering daily sync
  - Founders & salespeople
  - Global managers
  - Industry intelligence
  - X (Twitter) content automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)