### PR TITLE
style: align chat component styles with alloomi reference

### DIFF
--- a/apps/web/components/markdown.tsx
+++ b/apps/web/components/markdown.tsx
@@ -248,7 +248,7 @@ function createComponents(
       );
       return (
         <p
-          className="whitespace-pre-wrap break-words text-[14px] leading-relaxed text-slate-950 dark:text-slate-50 h-full mt-0 mb-1"
+          className="!mb-0 leading-relaxed text-[14px] text-zinc-950 dark:text-zinc-50 min-w-0 [&:not(:first-child)]:mt-3"
           {...props}
         >
           {content}
@@ -257,7 +257,10 @@ function createComponents(
     },
     ol: ({ node, children, ...props }) => {
       return (
-        <ol className="list-decimal list-outside ml-4 my-0" {...props}>
+        <ol
+          className="list-decimal list-outside ml-6 mb-4 space-y-1 min-w-0"
+          {...props}
+        >
           {children}
         </ol>
       );
@@ -268,14 +271,17 @@ function createComponents(
         renderInstructionBadges,
       );
       return (
-        <li className="mt-0 leading-normal" {...props}>
+        <li className="my-1 leading-relaxed break-words min-w-0" {...props}>
           {content}
         </li>
       );
     },
     ul: ({ node, children, ...props }) => {
       return (
-        <ul className="list-disc list-outside ml-4 my-0" {...props}>
+        <ul
+          className="list-disc list-outside ml-6 mb-4 space-y-1 min-w-0"
+          {...props}
+        >
           {children}
         </ul>
       );
@@ -306,60 +312,42 @@ function createComponents(
     },
     h1: ({ node, children, ...props }) => {
       return (
-        <h1
-          className="text-[20px] font-semibold mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h1 className="text-2xl font-bold mb-4 mt-6" {...props}>
           {children}
         </h1>
       );
     },
     h2: ({ node, children, ...props }) => {
       return (
-        <h2
-          className="text-[14px] font-medium mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h2 className="text-xl font-bold mb-3 mt-5" {...props}>
           {children}
         </h2>
       );
     },
     h3: ({ node, children, ...props }) => {
       return (
-        <h3
-          className="text-[16px] font-semibold mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h3 className="text-lg font-bold mb-3 mt-4" {...props}>
           {children}
         </h3>
       );
     },
     h4: ({ node, children, ...props }) => {
       return (
-        <h4
-          className="text-[15px] font-semibold mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h4 className="text-base font-bold mb-2 mt-4" {...props}>
           {children}
         </h4>
       );
     },
     h5: ({ node, children, ...props }) => {
       return (
-        <h5
-          className="text-[15px] font-semibold mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h5 className="text-sm font-bold mb-2 mt-4" {...props}>
           {children}
         </h5>
       );
     },
     h6: ({ node, children, ...props }) => {
       return (
-        <h6
-          className="text-[15px] font-semibold mt-2 mb-1 leading-tight"
-          {...props}
-        >
+        <h6 className="text-sm font-bold mb-2 mt-4" {...props}>
           {children}
         </h6>
       );
@@ -414,6 +402,16 @@ function createComponents(
         <td className="px-4 py-2 text-zinc-700 dark:text-zinc-300" {...props}>
           {children}
         </td>
+      );
+    },
+    blockquote: ({ node, children, ...props }) => {
+      return (
+        <blockquote
+          className="border-l-4 border-zinc-300 dark:border-zinc-600 pl-4 my-4 italic text-zinc-600 dark:text-zinc-400"
+          {...props}
+        >
+          {children}
+        </blockquote>
       );
     },
   };

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -763,8 +763,7 @@ const PurePreviewMessage = ({
                               className={cn(
                                 "flex flex-col gap-1 min-w-0 max-w-full break-words cursor-default",
                                 isUserMessage &&
-                                  "rounded-2xl p-4 bg-[var(--primary-50)] text-slate-900 border-0 dark:bg-[#1e3a5f]/30 dark:text-slate-100",
-                                !isUserMessage && "font-serif",
+                                  "rounded-[8px] bg-[#EDEDED] p-3 text-[14px] font-normal leading-5 text-black",
                               )}
                             >
                               {(() => {
@@ -1169,7 +1168,7 @@ const PurePreviewMessage = ({
                   {/* Edit mode for text messages */}
                   {mode === "edit" &&
                     message.parts?.some((p) => p.type === "text") && (
-                      <div className="flex w-full flex-row gap-2 items-start p-3 rounded-2xl bg-primary-50">
+                      <div className="flex w-full flex-row gap-2 items-start p-3 rounded-[8px] bg-[#EDEDED]">
                         <MessageEditor
                           key={message.id}
                           message={message}
@@ -1203,7 +1202,7 @@ const PurePreviewMessage = ({
               Array.isArray((message.metadata as any).ragDocuments) &&
               (message.metadata as any).ragDocuments.length > 0 && (
                 <div className="flex flex-row gap-2 items-end justify-end">
-                  <div className="flex flex-wrap gap-2 p-2 rounded-2xl bg-[var(--primary-50)] dark:bg-[#1e3a5f]/30 border-0">
+                  <div className="flex flex-wrap gap-2 p-2 rounded-[8px] bg-[#EDEDED]">
                     <div className="flex flex-wrap gap-1">
                       {(message.metadata as any).ragDocuments.map(
                         (doc: { id: string; name: string }) => {


### PR DESCRIPTION
## Summary

Align chat component styles with alloomi reference design:

- **User message bubble**: Update from `rounded-2xl p-4 bg-[var(--primary-50)]` to `rounded-[8px] bg-[#EDEDED] p-3` to match alloomi's cleaner, flatter design
- **Edit mode & RAG document bubbles**: Apply same style alignment
- **AI message markdown styles**: Sync paragraph, list, heading, and blockquote styles with alloomi's typography
- **Font**: Remove `font-serif` from AI messages, use `font-sans` to match alloomi

🤖 Generated with [Claude Code](https://claude.com/claude-code)