### PR TITLE
feat: split Founders & Salespeople into two separate use cases

### DIFF
--- a/apps/marketing/content/use-cases/founders.mdx
+++ b/apps/marketing/content/use-cases/founders.mdx
@@ -1,0 +1,148 @@
+---
+title: "Founders & Business Development"
+description: "Scale your personal brand and manage hundreds of relationships at scale"
+icon: "FaRocket"
+---
+
+# Founders & Business Development
+
+## Your Personal Brand, Operating at Scale
+
+OpenLoomi learns your communication style, automatically maintains hundreds of client relationships, and executes personalized outreach at scale — so you can focus on closing deals and building your network.
+
+**What it does:**
+
+| Step                      | Action                                                             |
+| ------------------------- | ------------------------------------------------------------------ |
+| 🧠 Learn your style       | Read past messages to mirror your tone and phrasing                |
+| 🤝 Maintain relationships | Auto-manage 500+ relationships without losing touch                |
+| ✉️ Outreach at scale      | Personalized one-to-many outreach across email, Telegram, LinkedIn |
+| 🔄 Never drop a lead      | Automated follow-up cadence that keeps every connection warm       |
+
+> "I can now manage what used to require a full BD team. OpenLoomi handles the follow-ups and personalized outreach while I focus on closing deals and building relationships."
+
+---
+
+## See It in Action
+
+### Your Communication Style, Preserved at Scale
+
+OpenLoomi reads your past messages and communication patterns to draft outreach that sounds like you — not generic AI. The more you use it, the better it mirrors your voice.
+
+---
+
+### Relationship Maintenance at Scale
+
+Manage 500+ relationships without the overhead. OpenLoomi tracks each connection's last touch point, engagement level, and priority — automatically scheduling follow-ups before relationships go cold.
+
+---
+
+### Personalized Outreach Without the Hours
+
+Draft personalized first messages to prospects and existing connections using the **cold-email** skill. OpenLoomi learns your tone, formality, and phrasing to generate outreach that feels human — sent at scale.
+
+---
+
+### Follow-Up Cadence That Works
+
+Set it and forget it. OpenLoomi manages your follow-up sequences — weekly check-ins, post-meeting touch points, competitive intel alerts — drafting each message for your approval before anything goes out.
+
+---
+
+## What Changed
+
+| Aspect                | Before                    | After                            |
+| --------------------- | ------------------------- | -------------------------------- |
+| Relationships managed | 50 manually               | 500+ with AI assistance          |
+| Outreach quality      | Generic mass emails       | Personalized at scale            |
+| Follow-up cadence     | Dropped after one touch   | 5-touch sequences, automated     |
+| Network growth        | Stalled by admin overhead | Growing while you focus on deals |
+
+---
+
+## How to Set Up
+
+**Option 1: Copy & Paste (Easiest)**
+
+Open OpenLoomi and paste this:
+
+```
+Please help me set up my personal outreach and relationship management workflow.
+
+1. Learn my communication style: read my past messages to understand my tone, formality, and phrasing
+
+2. Set up relationship tracking:
+   - Import my key connections and contacts
+   - Track engagement level and last touch point for each
+   - Flag relationships that need follow-up based on cadence I set
+
+3. Set up personalized outreach:
+   - When I flag a new contact, draft a personalized first message using the cold-email skill
+   - Mirror my communication style in every draft
+   - Draft everything — I approve before anything goes out
+
+4. Set up a 5-touch follow-up sequence for new connections (day 1, day 3, day 7, day 14, day 21)
+   - Each touch should add value, not just "checking in"
+   - Keep the connection warm without being pushy
+
+5. Track everything to my timeline
+```
+
+OpenLoomi will automatically create the scheduled tasks for you!
+
+---
+
+**Option 2: Manual Setup**
+
+### Step 1: Import Your Network
+
+1. Go to **Settings → Connectors**
+2. Connect your email or LinkedIn to import existing contacts
+3. OpenLoomi will start learning your communication patterns from past messages
+
+### Step 2: Configure Personalization
+
+1. Go to **Settings → Personalization → My Interests**
+2. Add your priority keywords: industries, companies, topics you care about
+3. Add communication preferences: formal/informal, preferred phrasing
+4. Set your follow-up cadence preferences
+
+### Step 3: Create Automation Tasks
+
+1. Go to the **Agent** page, then select **Automation** → **New Task**
+2. Create your relationship task:
+
+| Field            | Input                                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `Relationship Maintenance`                                                                                                                                                  |
+| Task Description | `1. Review all tracked relationships\n2. Flag those needing follow-up based on last touch point\n3. Draft personalized follow-up messages\n4. Log all activity to timeline` |
+| Schedule         | `Every 1 hour`                                                                                                                                                              |
+
+### Step 4: Use the Right Skills
+
+| Use Case                  | Skill to Invoke | What It Does                                       |
+| ------------------------- | --------------- | -------------------------------------------------- |
+| Personalized outreach     | **cold-email**  | Writes B2B outreach that sounds human              |
+| Network tracking          | **revops**      | Lead scoring, lifecycle stages                     |
+| Notion relationship notes | **notion-api**  | Create and manage contact notes and follow-up logs |
+
+---
+
+## Why This Works
+
+**🧠 It Sounds Like You, Not AI**
+
+- OpenLoomi reads your communication patterns and mirrors your tone in every draft
+- Your prospects and connections get personalized outreach, not mass-sent templates
+- The more you use it, the more it learns your style
+
+**🤝 Relationships Without the Admin Work**
+
+- No relationship goes cold from forgotten follow-ups
+- Your full network stays warm and engaged
+- You see every relationship's status at a glance
+
+**⚡ Scale Without Burnout**
+
+- Manage 500+ relationships without the mental overhead
+- AI handles the cadence; you focus on closing deals

