### PR TITLE
docs: add benchmark section to README

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -39,6 +39,17 @@ OpenLoomi 是一个开源的 AI 工作空间，运行在你的桌面上。它连
   <img src="screenshots/components.png" alt="架构图" width="100%">
 </p>
 
+## 测评基准
+
+OpenLoomi 的记忆系统在基准测试中进行了严格评估：
+
+| 基准测试                                                                                    | 指标         | 结果      |
+| ------------------------------------------------------------------------------------------- | ------------ | --------- |
+| [LoCoMo](https://github.com/melandlabs/openloomi/tree/main/benchmark/locomo)                | 端到端准确率 | **96.3%** |
+| [LongMemEval-S500](https://github.com/melandlabs/openloomi/tree/main/benchmark/longmemeval) | 端到端准确率 | **97.6%** |
+
+详细测评数据：[https://openloomi.ai/docs/benchmark](https://openloomi.ai/docs/benchmark)
+
 ## 快速开始
 
 **直接下载**（面向终端用户）：

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ OpenLoomi is an open-source AI workspace that runs on your desktop. It connects 
   <img src="screenshots/components.png" alt="Architecture" width="100%">
 </p>
 
+## Benchmarks
+
+OpenLoomi's memory system is rigorously evaluated against academic and industry benchmarks:
+
+| Benchmark                                                                                   | Metric              | Result    |
+| ------------------------------------------------------------------------------------------- | ------------------- | --------- |
+| [LoCoMo](https://github.com/melandlabs/openloomi/tree/main/benchmark/locomo)                | End-to-end accuracy | **96.3%** |
+| [LongMemEval-S500](https://github.com/melandlabs/openloomi/tree/main/benchmark/longmemeval) | End-to-end accuracy | **97.6%** |
+
+Full benchmark details: [https://openloomi.ai/docs/benchmark](https://openloomi.ai/docs/benchmark)
+
 ## Quick Start
 
 **Download directly** (for end users):


### PR DESCRIPTION
## Summary

- Add benchmark metrics table to both English and Chinese README files
- Include OpenLoomi's memory system performance on LoCoMo (96.3%) and LongMemEval-S500 (97.6%) benchmarks
- Add link to full benchmark documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)