### PR TITLE
feat(memory): add evidence cluster diagnostics

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  analyzeMemoryEvidenceClusters,
   buildMemoryEvidenceClusters,
   DefaultMemoryRecordScorer,
   type MemoryRecord,
@@ -259,6 +260,15 @@ function calculateConsolidationMetrics(
   };
 }
 
+function analyzeScenario(scenario: EvalScenario) {
+  return analyzeMemoryEvidenceClusters({
+    records: scenario.traces.map(traceToRecord),
+    now: NOW,
+    getClusterKey: (record) => String(record.metadata?.topic ?? ""),
+    highClusterScoreThreshold: 0.6,
+  });
+}
+
 describe("memory consolidation evaluation scenarios", () => {
   it("keeps expected long-term outcomes backed by repeated evidence", () => {
     for (const scenario of scenarios) {
@@ -304,5 +314,19 @@ describe("memory consolidation evaluation scenarios", () => {
       clusterTemporaryOverrideLeakageRate: 0,
       clusterAdaptationAccuracy: 1,
     });
+  });
+
+  it("surfaces low-record-score traces that belong to high-evidence clusters", () => {
+    const scenario = scenarios.find(
+      (item) => item.id === "one-shot-noise",
+    ) as EvalScenario;
+    const analysis = analyzeScenario(scenario);
+    const flaggedRecordIds = analysis.recordSignals
+      .filter((signal) => signal.lowRecordScoreHighClusterScore)
+      .map((signal) => signal.recordId);
+
+    expect(flaggedRecordIds).toEqual(["zh-1", "zh-2", "zh-3", "zh-4"]);
+    expect(flaggedRecordIds).not.toContain("noise-urgent");
+    expect(analysis.clusters[0]?.key).toBe("answer-language:zh");
   });
 });

--- a/packages/ai/src/memory/evidence-cluster.ts
+++ b/packages/ai/src/memory/evidence-cluster.ts
@@ -30,6 +30,25 @@ export interface BuildMemoryEvidenceClustersInput {
   weights?: Partial<MemoryEvidenceClusterWeights>;
 }
 
+export interface AnalyzeMemoryEvidenceClustersInput extends BuildMemoryEvidenceClustersInput {
+  lowRecordScoreThreshold?: number;
+  highClusterScoreThreshold?: number;
+}
+
+export interface MemoryEvidenceRecordSignal {
+  recordId: string;
+  clusterKey: string;
+  recordScore: number;
+  clusterScore: number;
+  clusterEvidenceCount: number;
+  lowRecordScoreHighClusterScore: boolean;
+}
+
+export interface MemoryEvidenceClusterAnalysis {
+  clusters: MemoryEvidenceCluster[];
+  recordSignals: MemoryEvidenceRecordSignal[];
+}
+
 const DEFAULT_WEIGHTS: MemoryEvidenceClusterWeights = {
   evidence: 0.45,
   recordScore: 0.2,
@@ -116,4 +135,49 @@ export function buildMemoryEvidenceClusters(
       };
     })
     .sort((a, b) => b.score - a.score);
+}
+
+export function analyzeMemoryEvidenceClusters(
+  input: AnalyzeMemoryEvidenceClustersInput,
+): MemoryEvidenceClusterAnalysis {
+  const scorer = input.scorer ?? new DefaultMemoryRecordScorer();
+  const lowRecordScoreThreshold = input.lowRecordScoreThreshold ?? 0.35;
+  const highClusterScoreThreshold = input.highClusterScoreThreshold ?? 0.65;
+  const clusters = buildMemoryEvidenceClusters({
+    ...input,
+    scorer,
+  });
+  const clusterByKey = new Map(
+    clusters.map((cluster) => [cluster.key, cluster]),
+  );
+  const recordSignals: MemoryEvidenceRecordSignal[] = [];
+
+  for (const record of input.records) {
+    const clusterKey = input.getClusterKey(record);
+    if (!clusterKey) {
+      continue;
+    }
+
+    const cluster = clusterByKey.get(clusterKey);
+    if (!cluster) {
+      continue;
+    }
+
+    const recordScore = scorer.score(record, { now: input.now });
+    recordSignals.push({
+      recordId: record.id,
+      clusterKey,
+      recordScore,
+      clusterScore: cluster.score,
+      clusterEvidenceCount: cluster.evidenceCount,
+      lowRecordScoreHighClusterScore:
+        recordScore <= lowRecordScoreThreshold &&
+        cluster.score >= highClusterScoreThreshold,
+    });
+  }
+
+  return {
+    clusters,
+    recordSignals,
+  };
 }


### PR DESCRIPTION
## Summary

Add a small diagnostics layer on top of `buildMemoryEvidenceClusters`.

`analyzeMemoryEvidenceClusters` returns both ranked evidence clusters and per-record signals, including whether a record has a low individual score while belonging to a high-scoring evidence cluster.

## Why

This creates an observation point before changing runtime forgetting behavior. It can help inspect whether records that look low-value individually are still part of a stronger repeated-evidence pattern.

## Scope

- Adds `analyzeMemoryEvidenceClusters`
- Adds per-record evidence signals for cluster diagnostics
- Extends the consolidation eval test to verify low-record-score / high-cluster-score traces are surfaced
- Does not change forgetting decisions, storage, retrieval, or runtime behavior

## Testing

- `corepack pnpm exec prettier --check packages/ai/src/memory/evidence-cluster.ts apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter web tsc`