### PR TITLE
Feat/support local embedding and extend vector backends

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -59,6 +59,31 @@ OPENAI_API_KEY=****
 LLM_EMBEDDING_BASE_URL=****
 LLM_EMBEDDING_MODEL=****
 
+# Vector store backend configuration (optional)
+# By default, OpenLoomi keeps using the existing local/database vector paths.
+# Set individual backends to "chroma" to use ChromaDB as the semantic vector index.
+#
+# Chroma runs as a separate vector database service. SQLite/Postgres still remain
+# the source of truth for documents, raw messages, and insights.
+#
+# Global fallback for raw messages and insights:
+# VECTOR_STORE_BACKEND=chroma
+#
+# Knowledge base / RAG chunks:
+# RAG_VECTOR_STORE_BACKEND=chroma
+# CHROMA_RAG_COLLECTION=openloomi_rag_chunks
+#
+# Raw message semantic memory:
+# RAW_MESSAGE_VECTOR_STORE_BACKEND=chroma
+# CHROMA_RAW_MESSAGES_COLLECTION=openloomi_raw_messages
+#
+# Insight semantic search:
+# INSIGHT_VECTOR_STORE_BACKEND=chroma
+# CHROMA_INSIGHTS_COLLECTION=openloomi_insights
+#
+# Chroma server URL:
+# CHROMA_URL=http://localhost:8000
+
 # Brave Search API (optional) - Get API key from https://brave.com/search/api/
 BRAVE_SEARCH_API_KEY=****
 

--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -4,6 +4,7 @@ import {
   getRawMessageStorageBackend,
   isRawMessageStorageAvailable,
 } from "@/lib/memory/raw-message-store";
+import { upsertRawMessagesToChroma } from "@/lib/memory/chroma-memory-index";
 import { AppError } from "@openloomi/shared/errors";
 import {
   queryMemoryWithFallback,
@@ -216,6 +217,7 @@ export async function POST(request: NextRequest) {
           createdAt: message.createdAt ?? now,
         })) as RawMessage[];
         const ids = await manager.storeMessages(normalized);