--- a/apps/marketing/content/use-cases/index.mdx
+++ b/apps/marketing/content/use-cases/index.mdx
@@ -11,4 +11,5 @@ OpenLoomi empowers professionals across industries to automate repetitive workfl
 - **[X Content Automation](/docs/use-cases/x-content-automation)** — Never miss important posts; automatically engage with relevant content
 - **[Engineering Daily Sync](/docs/use-cases/engineering-daily-sync)** — Keep engineering teams aligned with AI-powered daily standups
 - **[Global Managers](/docs/use-cases/global-managers)** — Run async standups across time zones without the scheduling headache
-- **[Founders & Salespeople](/docs/use-cases/founders-salespeople)** — Automate research and outreach so you can focus on closing deals
+- **[Founders & Business Development](/docs/use-cases/founders)** — Scale your personal brand and manage hundreds of relationships at scale
+- **[Sales Teams](/docs/use-cases/salespeople)** — Automate pipeline management, follow-ups, and proposal generation

--- a/apps/marketing/content/use-cases/salespeople.mdx
+++ b/apps/marketing/content/use-cases/salespeople.mdx
@@ -1,23 +1,23 @@
 ---
-title: "Founders & Salespeople"
-description: "One person does the work of many, at scale"
-icon: "FaLightbulb"
+title: "Sales Teams"
+description: "Automate pipeline management, follow-ups, and proposal generation"
+icon: "FaChartLine"
 ---
 
-# Founders & Salespeople
+# Sales Teams
 
-## One Person Does the Work of Many, at Scale
+## Your Full Pipeline, Running Itself
 
-OpenLoomi learns your communication style, automatically maintains hundreds of client relationships, follows up on leads, and generates personalized proposals — never burns out.
+OpenLoomi syncs with HubSpot/Salesforce, auto-updates your pipeline, generates personalized proposals, and manages follow-up sequences — never burns out.
 
 **What it does:**
 
 | Step                  | Action                                                           |
 | --------------------- | ---------------------------------------------------------------- |
