### PR TITLE
fix: update local API port from 3415 to 3414

### DIFF
--- a/apps/marketing/content/memory.mdx
+++ b/apps/marketing/content/memory.mdx
@@ -508,7 +508,7 @@ The Memory Skill supports 10+ communication channels including Gmail, Slack, Dis
 
 ### API Endpoints
 
-The skill exposes REST endpoints at `http://localhost:3415/api/`:
+The skill exposes REST endpoints at `http://localhost:3414/api/`:
 
 | Endpoint           | Description                           |
 | ------------------ | ------------------------------------- |

--- a/apps/web/src-tauri/src/constants.rs
+++ b/apps/web/src-tauri/src/constants.rs
@@ -11,7 +11,7 @@ pub const NEXTJS_PORT: u16 = 3515;
 
 /// The port where the Next.js production server runs.
 #[cfg(not(debug_assertions))]
-pub const NEXTJS_PORT: u16 = 3415;
+pub const NEXTJS_PORT: u16 = 3414;
 
 /// The base URL for the Next.js server.
 pub const NEXTJS_BASE_URL: &str = "http://localhost";

--- a/apps/web/src-tauri/src/node.rs
+++ b/apps/web/src-tauri/src/node.rs
@@ -1059,15 +1059,15 @@ pub fn try_start_nextjs(
         // Force single-worker mode so whatsappClientRegistry and activeAdapters are shared
         // across all API requests (module-level singletons are not shared across cluster workers).
         .env("WORKERS", "1")
-        .env("PORT", "3415")
+        .env("PORT", "3414")
         .env("IS_TAURI", "true")
         .env("TAURI_MODE", "1")
         .env("DEPLOYMENT_MODE", "tauri")
         .env("CLOUD_API_URL", "https://app.openloomi.ai")
         .env("NEXT_PUBLIC_CLOUD_API_URL", "https://app.openloomi.ai")
         .env("TAURI_DB_PATH", db_path)
-        .env("NEXTAUTH_URL", "http://localhost:3415")
-        .env("NEXT_PUBLIC_APP_URL", "http://localhost:3415")
+        .env("NEXTAUTH_URL", "http://localhost:3414")
+        .env("NEXT_PUBLIC_APP_URL", "http://localhost:3414")
         .env("LLM_BASE_URL", "https://openrouter.ai/api/v1")
         .env("LLM_MODEL", "google/gemini-3-flash-preview")
         .env("LLM_VISION_LANGUAGE_MODEL", "google/gemini-3-flash-preview")
@@ -1075,7 +1075,6 @@ pub fn try_start_nextjs(
         .env("LLM_EMBEDDING_MODEL", "qwen/qwen3-embedding-4b")
         .env("LLM_EMBEDDING_BASE_URL", "https://openrouter.ai/api/v1")
         .env("TELEGRAM_MODE", "pooling")
-        .env("ANTHROPIC_BASE_URL", "http://localhost:3415/api/ai")
         .env("API_TIMEOUT_MS", "3000000")
         .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
         .env("CLAUDE_CODE_TMPDIR", code_tmpdir)
@@ -1417,7 +1416,7 @@ pub fn start_nextjs_server() {
         for (node_type, node_path) in &node_candidates {
             println!("🔄 Trying {} Node.js at: {}", node_type, node_path);
 
-            cleanup_port(3415);
+            cleanup_port(3414);
 
             match try_start_nextjs(
                 node_path,
@@ -1467,8 +1466,8 @@ pub fn start_nextjs_server() {
                         }
 
                         use std::net::TcpStream;
-                        if TcpStream::connect("127.0.0.1:3415").is_ok() {
-                            println!("✅ Server is ready on port 3415!");
+                        if TcpStream::connect("127.0.0.1:3414").is_ok() {
+                            println!("✅ Server is ready on port 3414!");
                             server_ready = true;
                             break;
                         }
@@ -1507,20 +1506,20 @@ pub fn start_nextjs_server() {
                             }
                         );
                         eprintln!("⚠️  {}", last_error);
-                        cleanup_port(3415);
+                        cleanup_port(3414);
                         continue;
                     } else {
                         last_error =
                             format!("{} Node.js started but server not listening", node_type);
-                        eprintln!("⚠️  Server not responding on port 3415");
-                        cleanup_port(3415);
+                        eprintln!("⚠️  Server not responding on port 3414");
+                        cleanup_port(3414);
                         continue;
                     }
                 }
                 Err(e) => {
                     last_error = format!("{} Node.js failed: {}", node_type, e);
                     eprintln!("⚠️  {} Node.js failed to start: {}", node_type, e);
-                    cleanup_port(3415);
+                    cleanup_port(3414);
                     continue;
                 }
             }
@@ -1677,7 +1676,7 @@ pub fn cleanup_nodejs_process() {
         }
     }
 
-    cleanup_port(3415);
+    cleanup_port(3414);
 
     if let Ok(mut pid_guard) = NODEJS_PID.lock() {
         *pid_guard = None;
@@ -1689,8 +1688,8 @@ pub fn cleanup_nodejs_process() {
 
 /// Clean up any residual processes before starting
 pub fn cleanup_before_start() {
-    println!("🔍 Checking for existing processes on port 3415...");
-    cleanup_port(3415);
+    println!("🔍 Checking for existing processes on port 3414...");
+    cleanup_port(3414);
 }
 
 /// Server status returned to the frontend

--- a/apps/web/tests/unit/url.test.ts
+++ b/apps/web/tests/unit/url.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/env", () => ({
     }
     return process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL.replace(/\/$/, "")}`
-      : "http://localhost:3415";
+      : "http://localhost:3414";
   }),
   getAppUrl: vi.fn(() => {
     const envUrl =
@@ -29,7 +29,7 @@ vi.mock("@/lib/env", () => ({
     }
     return process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL.replace(/\/$/, "")}`
-      : "http://localhost:3415";
+      : "http://localhost:3414";
   }),
 }));
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,5 +1,5 @@
 export const DEV_PORT = "3515";
