### PR TITLE
feat: unify font stack with alloomi reference design

### DIFF
--- a/apps/marketing/app/globals.css
+++ b/apps/marketing/app/globals.css
@@ -73,13 +73,11 @@
 
   /* Fonts (aligned with alloomi apps/web design system) */
   --font-sans:
-    "Noto Sans SC", "Source Han Sans SC", "PingFang SC",
-    "Microsoft YaHei", "Helvetica Neue", -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
+    "Noto Sans SC", "Source Han Sans SC", "PingFang SC", "Microsoft YaHei",
+    "Helvetica Neue", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-serif:
     "Noto Serif SC", "Source Han Serif SC", "Songti SC", Georgia, serif;
-  --font-mono:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /* Border colors */
   --color-border-primary: #e5e7eb;

--- a/apps/marketing/app/globals.css
+++ b/apps/marketing/app/globals.css
@@ -71,12 +71,15 @@
   --color-banner-border: rgba(22, 93, 255, 0.12);
   --color-banner-divider: rgba(30, 58, 138, 0.2);
 
-  /* Fonts (aligned with apps/web design system) */
+  /* Fonts (aligned with alloomi apps/web design system) */
   --font-sans:
-    "Noto Sans SC", "思源黑体", "PingFang SC", "Helvetica Neue", -apple-system,
-    BlinkMacSystemFont, sans-serif;
-  --font-serif: "Noto Serif SC", "思源宋体", "Songti SC", Georgia, serif;
-  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    "Noto Sans SC", "Source Han Sans SC", "PingFang SC",
+    "Microsoft YaHei", "Helvetica Neue", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --font-serif:
+    "Noto Serif SC", "Source Han Serif SC", "Songti SC", Georgia, serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /* Border colors */
   --color-border-primary: #e5e7eb;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -315,13 +315,16 @@
   :root {
     --background: 220 10% 98%;
     --foreground: 220 44% 10%;
-    /* Sans-serif: unified to Noto Sans SC */
+    /* Sans-serif: Roboto → Noto Sans SC → system fonts */
     --font-sans:
-      "Noto Sans SC", "Source Han Sans", "PingFang SC", "Helvetica Neue",
-      -apple-system, BlinkMacSystemFont, sans-serif;
-    /* Serif: unified to Noto Serif SC */
+      var(--font-roboto), "Noto Sans SC", "Source Han Sans SC", "PingFang SC",
+      "Microsoft YaHei", "Helvetica Neue", -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+    /* Serif: Noto Serif SC → system serif */
     --font-serif:
-      "Noto Serif SC", "Source Han Serif", "Songti SC", Georgia, serif;
+      var(--font-noto-serif), "Noto Serif SC", "Source Han Serif SC",
+      "Songti SC", Georgia, serif;
+    /* Monospace */
     --font-mono:
       ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     --surface: 220 10% 98%;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Noto_Sans_SC, Noto_Serif_SC } from "next/font/google";
+import { Noto_Sans_SC, Noto_Serif_SC, Roboto } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { I18nProvider } from "@/components/i18n-provider";
 import { TooltipProvider } from "@openloomi/ui";
@@ -21,6 +21,13 @@ const notoSerifSC = Noto_Serif_SC({
   subsets: ["latin"],
   weight: ["400", "600"],
   display: "swap",
+  variable: "--font-noto-serif",
+});
+const roboto = Roboto({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-roboto",
 });
 
 export default async function RootLayout({
@@ -31,7 +38,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${notoSansSC.className} ${notoSerifSC.className}`}
+      className={`${notoSansSC.className} ${notoSerifSC.className} ${roboto.className}`}
       // `next-themes` injects an extra classname to the body element to avoid
       // visual flicker before hydration. Hence the `suppressHydrationWarning`
       // prop is necessary to avoid the React hydration mismatch warning.


### PR DESCRIPTION
## Summary

- Align font configurations across `apps/web` and `apps/marketing` with the alloomi project reference
- Add Roboto font via `next/font/google` with `--font-roboto` CSS variable
- Add `--font-noto-serif` variable to `Noto_Serif_SC`
- Complete font-sans and font-serif stacks with proper cross-platform fallbacks

## Changes

### apps/web
- **layout.tsx**: Import `Roboto` from `next/font/google`, configure `--font-roboto` variable, add `--font-noto-serif` variable to existing `Noto_Serif_SC`
- **globals.css**: Update CSS variables:
  - `--font-sans`: `var(--font-roboto) → Noto Sans SC → Source Han Sans SC → PingFang SC → Microsoft YaHei → Helvetica Neue → system`
  - `--font-serif`: `var(--font-noto-serif) → Noto Serif SC → Source Han Serif SC → Songti SC → Georgia`

### apps/marketing
- **globals.css**: Complete font stacks with `Source Han Sans/SC`, `Microsoft YaHei`, `Segoe UI` fallbacks; standardize font family names

🤖 Generated with [Claude Code](https://claude.com/claude-code)