### PR TITLE
docs: add missing benchmark links and CL-bench section

### DIFF
--- a/apps/marketing/content/benchmark.mdx
+++ b/apps/marketing/content/benchmark.mdx
@@ -45,3 +45,26 @@ Extracted from real multi-turn conversations, LongMemEval contains questions cov
 - **temporal-reasoning**: Time-sensitive query reasoning
 - **knowledge-update**: Knowledge iteration and fact changes
 - **single-session-preference**: User preference queries
+
+🔗 [GitHub Repository](https://github.com/melandlabs/openloomi/tree/main/benchmark/longmemeval)
+
+---
+
+## CL-bench (Context Learning Benchmark)
+
+**Source**: Tencent — Industry Benchmark Dataset
+
+**Scale**: 1,899 Tasks (CL-bench), 405 Tasks (CL-bench-Life)
+
+CL-bench evaluates AI models' context learning capabilities across professional and everyday life scenarios. It tests the model's ability to understand, reason about, and apply information from extended context.
+
+### Task Categories
+
+| Category                   | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| Domain Knowledge Reasoning | Professional domain-specific reasoning         |
+| Language Understanding     | Natural language comprehension                 |
+| Information Extraction     | Structured information extraction from context |
+| Text Generation            | Context-aware content generation               |
+
+🔗 [GitHub Repository](https://github.com/melandlabs/openloomi/tree/main/benchmark/clbench)


### PR DESCRIPTION
## Summary
- Add missing GitHub repository link for LongMemEval-S section in benchmark.mdx
- Add new CL-bench (Context Learning Benchmark) section with:
  - Source attribution to Tencent
  - Scale information (1,899 tasks for CL-bench, 405 tasks for CL-bench-Life)
  - Task categories table (Domain Knowledge Reasoning, Language Understanding, Information Extraction, Text Generation)
  - GitHub repository link

🤖 Generated with [Claude Code](https://claude.com/claude-code)