-export const PROD_PORT = "3415";
+export const PROD_PORT = "3414";
 
 export const maxChunkSummaryCount = 10;
 export const isProductionEnvironment = process.env.NODE_ENV === "production";

--- a/skills/openloomi-api/SKILL.md
+++ b/skills/openloomi-api/SKILL.md
@@ -251,11 +251,12 @@ curl -X POST https://app.openloomi.ai/api/ai/chat \
 
 ### Local API Access
 
-When running openloomi desktop app, the local API server runs on port **3415**:
+When running openloomi desktop app, the local API server runs on port **3414** (fallback: **3515**):
 
 | Environment | Base URL |
 |-------------|----------|
-| User Local Desktop | `http://localhost:3415` |
+| User Local Desktop | `http://localhost:3414` |
+| User Local Desktop (fallback) | `http://localhost:3515` |
 
 ### Authentication Token
 
@@ -278,45 +279,45 @@ echo "$TOKEN" | cut -d'.' -f2 | base64 -d 2>/dev/null | python3 -m json.tool
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
 
 # 1. Check AI API status (no auth required)
-curl http://localhost:3415/api/ai/chat
+curl http://localhost:3414/api/ai/chat
 
 # 2. Get current user info
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl http://localhost:3415/api/remote-auth/user \
+curl http://localhost:3414/api/remote-auth/user \
   -H "Authorization: Bearer $TOKEN"
 
 # 3. Get subscription info
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl http://localhost:3415/api/remote-auth/subscription \
+curl http://localhost:3414/api/remote-auth/subscription \
   -H "Authorization: Bearer $TOKEN"
 
 # 4. Chat with AI (streaming)
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl -X POST http://localhost:3415/api/ai/chat \
+curl -X POST http://localhost:3414/api/ai/chat \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"messages":[{"role":"user","content":"Hello!"}],"stream":true}'
 
 # 5. Get chat insights (requires chatId)
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl "http://localhost:3415/api/chat-insights?chatId=xxx" \
+curl "http://localhost:3414/api/chat-insights?chatId=xxx" \
   -H "Authorization: Bearer $TOKEN"
 
 # 6. Search RAG documents
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl -X POST http://localhost:3415/api/rag/search \
+curl -X POST http://localhost:3414/api/rag/search \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query":"search term","limit":5}'
 
 # 7. List workspace skills
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl http://localhost:3415/api/workspace/skills \
+curl http://localhost:3414/api/workspace/skills \
   -H "Authorization: Bearer $TOKEN"
 
 # 8. Submit feedback
 TOKEN=$(cat ~/.openloomi/token | base64 -d)
-curl -X POST http://localhost:3415/api/remote-feedback \
+curl -X POST http://localhost:3414/api/remote-feedback \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"content":"Feedback message","email":"user@example.com"}'

--- a/skills/openloomi-connectors/SKILL.md
+++ b/skills/openloomi-connectors/SKILL.md
@@ -74,6 +74,10 @@ openloomi runs a background agent on a continuous sync loop, actively gathering 
 
 The CLI auto-reads your token from `~/.openloomi/token` (base64 encoded JWT).
 
+### Local API Access
+
+The local API server runs on port **3414** (fallback: **3515**). If 3414 is unavailable, try 3515.
+
 ---
 
 ## API Endpoints
