### PR TITLE
ci: add RPM release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,26 +588,28 @@ jobs:
 
           EOF
 
-      - name: Patch tauri.conf.json to skip AppImage on Linux
+      - name: Patch tauri.conf.json to build Linux packages
         working-directory: ./apps/web
         run: |
           node -e "
             const fs = require('fs');
             const c = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
-            c.bundle.targets = ['deb'];
+            c.bundle.targets = ['deb', 'rpm'];
             fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(c, null, 2));
-            console.log('Patched targets to deb');
+            console.log('Patched targets to deb and rpm');
           "
 
       - name: Build Tauri app (Linux)
         working-directory: ./apps/web
         run: pnpm tauri:build
 
-      - name: Upload Linux AMD64 deb
+      - name: Upload Linux AMD64 packages
         uses: actions/upload-artifact@v4
         with:
           name: openloomi-linux-amd64
-          path: ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/deb/*.deb
+          path: |
+            ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/deb/*.deb
+            ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/rpm/*.rpm
 
   # ─── Windows CI ──────────────────────────────────────────────────────────────
   release-windows:
@@ -821,26 +823,28 @@ jobs:
 
           EOF
 
-      - name: Patch tauri.conf.json to skip AppImage on Linux ARM64
+      - name: Patch tauri.conf.json to build Linux packages
         working-directory: ./apps/web
         run: |
           node -e "
             const fs = require('fs');
             const c = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
-            c.bundle.targets = ['deb'];
+            c.bundle.targets = ['deb', 'rpm'];
             fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(c, null, 2));
-            console.log('Patched targets to deb');
+            console.log('Patched targets to deb and rpm');
           "
 
       - name: Build Tauri app (Linux ARM64)
         working-directory: ./apps/web
         run: pnpm tauri:build
 
-      - name: Upload Linux ARM64 deb
+      - name: Upload Linux ARM64 packages
         uses: actions/upload-artifact@v4
         with:
           name: openloomi-linux-arm64
-          path: ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/deb/*.deb
+          path: |
+            ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/deb/*.deb
+            ${{ github.workspace }}/apps/web/src-tauri/target/release/bundle/rpm/*.rpm
 
   # ─── Create Release ─────────────────────────────────────────────────────────
   create-release:
@@ -872,7 +876,9 @@ jobs:
           mv openloomi-dmg-aarch64/*.dmg "openloomi_${VERSION}_aarch64.dmg"
           mv openloomi-dmg-x64/*.dmg "openloomi_${VERSION}_amd64.dmg"
           mv openloomi-linux-amd64/*.deb "openloomi_${VERSION}_amd64.deb"
+          mv openloomi-linux-amd64/*.rpm "openloomi_${VERSION}_x86_64.rpm"
           mv openloomi-linux-arm64/*.deb "openloomi_${VERSION}_arm64.deb"
+          mv openloomi-linux-arm64/*.rpm "openloomi_${VERSION}_aarch64.rpm"
           mv openloomi-windows-nsis/*.exe "openloomi_${VERSION}_amd64.exe"
           rm -rf openloomi-dmg-aarch64 openloomi-dmg-x64 openloomi-linux-amd64 openloomi-linux-arm64 openloomi-windows-nsis
           ls -la
@@ -889,7 +895,9 @@ jobs:
             artifacts/openloomi_${{ steps.version.outputs.version }}_aarch64.dmg
             artifacts/openloomi_${{ steps.version.outputs.version }}_amd64.dmg
             artifacts/openloomi_${{ steps.version.outputs.version }}_amd64.deb
+            artifacts/openloomi_${{ steps.version.outputs.version }}_x86_64.rpm
             artifacts/openloomi_${{ steps.version.outputs.version }}_arm64.deb
+            artifacts/openloomi_${{ steps.version.outputs.version }}_aarch64.rpm
             artifacts/openloomi_${{ steps.version.outputs.version }}_amd64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -67,6 +67,20 @@ openloomi
 
 > **Note:** The symlink above is needed because of a known packaging issue where the binary looks for resources in `/usr/bin/_up_` instead of `/usr/lib/openloomi/_up_`. This will be fixed in a future release.
 
+**Linux (Fedora/RHEL)**
+
+| Option                                                                    | Notes                             |
+| ------------------------------------------------------------------------- | --------------------------------- |
+| [Download .rpm package](https://github.com/melandlabs/openloomi/releases) | For Fedora, RHEL, and derivatives |
+
+```bash
+sudo dnf install ./openloomi_<version>_x86_64.rpm
+# For ARM64 systems, use openloomi_<version>_aarch64.rpm
+
+# Start the application
+openloomi
+```
+
 **Windows**
 
 | Option                                                                                                                        | Notes                                               |


### PR DESCRIPTION
Summary
- build RPM packages alongside existing DEB packages in Linux release jobs
- upload RPM artifacts for both x86_64 and aarch64 release builds
- publish renamed RPM assets in GitHub Releases
- document Fedora/RHEL RPM installation in Getting Started

Closes #135

Testing
- Parsed `.github/workflows/release.yml` with PyYAML
- Asserted both Linux release jobs use `['deb', 'rpm']` and upload `bundle/rpm/*.rpm`
- Simulated the release artifact rename step for DMG, DEB, RPM, and EXE assets
- Ran `git diff --check`

Note
- This PR adds RPM support only. Flatpak packaging is left out because it would require a separate manifest/distribution flow.