### PR TITLE
chore: remove unused audit image from privacy-security page

### DIFF
--- a/apps/marketing/content/privacy-security.mdx
+++ b/apps/marketing/content/privacy-security.mdx
@@ -159,8 +159,4 @@ You can view exactly when and why OpenLoomi accessed your data. Every access is 
 - **Data Type**: What kind of data was accessed
 - **Reason**: Why the access was needed (e.g., "Generating insights", "Replying to messages")
 
-<p align="center">
-  <img src="/img/openloomi/audit.png" alt="OpenLoomi Audit Log" />
-</p>
-
 > 💡 **Transparency First**: You have full visibility into all data access. If you notice any suspicious activity, you can revoke access immediately from Settings.


### PR DESCRIPTION
## Summary
- Remove unused `<p align="center"><img src="/img/openloomi/audit.png">` from `apps/marketing/content/privacy-security.mdx`

## Test plan
- [ ] Verify `privacy-security.mdx` renders correctly without the removed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)