### PR TITLE
feat(memory): add relation graph assignment helper

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   analyzeMemoryEvidenceClusters,
+  assignMemoryRelationGraph,
   buildMemoryConsolidationPlan,
   buildMemoryEvidenceClusters,
+  deriveMemoryRelationGraphLifecycle,
 } from "@openloomi/memory-consolidation";
 import {
   DefaultMemoryRecordScorer,
@@ -299,6 +301,186 @@ function findPlanEntry(
   return entry;
 }
 
+function buildRelationGraphFixture() {
+  const records = [
+    trace("zh-a", "graph-input", "Use Chinese for repo work.", 20, {
+      accessCount: 1,
+    }),
+    trace("zh-b", "graph-input", "Prefer Chinese technical explanations.", 30, {
+      accessCount: 1,
+    }),
+    trace(
+      "zh-c",
+      "graph-input",
+      "Code explanations are easier in Chinese.",
+      40,
+      {
+        accessCount: 1,
+      },
+    ),
+    trace(
+      "en-a",
+      "graph-input",
+      "Use English-first answers for this workspace.",
+      100,
+      {
+        accessCount: 2,
+      },
+    ),
+    trace(
+      "en-b",
+      "graph-input",
+      "Default to English for technical discussions.",
+      110,
+      {
+        accessCount: 2,
+      },
+    ),
+    trace(
+      "en-c",
+      "graph-input",
+      "English is now preferred for repo work.",
+      118,
+      {
+        accessCount: 2,
+      },
+    ),
+    trace(
+      "en-d",
+      "graph-input",
+      "Please keep future technical answers in English.",
+      119,
+      {
+        accessCount: 2,
+      },
+    ),
+    trace("temp-en", "graph-input", "For this one reply, use English.", 119),
+    trace("noise", "graph-input", "random scratch note", 119),
+  ].map(traceToRecord);
+
+  const assignment = assignMemoryRelationGraph({
+    records,
+    nodes: records.map((record) => ({
+      id: `trace:${record.id}`,
+      recordId: record.id,
+      timestamp: record.timestamp,
+      activationCount: record.accessCount,
+      lastActivatedAt: record.lastAccessAt,
+    })),
+    now: NOW,
+    thresholds: {
+      relationDecayHalfLifeMs: 30 * DAY_MS,
+    },
+    relations: [
+      {
+        fromRecordId: "zh-a",
+        toRecordId: "zh-b",
+        relation: "support",
+        weight: 0.62,
+        evidenceCount: 2,
+        activationCount: 1,
+        lastActivatedAt: NOW,
+      },
+      {
+        fromRecordId: "zh-b",
+        toRecordId: "zh-c",
+        relation: "support",
+        weight: 0.78,
+      },
+      {
+        fromRecordId: "en-a",
+        toRecordId: "en-b",
+        relation: "support",
+        weight: 0.78,
+      },
+      {
+        fromRecordId: "en-b",
+        toRecordId: "en-c",
+        relation: "support",
+        weight: 0.8,
+      },
+      {
+        fromRecordId: "en-c",
+        toRecordId: "en-d",
+        relation: "support",
+        weight: 0.82,
+      },
+      {
+        fromRecordId: "temp-en",
+        toRecordId: "en-a",
+        relation: "support",
+        weight: 0.95,
+        lastActivatedAt: 10 * DAY_MS,
+      },
+      {
+        fromRecordId: "zh-a",
+        toRecordId: "en-a",
+        relation: "compete",
+        weight: 0.82,
+      },
+      {
+        fromRecordId: "zh-c",
+        toRecordId: "en-d",
+        relation: "compete",
+        weight: 0.74,
+      },
+      {
+        fromRecordId: "temp-en",
+        toRecordId: "en-a",
+        relation: "related",
+        weight: 0.9,
+      },
+      {
+        fromRecordId: "temp-en",
+        toRecordId: "missing-record",
+        relation: "related",
+        weight: 0.9,
+      },
+    ],
+  });
+  const plan = buildMemoryConsolidationPlan({
+    records,
+    now: NOW,
+    getClusterKey: assignment.getClusterKey,
+    getCompetitionKey: assignment.getCompetitionKey,
+    thresholds: {
+      preserveScore: 0.5,
+      preserveEvidence: 3,
+      competitionMargin: 0.05,
+    },
+  });
+  const lifecycle = deriveMemoryRelationGraphLifecycle({
+    assignment,
+    consolidatedClusterKeys: plan.actions.preserve.map(
+      (entry) => entry.clusterKey,
+    ),
+  });
+
+  return {
+    records,
+    assignment,
+    plan,
+    lifecycle,
+    zhClusterKey: assignment.recordClusterKeys["zh-a"],
+    enClusterKey: assignment.recordClusterKeys["en-a"],
+    tempClusterKey: assignment.recordClusterKeys["temp-en"],
+    noiseClusterKey: assignment.recordClusterKeys.noise,
+  };
+}
+
+function findGraphCluster(
+  assignment: ReturnType<typeof buildRelationGraphFixture>["assignment"],
+  clusterId: string,
+) {
+  const cluster = assignment.clusters.find(
+    (item) => item.clusterId === clusterId,
+  );
+  if (!cluster) {
+    throw new Error(`Missing graph cluster ${clusterId}`);
+  }
+  return cluster;
+}
+
 describe("memory consolidation evaluation scenarios", () => {
   it("keeps expected long-term outcomes backed by repeated evidence", () => {
     for (const scenario of scenarios) {
@@ -404,6 +586,192 @@ describe("memory consolidation evaluation scenarios", () => {
     );
     expect(findPlanEntry(adaptationPlan, "answer-language:zh").action).not.toBe(
       "preserve",
+    );
+  });
+
+  it("forms graph clusters from reinforced support edges", () => {
+    const { assignment, zhClusterKey, enClusterKey } =
+      buildRelationGraphFixture();
+    const zhCluster = findGraphCluster(assignment, zhClusterKey);
+    const enCluster = findGraphCluster(assignment, enClusterKey);
+
+    expect(assignment.nodes.map((node) => node.id)).toContain("trace:zh-a");
+    expect(assignment.recordClusterKeys["zh-b"]).toBe(zhClusterKey);
+    expect(assignment.recordClusterKeys["zh-c"]).toBe(zhClusterKey);
+    expect(assignment.recordClusterKeys["en-b"]).toBe(enClusterKey);
+    expect(assignment.recordClusterKeys["en-c"]).toBe(enClusterKey);
+    expect(assignment.recordClusterKeys["en-d"]).toBe(enClusterKey);
+    expect(zhCluster.supportEdgeIds).toEqual([
+      "zh-a:support:zh-b",
+      "zh-b:support:zh-c",
+    ]);
+    expect(enCluster.supportEdgeIds).toEqual([
+      "en-a:support:en-b",
+      "en-b:support:en-c",
+      "en-c:support:en-d",
+    ]);
+  });
+
+  it("generates stable graph keys without delimiter collisions", () => {
+    const relationRecords = ["a+b", "c", "a", "b+c"].map((id) =>
+      trace(id, "graph-input", id, 119),
+    );
+    const leftAssignment = assignMemoryRelationGraph({
+      records: [relationRecords[0], relationRecords[1]].map(traceToRecord),
+      now: NOW,
+      relations: [
+        {
+          fromRecordId: "a+b",
+          toRecordId: "c",
+          relation: "support",
+          weight: 0.9,
+        },
+      ],
+    });
+    const reversedLeftAssignment = assignMemoryRelationGraph({
+      records: [relationRecords[1], relationRecords[0]].map(traceToRecord),
+      now: NOW,
+      relations: [
+        {
+          fromRecordId: "c",
+          toRecordId: "a+b",
+          relation: "support",
+          weight: 0.9,
+        },
+      ],
+    });
+    const rightAssignment = assignMemoryRelationGraph({
+      records: [relationRecords[2], relationRecords[3]].map(traceToRecord),
+      now: NOW,
+      relations: [
+        {
+          fromRecordId: "a",
+          toRecordId: "b+c",
+          relation: "support",
+          weight: 0.9,
+        },
+      ],
+    });
+
+    expect(leftAssignment.recordClusterKeys["a+b"]).toBe(
+      reversedLeftAssignment.recordClusterKeys["a+b"],
+    );
+    expect(leftAssignment.recordClusterKeys["a+b"]).not.toBe(
+      rightAssignment.recordClusterKeys.a,
+    );
+
+    const competitionRecords = ["left+a", "left-b", "right+a", "right-b"].map(
+      (id) => trace(id, "graph-input", id, 119),
+    );
+    const relations = [
+      {
+        fromRecordId: "left+a",
+        toRecordId: "left-b",
+        relation: "support" as const,
+        weight: 0.9,
+      },
+      {
+        fromRecordId: "right+a",
+        toRecordId: "right-b",
+        relation: "support" as const,
+        weight: 0.9,
+      },
+      {
+        fromRecordId: "left+a",
+        toRecordId: "right+a",
+        relation: "compete" as const,
+        weight: 0.9,
+      },
+    ];
+    const competitionAssignment = assignMemoryRelationGraph({
+      records: competitionRecords.map(traceToRecord),
+      now: NOW,
+      relations,
+    });
+    const reversedCompetitionAssignment = assignMemoryRelationGraph({
+      records: [...competitionRecords].reverse().map(traceToRecord),
+      now: NOW,
+      relations,
+    });
+
+    expect(
+      competitionAssignment.getCompetitionKey({
+        key: competitionAssignment.recordClusterKeys["left+a"],
+      }),
+    ).toBe(
+      reversedCompetitionAssignment.getCompetitionKey({
+        key: reversedCompetitionAssignment.recordClusterKeys["left+a"],
+      }),
+    );
+  });
+
+  it("keeps weak related traces separate from stable support clusters", () => {
+    const { assignment, enClusterKey, tempClusterKey } =
+      buildRelationGraphFixture();
+    const enCluster = findGraphCluster(assignment, enClusterKey);
+    const tempCluster = findGraphCluster(assignment, tempClusterKey);
+
+    expect(tempClusterKey).not.toBe(enClusterKey);
+    expect(
+      assignment.edges.find((edge) => edge.id === "temp-en:support:en-a")
+        ?.effectiveWeight,
+    ).toBeLessThan(0.7);
+    expect(tempCluster.status).toBe("tentative");
+    expect(tempCluster.relatedEdgeIds).toEqual(["temp-en:related:en-a"]);
+    expect(enCluster.relatedEdgeIds).toEqual(["temp-en:related:en-a"]);
+  });
+
+  it("lets recent repeated evidence compete with and replace an older stable cluster", () => {
+    const { assignment, plan, lifecycle, zhClusterKey, enClusterKey } =
+      buildRelationGraphFixture();
+    const enLifecycle = lifecycle.find(
+      (entry) => entry.clusterId === enClusterKey,
+    );
+    const zhLifecycle = lifecycle.find(
+      (entry) => entry.clusterId === zhClusterKey,
+    );
+
+    expect(assignment.getCompetitionKey({ key: zhClusterKey })).toBe(
+      assignment.getCompetitionKey({ key: enClusterKey }),
+    );
+    expect(findGraphCluster(assignment, zhClusterKey).status).toBe("contested");
+    expect(findGraphCluster(assignment, enClusterKey).status).toBe("contested");
+    expect(findPlanEntry(plan, enClusterKey)).toEqual(
+      expect.objectContaining({
+        action: "preserve",
+        competitionKey: assignment.getCompetitionKey({ key: enClusterKey }),
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+      }),
+    );
+    expect(findPlanEntry(plan, zhClusterKey).action).not.toBe("preserve");
+    expect(enLifecycle).toEqual(
+      expect.objectContaining({
+        graphStatus: "contested",
+        status: "consolidated",
+        consolidated: true,
+      }),
+    );
+    expect(zhLifecycle).toEqual(
+      expect.objectContaining({
+        graphStatus: "contested",
+        status: "contested",
+        consolidated: false,
+      }),
+    );
+  });
+
+  it("keeps isolated noise as a tentative micro-cluster that decays in the plan", () => {
+    const { assignment, plan, noiseClusterKey } = buildRelationGraphFixture();
+    const noiseCluster = findGraphCluster(assignment, noiseClusterKey);
+
+    expect(noiseCluster.recordIds).toEqual(["noise"]);
+    expect(noiseCluster.supportEdgeIds).toEqual([]);
+    expect(noiseCluster.status).toBe("tentative");
+    expect(findPlanEntry(plan, noiseClusterKey)).toEqual(
+      expect.objectContaining({
+        action: "decay",
+        reasonCodes: ["isolated_low_confidence"],
+      }),
     );
   });
 });

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -9,6 +9,7 @@ storage, retrieval, or summarization behavior.
 ## Scope
 
 - Build evidence clusters from `MemoryEvidenceRecord[]` or structurally compatible memory records.
+- Assign graph clusters and competition groups from explicit trace relation edges.
 - Score clusters with evidence, record score, activation, and recency signals.
 - Produce per-record diagnostics for low individual scores inside high-scoring clusters.
 - Build an explainable consolidation plan with `preserve`, `observe`, and `decay`
@@ -19,6 +20,7 @@ storage, retrieval, or summarization behavior.
 - No runtime integration with the forgetting engine.
 - No storage schema changes.
 - No retrieval behavior changes.
+- No automatic relation generation with embeddings or LLMs.
 
 ## Consolidation plan
 
@@ -29,3 +31,17 @@ key, ranks competing clusters, and emits explainable recommendations.
 - `preserve`: repeated evidence is strong enough to become a consolidation candidate.
 - `observe`: evidence is ambiguous, outscored, or not strong enough yet.
 - `decay`: isolated or weak competing evidence should not be promoted into long-term consolidation.
+
+## Relation graph prototype
+
+`assignMemoryRelationGraph` is a small pure helper for the upstream side of
+consolidation. Given trace nodes, records, and explicit `support` / `compete` /
+`related` edges, it applies edge reinforcement and decay, forms graph clusters
+from strong support edges, keeps related edges as observation signals, forms
+competition groups from strong compete edges, and returns `getClusterKey` /
+`getCompetitionKey` resolvers that can be passed into
+`buildMemoryConsolidationPlan`.
+
+`deriveMemoryRelationGraphLifecycle` can then mark preserved graph clusters as
+`consolidated` after a consolidation plan is produced. The relation graph itself
+only assigns `tentative`, `stable`, and `contested` graph states.

--- a/packages/ai/memory-consolidation/docs/design-zh.md
+++ b/packages/ai/memory-consolidation/docs/design-zh.md
@@ -40,6 +40,8 @@ Summary 是稳定记忆的可读表达
 `@openloomi/memory-consolidation` 目前只提供纯函数能力：
 
 - 构建 evidence clusters。
+- 从显式 trace relation 中分配 graph clusters 和 competition groups。
+- 保留 weak related edges 作为观察信号，而不是直接参与合并。
 - 计算 cluster-level score。
 - 输出 per-record diagnostics。
 - 输出 consolidation plan，将记忆簇信号转成 `preserve`、`observe`、`decay` 建议。
@@ -62,6 +64,9 @@ Summary 是稳定记忆的可读表达
 
 这种设计的目的不是让系统判断“这是不是噪声”，而是让噪声因为没有重复证据、
 没有再激活、没有赢得竞争而无法进入长期整合。
+
+关系图层只负责输出 `tentative`、`stable` 和 `contested` 状态；`consolidated` 是
+consolidation plan 产生 `preserve` 建议之后的派生状态，不由关系图直接决定。
 
 ## 后续验证方向
 

--- a/packages/ai/memory-consolidation/docs/relation-graph-prototype-zh.md
+++ b/packages/ai/memory-consolidation/docs/relation-graph-prototype-zh.md
@@ -1,0 +1,374 @@
+# 记忆关系图原型设计
+
+## 目标
+
+当前 `@openloomi/memory-consolidation` 已经具备从 `cluster` 到
+`consolidation plan` 的决策能力：
+
+```text
+cluster -> score -> competition -> preserve / observe / decay
+```
+
+但更上游的问题还没有解决：相似 trace 如何形成 cluster，互斥模式如何形成
+competition。这个原型设计把记忆看成一张动态关系图：
+
+```text
+trace -> relation graph -> graph clusters -> competition groups -> consolidation plan
+```
+
+核心思想是：不要在写入入口判断“这是不是噪声”，也不要立刻给 trace 贴永久标签；
+先保留 trace 之间的关系，让支持边、竞争边和激活历史逐步决定哪些结构稳定下来。
+
+## 原型闭环
+
+这个原型把前面讨论过的强化、聚簇、竞争和 consolidation plan 串成一个闭环：
+
+```text
+new trace
+  -> create / update relation edges
+  -> reinforce or decay node and edge weights
+  -> form graph clusters from strong support edges
+  -> form competition groups from strong compete edges
+  -> reuse buildMemoryConsolidationPlan
+  -> preserve / observe / decay
+```
+
+这里的关键约束是：前半段只负责发现结构，后半段才负责做决策。关系图不会直接决定
+“应该记住什么”，它只回答两个问题：
+
+- 哪些 trace 已经形成同一个稳定证据簇？
+- 哪些稳定证据簇处在同一个竞争维度里？
+
+这样能避免把图机制做成另一个 upfront classifier，也能继续复用当前 package 里已经存在的
+score、competition 和 plan 逻辑。
+
+## 非目标
+
+这个原型不解决完整自动聚类问题：
+
+- 不接入 forgetting engine runtime。
+- 不修改 storage schema。
+- 不引入 embedding / LLM 依赖。
+- 不自动判断两条 trace 是否支持或冲突。
+- 不生成长期 summary。
+
+mini 版本只验证：如果已经有一组 trace relation，是否可以从图结构中得到
+`clusterKey` 和 `competitionKey`，再复用现有 consolidation plan。
+
+## 核心对象
+
+### Trace Node
+
+`TraceNode` 表示一个原始记忆痕迹。它可以来自消息、观察、用户反馈或任务状态。
+
+```text
+id
+recordId
+timestamp
+activationCount
+lastActivatedAt
+```
+
+节点本身不需要知道自己属于哪个分类。它只需要保留足够的身份和激活信息。
+
+### Relation Edge
+
+`RelationEdge` 表示两个 trace 之间的关系。
+
+```text
+fromRecordId
+toRecordId
+relation: support | compete | related
+weight
+evidenceCount
+activationCount
+lastActivatedAt
+```
+
+三类边的含义不同：
+
+- `support`：两个 trace 支持同一个记忆模式，可以促成聚簇。
+- `compete`：两个 trace 指向互斥或冲突的模式，不应该合并。
+- `related`：语义相关但不能确定支持或冲突，只作为观察信号。
+
+mini 版本中，关系边先由测试或调用方显式传入。未来可以由 embedding、LLM 或规则
+生成候选边。
+
+### Graph Cluster
+
+`GraphCluster` 由强 `support` 边形成。
+
+```text
+clusterId
+recordIds
+supportEdgeIds
+relatedEdgeIds
+status: tentative | stable | contested
+supportScore
+latestTimestamp
+```
+
+聚簇不是分类结果，而是图中的稳定社区。孤立节点也可以形成一个 tentative
+micro-cluster，但不会因为孤立就被提升为长期记忆。
+
+### Competition Group
+
+`CompetitionGroup` 由 cluster 之间的强 `compete` 边形成。
+
+```text
+competitionKey
+clusterIds
+competeEdgeIds
+```
+
+竞争关系不合并 cluster，只说明这些 cluster 在同一个使用场景或记忆维度上互斥。
+例如中文回答偏好和英文回答偏好不应该合并，但可以进入同一个竞争组。
+
+## 边权强化与衰减
+
+关系图的关键不是边是否存在，而是边权会变化。
+
+### 强化
+
+当相似 trace 反复出现，或在检索时一起被激活，边权增强：
+
+```text
+newWeight = oldWeight + evidenceBoost + activationBoost
+```
+
+可以区分两种强化：
+
+- `evidenceBoost`：新的独立 trace 提供重复证据。
+- `activationBoost`：已有 trace 在同一上下文中共同被召回或使用。
+
+这样一条安静偏好如果多次出现，会逐步形成强 support 边。
+
+### 衰减
+
+长期没有新证据或再激活的边会衰减：
+
+```text
+decayedWeight = weight * timeDecay(lastActivatedAt, now)
+```
+
+衰减应该作用在边和节点上，而不只是作用在单条记忆上。这样孤立噪声会自然失去
+连接能力，而稳定簇会因为持续再激活保持活性。
+
+## 从关系图形成聚簇
+
+mini 版本可以使用很保守的规则：
+
+1. 只选择 `relation = support` 且 `weight >= supportThreshold` 的边。
+2. 用这些边构造无向图。
+3. 图中的 connected components 形成 graph clusters。
+4. 没有强 support 边的节点形成 tentative micro-cluster。
+5. `related` 边不参与合并，只保留为观察信号。
+
+这种规则故意简单。它不是最终聚类算法，但能验证“簇由支持关系形成”这个方向。
+
+## 从竞争边形成竞争组
+
+competition 的形成也保持保守：
+
+1. 先根据 support 边得到 graph clusters。
+2. 检查所有 `relation = compete` 且 `weight >= competeThreshold` 的边。
+3. 如果一条 compete 边连接了两个不同 cluster，就建立 cluster-level compete edge。
+4. 通过 cluster-level compete edge 的 connected components 得到 competition groups。
+5. 没有竞争边的 cluster 使用自己的 clusterId 作为 competitionKey。
+
+这样可以表达：
+
+```text
+cluster: 中文回答偏好
+cluster: 英文回答偏好
+competition group: answer-language-like
+```
+
+mini 版本不需要理解它们为什么是回答语言偏好，只需要看到两个稳定簇之间存在强竞争。
+
+## 生命周期
+
+关系图中的 cluster 可以有三个图状态：
+
+```text
+tentative -> stable -> contested
+```
+
+- `tentative`：证据少，只有单点或弱连接。
+- `stable`：support 边足够强，形成稳定簇。
+- `contested`：存在强 competition group，需要交给 plan 决策。
+
+是否最终进入长期整合，仍然由 `buildMemoryConsolidationPlan` 决定。plan 给出
+`preserve` 后，可以派生出第四个生命周期状态：
+
+```text
+contested / stable -> consolidated
+```
+
+`consolidated` 不由 relation graph 直接判断，它表示某个 graph cluster 已经在 plan 层
+被选为长期整合候选。
+
+## 与现有 plan helper 的连接
+
+relation graph 不直接做 `preserve` / `observe` / `decay` 决策。它只生成 resolver：
+
+```text
+getClusterKey(record) -> graph cluster id
+getCompetitionKey(cluster) -> graph competition key
+```
+
+然后复用现有链路：
+
+```text
+records
+  -> relation graph assignment
+  -> buildMemoryEvidenceClusters
+  -> buildMemoryConsolidationPlan
+```
+
+这样可以让新机制作为现有 package 的前半段，而不是替换已有 scoring 和 plan。
+
+## 示例
+
+原始 trace：
+
+```text
+A: 以后技术问题用中文解释
+B: 我更喜欢中文回答
+C: 代码解释默认中文
+D: 这次先用英文
+E: 以后默认英文
+F: 技术讨论用英文
+N: urgent todo blocker random note
+```
+
+关系边：
+
+```text
+A support B 0.82
+B support C 0.78
+A support C 0.74
+E support F 0.80
+A compete E 0.76
+B compete E 0.73
+C compete F 0.70
+D related E 0.45
+```
+
+形成的 graph clusters：
+
+```text
+cluster-zh: A, B, C
+cluster-en: E, F
+cluster-temp: D
+cluster-noise: N
+```
+
+形成的 competition groups：
+
+```text
+competition-1: cluster-zh, cluster-en
+cluster-temp: no strong competition
+cluster-noise: no strong competition
+```
+
+再交给 consolidation plan 后，可能得到：
+
+```text
+cluster-zh -> preserve
+cluster-en -> observe 或 preserve，取决于最近重复证据
+cluster-temp -> decay
+cluster-noise -> decay
+```
+
+如果后续出现更多英文偏好 trace，`cluster-en` 的 evidence 和 recency 会增强，并可能在
+competition 中赢过旧的中文偏好簇。
+
+## 信号如何传递
+
+原型里每一层只向下一层传递必要信号：
+
+| 层级               | 输入                                  | 输出                           | 不做什么           |
+| ------------------ | ------------------------------------- | ------------------------------ | ------------------ |
+| relation graph     | trace nodes + relation edges          | decayed / reinforced edges     | 不判断长期记忆     |
+| graph cluster      | strong support edges                  | `clusterId -> recordIds`       | 不生成 summary     |
+| competition group  | strong compete edges between clusters | `competitionKey -> clusterIds` | 不合并冲突簇       |
+| evidence cluster   | records + `getClusterKey`             | cluster score                  | 不接触 storage     |
+| consolidation plan | cluster score + `getCompetitionKey`   | preserve / observe / decay     | 不直接修改 runtime |
+
+因此强化机制的作用不是“强行保存某条 trace”，而是让相关边更容易跨过
+`supportThreshold` 或 `competeThreshold`。跨过阈值之后，trace 才会进入更稳定的图结构；
+没有跨过阈值的孤立痕迹仍然可以被现有 forgetting policy 自然压缩或归档。
+
+## 最小 API 形状
+
+如果后续进入代码实现，mini 版本可以只暴露一个纯函数：
+
+```text
+assignMemoryRelationGraph({
+  records,
+  nodes,
+  relations,
+  now,
+  thresholds,
+}) -> {
+  clusters,
+  competitionGroups,
+  getClusterKey(record),
+  getCompetitionKey(cluster),
+}
+```
+
+`relations` 由调用方显式提供，不在 mini 版本里自动生成。函数内部只做三件事：
+
+1. 对节点和边应用时间衰减。
+2. 用强 `support` 边计算 connected components。
+3. 用强 `compete` 边计算 cluster-level competition groups。
+
+然后调用方可以把 resolver 交给现有函数：
+
+```text
+assignMemoryRelationGraph
+  -> buildMemoryEvidenceClusters
+  -> buildMemoryConsolidationPlan
+```
+
+这个 API 的好处是实现范围很小，但已经能验证最关键的假设：聚簇和竞争关系可以从图结构
+自然形成，而不是由写死分类规则提前决定。
+
+## 复杂度边界
+
+relation graph 不能做全量两两比较。mini 版本只处理已传入的 relation edges：
+
+```text
+cluster assignment: O(nodes + supportEdges)
+competition assignment: O(clusters + competeEdges)
+```
+
+未来如果自动生成 relation edges，也应该只做局部 topK 候选：
+
+```text
+new trace -> retrieve topK candidate nodes/clusters -> create/update edges
+```
+
+不能退化成所有 trace 两两比较。
+
+## 后续实现顺序
+
+建议分三步推进：
+
+1. **关系图原型**
+   - 输入 records + explicit relations。
+   - 输出 cluster assignment + competition assignment。
+   - 复用现有 consolidation plan。
+
+2. **关系候选生成**
+   - 用 embedding 或轻量规则召回 topK 候选。
+   - 只生成候选边，不直接合并。
+
+3. **模糊关系裁决**
+   - 对低置信度候选边做 LLM/规则裁决。
+   - 输出 `support` / `compete` / `related` / `uncertain`。
+   - `uncertain` 保持 tentative，不做强合并。
+
+这个顺序能把复杂问题延迟到足够需要的时候，同时让当前 package 先形成完整概念闭环。

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./evidence-cluster": "./src/evidence-cluster.ts"
+    "./evidence-cluster": "./src/evidence-cluster.ts",
+    "./relation-graph": "./src/relation-graph.ts"
   },
   "devDependencies": {
     "@openloomi/config": "workspace:*",

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./evidence-cluster";
 export * from "./plan";
+export * from "./relation-graph";

--- a/packages/ai/memory-consolidation/src/relation-graph.ts
+++ b/packages/ai/memory-consolidation/src/relation-graph.ts
@@ -1,0 +1,439 @@
+import type {
+  MemoryEvidenceCluster,
+  MemoryEvidenceRecord,
+} from "./evidence-cluster";
+
+export type MemoryRelationKind = "support" | "compete" | "related";
+
+export interface MemoryTraceNode {
+  id: string;
+  recordId: string;
+  timestamp: number;
+  activationCount?: number;
+  lastActivatedAt?: number;
+}
+
+export interface MemoryRelationEdge {
+  id?: string;
+  fromRecordId: string;
+  toRecordId: string;
+  relation: MemoryRelationKind;
+  weight: number;
+  evidenceCount?: number;
+  activationCount?: number;
+  lastActivatedAt?: number;
+}
+
+export interface MemoryRelationGraphThresholds {
+  supportThreshold: number;
+  competeThreshold: number;
+  stableSupportScore: number;
+  relationDecayHalfLifeMs: number;
+  evidenceBoost: number;
+  activationBoost: number;
+}
+
+export type MemoryGraphClusterStatus = "tentative" | "stable" | "contested";
+export type MemoryGraphClusterLifecycleStatus =
+  | MemoryGraphClusterStatus
+  | "consolidated";
+
+export interface MemoryRelationGraphEdgeSignal {
+  id: string;
+  fromRecordId: string;
+  toRecordId: string;
+  relation: MemoryRelationKind;
+  weight: number;
+  effectiveWeight: number;
+  evidenceCount: number;
+  activationCount: number;
+  lastActivatedAt?: number;
+}
+
+export interface MemoryRelationGraphCluster {
+  clusterId: string;
+  recordIds: string[];
+  supportEdgeIds: string[];
+  relatedEdgeIds: string[];
+  status: MemoryGraphClusterStatus;
+  supportScore: number;
+  latestTimestamp: number;
+}
+
+export interface MemoryRelationCompetitionGroup {
+  competitionKey: string;
+  clusterIds: string[];
+  competeEdgeIds: string[];
+}
+
+export interface AssignMemoryRelationGraphInput {
+  records: MemoryEvidenceRecord[];
+  nodes?: MemoryTraceNode[];
+  relations: MemoryRelationEdge[];
+  now: number;
+  thresholds?: Partial<MemoryRelationGraphThresholds>;
+}
+
+export interface MemoryRelationGraphAssignment {
+  nodes: MemoryTraceNode[];
+  edges: MemoryRelationGraphEdgeSignal[];
+  clusters: MemoryRelationGraphCluster[];
+  competitionGroups: MemoryRelationCompetitionGroup[];
+  recordClusterKeys: Record<string, string>;
+  clusterCompetitionKeys: Record<string, string>;
+  getClusterKey(record: MemoryEvidenceRecord): string | undefined;
+  getCompetitionKey(cluster: Pick<MemoryEvidenceCluster, "key">): string;
+}
+
+export interface MemoryRelationGraphLifecycleEntry {
+  clusterId: string;
+  status: MemoryGraphClusterLifecycleStatus;
+  graphStatus: MemoryGraphClusterStatus;
+  consolidated: boolean;
+}
+
+export interface DeriveMemoryRelationGraphLifecycleInput {
+  assignment: Pick<MemoryRelationGraphAssignment, "clusters">;
+  consolidatedClusterKeys: Iterable<string>;
+}
+
+const DEFAULT_THRESHOLDS: MemoryRelationGraphThresholds = {
+  supportThreshold: 0.7,
+  competeThreshold: 0.7,
+  stableSupportScore: 0.7,
+  relationDecayHalfLifeMs: 90 * 24 * 60 * 60 * 1000,
+  evidenceBoost: 0.04,
+  activationBoost: 0.02,
+};
+
+function resolveThresholds(
+  thresholds: Partial<MemoryRelationGraphThresholds> | undefined,
+): MemoryRelationGraphThresholds {
+  return {
+    supportThreshold:
+      thresholds?.supportThreshold ?? DEFAULT_THRESHOLDS.supportThreshold,
+    competeThreshold:
+      thresholds?.competeThreshold ?? DEFAULT_THRESHOLDS.competeThreshold,
+    stableSupportScore:
+      thresholds?.stableSupportScore ?? DEFAULT_THRESHOLDS.stableSupportScore,
+    relationDecayHalfLifeMs:
+      thresholds?.relationDecayHalfLifeMs ??
+      DEFAULT_THRESHOLDS.relationDecayHalfLifeMs,
+    evidenceBoost:
+      thresholds?.evidenceBoost ?? DEFAULT_THRESHOLDS.evidenceBoost,
+    activationBoost:
+      thresholds?.activationBoost ?? DEFAULT_THRESHOLDS.activationBoost,
+  };
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function relationId(edge: MemoryRelationEdge): string {
+  return edge.id ?? `${edge.fromRecordId}:${edge.relation}:${edge.toRecordId}`;
+}
+
+function nodeFromRecord(record: MemoryEvidenceRecord): MemoryTraceNode {
+  return {
+    id: record.id,
+    recordId: record.id,
+    timestamp: record.timestamp,
+    activationCount: record.accessCount,
+    lastActivatedAt: record.lastAccessAt,
+  };
+}
+
+function resolveNodes(
+  records: MemoryEvidenceRecord[],
+  nodes: MemoryTraceNode[] | undefined,
+): MemoryTraceNode[] {
+  const nodesByRecordId = new Map(
+    (nodes ?? []).map((node) => [node.recordId, node]),
+  );
+
+  return records.map(
+    (record) => nodesByRecordId.get(record.id) ?? nodeFromRecord(record),
+  );
+}
+
+function decayWeight(
+  weight: number,
+  lastActivatedAt: number | undefined,
+  now: number,
+  halfLifeMs: number,
+): number {
+  if (lastActivatedAt === undefined) {
+    return weight;
+  }
+
+  const ageMs = Math.max(0, now - lastActivatedAt);
+  return weight * 0.5 ** (ageMs / Math.max(1, halfLifeMs));
+}
+
+function effectiveWeight(
+  edge: MemoryRelationEdge,
+  now: number,
+  thresholds: MemoryRelationGraphThresholds,
+): number {
+  const evidenceCount = edge.evidenceCount ?? 0;
+  const activationCount = edge.activationCount ?? 0;
+  const decayedWeight = decayWeight(
+    edge.weight,
+    edge.lastActivatedAt,
+    now,
+    thresholds.relationDecayHalfLifeMs,
+  );
+
+  return clamp01(
+    decayedWeight +
+      evidenceCount * thresholds.evidenceBoost +
+      activationCount * thresholds.activationBoost,
+  );
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+class DisjointSet {
+  private readonly parent = new Map<string, string>();
+
+  constructor(ids: string[]) {
+    for (const id of ids) {
+      this.parent.set(id, id);
+    }
+  }
+
+  find(id: string): string {
+    const parent = this.parent.get(id);
+    if (!parent || parent === id) {
+      return id;
+    }
+
+    const root = this.find(parent);
+    this.parent.set(id, root);
+    return root;
+  }
+
+  union(left: string, right: string): void {
+    const leftRoot = this.find(left);
+    const rightRoot = this.find(right);
+
+    if (leftRoot !== rightRoot) {
+      this.parent.set(rightRoot, leftRoot);
+    }
+  }
+}
+
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function stableKeyParts(ids: string[]): string[] {
+  return [...ids].sort().map(encodeKeyPart);
+}
+
+function clusterId(recordIds: string[]): string {
+  return `graph:${stableKeyParts(recordIds).join("|")}`;
+}
+
+function competitionKey(clusterIds: string[]): string {
+  return clusterIds.length === 1
+    ? (clusterIds[0] ?? "competition:empty")
+    : `competition:${stableKeyParts(clusterIds).join("|")}`;
+}
+
+function groupByRoot(
+  ids: string[],
+  disjointSet: DisjointSet,
+): Map<string, string[]> {
+  const grouped = new Map<string, string[]>();
+
+  for (const id of ids) {
+    const root = disjointSet.find(id);
+    const existing = grouped.get(root) ?? [];
+    existing.push(id);
+    grouped.set(root, existing);
+  }
+
+  return grouped;
+}
+
+export function assignMemoryRelationGraph(
+  input: AssignMemoryRelationGraphInput,
+): MemoryRelationGraphAssignment {
+  const thresholds = resolveThresholds(input.thresholds);
+  const recordsById = new Map(
+    input.records.map((record) => [record.id, record]),
+  );
+  const nodes = resolveNodes(input.records, input.nodes);
+  const nodesByRecordId = new Map(nodes.map((node) => [node.recordId, node]));
+  const recordIds = nodes.map((node) => node.recordId);
+  const edgeSignals = input.relations.map((edge) => ({
+    id: relationId(edge),
+    fromRecordId: edge.fromRecordId,
+    toRecordId: edge.toRecordId,
+    relation: edge.relation,
+    weight: clamp01(edge.weight),
+    effectiveWeight: effectiveWeight(edge, input.now, thresholds),
+    evidenceCount: edge.evidenceCount ?? 0,
+    activationCount: edge.activationCount ?? 0,
+    lastActivatedAt: edge.lastActivatedAt,
+  }));
+
+  const recordDisjointSet = new DisjointSet(recordIds);
+  const strongSupportEdges = edgeSignals.filter(
+    (edge) =>
+      edge.relation === "support" &&
+      edge.effectiveWeight >= thresholds.supportThreshold &&
+      recordsById.has(edge.fromRecordId) &&
+      recordsById.has(edge.toRecordId),
+  );
+
+  for (const edge of strongSupportEdges) {
+    recordDisjointSet.union(edge.fromRecordId, edge.toRecordId);
+  }
+
+  const groupedRecords = groupByRoot(recordIds, recordDisjointSet);
+  const clusters = [...groupedRecords.values()].map((recordIdsInCluster) => {
+    const recordIdSet = new Set(recordIdsInCluster);
+    const supportEdges = strongSupportEdges.filter(
+      (edge) =>
+        recordIdSet.has(edge.fromRecordId) && recordIdSet.has(edge.toRecordId),
+    );
+    const relatedEdges = edgeSignals.filter(
+      (edge) =>
+        edge.relation === "related" &&
+        recordsById.has(edge.fromRecordId) &&
+        recordsById.has(edge.toRecordId) &&
+        (recordIdSet.has(edge.fromRecordId) ||
+          recordIdSet.has(edge.toRecordId)),
+    );
+    const supportScore = mean(supportEdges.map((edge) => edge.effectiveWeight));
+    const latestTimestamp = Math.max(
+      ...recordIdsInCluster.map(
+        (recordId) =>
+          nodesByRecordId.get(recordId)?.timestamp ??
+          recordsById.get(recordId)!.timestamp,
+      ),
+    );
+    const status: MemoryGraphClusterStatus =
+      recordIdsInCluster.length > 1 &&
+      supportScore >= thresholds.stableSupportScore
+        ? "stable"
+        : "tentative";
+
+    return {
+      clusterId: clusterId(recordIdsInCluster),
+      recordIds: recordIdsInCluster,
+      supportEdgeIds: supportEdges.map((edge) => edge.id),
+      relatedEdgeIds: relatedEdges.map((edge) => edge.id),
+      status,
+      supportScore,
+      latestTimestamp,
+    };
+  });
+
+  const clusterByRecordId = new Map<string, string>();
+  for (const cluster of clusters) {
+    for (const recordId of cluster.recordIds) {
+      clusterByRecordId.set(recordId, cluster.clusterId);
+    }
+  }
+
+  const clusterIds = clusters.map((cluster) => cluster.clusterId);
+  const clusterDisjointSet = new DisjointSet(clusterIds);
+  const strongCompeteEdges = edgeSignals.filter(
+    (edge) =>
+      edge.relation === "compete" &&
+      edge.effectiveWeight >= thresholds.competeThreshold &&
+      clusterByRecordId.has(edge.fromRecordId) &&
+      clusterByRecordId.has(edge.toRecordId) &&
+      clusterByRecordId.get(edge.fromRecordId) !==
+        clusterByRecordId.get(edge.toRecordId),
+  );
+
+  for (const edge of strongCompeteEdges) {
+    clusterDisjointSet.union(
+      clusterByRecordId.get(edge.fromRecordId)!,
+      clusterByRecordId.get(edge.toRecordId)!,
+    );
+  }
+
+  const groupedClusters = groupByRoot(clusterIds, clusterDisjointSet);
+  const competitionGroups = [...groupedClusters.values()].map(
+    (clusterIdsInGroup) => {
+      const clusterIdSet = new Set(clusterIdsInGroup);
+      const competeEdges = strongCompeteEdges.filter((edge) => {
+        const fromClusterId = clusterByRecordId.get(edge.fromRecordId);
+        const toClusterId = clusterByRecordId.get(edge.toRecordId);
+        return (
+          fromClusterId !== undefined &&
+          toClusterId !== undefined &&
+          clusterIdSet.has(fromClusterId) &&
+          clusterIdSet.has(toClusterId)
+        );
+      });
+
+      return {
+        competitionKey: competitionKey(clusterIdsInGroup),
+        clusterIds: clusterIdsInGroup,
+        competeEdgeIds: competeEdges.map((edge) => edge.id),
+      };
+    },
+  );
+
+  const clusterCompetitionKeys = Object.fromEntries(
+    competitionGroups.flatMap((group) =>
+      group.clusterIds.map((clusterId) => [clusterId, group.competitionKey]),
+    ),
+  );
+  const recordClusterKeys = Object.fromEntries(clusterByRecordId.entries());
+  const contestedClusterIds = new Set(
+    competitionGroups
+      .filter((group) => group.clusterIds.length > 1)
+      .flatMap((group) => group.clusterIds),
+  );
+  const clustersWithCompetitionStatus = clusters.map((cluster) => ({
+    ...cluster,
+    status: contestedClusterIds.has(cluster.clusterId)
+      ? ("contested" as const)
+      : cluster.status,
+  }));
+
+  return {
+    nodes,
+    edges: edgeSignals,
+    clusters: clustersWithCompetitionStatus,
+    competitionGroups,
+    recordClusterKeys,
+    clusterCompetitionKeys,
+    getClusterKey(record) {
+      return recordClusterKeys[record.id];
+    },
+    getCompetitionKey(cluster) {
+      return clusterCompetitionKeys[cluster.key] ?? cluster.key;
+    },
+  };
+}
+
+export function deriveMemoryRelationGraphLifecycle(
+  input: DeriveMemoryRelationGraphLifecycleInput,
+): MemoryRelationGraphLifecycleEntry[] {
+  const consolidatedClusterKeys = new Set(input.consolidatedClusterKeys);
+
+  return input.assignment.clusters.map((cluster) => {
+    const consolidated = consolidatedClusterKeys.has(cluster.clusterId);
+
+    return {
+      clusterId: cluster.clusterId,
+      status: consolidated ? "consolidated" : cluster.status,
+      graphStatus: cluster.status,
+      consolidated,
+    };
+  });
+}


### PR DESCRIPTION
Summary
Add a lightweight relation graph prototype to @openloomi/memory-consolidation.

This introduces assignMemoryRelationGraph, a pure helper that turns explicit trace relations into graph cluster and competition assignments:

- support edges above threshold form graph clusters
- compete edges between clusters form competition groups
- related edges are kept as observation signals and do not merge clusters
- graph assignment returns getClusterKey / getCompetitionKey resolvers for buildMemoryConsolidationPlan
- deriveMemoryRelationGraphLifecycle marks preserved clusters as consolidated after a plan is produced

Why
This fills the missing upstream half of the consolidation package without changing runtime memory behavior. The package can now model:

relation graph -> cluster assignment -> competition assignment -> consolidation plan

Scope
- Adds packages/ai/memory-consolidation/src/relation-graph.ts
- Exports the helper from @openloomi/memory-consolidation
- Adds relation graph eval scenarios to memory-consolidation-eval.test.ts
- Adds package docs for the prototype design
- Does not modify forgetting engine runtime, storage schema, retrieval, or summarization behavior
- Does not introduce embedding / LLM relation generation

Testing
- corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/relation-graph.ts apps/web/tests/unit/memory-consolidation-eval.test.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json packages/ai/memory-consolidation/README.md packages/ai/memory-consolidation/docs/design-zh.md packages/ai/memory-consolidation/docs/relation-graph-prototype-zh.md
- corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts
- corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit
- corepack pnpm --filter web tsc
- git diff --check