@@ -85,7 +89,7 @@ The CLI auto-reads your token from `~/.openloomi/token` (base64 encoded JWT).
 Returns all connected platform accounts for the authenticated user.
 
 ```bash
-curl http://localhost:3415/api/integrations/accounts \
+curl http://localhost:3414/api/integrations/accounts \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -118,7 +122,7 @@ curl http://localhost:3415/api/integrations/accounts \
 Returns the Slack OAuth authorization URL. The CLI opens this URL in the browser for the user to complete authorization.
 
 ```bash
-curl "http://localhost:3415/api/integrations/slack/oauth/start?userId=<userId>"
+curl "http://localhost:3414/api/integrations/slack/oauth/start?userId=<userId>"
 ```
 
 **Response:**
@@ -172,7 +176,7 @@ Exchange OAuth code for Discord access.
 Delete a connected integration account.
 
 ```bash
-curl -X DELETE http://localhost:3415/api/integrations/int_xxx \
+curl -X DELETE http://localhost:3414/api/integrations/int_xxx \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -192,7 +196,7 @@ curl -X DELETE http://localhost:3415/api/integrations/int_xxx \
 Query user contacts with optional filtering and pagination.
 
 ```bash
-curl "http://localhost:3415/api/contacts?name=John&page=1&pageSize=10" \
+curl "http://localhost:3414/api/contacts?name=John&page=1&pageSize=10" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -232,7 +236,7 @@ curl "http://localhost:3415/api/contacts?name=John&page=1&pageSize=10" \
 Send a message via a connected platform bot.
 
 ```bash
