### PR TITLE
feat: prompt users to configure API key before chatting

### DIFF
--- a/apps/web/app/(chat)/layout.tsx
+++ b/apps/web/app/(chat)/layout.tsx
@@ -13,6 +13,7 @@ import { SidePanelShell } from "@/components/agent/side-panel-shell";
 import { SidePanelProvider } from "@/components/agent/side-panel-context";
 import { ChatContextProvider } from "@/components/chat-context";
 import { SessionAuthChecker } from "@/components/session-auth-checker";
+import { ConversationApiOnboardingGuard } from "@/components/conversation-api-onboarding-guard";
 
 export default async function Layout({
   children,
@@ -31,21 +32,23 @@ export default async function Layout({
       {/** AppSidebar needs session email info and quota usage */}
       <SessionProvider session={session}>
         <SessionAuthChecker />
-        <SidebarProvider defaultOpen={true}>
-          <AppSidebar />
-          <SidebarInset className="relative z-10 md:h-svh md:max-h-svh md:overflow-hidden md:m-0 p-2 pl-0 sm:p-3 sm:pl-0">
-            <Suspense fallback={null}>
-              {/* SidePanelShell renders main content + temporary sidebar (flex-row) */}
-              <SidePanelProvider>
-                <ChatContextProvider>
-                  <GlobalInsightDrawerProvider>
-                    <SidePanelShell>{children}</SidePanelShell>
-                  </GlobalInsightDrawerProvider>
-                </ChatContextProvider>
-              </SidePanelProvider>
-            </Suspense>
-          </SidebarInset>
-        </SidebarProvider>
+        <ConversationApiOnboardingGuard>
+          <SidebarProvider defaultOpen={true}>
+            <AppSidebar />
+            <SidebarInset className="relative z-10 md:h-svh md:max-h-svh md:overflow-hidden md:m-0 p-2 pl-0 sm:p-3 sm:pl-0">
+              <Suspense fallback={null}>
+                {/* SidePanelShell renders main content + temporary sidebar (flex-row) */}
+                <SidePanelProvider>
+                  <ChatContextProvider>
+                    <GlobalInsightDrawerProvider>
+                      <SidePanelShell>{children}</SidePanelShell>
+                    </GlobalInsightDrawerProvider>
+                  </ChatContextProvider>
+                </SidePanelProvider>
+              </Suspense>
+            </SidebarInset>
+          </SidebarProvider>
+        </ConversationApiOnboardingGuard>
       </SessionProvider>
       {!isTauriMode() && (
         <CookieConfirm userCookieConfirm={userCookieConfirm} />

--- a/apps/web/components/ai-api-settings.tsx
+++ b/apps/web/components/ai-api-settings.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Badge, Button, Input, Label, Separator, Switch } from "@openloomi/ui";
 import { RemixIcon } from "@/components/remix-icon";
 import { toast } from "@/components/toast";
 import { fetchWithAuth } from "@/lib/utils";
 import { cn } from "@/lib/utils";
+import {
+  AI_SETTINGS_CHANGED_EVENT,
+  MISSING_API_KEY_REASON,
+} from "@/lib/ai/conversation-api-configuration";
 
 type ProviderType = "openai_compatible" | "anthropic_compatible";
 
@@ -94,6 +99,10 @@ function createDraft(setting?: AiSetting): ProviderDraft {
 
 export function AiApiSettings() {
   const { t } = useTranslation();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const showMissingApiKeyNotice =
+    searchParams.get("reason") === MISSING_API_KEY_REASON;
   const [settings, setSettings] = useState<AiSetting[]>([]);
   const [systemDefaults, setSystemDefaults] = useState<
     Record<ProviderType, SystemDefault>
@@ -226,6 +235,17 @@ export function AiApiSettings() {
         apiKey: "",
         enabled: savedSetting.enabled,
       });
+      window.dispatchEvent(new Event(AI_SETTINGS_CHANGED_EVENT));
+      if (
+        showMissingApiKeyNotice &&
+        providerType === "anthropic_compatible" &&
+        savedSetting.enabled &&
+        savedSetting.hasApiKey &&
+        savedSetting.baseUrl?.trim() &&
+        savedSetting.model?.trim()
+      ) {
+        router.replace("/?page=ai-api-settings", { scroll: false });
+      }
       if (options.showToast !== false) {
         toast({
           type: "success",
@@ -270,6 +290,7 @@ export function AiApiSettings() {
         current.filter((setting) => setting.providerType !== providerType),
       );
       updateDraft(providerType, createDraft());
+      window.dispatchEvent(new Event(AI_SETTINGS_CHANGED_EVENT));
       toast({
         type: "success",
         description: t(
@@ -347,6 +368,32 @@ export function AiApiSettings() {
   return (
     <div className="w-full max-w-none space-y-8">
       <div className="w-full px-1 sm:px-0 space-y-8">
+        {showMissingApiKeyNotice && (
+          <div
+            role="status"
+            className="flex gap-3 rounded-lg border border-primary/25 bg-primary/5 p-4 text-sm"
+          >
+            <RemixIcon
+              name="info"
+              size="size-5"
+              className="mt-0.5 shrink-0 text-primary"
+            />
+            <div className="space-y-1">
+              <p className="font-medium text-foreground">
+                {t(
+                  "settings.aiSettingsRequiredTitle",
+                  "Configure an API key to start chatting",
+                )}
+              </p>
+              <p className="text-muted-foreground">
+                {t(
+                  "settings.aiSettingsRequiredDescription",
+                  "Enable an Anthropic-compatible provider and save its API key, base URL, and model before starting a conversation.",
+                )}
+              </p>
+            </div>
+          </div>
+        )}
         <div className="flex flex-col gap-2">
           <p className="text-base font-semibold text-foreground-secondary">
             {t("settings.aiSettingsTitle", "API Settings")}

--- a/apps/web/components/conversation-api-onboarding-guard.tsx
+++ b/apps/web/components/conversation-api-onboarding-guard.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { type ReactNode, useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@openloomi/ui";
+
+import { RemixIcon } from "@/components/remix-icon";
+import { getAuthToken } from "@/lib/auth/token-manager";
+import {
+  AI_SETTINGS_CHANGED_EVENT,
+  type ConversationApiSettingsResponse,
+  hasUsableConversationApiConfiguration,
+  MISSING_API_KEY_REASON,
+} from "@/lib/ai/conversation-api-configuration";
+import { isTauri } from "@/lib/tauri";
+import { fetchWithAuth } from "@/lib/utils";
+
+export function ConversationApiOnboardingGuard({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const { status } = useSession();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const page = searchParams.get("page");
+  const isGuardedRoute =
+    (pathname === "/" && (page === null || page === "chat")) ||
+    pathname === "/workspace";
+  const [configurationState, setConfigurationState] = useState<
+    "checking" | "available" | "missing"
+  >("checking");
+  const [settingsRevision, setSettingsRevision] = useState(0);
+
+  useEffect(() => {
+    const handleSettingsChanged = () => {
+      setConfigurationState("checking");
+      setSettingsRevision((current) => current + 1);
+    };
+
+    window.addEventListener(AI_SETTINGS_CHANGED_EVENT, handleSettingsChanged);
+    return () => {
+      window.removeEventListener(
+        AI_SETTINGS_CHANGED_EVENT,
+        handleSettingsChanged,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status === "loading") {
+      return;
+    }
+
+    if (status !== "authenticated") {
+      setConfigurationState("available");
+      return;
+    }
+
+    if (!isGuardedRoute) {
+      return;
+    }
+
+    if (isTauri() && getAuthToken()) {
+      setConfigurationState("available");
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    async function checkConfiguration() {
+      setConfigurationState("checking");
+      try {
+        const response = await fetchWithAuth("/api/preferences/ai", {
+          cache: "no-store",
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to load AI API settings");
+        }
+
+        const settings =
+          (await response.json()) as ConversationApiSettingsResponse;
+        if (hasUsableConversationApiConfiguration(settings)) {
+          setConfigurationState("available");
+          return;
+        }
+
+        setConfigurationState("missing");
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+
+        console.error(
+          "[API Onboarding] Failed to check conversation API settings",
+          error,
+        );
+        // Fail open when the settings check itself is unavailable.
+        setConfigurationState("available");
+      }
+    }
+
+    void checkConfiguration();
+    return () => abortController.abort();
+  }, [isGuardedRoute, router, settingsRevision, status]);
+
+  return (
+    <>
+      {children}
+      {isGuardedRoute &&
+        configurationState === "missing" &&
+        status === "authenticated" && (
+          <div className="fixed left-1/2 top-4 z-[1000] flex w-[min(92vw,680px)] -translate-x-1/2 items-start gap-3 rounded-xl border border-primary/25 bg-background/95 p-4 shadow-lg backdrop-blur">
+            <RemixIcon
+              name="info"
+              size="size-5"
+              className="mt-0.5 shrink-0 text-primary"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-foreground">
+                {t(
+                  "settings.aiSettingsMissingBannerTitle",
+                  "No conversation API key configured",
+                )}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "settings.aiSettingsMissingBannerDescription",
+                  "Configure an Anthropic-compatible provider before starting a conversation.",
+                )}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              className="shrink-0"
+              onClick={() =>
+                router.push(
+                  `/?page=ai-api-settings&reason=${MISSING_API_KEY_REASON}`,
+                )
+              }
+            >
+              {t("settings.aiSettingsConfigureButton", "Configure")}
+            </Button>
+          </div>
+        )}
+    </>
+  );
+}

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -49,6 +49,13 @@ const en = {
     aiSettingsReset: "User override reset to system defaults.",
     aiSettingsResetError: "Failed to reset API settings.",
     aiSettingsLoadError: "Failed to load API settings.",
+    aiSettingsRequiredTitle: "Configure an API key to start chatting",
+    aiSettingsRequiredDescription:
+      "Enable an Anthropic-compatible provider and save its API key, base URL, and model before starting a conversation.",
+    aiSettingsMissingBannerTitle: "No conversation API key configured",
+    aiSettingsMissingBannerDescription:
+      "Configure an Anthropic-compatible provider before starting a conversation.",
+    aiSettingsConfigureButton: "Configure",
   },
   insight: {
     ...(baseEn.insight ?? {}),

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -47,6 +47,13 @@ const zh = {
     aiSettingsReset: "已重置为系统默认配置",
     aiSettingsResetError: "API 设置重置失败",
     aiSettingsLoadError: "API 设置加载失败",
+    aiSettingsRequiredTitle: "请先配置 API 密钥再开始聊天",
+    aiSettingsRequiredDescription:
+      "请启用一个 Anthropic 兼容服务，并保存 API 密钥、接口地址和模型。",
+    aiSettingsMissingBannerTitle: "尚未配置对话 API 密钥",
+    aiSettingsMissingBannerDescription:
+      "请先配置 Anthropic 兼容服务，再开始聊天。",
+    aiSettingsConfigureButton: "去配置",
   },
   insight: {
     ...(baseZh.insight ?? {}),

--- a/apps/web/lib/ai/conversation-api-configuration.ts
+++ b/apps/web/lib/ai/conversation-api-configuration.ts
@@ -1,0 +1,44 @@
+export const AI_SETTINGS_CHANGED_EVENT = "openloomi:ai-settings-changed";
+export const MISSING_API_KEY_REASON = "missing-api-key";
+
+type ConversationProviderSetting = {
+  providerType: string;
+  baseUrl: string | null;
+  model: string | null;
+  enabled: boolean;
+  hasApiKey: boolean;
+};
+
+type ConversationSystemDefault = {
+  hasApiKey: boolean;
+};
+
+export type ConversationApiSettingsResponse = {
+  settings: ConversationProviderSetting[];
+  systemDefaults: {
+    anthropic_compatible: ConversationSystemDefault;
+  };
+};
+
+function hasText(value: string | null) {
+  return Boolean(value?.trim());
+}
+
+export function hasUsableConversationApiConfiguration(
+  response: ConversationApiSettingsResponse,
+) {
+  const userSetting = response.settings.find(
+    (setting) => setting.providerType === "anthropic_compatible",
+  );
+  const hasUserConfiguration = Boolean(
+    userSetting?.enabled &&
+    userSetting.hasApiKey &&
+    hasText(userSetting.baseUrl) &&
+    hasText(userSetting.model),
+  );
+
+  return (
+    hasUserConfiguration ||
+    response.systemDefaults.anthropic_compatible.hasApiKey
+  );
+}

--- a/apps/web/tests/unit/conversation-api-configuration.test.ts
+++ b/apps/web/tests/unit/conversation-api-configuration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { hasUsableConversationApiConfiguration } from "@/lib/ai/conversation-api-configuration";
+
+function createResponse(
+  overrides: {
+    enabled?: boolean;
+    hasApiKey?: boolean;
+    baseUrl?: string | null;
+    model?: string | null;
+    systemHasApiKey?: boolean;
+  } = {},
+) {
+  return {
+    settings: [
+      {
+        providerType: "anthropic_compatible",
+        enabled: overrides.enabled ?? false,
+        hasApiKey: overrides.hasApiKey ?? false,
+        baseUrl: overrides.baseUrl ?? null,
+        model: overrides.model ?? null,
+      },
+    ],
+    systemDefaults: {
+      anthropic_compatible: {
+        hasApiKey: overrides.systemHasApiKey ?? false,
+      },
+    },
+  };
+}
+
+describe("conversation API configuration", () => {
+  it("accepts a complete enabled user provider", () => {
+    expect(
+      hasUsableConversationApiConfiguration(
+        createResponse({
+          enabled: true,
+          hasApiKey: true,
+          baseUrl: "https://api.anthropic.com",
+          model: "claude-sonnet-4-6",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects incomplete or disabled user providers", () => {
+    expect(
+      hasUsableConversationApiConfiguration(
+        createResponse({
+          enabled: false,
+          hasApiKey: true,
+          baseUrl: "https://api.anthropic.com",
+          model: "claude-sonnet-4-6",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasUsableConversationApiConfiguration(
+        createResponse({
+          enabled: true,
+          hasApiKey: true,
+          baseUrl: " ",
+          model: "claude-sonnet-4-6",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat an OpenAI-compatible provider as chat configuration", () => {
+    const response = createResponse();
+    response.settings = [
+      {
+        providerType: "openai_compatible",
+        enabled: true,
+        hasApiKey: true,
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "openai/gpt-4o-mini",
+      },
+    ];
+
+    expect(hasUsableConversationApiConfiguration(response)).toBe(false);
+  });
+
+  it("accepts the system Anthropic API key fallback", () => {
+    expect(
+      hasUsableConversationApiConfiguration(
+        createResponse({ systemHasApiKey: true }),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- detect whether a usable conversation API configuration is available
- show a clear banner on chat-related pages when no API key is configured
- provide a direct link to the API settings page
- recognize user settings, system environment configuration, and Tauri cloud authentication
- refresh the banner state after API settings are saved or reset
- add English and Simplified Chinese translations

## Behavior

When neither a user-level nor system-level conversation API configuration is available, users see a banner prompting them to configure an Anthropic-compatible provider.
No banner is shown when a valid system API key, user API configuration, or Tauri cloud token is available.

## Testing

- unit tests for conversation API configuration detection
- manually verified the onboarding flow in the running app
 
Closes #163 