### PR TITLE
feat(memory): add evidence cluster scoring helper

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildMemoryEvidenceClusters,
   DefaultMemoryRecordScorer,
   type MemoryRecord,
 } from "../../../../packages/ai/src/memory";
@@ -146,10 +147,6 @@ const scenarios: EvalScenario[] = [
   },
 ];
 
-function clamp01(value: number): number {
-  return Math.max(0, Math.min(1, value));
-}
-
 function traceToRecord(trace: EvalTrace): MemoryRecord {
   return {
     id: trace.id,
@@ -159,6 +156,9 @@ function traceToRecord(trace: EvalTrace): MemoryRecord {
     tier: "short",
     accessCount: trace.accessCount,
     importanceScore: trace.importanceScore,
+    metadata: {
+      topic: trace.topic,
+    },
   };
 }
 
@@ -172,45 +172,16 @@ function rankSingleTraces(scenario: EvalScenario): EvalTrace[] {
 }
 
 function scoreClusters(scenario: EvalScenario): ClusterScore[] {
-  const scorer = new DefaultMemoryRecordScorer();
-  const clusters = new Map<string, EvalTrace[]>();
-
-  for (const trace of scenario.traces) {
-    const existing = clusters.get(trace.topic) ?? [];
-    existing.push(trace);
-    clusters.set(trace.topic, existing);
-  }
-
-  return [...clusters.entries()]
-    .map(([topic, traces]) => {
-      const evidenceScore = clamp01(traces.length / 4);
-      const traceScores = traces.map((trace) =>
-        scorer.score(traceToRecord(trace), { now: NOW }),
-      );
-      const meanTraceScore =
-        traceScores.reduce((sum, score) => sum + score, 0) / traceScores.length;
-      const accessCount = traces.reduce(
-        (sum, trace) => sum + (trace.accessCount ?? 0),
-        0,
-      );
-      const activationScore = clamp01(Math.log1p(accessCount) / Math.log(10));
-      const latestDay = Math.max(...traces.map((trace) => trace.day));
-      const recencyScore = clamp01(
-        1 - (NOW - latestDay * DAY_MS) / (180 * DAY_MS),
-      );
-
-      return {
-        topic,
-        evidenceCount: traces.length,
-        traceIds: traces.map((trace) => trace.id),
-        score:
-          0.45 * evidenceScore +
-          0.2 * meanTraceScore +
-          0.15 * activationScore +
-          0.1 * recencyScore,
-      };
-    })
-    .sort((a, b) => b.score - a.score);
+  return buildMemoryEvidenceClusters({
+    records: scenario.traces.map(traceToRecord),
+    now: NOW,
+    getClusterKey: (record) => String(record.metadata?.topic ?? ""),
+  }).map((cluster) => ({
+    topic: cluster.key,
+    score: cluster.score,
+    evidenceCount: cluster.evidenceCount,
+    traceIds: cluster.recordIds,
+  }));
 }
 
 function evaluateScenario(scenario: EvalScenario): ScenarioEvaluation {

--- a/packages/ai/src/memory/evidence-cluster.ts
+++ b/packages/ai/src/memory/evidence-cluster.ts
@@ -1,0 +1,119 @@
+import type { MemoryRecord, MemoryRecordScorer } from "./contracts";
+import { DefaultMemoryRecordScorer } from "./scorer";
+
+const DEFAULT_RECENCY_WINDOW_MS = 180 * 24 * 60 * 60 * 1000;
+
+export interface MemoryEvidenceClusterWeights {
+  evidence: number;
+  recordScore: number;
+  activation: number;
+  recency: number;
+}
+
+export interface MemoryEvidenceCluster {
+  key: string;
+  recordIds: string[];
+  evidenceCount: number;
+  meanRecordScore: number;
+  activationScore: number;
+  recencyScore: number;
+  score: number;
+}
+
+export interface BuildMemoryEvidenceClustersInput {
+  records: MemoryRecord[];
+  now: number;
+  getClusterKey(record: MemoryRecord): string | undefined;
+  scorer?: MemoryRecordScorer;
+  evidenceNorm?: number;
+  recencyWindowMs?: number;
+  weights?: Partial<MemoryEvidenceClusterWeights>;
+}
+
+const DEFAULT_WEIGHTS: MemoryEvidenceClusterWeights = {
+  evidence: 0.45,
+  recordScore: 0.2,
+  activation: 0.15,
+  recency: 0.1,
+};
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function resolveWeights(
+  overrides: Partial<MemoryEvidenceClusterWeights> | undefined,
+): MemoryEvidenceClusterWeights {
+  return {
+    evidence: overrides?.evidence ?? DEFAULT_WEIGHTS.evidence,
+    recordScore: overrides?.recordScore ?? DEFAULT_WEIGHTS.recordScore,
+    activation: overrides?.activation ?? DEFAULT_WEIGHTS.activation,
+    recency: overrides?.recency ?? DEFAULT_WEIGHTS.recency,
+  };
+}
+
+export function buildMemoryEvidenceClusters(
+  input: BuildMemoryEvidenceClustersInput,
+): MemoryEvidenceCluster[] {
+  const scorer = input.scorer ?? new DefaultMemoryRecordScorer();
+  const evidenceNorm = Math.max(1, input.evidenceNorm ?? 4);
+  const recencyWindowMs = Math.max(
+    1,
+    input.recencyWindowMs ?? DEFAULT_RECENCY_WINDOW_MS,
+  );
+  const weights = resolveWeights(input.weights);
+  const grouped = new Map<string, MemoryRecord[]>();
+
+  for (const record of input.records) {
+    const key = input.getClusterKey(record);
+    if (!key) {
+      continue;
+    }
+
+    const existing = grouped.get(key) ?? [];
+    existing.push(record);
+    grouped.set(key, existing);
+  }
+
+  return [...grouped.entries()]
+    .map(([key, records]) => {
+      const recordScores = records.map((record) =>
+        scorer.score(record, { now: input.now }),
+      );
+      const accessCount = records.reduce(
+        (sum, record) => sum + (record.accessCount ?? 0),
+        0,
+      );
+      const latestTimestamp = Math.max(
+        ...records.map((record) => record.timestamp),
+      );
+      const evidenceScore = clamp01(records.length / evidenceNorm);
+      const meanRecordScore = mean(recordScores);
+      const activationScore = clamp01(Math.log1p(accessCount) / Math.log(10));
+      const recencyScore = clamp01(
+        1 - Math.max(0, input.now - latestTimestamp) / recencyWindowMs,
+      );
+
+      return {
+        key,
+        recordIds: records.map((record) => record.id),
+        evidenceCount: records.length,
+        meanRecordScore,
+        activationScore,
+        recencyScore,
+        score:
+          weights.evidence * evidenceScore +
+          weights.recordScore * meanRecordScore +
+          weights.activation * activationScore +
+          weights.recency * recencyScore,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+}

--- a/packages/ai/src/memory/index.ts
+++ b/packages/ai/src/memory/index.ts
@@ -2,6 +2,7 @@ export * from "./api";
 export * from "./contracts";
 export * from "./engine";
 export * from "./embedding";
+export * from "./evidence-cluster";
 export * from "./ingest";
 export * from "./policy";
 export * from "./scorer";


### PR DESCRIPTION
## Summary

Add a small pure helper for evidence-based memory cluster scoring.

This extracts the cluster scoring logic that was introduced in the memory consolidation eval scenarios into `packages/ai/src/memory/evidence-cluster.ts`, then updates the eval test to use the shared helper.

## Scope

- Adds `buildMemoryEvidenceClusters`
- Exports the helper from `packages/ai/src/memory`
- Reuses the helper in `memory-consolidation-eval.test.ts`
- Does not integrate cluster scoring into the forgetting engine, storage, or runtime retrieval paths

## Testing

- `corepack pnpm exec prettier --check packages/ai/src/memory/evidence-cluster.ts packages/ai/src/memory/index.ts apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter web tsc`