### PR TITLE
fix(benchmark/locomo): handle dialog turns as objects with speaker and text

### DIFF
--- a/benchmark/locomo/src/evaluator.ts
+++ b/benchmark/locomo/src/evaluator.ts
@@ -78,10 +78,19 @@ function createMemoryRecordsFromDialog(sample: LoCoMoSample): MemoryRecord[] {
     dialogParts.push("");
 
     for (const turn of session) {
+      // Each turn is an object with speaker, dia_id, and text properties
+      const turnText =
+        typeof turn === "string"
+          ? turn
+          : (turn as { text?: string }).text || JSON.stringify(turn);
+      const speaker =
+        typeof turn === "string"
+          ? ""
+          : `[${(turn as { speaker?: string }).speaker || ""}]`;
       if (sessionTimestamp) {
-        dialogParts.push(`[${sessionTimestamp}] ${turn}`);
+        dialogParts.push(`[${sessionTimestamp}] ${speaker} ${turnText}`);
       } else {
-        dialogParts.push(turn);
+        dialogParts.push(`${speaker} ${turnText}`);
       }
     }
 


### PR DESCRIPTION
## Summary

- Handle dialog turns that are objects with `speaker` and `text` properties, not just plain strings
- Extract speaker info and include it in the dialog output when available

## Test plan

- [ ] Verify evaluator correctly processes both string and object-formatted dialog turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)