-curl -X POST http://localhost:3415/api/messages \
+curl -X POST http://localhost:3414/api/messages \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
+++ b/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
@@ -394,7 +394,7 @@ async function main() {
           const nameArg = args.find(a => a.startsWith('--name='));
 
           if (!clientIdArg || !clientSecretArg) {
-            throw new Error(`Missing credentials. For DingTalk, provide:\n  connect dingtalk --clientId=your_client_id --clientSecret=your_client_secret`);
+            throw new Error("Missing credentials. For DingTalk, provide:\n  connect dingtalk --clientId=your_client_id --clientSecret=your_client_secret");
           }
 
           const result = await connectAppCredentialsPlatform(platformId, {
@@ -412,7 +412,7 @@ async function main() {
           const nameArg = args.find(a => a.startsWith('--name='));
 
           if (!appIdArg || !appSecretArg) {
-            throw new Error(`Missing credentials. For QQ Bot, provide:\n  connect qq --appId=your_app_id --appSecret=your_app_secret`);
+            throw new Error("Missing credentials. For QQ Bot, provide:\n  connect qq --appId=your_app_id --appSecret=your_app_secret");
           }
 
           const result = await connectAppCredentialsPlatform(platformId, {
@@ -430,7 +430,7 @@ async function main() {
           const nameArg = args.find(a => a.startsWith('--name='));
 
           if (!appIdArg || !appSecretArg) {
-            throw new Error(`Missing credentials. For Feishu, provide:\n  connect feishu --appId=your_app_id --appSecret=your_app_secret`);
+            throw new Error("Missing credentials. For Feishu, provide:\n  connect feishu --appId=your_app_id --appSecret=your_app_secret");
           }
 
           const result = await connectAppCredentialsPlatform(platformId, {
@@ -446,7 +446,7 @@ async function main() {
           const tokenArg = args.find(a => a.startsWith('--token='));
 
           if (!tokenArg) {
-            throw new Error(`Missing iLink token. For WeChat, provide:\n  connect wechat --token=your_ilink_token`);
+            throw new Error("Missing iLink token. For WeChat, provide:\n  connect wechat --token=your_ilink_token");
           }
 
           const result = await connectWeChat(tokenArg.split('=')[1]);
@@ -467,7 +467,7 @@ async function main() {
         }
 
         // Platforms requiring browser (WhatsApp, etc)
-        throw new Error(`${platformId} requires browser interaction. Open in browser:\n  open "http://localhost:3415/connectors?addPlatform=true&platform=${platformId}"`);
+        throw new Error(`${platformId} requires browser interaction. Open in browser:\n  open "http://localhost:3414/connectors?addPlatform=true&platform=${platformId}"`);
       }
 
       case 'disconnect': {

--- a/skills/openloomi-memory/SKILL.md
+++ b/skills/openloomi-memory/SKILL.md
@@ -126,7 +126,7 @@ node $SKILL_DIR/scripts/openloomi-memory.cjs delete-memory filename.md --directo
 Semantic search of uploaded documents using embeddings.
 
 ```bash
-curl -X POST http://localhost:3415/api/rag/search \
+curl -X POST http://localhost:3414/api/rag/search \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "project plan", "limit": 5}'
@@ -156,7 +156,7 @@ curl -X POST http://localhost:3415/api/rag/search \
 List all documents in the knowledge base.
 
 ```bash
-curl http://localhost:3415/api/rag/documents?limit=50 \
+curl http://localhost:3414/api/rag/documents?limit=50 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -185,7 +185,7 @@ curl http://localhost:3415/api/rag/documents?limit=50 \
 Get a single document by ID.
 
 ```bash
-curl http://localhost:3415/api/rag/documents/doc_xxx \
+curl http://localhost:3414/api/rag/documents/doc_xxx \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -212,7 +212,7 @@ Insights are structured information extracted from chat history, such as key dec
 List all insights from a time period.
 
 ```bash
-curl "http://localhost:3415/api/insights?days=7&limit=50" \
+curl "http://localhost:3414/api/insights?days=7&limit=50" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -266,7 +266,7 @@ Each insight contains a `groups` field—an array of channel identifiers indicat
 Create a new insight manually.
 
 ```bash
-curl -X POST http://localhost:3415/api/insights \
+curl -X POST http://localhost:3414/api/insights \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"type": "preference", "content": "I prefer Americano coffee", "groups": ["whatsapp"]}'
@@ -295,7 +295,7 @@ curl -X POST http://localhost:3415/api/insights \
 Partial update an existing insight. Arrays (details, timeline, insights) are appended to, not replaced.
 
 ```bash
-curl -X PUT http://localhost:3415/api/insights/insight_xxx \
+curl -X PUT http://localhost:3414/api/insights/insight_xxx \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -333,7 +333,7 @@ curl -X PUT http://localhost:3415/api/insights/insight_xxx \
 Get a single insight by ID, including associated chat.
 
 ```bash
-curl "http://localhost:3415/api/insights/insight_xxx?fetch=true" \
+curl "http://localhost:3414/api/insights/insight_xxx?fetch=true" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -359,7 +359,7 @@ curl "http://localhost:3415/api/insights/insight_xxx?fetch=true" \
 Delete a specific insight.
 
 ```bash
-curl -X DELETE http://localhost:3415/api/insights/insight_xxx \
+curl -X DELETE http://localhost:3414/api/insights/insight_xxx \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -376,7 +376,7 @@ curl -X DELETE http://localhost:3415/api/insights/insight_xxx \
 Get all insights for a specific chat.
 
 ```bash
-curl "http://localhost:3415/api/chat-insights?chatId=chat_xxx" \
+curl "http://localhost:3414/api/chat-insights?chatId=chat_xxx" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -431,7 +431,7 @@ System automatically runs two maintenance tasks:
 #### GET `/api/insights/analytics` - Get Insight Usage Analytics
 
 ```bash
-curl "http://localhost:3415/api/insights/analytics" \
+curl "http://localhost:3414/api/insights/analytics" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -489,7 +489,7 @@ curl "http://localhost:3415/api/insights/analytics" \
 #### POST `/api/insights/[id]/view` - Record Insight View
 
 ```bash
-curl -X POST "http://localhost:3415/api/insights/insight_xxx/view" \
+curl -X POST "http://localhost:3414/api/insights/insight_xxx/view" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"viewSource": "search"}'


### PR DESCRIPTION
## Summary

- Update local API server port from `3415` to `3414` across all code and documentation
- Remove unused `ANTHROPIC_BASE_URL` environment variable in `node.rs`
- Clean up template literal usage in error messages (`openloomi-connectors.cjs`)

## Changes

| File | Change |
|------|--------|
| `apps/web/src-tauri/src/constants.rs` | `NEXTJS_PORT` production constant: 3415 → 3414 |
| `apps/web/src-tauri/src/node.rs` | All `3415` port references → `3414`, removed `ANTHROPIC_BASE_URL` |
| `apps/web/tests/unit/url.test.ts` | Test URL fallback: 3415 → 3414 |
| `packages/shared/src/constants.ts` | `PROD_PORT`: 3415 → 3414 |
| `apps/marketing/content/memory.mdx` | API endpoint documentation: 3415 → 3414 |
| `skills/openloomi-api/SKILL.md` | All curl examples: 3415 → 3414, added fallback port note |
| `skills/openloomi-connectors/SKILL.md` | All curl examples: 3415 → 3414, added port note |
| `skills/openloomi-connectors/scripts/openloomi-connectors.cjs` | Port in browser URL + string formatting fixes |
| `skills/openloomi-memory/SKILL.md` | All curl examples: 3415 → 3414 |


🤖 Generated with [Claude Code](https://claude.com/claude-code)