### PR TITLE
feat(memory): add consolidation plan helper

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   analyzeMemoryEvidenceClusters,
+  buildMemoryConsolidationPlan,
   buildMemoryEvidenceClusters,
 } from "@openloomi/memory-consolidation";
 import {
@@ -271,6 +272,33 @@ function analyzeScenario(scenario: EvalScenario) {
   });
 }
 
+function getCompetitionKey(clusterKey: string): string {
+  if (clusterKey.startsWith("answer-language:")) {
+    return "answer-language";
+  }
+  return clusterKey;
+}
+
+function planScenario(scenario: EvalScenario) {
+  return buildMemoryConsolidationPlan({
+    records: scenario.traces.map(traceToRecord),
+    now: NOW,
+    getClusterKey: (record) => String(record.metadata?.topic ?? ""),
+    getCompetitionKey: (cluster) => getCompetitionKey(cluster.key),
+  });
+}
+
+function findPlanEntry(
+  plan: ReturnType<typeof planScenario>,
+  clusterKey: string,
+) {
+  const entry = plan.entries.find((item) => item.clusterKey === clusterKey);
+  if (!entry) {
+    throw new Error(`Missing consolidation plan entry for ${clusterKey}`);
+  }
+  return entry;
+}
+
 describe("memory consolidation evaluation scenarios", () => {
   it("keeps expected long-term outcomes backed by repeated evidence", () => {
     for (const scenario of scenarios) {
@@ -330,5 +358,52 @@ describe("memory consolidation evaluation scenarios", () => {
     expect(flaggedRecordIds).toEqual(["zh-1", "zh-2", "zh-3", "zh-4"]);
     expect(flaggedRecordIds).not.toContain("noise-urgent");
     expect(analysis.clusters[0]?.key).toBe("answer-language:zh");
+  });
+
+  it("builds an explainable consolidation plan from cluster competition", () => {
+    const noisePlan = planScenario(
+      scenarios.find((item) => item.id === "one-shot-noise") as EvalScenario,
+    );
+    const overridePlan = planScenario(
+      scenarios.find(
+        (item) => item.id === "temporary-override",
+      ) as EvalScenario,
+    );
+    const adaptationPlan = planScenario(
+      scenarios.find(
+        (item) => item.id === "preference-adaptation",
+      ) as EvalScenario,
+    );
+
+    expect(findPlanEntry(noisePlan, "answer-language:zh")).toEqual(
+      expect.objectContaining({
+        action: "preserve",
+        winningClusterKey: "answer-language:zh",
+        reasonCodes: ["strong_repeated_evidence"],
+      }),
+    );
+    expect(findPlanEntry(noisePlan, "one-shot:noise")).toEqual(
+      expect.objectContaining({
+        action: "decay",
+        reasonCodes: ["isolated_low_confidence"],
+      }),
+    );
+    expect(findPlanEntry(overridePlan, "answer-language:en")).toEqual(
+      expect.objectContaining({
+        action: "decay",
+        winningClusterKey: "answer-language:zh",
+        reasonCodes: ["outscored_by_competitor", "isolated_low_confidence"],
+      }),
+    );
+    expect(findPlanEntry(adaptationPlan, "answer-language:en")).toEqual(
+      expect.objectContaining({
+        action: "preserve",
+        winningClusterKey: "answer-language:en",
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+      }),
+    );
+    expect(findPlanEntry(adaptationPlan, "answer-language:zh").action).not.toBe(
+      "preserve",
+    );
   });
 });

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -11,9 +11,21 @@ storage, retrieval, or summarization behavior.
 - Build evidence clusters from `MemoryEvidenceRecord[]` or structurally compatible memory records.
 - Score clusters with evidence, record score, activation, and recency signals.
 - Produce per-record diagnostics for low individual scores inside high-scoring clusters.
+- Build an explainable consolidation plan with `preserve`, `observe`, and `decay`
+  recommendations.
 
 ## Non-goals
 
 - No runtime integration with the forgetting engine.
 - No storage schema changes.
 - No retrieval behavior changes.
+
+## Consolidation plan
+
+`buildMemoryConsolidationPlan` turns cluster signals into a decision plan without
+changing runtime behavior. It groups related clusters by an optional competition
+key, ranks competing clusters, and emits explainable recommendations.
+
+- `preserve`: repeated evidence is strong enough to become a consolidation candidate.
+- `observe`: evidence is ambiguous, outscored, or not strong enough yet.
+- `decay`: isolated or weak competing evidence should not be promoted into long-term consolidation.

--- a/packages/ai/memory-consolidation/docs/design-zh.md
+++ b/packages/ai/memory-consolidation/docs/design-zh.md
@@ -42,9 +42,26 @@ Summary 是稳定记忆的可读表达
 - 构建 evidence clusters。
 - 计算 cluster-level score。
 - 输出 per-record diagnostics。
+- 输出 consolidation plan，将记忆簇信号转成 `preserve`、`observe`、`decay` 建议。
 - 支持 eval 场景比较 trace-level signal 和 cluster-level signal。
 
 它不会修改 forgetting decision、storage schema、retrieval behavior 或 summarization behavior。
+
+## 决策层设计
+
+`buildMemoryConsolidationPlan` 是当前 package 内的核心决策层。它不直接删除、
+保留或写入长期记忆，而是把 cluster 信号转成可解释的候选计划：
+
+- `preserve`：重复证据足够强，可以作为后续长期整合候选。
+- `observe`：证据还不够清晰，或者竞争结果接近，需要继续观察。
+- `decay`：孤立证据或被稳定竞争簇压过的一次性证据，不应该被提升为长期记忆。
+
+竞争关系由调用方通过 `getCompetitionKey` 显式提供。例如
+`answer-language:zh` 和 `answer-language:en` 可以归入同一个
+`answer-language` 竞争组；而一次性噪声可以保持独立分组，自然因为缺少重复证据而衰减。
+
+这种设计的目的不是让系统判断“这是不是噪声”，而是让噪声因为没有重复证据、
+没有再激活、没有赢得竞争而无法进入长期整合。
 
 ## 后续验证方向
 

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./evidence-cluster";
+export * from "./plan";

--- a/packages/ai/memory-consolidation/src/plan.ts
+++ b/packages/ai/memory-consolidation/src/plan.ts
@@ -1,0 +1,251 @@
+import {
+  buildMemoryEvidenceClusters,
+  type BuildMemoryEvidenceClustersInput,
+  type MemoryEvidenceCluster,
+} from "./evidence-cluster";
+
+export type MemoryConsolidationAction = "preserve" | "observe" | "decay";
+
+export type MemoryConsolidationReasonCode =
+  | "strong_repeated_evidence"
+  | "wins_competition"
+  | "outscored_by_competitor"
+  | "ambiguous_competition"
+  | "isolated_low_confidence"
+  | "insufficient_signal";
+
+export interface MemoryConsolidationPlanThresholds {
+  preserveScore: number;
+  preserveEvidence: number;
+  decayScore: number;
+  decayEvidence: number;
+  competitionMargin: number;
+}
+
+export interface BuildMemoryConsolidationPlanInput extends BuildMemoryEvidenceClustersInput {
+  getCompetitionKey?(cluster: MemoryEvidenceCluster): string | undefined;
+  thresholds?: Partial<MemoryConsolidationPlanThresholds>;
+}
+
+export interface MemoryConsolidationPlanEntry {
+  clusterKey: string;
+  competitionKey: string;
+  action: MemoryConsolidationAction;
+  score: number;
+  evidenceCount: number;
+  recordIds: string[];
+  rankInCompetition: number;
+  winningClusterKey: string;
+  competingClusterKeys: string[];
+  scoreMargin: number;
+  reasonCodes: MemoryConsolidationReasonCode[];
+  explanation: string;
+}
+
+export interface MemoryConsolidationPlan {
+  clusters: MemoryEvidenceCluster[];
+  entries: MemoryConsolidationPlanEntry[];
+  actions: Record<MemoryConsolidationAction, MemoryConsolidationPlanEntry[]>;
+}
+
+const DEFAULT_THRESHOLDS: MemoryConsolidationPlanThresholds = {
+  preserveScore: 0.6,
+  preserveEvidence: 3,
+  decayScore: 0.55,
+  decayEvidence: 1,
+  competitionMargin: 0.12,
+};
+
+function resolveThresholds(
+  thresholds: Partial<MemoryConsolidationPlanThresholds> | undefined,
+): MemoryConsolidationPlanThresholds {
+  return {
+    preserveScore:
+      thresholds?.preserveScore ?? DEFAULT_THRESHOLDS.preserveScore,
+    preserveEvidence:
+      thresholds?.preserveEvidence ?? DEFAULT_THRESHOLDS.preserveEvidence,
+    decayScore: thresholds?.decayScore ?? DEFAULT_THRESHOLDS.decayScore,
+    decayEvidence:
+      thresholds?.decayEvidence ?? DEFAULT_THRESHOLDS.decayEvidence,
+    competitionMargin:
+      thresholds?.competitionMargin ?? DEFAULT_THRESHOLDS.competitionMargin,
+  };
+}
+
+function groupByCompetition(
+  clusters: MemoryEvidenceCluster[],
+  getCompetitionKey:
+    | ((cluster: MemoryEvidenceCluster) => string | undefined)
+    | undefined,
+): Map<string, MemoryEvidenceCluster[]> {
+  const grouped = new Map<string, MemoryEvidenceCluster[]>();
+
+  for (const cluster of clusters) {
+    const competitionKey = getCompetitionKey?.(cluster) ?? cluster.key;
+    const existing = grouped.get(competitionKey) ?? [];
+    existing.push(cluster);
+    grouped.set(competitionKey, existing);
+  }
+
+  return grouped;
+}
+
+function getBestOtherCluster(
+  cluster: MemoryEvidenceCluster,
+  ranked: MemoryEvidenceCluster[],
+): MemoryEvidenceCluster | undefined {
+  return ranked.find((candidate) => candidate.key !== cluster.key);
+}
+
+function explain(
+  action: MemoryConsolidationAction,
+  reasonCodes: MemoryConsolidationReasonCode[],
+): string {
+  if (action === "preserve" && reasonCodes.includes("wins_competition")) {
+    return "Repeated evidence is strong enough and wins its competition group.";
+  }
+  if (action === "preserve") {
+    return "Repeated evidence is strong enough to preserve as a consolidation candidate.";
+  }
+  if (reasonCodes.includes("outscored_by_competitor")) {
+    return action === "decay"
+      ? "Weak competing evidence is outscored by a stronger repeated cluster."
+      : "The cluster is outscored by a stronger competitor, but still has enough evidence to observe.";
+  }
+  if (reasonCodes.includes("ambiguous_competition")) {
+    return "Cluster competition is too close for a consolidation decision.";
+  }
+  if (reasonCodes.includes("isolated_low_confidence")) {
+    return "Single or weak evidence has not been reactivated enough for consolidation.";
+  }
+  return "The cluster does not meet preserve or decay thresholds yet.";
+}
+
+function decideCluster(
+  cluster: MemoryEvidenceCluster,
+  ranked: MemoryEvidenceCluster[],
+  thresholds: MemoryConsolidationPlanThresholds,
+): Pick<
+  MemoryConsolidationPlanEntry,
+  "action" | "scoreMargin" | "reasonCodes" | "winningClusterKey"
+> {
+  const winner = ranked[0] ?? cluster;
+  const bestOther = getBestOtherCluster(cluster, ranked);
+  const isWinner = winner.key === cluster.key;
+  const scoreMargin = bestOther
+    ? cluster.score - bestOther.score
+    : cluster.score;
+  const isRepeated = cluster.evidenceCount >= thresholds.preserveEvidence;
+  const isStrong = cluster.score >= thresholds.preserveScore;
+  const hasClearMargin =
+    !bestOther || scoreMargin >= thresholds.competitionMargin;
+  const isWeakIsolated =
+    cluster.evidenceCount <= thresholds.decayEvidence &&
+    cluster.score <= thresholds.decayScore;
+  const isClearlyOutscored =
+    bestOther !== undefined &&
+    !isWinner &&
+    scoreMargin <= -thresholds.competitionMargin;
+
+  if (isWinner && isRepeated && isStrong && hasClearMargin) {
+    return {
+      action: "preserve",
+      scoreMargin,
+      winningClusterKey: winner.key,
+      reasonCodes: bestOther
+        ? ["strong_repeated_evidence", "wins_competition"]
+        : ["strong_repeated_evidence"],
+    };
+  }
+
+  if (isClearlyOutscored && cluster.evidenceCount <= thresholds.decayEvidence) {
+    return {
+      action: "decay",
+      scoreMargin,
+      winningClusterKey: winner.key,
+      reasonCodes: ["outscored_by_competitor", "isolated_low_confidence"],
+    };
+  }
+
+  if (isWeakIsolated) {
+    return {
+      action: "decay",
+      scoreMargin,
+      winningClusterKey: winner.key,
+      reasonCodes: ["isolated_low_confidence"],
+    };
+  }
+
+  if (
+    bestOther !== undefined &&
+    Math.abs(scoreMargin) < thresholds.competitionMargin
+  ) {
+    return {
+      action: "observe",
+      scoreMargin,
+      winningClusterKey: winner.key,
+      reasonCodes: ["ambiguous_competition"],
+    };
+  }
+
+  if (isClearlyOutscored) {
+    return {
+      action: "observe",
+      scoreMargin,
+      winningClusterKey: winner.key,
+      reasonCodes: ["outscored_by_competitor"],
+    };
+  }
+
+  return {
+    action: "observe",
+    scoreMargin,
+    winningClusterKey: winner.key,
+    reasonCodes: ["insufficient_signal"],
+  };
+}
+
+export function buildMemoryConsolidationPlan(
+  input: BuildMemoryConsolidationPlanInput,
+): MemoryConsolidationPlan {
+  const clusters = buildMemoryEvidenceClusters(input);
+  const thresholds = resolveThresholds(input.thresholds);
+  const grouped = groupByCompetition(clusters, input.getCompetitionKey);
+  const entries: MemoryConsolidationPlanEntry[] = [];
+
+  for (const [competitionKey, competitionClusters] of grouped.entries()) {
+    const ranked = [...competitionClusters].sort((a, b) => b.score - a.score);
+
+    for (const [index, cluster] of ranked.entries()) {
+      const decision = decideCluster(cluster, ranked, thresholds);
+      const competingClusterKeys = ranked
+        .filter((candidate) => candidate.key !== cluster.key)
+        .map((candidate) => candidate.key);
+
+      entries.push({
+        clusterKey: cluster.key,
+        competitionKey,
+        action: decision.action,
+        score: cluster.score,
+        evidenceCount: cluster.evidenceCount,
+        recordIds: cluster.recordIds,
+        rankInCompetition: index + 1,
+        winningClusterKey: decision.winningClusterKey,
+        competingClusterKeys,
+        scoreMargin: decision.scoreMargin,
+        reasonCodes: decision.reasonCodes,
+        explanation: explain(decision.action, decision.reasonCodes),
+      });
+    }
+  }
+
+  return {
+    clusters,
+    entries,
+    actions: {
+      preserve: entries.filter((entry) => entry.action === "preserve"),
+      observe: entries.filter((entry) => entry.action === "observe"),
+      decay: entries.filter((entry) => entry.action === "decay"),
+    },
+  };
+}


### PR DESCRIPTION
## 摘要

在 `@openloomi/memory-consolidation` 中新增一个纯函数决策层：`buildMemoryConsolidationPlan`。

它把现有 evidence cluster 信号进一步转换成可解释的 consolidation plan，用 `preserve`、`observe`、`decay` 表达后续整合建议。这个 PR 仍然不接入 runtime forgetting 行为，只完善 package 内的核心逻辑。

## 设计

- 按 `getCompetitionKey` 将相关 cluster 放入同一竞争组，例如 `answer-language:zh` / `answer-language:en`
- 根据重复证据、cluster score、竞争分差和孤立证据阈值给出建议
- 输出 reason codes、winning cluster、competition rank、score margin 和解释文本
- `decay` 表示不提升为长期整合候选，不表示删除原始记忆

## 范围

- 新增 `packages/ai/memory-consolidation/src/plan.ts`
- 从 package index 导出 plan helper
- 扩展 consolidation eval，覆盖：
  - repeated preference vs one-shot noise
  - temporary override vs long-term preference
  - repeated recent evidence adapting to preference change
- 更新 package README 和中文设计说明
- 不修改 forgetting decisions、storage、retrieval 或 summarization 行为

## 验证

- `corepack pnpm exec prettier --check packages/ai/memory-consolidation/README.md packages/ai/memory-consolidation/docs/design-zh.md packages/ai/memory-consolidation/src/evidence-cluster.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/src/plan.ts apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm --filter web tsc`

Related to #165