+        await upsertRawMessagesToChroma(normalized);
         return Response.json({
           success: true,
           stored: ids.length,
@@ -268,6 +270,17 @@ export async function POST(request: NextRequest) {
       case "updateEmbeddings": {
         const updates = Array.isArray(body.updates) ? body.updates : [];
         const updated = await manager.updateMessageEmbeddings(updates, userId);
+        const updatedMessages = (
+          await Promise.all(
+            updates.map(async (update: { messageId?: unknown }) => {
+              if (typeof update.messageId !== "string") {
+                return null;
+              }
+              return manager.getMessageById(update.messageId);
+            }),
+          )
+        ).filter((message): message is RawMessage => message !== null);
+        await upsertRawMessagesToChroma(updatedMessages);
         return Response.json({ success: true, updated });
       }
 

--- a/apps/web/app/api/rag/upload/async/route.ts
+++ b/apps/web/app/api/rag/upload/async/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/app/(auth)/auth";
 import { randomUUID } from "node:crypto";
 import { jobs } from "./job-store";
-import { isTauriMode } from "@/lib/env";
+import { shouldSkipRAGEmbeddings } from "@/lib/ai/rag/langchain-service";
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -14,9 +14,9 @@ export async function POST(request: Request) {
     const formData = await request.formData();
     const uploadedFile = formData.get("file");
     const cloudAuthToken = formData.get("cloudAuthToken") as string | null;
-    // In Tauri mode, always skip embeddings (no external API available)
-    const skipEmbeddings =
-      formData.get("skipEmbeddings") === "true" || isTauriMode();
+    const skipEmbeddings = shouldSkipRAGEmbeddings(
+      formData.get("skipEmbeddings") === "true",
+    );
 
     if (!(uploadedFile instanceof File)) {
       return NextResponse.json({ error: "No file uploaded" }, { status: 400 });

--- a/apps/web/app/api/rag/upload/complete/route.ts
+++ b/apps/web/app/api/rag/upload/complete/route.ts
@@ -9,8 +9,8 @@ import { randomUUID } from "node:crypto";
 import {
   processDocument,
   getUserRAGStats,
+  shouldSkipRAGEmbeddings,
 } from "@/lib/ai/rag/langchain-service";
-import { isTauriMode } from "@/lib/env";
 import {
   SUPPORTED_RAG_MIME_TYPES,
   getMimeTypeFromExtension,
@@ -181,7 +181,7 @@ export async function POST(request: Request) {
         chunkSize: 1000,
         chunkOverlap: 200,
         blobPath, // Pass original file path
-        skipEmbeddings: isTauriMode(),
+        skipEmbeddings: shouldSkipRAGEmbeddings(),
       },
       cloudAuthToken || undefined,
     );

--- a/apps/web/app/api/rag/upload/route.ts
+++ b/apps/web/app/api/rag/upload/route.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import {
   processDocumentFromFile,
   getUserRAGStats,
+  shouldSkipRAGEmbeddings,
 } from "@/lib/ai/rag/langchain-service";
 import {
   SUPPORTED_RAG_MIME_TYPES,
@@ -16,7 +17,6 @@ import { unlink, readFile } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isTauriMode } from "@/lib/env";
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -31,11 +31,12 @@ export async function POST(request: Request) {
     const formData = await request.formData();
     const uploadedFile = formData.get("file");
 
-    // Extract cloudAuthToken and skipEmbeddings from formData if provided
-    // In Tauri mode, always skip embeddings (no external API available)
+    // Extract cloudAuthToken and skipEmbeddings from formData if provided.
+    // Tauri skips embeddings unless a local/vector backend such as Chroma is configured.
     const cloudAuthToken = formData.get("cloudAuthToken") as string | null;
-    const skipEmbeddings =
-      formData.get("skipEmbeddings") === "true" || isTauriMode();
+    const skipEmbeddings = shouldSkipRAGEmbeddings(
+      formData.get("skipEmbeddings") === "true",
+    );
 
     if (!(uploadedFile instanceof File)) {
       return NextResponse.json({ error: "No file uploaded" }, { status: 400 });

--- a/apps/web/lib/ai/rag/langchain-service.ts
+++ b/apps/web/lib/ai/rag/langchain-service.ts
@@ -118,7 +118,7 @@ async function getConfiguredVectorStore() {
     return null;
   }
 
-  const { getChromaVectorStore } = await import("@openloomi/rag/chroma-store");
+  const { getChromaVectorStore } = await import("@openloomi/rag");
   return getChromaVectorStore({
     url: process.env.CHROMA_URL,
     collectionName:

--- a/apps/web/lib/ai/rag/langchain-service.ts
+++ b/apps/web/lib/ai/rag/langchain-service.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import { isTauriMode } from "@/lib/env";
 import { estimateTokens } from "@/lib/ai";
 import { UniversalEmbeddings } from "@openloomi/rag/universal-embeddings";
+import type { DocumentChunk } from "@openloomi/rag/vector-service";
 
 // Re-export for consumers of langchain-service
 export { UniversalEmbeddings };
@@ -85,6 +86,44 @@ export interface SearchOptions {
   limit?: number;
   threshold?: number; // Minimum similarity score (0-1)
   documentIds?: string[]; // Optional: filter to specific document IDs
+}
+
+type StoredRAGChunk = InsertRAGChunk & {
+  id: string;
+  documentId: string;
+  userId: string;
+  chunkIndex: number;
+  content: string;
+};
+
+type RAGVectorStoreBackend = "sqlite-vec" | "chroma";
+
+export function getRAGVectorStoreBackend(): RAGVectorStoreBackend {
+  const backend = (
+    process.env.RAG_VECTOR_STORE_BACKEND ||
+    process.env.VECTOR_STORE_BACKEND ||
+    "sqlite-vec"
+  ).toLowerCase();
+
+  return backend === "chroma" ? "chroma" : "sqlite-vec";
+}
+
+export function shouldSkipRAGEmbeddings(explicitSkip = false): boolean {
+  if (explicitSkip) return true;
+  return isTauriMode() && getRAGVectorStoreBackend() !== "chroma";
+}
+
+async function getConfiguredVectorStore() {
+  if (getRAGVectorStoreBackend() !== "chroma") {
+    return null;
+  }
+
+  const { getChromaVectorStore } = await import("@openloomi/rag/chroma-store");
+  return getChromaVectorStore({
+    url: process.env.CHROMA_URL,
+    collectionName:
+      process.env.CHROMA_RAG_COLLECTION || process.env.CHROMA_COLLECTION,
+  });
 }
 
 /**
@@ -194,7 +233,7 @@ export async function processDocument(
   }
 
   // 7. Insert chunks with pgvector embeddings
-  const chunkData: InsertRAGChunk[] = chunks.map(
+  const chunkData: StoredRAGChunk[] = chunks.map(
     (chunk: any, index: number) => {
       if (embeddingVectors) {
         const embeddingArray = embeddingVectors[index];
@@ -225,6 +264,28 @@ export async function processDocument(
   for (let i = 0; i < chunkData.length; i += BATCH_SIZE) {
     const batch = chunkData.slice(i, i + BATCH_SIZE);
     await db.insert(ragChunks).values(batch);
+  }
+
+  const vectorStore = await getConfiguredVectorStore();
+  if (vectorStore && embeddingVectors) {
+    const vectorChunks: DocumentChunk[] = chunkData.map((chunk, index) => ({
+      id: chunk.id,
+      documentId: document.id,
+      content: chunk.content,
+      embedding: embeddingVectors[index],
+      metadata: {
+        userId,
+        fileName,
+        contentType,
+        chunkIndex: chunk.chunkIndex,
+      },
+    }));
+
+    await vectorStore.addChunks(vectorChunks);
+    console.log("[RAG] Added chunks to Chroma vector store", {
+      documentId: document.id,
+      chunks: vectorChunks.length,
+    });
   }
 
   return {
@@ -277,6 +338,46 @@ export async function searchSimilarChunks(
   // 1. Generate embedding for query
   const embeddings = getEmbeddings(authToken);
   const queryEmbedding = await embeddings.embedQuery(query);
+
+  const vectorStore = await getConfiguredVectorStore();
+  if (vectorStore) {
+    const searchLimit = documentIds?.length
+      ? Math.max(limit * 3, limit)
+      : limit;
+    const vectorResults = await vectorStore.similaritySearch(
+      queryEmbedding,
+      searchLimit,
+      userId,
+    );
+
+    const filteredResults = vectorResults
+      .filter((result) => {
+        if (!documentIds || documentIds.length === 0) return true;
+        return documentIds.includes(result.documentId);
+      })
+      .filter((result) => result.score >= threshold)
+      .slice(0, limit)
+      .map((result) => {
+        const metadata = result.metadata ?? {};
+        return {
+          chunkId: result.id,
+          documentId: result.documentId,
+          documentName: String(metadata.fileName ?? result.documentId),
+          content: result.content,
+          similarity: result.score,
+          chunkIndex:
+            typeof metadata.chunkIndex === "number" ? metadata.chunkIndex : 0,
+        };
+      });
+
+    console.log("[RAG] Chroma vector search completed", {
+      query,
+      count: filteredResults.length,
+      backend: getRAGVectorStoreBackend(),
+    });
+
+    return filteredResults;
+  }
 
   // Convert embedding to pgvector format string
   const embeddingString = `[${queryEmbedding.join(",")}]`;
@@ -435,6 +536,11 @@ export async function getDocumentFullContent(documentId: string): Promise<{
  * Delete a document and all its chunks
  */
 export async function deleteDocument(documentId: string): Promise<void> {
+  const vectorStore = await getConfiguredVectorStore();
+  if (vectorStore) {
+    await vectorStore.deleteDocument(documentId);
+  }
+
   await db.delete(ragChunks).where(eq(ragChunks.documentId, documentId));
   await db.delete(ragDocuments).where(eq(ragDocuments.id, documentId));
 }

--- a/apps/web/lib/cron/insight-maintenance.ts
+++ b/apps/web/lib/cron/insight-maintenance.ts
@@ -10,6 +10,7 @@ import {
 import { runWeeklyInsightMaintenance } from "@/lib/insights/maintenance";
 import { runInsightEmbeddingDream } from "@/lib/insights/dream";
 import { getRawMessageManager } from "@/lib/memory/raw-message-store";
+import { upsertRawMessagesToChroma } from "@/lib/memory/chroma-memory-index";
 import {
   getInsightEmbeddingModelName,
   hasInsightEmbeddingProviderConfig,
@@ -142,11 +143,19 @@ export async function runRawMessageEmbeddingDreamIfDue(
     embedDocuments: (documents) => embeddings.embedDocuments(documents),
     limit: 100,
   });
+  const recentMessages = await manager.queryMessages({
+    userId: schedulerUserId,
+    includeArchived: false,
+    pageSize: 200,
+    reverse: true,
+  });
+  const chromaSynced = await upsertRawMessagesToChroma(recentMessages);
 
   console.log("[LocalScheduler] Raw message embedding dream completed", {
     scanned: result.scanned,
     selected: result.selected,
     embedded: result.embedded,
+    chromaSynced,
     reasons: result.reasons,
   });
 

--- a/apps/web/lib/insights/dream.ts
+++ b/apps/web/lib/insights/dream.ts
@@ -5,6 +5,7 @@ import { normalizeInsight } from "@/lib/db/serialization";
 import { buildInsightEmbeddingDocument } from "@/lib/insights/embedding";
 import {
   getInsightEmbeddingModelName,
+  syncInsightEmbeddingsToChroma,
   upsertInsightEmbeddingsForCandidates,
   type InsightEmbeddingCandidate,
   type UpsertInsightEmbeddingsResult,
@@ -33,6 +34,7 @@ export interface RunInsightEmbeddingDreamResult {
   embedded: number;
   dryRun: boolean;
   reasons: Record<InsightEmbeddingDreamReason, number>;
+  chromaSynced?: number;
   upsert?: UpsertInsightEmbeddingsResult;
 }
 
@@ -144,13 +146,31 @@ export async function runInsightEmbeddingDream(
     }
   }
 
-  if (input.dryRun || candidates.length === 0) {
+  if (input.dryRun) {
     return {
       scanned: rows.length,
       selected: candidates.length,
       embedded: 0,
       dryRun: Boolean(input.dryRun),
       reasons,
+    };
+  }
+
+  if (candidates.length === 0) {
+    const chromaSync = await syncInsightEmbeddingsToChroma({
+      db,
+      userId: input.userId,
+      botId: input.botId,
+      limit: scanLimit,
+      includeArchived,
+    });
+    return {
+      scanned: rows.length,
+      selected: candidates.length,
+      embedded: 0,
+      dryRun: false,
+      reasons,
+      chromaSynced: chromaSync.synced,
     };
   }
 
@@ -161,6 +181,13 @@ export async function runInsightEmbeddingDream(
       authToken: input.authToken,
     },
   });
+  const chromaSync = await syncInsightEmbeddingsToChroma({
+    db,
+    userId: input.userId,
+    botId: input.botId,
+    limit: scanLimit,
+    includeArchived,
+  });
 
   return {
     scanned: rows.length,
@@ -168,6 +195,7 @@ export async function runInsightEmbeddingDream(
     embedded: upsert.embedded,
     dryRun: false,
     reasons,
+    chromaSynced: chromaSync.synced,
     upsert,
   };
 }

--- a/apps/web/lib/insights/embedding-service.ts
+++ b/apps/web/lib/insights/embedding-service.ts
@@ -1,10 +1,15 @@
-import { inArray, sql } from "drizzle-orm";
-import { bot, insightEmbeddings } from "@/lib/db/schema";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { bot, insight, insightEmbeddings } from "@/lib/db/schema";
 import type { DrizzleDB } from "@/lib/db/types";
 import {
   buildInsightEmbeddingDocument,
   type InsightEmbeddingTextInput,
 } from "@/lib/insights/embedding";
+import {
+  isInsightChromaEnabled,
+  type ChromaInsightVectorInput,
+  upsertInsightsToChroma,
+} from "@/lib/memory/chroma-memory-index";
 
 export type InsightEmbeddingCandidate = {
   insightId: string;
@@ -29,6 +34,11 @@ export interface UpsertInsightEmbeddingsResult {
   skippedNoProvider: boolean;
   failed: boolean;
   error?: string;
+}
+
+export interface SyncInsightEmbeddingsToChromaResult {
+  scanned: number;
+  synced: number;
 }
 
 function emptyResult(requested: number): UpsertInsightEmbeddingsResult {
@@ -60,6 +70,88 @@ export function getInsightEmbeddingModelName(): string {
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function parseEmbeddingVector(value: string): number[] | null {
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    const vector = parsed.map((item) => Number(item));
+    return vector.every((item) => Number.isFinite(item)) ? vector : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function syncInsightEmbeddingsToChroma({
+  db,
+  userId,
+  botId,
+  limit = 200,
+  includeArchived = false,
+}: {
+  db: DrizzleDB;
+  userId?: string;
+  botId?: string;
+  limit?: number;
+  includeArchived?: boolean;
+}): Promise<SyncInsightEmbeddingsToChromaResult> {
+  if (!isInsightChromaEnabled()) {
+    return { scanned: 0, synced: 0 };
+  }
+
+  const whereClauses = [isNull(insight.pendingDeletionAt)];
+  if (userId) {
+    whereClauses.push(eq(insightEmbeddings.userId, userId));
+  }
+  if (botId) {
+    whereClauses.push(eq(insightEmbeddings.botId, botId));
+  }
+  if (!includeArchived) {
+    whereClauses.push(eq(insight.isArchived, false));
+  }
+
+  const rows = await db
+    .select({
+      insightId: insightEmbeddings.insightId,
+      userId: insightEmbeddings.userId,
+      botId: insightEmbeddings.botId,
+      content: insightEmbeddings.content,
+      contentHash: insightEmbeddings.contentHash,
+      embedding: insightEmbeddings.embedding,
+      embeddingModel: insightEmbeddings.embeddingModel,
+      embeddingDimensions: insightEmbeddings.embeddingDimensions,
+      title: insight.title,
+      description: insight.description,
+      taskLabel: insight.taskLabel,
+      importance: insight.importance,
+      urgency: insight.urgency,
+      platform: insight.platform,
+      account: insight.account,
+      time: insight.time,
+      archived: insight.isArchived,
+    })
+    .from(insightEmbeddings)
+    .innerJoin(insight, eq(insight.id, insightEmbeddings.insightId))
+    .where(and(...whereClauses))
+    .orderBy(desc(insightEmbeddings.updatedAt))
+    .limit(Math.min(1_000, Math.max(1, Math.floor(limit))));
+
+  const synced = await upsertInsightsToChroma(
+    rows
+      .map((row: any) => ({
+        ...row,
+        embedding: parseEmbeddingVector(row.embedding),
+      }))
+      .filter(
+        (row: any): row is ChromaInsightVectorInput =>
+          Array.isArray(row.embedding) && row.embedding.length > 0,
+      ),
+  );
+
+  return { scanned: rows.length, synced };
 }
 
 export async function upsertInsightEmbeddingsForCandidates({
@@ -211,6 +303,35 @@ export async function upsertInsightEmbeddingsForCandidates({
           updatedAt: now,
         },
       });
+
+    try {
+      await upsertInsightsToChroma(
+        changedDocuments.map((document, index) => {
+          const embedding = embeddingVectors[index];
+          return {
+            insightId: document.insightId,
+            userId: document.userId,
+            botId: document.botId,
+            content: document.content,
+            contentHash: document.contentHash,
+            embedding,
+            embeddingModel: modelName,
+            embeddingDimensions: embedding.length,
+            title: document.payload.title,
+            description: document.payload.description,
+            taskLabel: document.payload.taskLabel,
+            importance: document.payload.importance,
+            urgency: document.payload.urgency,
+            platform: document.payload.platform,
+            account: document.payload.account,
+            time: document.payload.time,
+            archived: (document.payload as any).isArchived,
+          };
+        }),
+      );
+    } catch (error) {
+      console.warn("[InsightEmbedding] Failed to sync Chroma index:", error);
+    }
 
     result.embedded = rows.length;
     return result;

--- a/apps/web/lib/insights/search.ts
+++ b/apps/web/lib/insights/search.ts
@@ -1,6 +1,10 @@
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { db, insight, insightEmbeddings } from "@/lib/db";
 import { isTauriMode } from "@/lib/env/constants";
+import {
+  isInsightChromaEnabled,
+  searchInsightsWithChroma,
+} from "@/lib/memory/chroma-memory-index";
 
 const DEFAULT_LIMIT = 10;
 const DEFAULT_THRESHOLD = 0.7;
@@ -294,6 +298,29 @@ export async function searchInsightsSemantically(
   const limit = clampLimit(input.limit);
   const threshold = clampThreshold(input.threshold);
   const queryEmbedding = await embedQuery(query, input.authToken);
+
+  if (isInsightChromaEnabled()) {
+    try {
+      const results = await searchInsightsWithChroma({
+        userId: input.userId,
+        queryEmbedding,
+        limit,
+        threshold,
+        botIds: input.botIds,
+        includeArchived: input.includeArchived,
+      });
+
+      return results.map((result) => ({
+        type: "insight",
+        ...result,
+      }));
+    } catch (error) {
+      console.warn(
+        "[InsightSearch] Chroma insight search failed; falling back to database search:",
+        error,
+      );
+    }
+  }
 
   if (isTauriMode()) {
     return searchInsightEmbeddingsWithSqlite({

--- a/apps/web/lib/integrations/feishu/handler.ts
+++ b/apps/web/lib/integrations/feishu/handler.ts
@@ -19,6 +19,7 @@ import { DEFAULT_AI_MODEL, AI_PROXY_BASE_URL } from "@/lib/env/constants";
 import { getCloudAuthToken } from "@/lib/auth/token-manager";
 import { handleAgentRuntime } from "@/lib/ai/runtime/shared";
 import { getRawMessageManager } from "@/lib/memory/raw-message-store";
+import { upsertRawMessagesToChroma } from "@/lib/memory/chroma-memory-index";
 import {
   getInsightEmbeddingModelName,
   hasInsightEmbeddingProviderConfig,
@@ -39,6 +40,18 @@ import { FeishuAdapter } from "@openloomi/integrations/feishu";
 import { createTaskSession } from "@/lib/files/workspace/sessions";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+const FEISHU_UNIFIED_MEMORY_SEARCH_ONLY =
+  process.env.FEISHU_UNIFIED_MEMORY_SEARCH_ONLY === "true";
+const FEISHU_UNIFIED_MEMORY_EXCLUDED_TOOLS = [
+  "chatInsight",
+  "searchKnowledgeBase",
+  "getFullDocumentContent",
+  "listKnowledgeBaseDocuments",
+  "getRawMessages",
+  "searchRawMessages",
+  "searchMemoryPath",
+];
 
 type FeishuCredentials = {
   appId?: string;
@@ -164,6 +177,7 @@ async function storeFeishuRawMessage(input: {
       input.authToken,
     );
     await manager.storeMessage(messageWithEmbedding);
+    await upsertRawMessagesToChroma([messageWithEmbedding]);
     console.log("[Feishu] Stored raw message", {
       messageId: input.messageId,
       role: input.role,
@@ -737,6 +751,9 @@ export async function handleFeishuInboundMessage(
           language: insightSettings?.language ?? null,
           abortController,
           workDir,
+          ...(FEISHU_UNIFIED_MEMORY_SEARCH_ONLY
+            ? { excludeTools: FEISHU_UNIFIED_MEMORY_EXCLUDED_TOOLS }
+            : {}),
           ...(token && {
             modelConfig: {
               apiKey: token,

--- a/apps/web/lib/memory/chroma-memory-index.ts
+++ b/apps/web/lib/memory/chroma-memory-index.ts
@@ -3,7 +3,7 @@ import {
   rawMessageToMemoryRecord,
   type RawMessage,
 } from "@openloomi/indexeddb";
-import { ChromaVectorStore } from "@openloomi/rag/chroma-store";
+import { ChromaVectorStore } from "@openloomi/rag";
 import type { DocumentChunk } from "@openloomi/rag/vector-service";
 
 const DEFAULT_RAW_MESSAGES_COLLECTION = "openloomi_raw_messages";

--- a/apps/web/lib/memory/chroma-memory-index.ts
+++ b/apps/web/lib/memory/chroma-memory-index.ts
@@ -1,0 +1,340 @@
+import { buildMemoryRecordEmbeddingDocument } from "@openloomi/ai/memory";
+import {
+  rawMessageToMemoryRecord,
+  type RawMessage,
+} from "@openloomi/indexeddb";
+import { ChromaVectorStore } from "@openloomi/rag/chroma-store";
+import type { DocumentChunk } from "@openloomi/rag/vector-service";
+
+const DEFAULT_RAW_MESSAGES_COLLECTION = "openloomi_raw_messages";
+const DEFAULT_INSIGHTS_COLLECTION = "openloomi_insights";
+const RAW_VECTOR_BACKEND_ENV_KEYS = [
+  "RAW_MESSAGE_VECTOR_STORE_BACKEND",
+  "MEMORY_VECTOR_STORE_BACKEND",
+  "VECTOR_STORE_BACKEND",
+] as const;
+const INSIGHT_VECTOR_BACKEND_ENV_KEYS = [
+  "INSIGHT_VECTOR_STORE_BACKEND",
+  "MEMORY_VECTOR_STORE_BACKEND",
+  "VECTOR_STORE_BACKEND",
+] as const;
+
+export interface ChromaInsightVectorInput {
+  insightId: string;
+  userId: string;
+  botId: string;
+  content: string;
+  contentHash: string;
+  embedding: number[];
+  embeddingModel: string;
+  embeddingDimensions: number;
+  title?: unknown;
+  description?: unknown;
+  taskLabel?: unknown;
+  importance?: unknown;
+  urgency?: unknown;
+  platform?: unknown;
+  account?: unknown;
+  time?: unknown;
+  archived?: unknown;
+}
+
+export interface ChromaInsightSearchResult {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: {
+    botId: string;
+    title: string;
+    description: string;
+    taskLabel: string;
+    importance: string;
+    urgency: string;
+    platform: string | null;
+    account: string | null;
+    time: Date | null;
+    embeddingModel: string;
+    embeddingDimensions: number;
+    contentHash: string;
+  };
+}
+
+function getBackend(keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]?.trim().toLowerCase();
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+export function isRawMessageChromaEnabled(): boolean {
+  return getBackend(RAW_VECTOR_BACKEND_ENV_KEYS) === "chroma";
+}
+
+export function isInsightChromaEnabled(): boolean {
+  return getBackend(INSIGHT_VECTOR_BACKEND_ENV_KEYS) === "chroma";
+}
+
+function getRawMessagesCollectionName(): string {
+  return (
+    process.env.CHROMA_RAW_MESSAGES_COLLECTION ||
+    process.env.CHROMA_MEMORY_COLLECTION ||
+    DEFAULT_RAW_MESSAGES_COLLECTION
+  );
+}
+
+function getInsightsCollectionName(): string {
+  return process.env.CHROMA_INSIGHTS_COLLECTION || DEFAULT_INSIGHTS_COLLECTION;
+}
+
+function getChromaStore(collectionName: string): ChromaVectorStore {
+  return new ChromaVectorStore({
+    url: process.env.CHROMA_URL,
+    collectionName,
+  });
+}
+
+function normalizeTimestampToMs(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if ((value as number) < 1e11) {
+    return Math.floor((value as number) * 1000);
+  }
+  return Math.floor(value as number);
+}
+
+function toStringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : fallback;
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function toBooleanValue(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function toDateValue(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function rawMessageToChunk(message: RawMessage): DocumentChunk | null {
+  if (!message.embedding || message.embedding.length === 0) {
+    return null;
+  }
+
+  const record = rawMessageToMemoryRecord(message);
+  const document = buildMemoryRecordEmbeddingDocument(record);
+  if (!document.content) {
+    return null;
+  }
+
+  return {
+    id: message.messageId,
+    documentId: message.messageId,
+    content: document.content,
+    embedding: message.embedding,
+    metadata: {
+      sourceType: "raw_message",
+      userId: message.userId,
+      platform: message.platform,
+      botId: message.botId,
+      channel: message.channel,
+      person: message.person,
+      timestamp: normalizeTimestampToMs(message.timestamp),
+      memoryStage: message.memoryStage,
+      embeddingModel: message.embeddingModel,
+      embeddingDimensions: message.embeddingDimensions,
+      contentHash: message.embeddingContentHash,
+      archived: Boolean(message.archivedAt),
+      role:
+        typeof message.metadata?.role === "string"
+          ? message.metadata.role
+          : undefined,
+    },
+  };
+}
+
+export async function upsertRawMessagesToChroma(
+  messages: RawMessage[],
+): Promise<number> {
+  if (!isRawMessageChromaEnabled() || messages.length === 0) {
+    return 0;
+  }
+
+  const chunks = messages
+    .map(rawMessageToChunk)
+    .filter((chunk): chunk is DocumentChunk => chunk !== null);
+  if (chunks.length === 0) {
+    return 0;
+  }
+
+  const store = getChromaStore(getRawMessagesCollectionName());
+  await store.addChunks(chunks);
+  return chunks.length;
+}
+
+export async function searchRawMessagesWithChroma(input: {
+  userId: string;
+  queryEmbedding: number[];
+  limit: number;
+  threshold: number;
+  botId?: string;
+}): Promise<
+  Array<{
+    id: string;
+    content: string;
+    similarity: number;
+    metadata: Record<string, unknown>;
+  }>
+> {
+  if (!isRawMessageChromaEnabled() || input.queryEmbedding.length === 0) {
+    return [];
+  }
+
+  const store = getChromaStore(getRawMessagesCollectionName());
+  const results = await store.similaritySearch(
+    input.queryEmbedding,
+    Math.max(input.limit * 5, input.limit),
+    input.userId,
+  );
+
+  return results
+    .filter((result) => {
+      const metadata = result.metadata ?? {};
+      if (toBooleanValue(metadata.archived)) {
+        return false;
+      }
+      if (input.botId && metadata.botId !== input.botId) {
+        return false;
+      }
+      return result.score >= input.threshold;
+    })
+    .map((result) => ({
+      id: result.id,
+      content: result.content,
+      similarity: result.score,
+      metadata: result.metadata ?? {},
+    }))
+    .slice(0, input.limit);
+}
+
+export async function upsertInsightsToChroma(
+  insights: ChromaInsightVectorInput[],
+): Promise<number> {
+  if (!isInsightChromaEnabled() || insights.length === 0) {
+    return 0;
+  }
+
+  const chunks = insights
+    .filter(
+      (item) =>
+        item.content.trim().length > 0 &&
+        Array.isArray(item.embedding) &&
+        item.embedding.length > 0,
+    )
+    .map<DocumentChunk>((item) => ({
+      id: item.insightId,
+      documentId: item.insightId,
+      content: item.content,
+      embedding: item.embedding,
+      metadata: {
+        sourceType: "insight",
+        insightId: item.insightId,
+        userId: item.userId,
+        botId: item.botId,
+        title: toStringValue(item.title),
+        description: toStringValue(item.description),
+        taskLabel: toStringValue(item.taskLabel),
+        importance: toStringValue(item.importance),
+        urgency: toStringValue(item.urgency),
+        platform: toNullableString(item.platform),
+        account: toNullableString(item.account),
+        time: toDateValue(item.time)?.toISOString(),
+        embeddingModel: item.embeddingModel,
+        embeddingDimensions: item.embeddingDimensions,
+        contentHash: item.contentHash,
+        archived: toBooleanValue(item.archived),
+      },
+    }));
+
+  if (chunks.length === 0) {
+    return 0;
+  }
+
+  const store = getChromaStore(getInsightsCollectionName());
+  await store.addChunks(chunks);
+  return chunks.length;
+}
+
+export async function searchInsightsWithChroma(input: {
+  userId: string;
+  queryEmbedding: number[];
+  limit: number;
+  threshold: number;
+  botIds?: string[];
+  includeArchived?: boolean;
+}): Promise<ChromaInsightSearchResult[]> {
+  if (!isInsightChromaEnabled() || input.queryEmbedding.length === 0) {
+    return [];
+  }
+
+  const botIdSet =
+    input.botIds && input.botIds.length > 0 ? new Set(input.botIds) : null;
+  const store = getChromaStore(getInsightsCollectionName());
+  const results = await store.similaritySearch(
+    input.queryEmbedding,
+    Math.max(input.limit * 5, input.limit),
+    input.userId,
+  );
+
+  return results
+    .filter((result) => {
+      const metadata = result.metadata ?? {};
+      if (!input.includeArchived && toBooleanValue(metadata.archived)) {
+        return false;
+      }
+      if (botIdSet && !botIdSet.has(String(metadata.botId ?? ""))) {
+        return false;
+      }
+      return result.score >= input.threshold;
+    })
+    .map((result) => {
+      const metadata = result.metadata ?? {};
+      return {
+        id: result.id,
+        content: result.content,
+        similarity: result.score,
+        metadata: {
+          botId: toStringValue(metadata.botId),
+          title: toStringValue(metadata.title),
+          description: toStringValue(metadata.description),
+          taskLabel: toStringValue(metadata.taskLabel),
+          importance: toStringValue(metadata.importance),
+          urgency: toStringValue(metadata.urgency),
+          platform: toNullableString(metadata.platform),
+          account: toNullableString(metadata.account),
+          time: toDateValue(metadata.time),
+          embeddingModel: toStringValue(metadata.embeddingModel),
+          embeddingDimensions: Number(metadata.embeddingDimensions ?? 0),
+          contentHash: toStringValue(metadata.contentHash),
+        },
+      };
+    })
+    .slice(0, input.limit);
+}

--- a/apps/web/lib/memory/unified-search.ts
+++ b/apps/web/lib/memory/unified-search.ts
@@ -4,6 +4,10 @@ import {
   getRawMessageManager,
   isRawMessageStorageAvailable,
 } from "@/lib/memory/raw-message-store";
+import {
+  isRawMessageChromaEnabled,
+  searchRawMessagesWithChroma,
+} from "@/lib/memory/chroma-memory-index";
 import type { RawMessage } from "@openloomi/indexeddb";
 
 export type UnifiedMemorySearchSource = "memory" | "insights" | "knowledge";
@@ -328,28 +332,56 @@ async function searchRawMemoryHybrid(input: {
   ).flat();
 
   let semanticResults: UnifiedMemorySearchResult[] = [];
-  if (
-    typeof manager.searchMessagesSemantically === "function" &&
-    hasEmbeddingProviderConfig(input.authToken)
-  ) {
+  if (hasEmbeddingProviderConfig(input.authToken)) {
     const queryEmbedding = await embedQuery(input.query, input.authToken);
     if (queryEmbedding.length > 0) {
-      semanticResults = (
-        await Promise.all(
-          filters.map((filter) =>
-            manager.searchMessagesSemantically?.({
-              userId: input.userId,
-              queryEmbedding,
-              limit: input.limit,
-              threshold: input.threshold,
-              ...filter,
-            }),
-          ),
+      if (isRawMessageChromaEnabled()) {
+        try {
+          semanticResults = (
+            await Promise.all(
+              filters.map((filter) => {
+                const botId = "botId" in filter ? filter.botId : undefined;
+                return searchRawMessagesWithChroma({
+                  userId: input.userId,
+                  queryEmbedding,
+                  limit: input.limit,
+                  threshold: input.threshold,
+                  botId,
+                });
+              }),
+            )
+          )
+            .flat()
+            .map(toMemoryResult);
+        } catch (error) {
+          console.warn(
+            "[UnifiedMemory] Chroma raw message search failed; falling back to database search:",
+            error,
+          );
+        }
+      }
+
+      if (
+        semanticResults.length === 0 &&
+        typeof manager.searchMessagesSemantically === "function"
+      ) {
+        semanticResults = (
+          await Promise.all(
+            filters.map((filter) =>
+              manager.searchMessagesSemantically?.({
+                userId: input.userId,
+                queryEmbedding,
+                limit: input.limit,
+                threshold: input.threshold,
+                ...filter,
+              }),
+            ),
+          )
         )
-      )
-        .flat()
-        .filter(isRawMemorySemanticResult)
-        .map(toMemoryResult);
+          .flat()
+          .filter(isRawMemorySemanticResult)
+          .map(toMemoryResult);
+      }
     }
   }
 

--- a/packages/ai/rag/package.json
+++ b/packages/ai/rag/package.json
@@ -10,6 +10,7 @@
     "./vector-service": "./src/vector-service.ts",
     "./parsers": "./src/parsers.ts",
     "./universal-embeddings": "./src/universal-embeddings.ts",
+    "./chroma-store": "./src/chroma-store.ts",
     "./sqlite-vec-store": "./src/sqlite-vec-store.ts",
     "./pgvector-store": "./src/pgvector-store.ts"
   },
@@ -23,6 +24,7 @@
     "pdfjs-dist": "^4.9.155",
     "jszip": "^3.10.1",
     "better-sqlite3": "^11.7.0",
+    "chromadb": "^3.4.3",
     "sqlite-vec": "^0.1.6-alpha.5",
     "pg": "^8.13.1",
     "openai": "^4.85.2"

--- a/packages/ai/rag/src/chroma-store.ts
+++ b/packages/ai/rag/src/chroma-store.ts
@@ -1,0 +1,230 @@
+/**
+ * ChromaDB Vector Store.
+ * Client-server vector search using ChromaDB's TypeScript client.
+ */
+
+import { ChromaClient } from "chromadb";
+import type {
+  DocumentChunk,
+  IVectorStore,
+  VectorSearchResult,
+} from "./vector-service";
+
+type ChromaCollection = Awaited<
+  ReturnType<InstanceType<typeof ChromaClient>["getOrCreateCollection"]>
+>;
+
+export interface ChromaVectorStoreOptions {
+  url?: string;
+  host?: string;
+  port?: number;
+  ssl?: boolean;
+  collectionName?: string;
+}
+
+type ChromaMetadataValue = string | number | boolean | null;
+type ChromaMetadata = Record<string, ChromaMetadataValue>;
+
+const DEFAULT_CHROMA_URL = "http://localhost:8000";
+const DEFAULT_COLLECTION_NAME = "openloomi_rag_chunks";
+
+/**
+ * Chroma-backed implementation of the shared vector store interface.
+ */
+export class ChromaVectorStore implements IVectorStore {
+  private client: InstanceType<typeof ChromaClient>;
+  private collectionName: string;
+  private collection: ChromaCollection | null = null;
+
+  constructor(options: ChromaVectorStoreOptions = {}) {
+    const clientOptions = buildClientOptions(options);
+    this.client = new ChromaClient(clientOptions);
+    this.collectionName =
+      options.collectionName ||
+      process.env.CHROMA_COLLECTION ||
+      DEFAULT_COLLECTION_NAME;
+  }
+
+  async addChunk(chunk: DocumentChunk): Promise<void> {
+    await this.addChunks([chunk]);
+  }
+
+  async addChunks(chunks: DocumentChunk[]): Promise<void> {
+    if (chunks.length === 0) return;
+
+    const collection = await this.getCollection();
+
+    await collection.upsert({
+      ids: chunks.map((chunk) => chunk.id),
+      embeddings: chunks.map((chunk) => chunk.embedding),
+      documents: chunks.map((chunk) => chunk.content),
+      metadatas: chunks.map((chunk) => this.toMetadata(chunk)),
+    });
+  }
+
+  async similaritySearch(
+    queryEmbedding: number[],
+    limit = 10,
+    userId?: string,
+  ): Promise<VectorSearchResult[]> {
+    const collection = await this.getCollection();
+
+    const result = await collection.query({
+      queryEmbeddings: [queryEmbedding],
+      nResults: limit,
+      where: userId ? { userId } : undefined,
+    });
+
+    const ids = result.ids?.[0] ?? [];
+    const documents = result.documents?.[0] ?? [];
+    const metadatas = result.metadatas?.[0] ?? [];
+    const distances = result.distances?.[0] ?? [];
+
+    return ids.map((id, index) => {
+      const metadata = normalizeMetadata(metadatas[index]);
+      return {
+        id,
+        content: documents[index] ?? "",
+        score: distanceToScore(distances[index]),
+        documentId: String(metadata.documentId ?? ""),
+        metadata,
+      };
+    });
+  }
+
+  async deleteDocument(documentId: string): Promise<void> {
+    const collection = await this.getCollection();
+
+    await collection.delete({
+      where: { documentId },
+    });
+  }
+
+  async getDocumentCount(): Promise<number> {
+    return await this.getChunkCount();
+  }
+
+  async getChunkCount(): Promise<number> {
+    const collection = await this.getCollection();
+    return await collection.count();
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await this.client.deleteCollection({ name: this.collectionName });
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        throw error;
+      }
+    } finally {
+      this.collection = null;
+    }
+  }
+
+  private async getCollection(): Promise<ChromaCollection> {
+    if (!this.collection) {
+      this.collection = await this.client.getOrCreateCollection({
+        name: this.collectionName,
+        metadata: {
+          source: "@openloomi/rag",
+          store: "chroma",
+        },
+      });
+    }
+
+    return this.collection;
+  }
+
+  private toMetadata(chunk: DocumentChunk): ChromaMetadata {
+    return sanitizeMetadata({
+      ...chunk.metadata,
+      documentId: chunk.documentId,
+    });
+  }
+}
+
+let chromaVectorStoreInstance: ChromaVectorStore | null = null;
+
+export function getChromaVectorStore(
+  options: ChromaVectorStoreOptions = {},
+): ChromaVectorStore {
+  if (!chromaVectorStoreInstance) {
+    chromaVectorStoreInstance = new ChromaVectorStore(options);
+  }
+
+  return chromaVectorStoreInstance;
+}
+
+export function resetChromaVectorStore(): void {
+  chromaVectorStoreInstance = null;
+}
+
+function buildClientOptions(
+  options: ChromaVectorStoreOptions,
+): ConstructorParameters<typeof ChromaClient>[0] {
+  const url = options.url || process.env.CHROMA_URL || DEFAULT_CHROMA_URL;
+
+  if (options.host || options.port || options.ssl !== undefined) {
+    return {
+      host: options.host,
+      port: options.port,
+      ssl: options.ssl,
+    };
+  }
+
+  const parsedUrl = new URL(url);
+
+  return {
+    host: parsedUrl.hostname,
+    port: parsedUrl.port ? Number(parsedUrl.port) : undefined,
+    ssl: parsedUrl.protocol === "https:",
+  };
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown>): ChromaMetadata {
+  const sanitized: ChromaMetadata = {};
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (isChromaMetadataValue(value)) {
+      sanitized[key] = value;
+      continue;
+    }
+
+    if (value === undefined) {
+      continue;
+    }
+
+    sanitized[key] = JSON.stringify(value);
+  }
+
+  return sanitized;
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {};
+  }
+
+  return metadata as Record<string, unknown>;
+}
+
+function isChromaMetadataValue(value: unknown): value is ChromaMetadataValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function distanceToScore(distance: number | null | undefined): number {
+  if (typeof distance !== "number") return 0;
+  return 1 / (1 + Math.max(0, distance));
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const message = "message" in error ? String(error.message) : "";
+  return /not.?found|does not exist|404/i.test(message);
+}

--- a/packages/ai/rag/src/index.ts
+++ b/packages/ai/rag/src/index.ts
@@ -56,6 +56,12 @@ export {
 } from "./sqlite-vec-store";
 
 export {
+  ChromaVectorStore,
+  getChromaVectorStore,
+  resetChromaVectorStore,
+} from "./chroma-store";
+
+export {
   getPGVectorStore,
   processDocumentWithPGVector,
   searchWithPGVector,

--- a/packages/ai/rag/src/universal-embeddings.ts
+++ b/packages/ai/rag/src/universal-embeddings.ts
@@ -7,6 +7,8 @@
 const EMBEDDING_BASE_URL =
   process.env.LLM_EMBEDDING_BASE_URL || "https://openrouter.ai/api/v1";
 
+const DEFAULT_EMBEDDING_BATCH_SIZE = 10;
+
 /**
  * Custom embeddings implementation that can use OpenAI or OpenRouter API.
  * Auth strategy is determined by the base URL and env vars set by the caller.
@@ -38,7 +40,7 @@ export class UniversalEmbeddings {
       throw new Error("No texts provided for embedding");
     }
 
-    const batchSize = 100;
+    const batchSize = getEmbeddingBatchSize();
     const results: number[][] = [];
 
     for (let i = 0; i < texts.length; i += batchSize) {
@@ -122,4 +124,19 @@ export class UniversalEmbeddings {
       return item.embedding;
     });
   }
+}
+
+function getEmbeddingBatchSize(): number {
+  const rawBatchSize = process.env.LLM_EMBEDDING_BATCH_SIZE;
+  if (!rawBatchSize) return DEFAULT_EMBEDDING_BATCH_SIZE;
+
+  const parsedBatchSize = Number(rawBatchSize);
+  if (!Number.isFinite(parsedBatchSize) || parsedBatchSize < 1) {
+    console.warn(
+      `[RAG] Invalid LLM_EMBEDDING_BATCH_SIZE=${rawBatchSize}; using ${DEFAULT_EMBEDDING_BATCH_SIZE}`,
+    );
+    return DEFAULT_EMBEDDING_BATCH_SIZE;
+  }
+
+  return Math.floor(parsedBatchSize);
 }

--- a/packages/ai/rag/src/vector-service.ts
+++ b/packages/ai/rag/src/vector-service.ts
@@ -11,6 +11,8 @@
 
 export { SQLiteVecStore } from "./sqlite-vec-store";
 export { getSQLiteVecStore, resetSQLiteVecStore } from "./sqlite-vec-store";
+export { ChromaVectorStore } from "./chroma-store";
+export { getChromaVectorStore, resetChromaVectorStore } from "./chroma-store";
 
 export {
   getPGVectorStore,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(fdfe7f397b05cc6db33b65af19063568)
+        version: 1.1.27(38b2b0894bd37534776619749b0a4b66)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -950,7 +950,7 @@ importers:
     dependencies:
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(a1feb36706f300ff7d193e81a5c5d11a)
+        version: 1.1.27(400edf63b65f130ad7dd9a4afb6e7c00)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -963,6 +963,9 @@ importers:
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0
+      chromadb:
+        specifier: ^3.4.3
+        version: 3.4.3
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -1373,7 +1376,7 @@ importers:
     dependencies:
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(a1feb36706f300ff7d193e81a5c5d11a)
+        version: 1.1.27(400edf63b65f130ad7dd9a4afb6e7c00)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -1592,25 +1595,21 @@ packages:
     resolution: {integrity: sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.117':
     resolution: {integrity: sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.117':
     resolution: {integrity: sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.117':
     resolution: {integrity: sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.117':
     resolution: {integrity: sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA==}
@@ -1997,28 +1996,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -3043,105 +3038,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3345,6 +3324,7 @@ packages:
   '@langchain/community@1.1.27':
     resolution: {integrity: sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==}
     engines: {node: '>=20'}
+    deprecated: This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info
     peerDependencies:
       '@arcjet/redact': ^v1.2.0
       '@aws-crypto/sha256-js': ^5.0.0
@@ -3836,35 +3816,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
     resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
     resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
     resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
     resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
@@ -3958,70 +3933,60 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
     resolution: {integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.99':
     resolution: {integrity: sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
     resolution: {integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.99':
     resolution: {integrity: sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.99':
     resolution: {integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -4087,28 +4052,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.1':
     resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.1':
     resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.1':
     resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.1':
     resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
@@ -5186,79 +5147,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -5776,28 +5724,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -5870,35 +5814,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -6499,49 +6438,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -7344,6 +7275,41 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    resolution: {integrity: sha512-pDdWCcR0hCz3pSDiIijBito7YG6FumewfzYE2mIjSwjrO1CKSfQKLwDdTVK4ZNpVGQa16ePoMX+pg7ShSUARJg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    resolution: {integrity: sha512-5vKVFXSFo+S9qC9by/7oofjcXqQK4IGHiUnPrvTfc7B52gNlPSKeyDO1wha556COc3KtXSZjICEH0nYBJ8UXng==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    resolution: {integrity: sha512-ELiqDZzU5mZd1BvZugGrhoMkVeNyQaa+PGizd06WIpIJVoHY+S+9ZBjdeM6ZkRnL3vTxD79XBrosxNWhzqy/kg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  chromadb@3.4.3:
+    resolution: {integrity: sha512-AouHyTh70Ux1w5TKDmk54wGAszY7NtU/DXyC7o3qGuE8b+b1nT/W3+s8UVd9XwqGZIR4A76+g4u7yJuV/WU3OA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -8942,7 +8908,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.4:
     resolution: {integrity: sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==}
@@ -9737,8 +9703,8 @@ packages:
   libqp@2.1.1:
     resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
+  libsignal@git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    resolution: {commit: bcea72df9ec34d9d9140ab30619cf479c7c144c7, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
     version: 6.0.0
 
   lie@3.3.0:
@@ -9779,28 +9745,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -12687,7 +12649,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -15335,57 +15297,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.27(a1feb36706f300ff7d193e81a5c5d11a)':
-    dependencies:
-      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
-      '@langchain/classic': 1.0.27(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@langchain/openai': 1.4.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      binary-extensions: 2.3.0
-      flat: 5.0.2
-      ibm-cloud-sdk-core: 5.4.11
-      js-yaml: 4.1.1
-      langsmith: 0.5.21(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      math-expression-evaluator: 2.0.7
-      openai: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
-      uuid: 10.0.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/credential-provider-node': 3.972.44
-      '@browserbasehq/sdk': 2.10.0
-      '@mozilla/readability': 0.6.0
-      '@neondatabase/serverless': 0.9.5
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.4.4
-      '@smithy/util-utf8': 4.2.2
-      '@vercel/postgres': 0.10.0(utf-8-validate@5.0.10)
-      better-sqlite3: 11.10.0
-      crypto-js: 4.2.0
-      d3-dsv: 3.0.1
-      discord.js: 14.26.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      fast-xml-parser: 5.7.3
-      google-auth-library: 10.6.2
-      googleapis: 140.0.1
-      html-to-text: 9.0.5
-      ignore: 7.0.5
-      ioredis: 5.10.1
-      jsdom: 28.1.0
-      jsonwebtoken: 9.0.3
-      lodash: 4.18.1
-      mammoth: 1.12.0
-      pg: 8.20.0
-      playwright: 1.59.1
-      puppeteer: 24.42.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - peggy
-
-  '@langchain/community@1.1.27(fdfe7f397b05cc6db33b65af19063568)':
+  '@langchain/community@1.1.27(38b2b0894bd37534776619749b0a4b66)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@16.6.1)(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
@@ -15412,6 +15324,7 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       '@vercel/postgres': 0.10.0(utf-8-validate@5.0.10)
       better-sqlite3: 11.10.0
+      chromadb: 3.4.3
       crypto-js: 4.2.0
       d3-dsv: 3.0.1
       discord.js: 14.26.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -15432,6 +15345,57 @@ snapshots:
       puppeteer: 24.42.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       redis: 5.12.1(@opentelemetry/api@1.9.1)
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - peggy
+
+  '@langchain/community@1.1.27(400edf63b65f130ad7dd9a4afb6e7c00)':
+    dependencies:
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
+      '@langchain/classic': 1.0.27(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 1.4.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      binary-extensions: 2.3.0
+      flat: 5.0.2
+      ibm-cloud-sdk-core: 5.4.11
+      js-yaml: 4.1.1
+      langsmith: 0.5.21(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      math-expression-evaluator: 2.0.7
+      openai: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      uuid: 10.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@browserbasehq/sdk': 2.10.0
+      '@mozilla/readability': 0.6.0
+      '@neondatabase/serverless': 0.9.5
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/util-utf8': 4.2.2
+      '@vercel/postgres': 0.10.0(utf-8-validate@5.0.10)
+      better-sqlite3: 11.10.0
+      chromadb: 3.4.3
+      crypto-js: 4.2.0
+      d3-dsv: 3.0.1
+      discord.js: 14.26.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      fast-xml-parser: 5.7.3
+      google-auth-library: 10.6.2
+      googleapis: 140.0.1
+      html-to-text: 9.0.5
+      ignore: 7.0.5
+      ioredis: 5.10.1
+      jsdom: 28.1.0
+      jsonwebtoken: 9.0.3
+      lodash: 4.18.1
+      mammoth: 1.12.0
+      pg: 8.20.0
+      playwright: 1.59.1
+      puppeteer: 24.42.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -18807,7 +18771,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
+      libsignal: git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7
       lru-cache: 11.3.5
       music-metadata: 11.12.3
       p-queue: 9.1.2
@@ -19446,6 +19410,31 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
+
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    optional: true
+
+  chromadb@3.4.3:
+    dependencies:
+      semver: 7.7.4
+    optionalDependencies:
+      chromadb-js-bindings-darwin-arm64: 1.3.4
+      chromadb-js-bindings-darwin-x64: 1.3.4
+      chromadb-js-bindings-linux-arm64-gnu: 1.3.4
+      chromadb-js-bindings-linux-x64-gnu: 1.3.4
+      chromadb-js-bindings-win32-x64-msvc: 1.3.4
 
   chrome-trace-event@1.0.4: {}
 
@@ -22496,7 +22485,7 @@ snapshots:
 
   libqp@2.1.1: {}
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+  libsignal@git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7:
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 7.5.5


### PR DESCRIPTION
## Title

feat: add ChromaDB support for raw messages, insights, and knowledge

## Summary

* Add a ChromaDB vector store adapter for the shared RAG vector store interface
* Add optional ChromaDB-backed semantic indexes for raw messages, insights, and RAG chunks
* Add ChromaDB sync helpers for raw message and insight embeddings
* Route semantic memory and insight search through ChromaDB when enabled, with fallback to the existing database search paths
* Add ChromaDB backend and collection configuration examples to `.env.example`

## Testing

* Verified raw messages are synced to ChromaDB after storage and embedding updates
* Verified insight embeddings are synced to ChromaDB during embedding maintenance
* Verified RAG chunks are written to ChromaDB when the Chroma backend is enabled

re #91 