-| 🧠 Learn your style   | Read past messages to mirror your tone and phrasing              |
-| 📊 Track all leads    | HubSpot/Salesforce sync — auto-updated pipeline with deal stages |
+| 📊 Pipeline sync      | HubSpot/Salesforce sync — auto-updated pipeline with deal stages |
 | ✉️ Follow-up at scale | Personalized outreach sequences across email, Telegram, LinkedIn |
 | 📄 Generate proposals | Auto-draft proposals from conversation context and CRM data      |
+| 🔄 Never lose a lead  | 5-touch automated sequences, every touch adds value              |
 
 > "I can now manage what used to require a full sales team. OpenLoomi handles the follow-ups, the personalized outreach, the proposal generation — while I focus on closing deals."
 
@@ -33,7 +33,7 @@ Connect HubSpot in **Settings → Connectors** to sync your full pipeline. OpenL
 
 ### Personalized Outreach Draft
 
-OpenLoomi reads your past messages and communication patterns to draft follow-ups that sound like you — not generic AI output. Use the **cold-email** and **revops** skills to generate personalized sequences at scale.
+OpenLoomi drafts follow-ups that sound like you — not generic AI output. Use the **cold-email** and **revops** skills to generate personalized sequences at scale.
 
 ---
 
@@ -90,7 +90,6 @@ Please help me set up my sales automation workflow.
 1. Connect HubSpot in Settings → Connectors so OpenLoomi can read my pipeline (deals, stages, owners, close dates)
 
 2. Set up a personalized outreach system:
-   - Read my past emails to learn my communication style (tone, formality, phrasing)
    - When I flag a lead in HubSpot, draft a personalized first outreach using the cold-email skill
    - Schedule a 5-touch follow-up sequence: day 1, day 3, day 7, day 14, day 21
    - Each touch should add new value (not just "checking in")
@@ -119,7 +118,7 @@ OpenLoomi will automatically create the scheduled tasks for you!
 ### Step 2: Configure Personalization
 
 1. Go to **Settings → Personalization → My Interests**
-2. Add your priority keywords: client names, deal stages, competitors to track
+2. Add your priority keywords: deal stages, competitors to track
 3. Add communication preferences: formal/informal, preferred phrasing
 
 ### Step 3: Create Automation Tasks
@@ -135,11 +134,11 @@ OpenLoomi will automatically create the scheduled tasks for you!
 
 3. Create the second task:
 
-| Field            | Input                                                                                                                                                                                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task Name        | `Outreach Sequence Manager`                                                                                                                                                                                                                                                                       |
-| Task Description | `1. Check for new leads flagged in HubSpot\n2. Draft personalized first outreach using cold-email skill, mirroring user's communication style\n3. Schedule 5-touch follow-up sequence (day 1, 3, 7, 14, 21)\n4. Draft each touch — user approves before sending\n5. Log all outreach to timeline` |
-| Schedule         | `Every 4 hours`                                                                                                                                                                                                                                                                                   |
+| Field            | Input                                                                                                                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task Name        | `Outreach Sequence Manager`                                                                                                                                                                                                                                 |
+| Task Description | `1. Check for new leads flagged in HubSpot\n2. Draft personalized first outreach using cold-email skill\n3. Schedule 5-touch follow-up sequence (day 1, 3, 7, 14, 21)\n4. Draft each touch — user approves before sending\n5. Log all outreach to timeline` |
+| Schedule         | `Every 4 hours`                                                                                                                                                                                                                                             |
 
 ### Step 4: Use the Right Skills
 


### PR DESCRIPTION
## Summary
- Split the combined "Founders & Salespeople" use case into two distinct pages targeting different audiences
- **Founders & Business Development** — personal brand scaling, relationship maintenance, one-to-many outreach
- **Sales Teams** — pipeline automation, HubSpot sync, follow-up sequences, proposal generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)