### PR TITLE
feat(memory): add relation pipeline prototype

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -4,6 +4,8 @@ import {
   assignMemoryRelationGraph,
   buildMemoryConsolidationPlan,
   buildMemoryEvidenceClusters,
+  buildMemoryRelationCandidates,
+  buildMemoryRelationPipeline,
   deriveMemoryRelationGraphLifecycle,
 } from "@openloomi/memory-consolidation";
 import {
@@ -481,6 +483,132 @@ function findGraphCluster(
   return cluster;
 }
 
+function relationPipelineRecord(
+  id: string,
+  text: string,
+  day: number,
+  relationValue: "zh" | "en",
+  options: {
+    accessCount?: number;
+    scope?: "temporary" | "long-term";
+  } = {},
+): MemoryRecord {
+  return {
+    id,
+    userId: "eval-user",
+    timestamp: day * DAY_MS,
+    text,
+    tier: "short",
+    accessCount: options.accessCount,
+    metadata: {
+      relationGroup: "answer-language",
+      relationValue,
+      relationScope: options.scope ?? "long-term",
+    },
+  };
+}
+
+function buildRelationPipelineFixture() {
+  const records: MemoryRecord[] = [
+    relationPipelineRecord(
+      "pipe-zh-a",
+      "Use Chinese for repo work.",
+      20,
+      "zh",
+      {
+        accessCount: 1,
+      },
+    ),
+    relationPipelineRecord(
+      "pipe-zh-b",
+      "Prefer Chinese technical explanations.",
+      30,
+      "zh",
+      { accessCount: 1 },
+    ),
+    relationPipelineRecord(
+      "pipe-zh-c",
+      "Code explanations are easier in Chinese.",
+      40,
+      "zh",
+      { accessCount: 1 },
+    ),
+    relationPipelineRecord(
+      "pipe-en-a",
+      "Use English-first answers for this workspace.",
+      100,
+      "en",
+      { accessCount: 2 },
+    ),
+    relationPipelineRecord(
+      "pipe-en-b",
+      "Default to English for technical discussions.",
+      110,
+      "en",
+      { accessCount: 2 },
+    ),
+    relationPipelineRecord(
+      "pipe-en-c",
+      "English is now preferred for repo work.",
+      118,
+      "en",
+      { accessCount: 2 },
+    ),
+    relationPipelineRecord(
+      "pipe-en-d",
+      "Please keep future technical answers in English.",
+      119,
+      "en",
+      { accessCount: 2 },
+    ),
+    relationPipelineRecord(
+      "pipe-temp-en",
+      "For this one reply, use English.",
+      119,
+      "en",
+      { scope: "temporary" },
+    ),
+    {
+      id: "pipe-noise",
+      userId: "eval-user",
+      timestamp: 119 * DAY_MS,
+      text: "random scratch note",
+      tier: "short",
+    },
+  ];
+
+  return buildMemoryRelationPipeline({
+    records,
+    now: NOW,
+    candidate: {
+      maxCandidatesPerRecord: 12,
+    },
+    judgment: {
+      judgeCandidate(candidate, context) {
+        const fromScope = context.fromRecord.metadata?.relationScope;
+        const toScope = context.toRecord.metadata?.relationScope;
+
+        if (fromScope === "temporary" || toScope === "temporary") {
+          return {
+            relation: "related",
+            weight: 0.45,
+            reasonCodes: ["candidate_related"],
+          };
+        }
+
+        return context.defaultDecision;
+      },
+    },
+    plan: {
+      thresholds: {
+        preserveScore: 0.5,
+        preserveEvidence: 3,
+        competitionMargin: 0.05,
+      },
+    },
+  });
+}
+
 describe("memory consolidation evaluation scenarios", () => {
   it("keeps expected long-term outcomes backed by repeated evidence", () => {
     for (const scenario of scenarios) {
@@ -773,5 +901,175 @@ describe("memory consolidation evaluation scenarios", () => {
         reasonCodes: ["isolated_low_confidence"],
       }),
     );
+  });
+
+  it("builds relation candidates and judgments without promoting temporary traces", () => {
+    const pipeline = buildRelationPipelineFixture();
+    const supportRelations = pipeline.relations.filter(
+      (relation) => relation.relation === "support",
+    );
+    const competeRelations = pipeline.relations.filter(
+      (relation) => relation.relation === "compete",
+    );
+    const relatedRelations = pipeline.relations.filter(
+      (relation) => relation.relation === "related",
+    );
+
+    expect(pipeline.candidates.length).toBeGreaterThan(0);
+    expect(supportRelations.length).toBeGreaterThan(0);
+    expect(competeRelations.length).toBeGreaterThan(0);
+    expect(relatedRelations).toEqual([
+      expect.objectContaining({
+        fromRecordId: "pipe-en-a",
+        toRecordId: "pipe-temp-en",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-en-b",
+        toRecordId: "pipe-temp-en",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-en-c",
+        toRecordId: "pipe-temp-en",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-en-d",
+        toRecordId: "pipe-temp-en",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-temp-en",
+        toRecordId: "pipe-zh-a",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-temp-en",
+        toRecordId: "pipe-zh-b",
+        relation: "related",
+      }),
+      expect.objectContaining({
+        fromRecordId: "pipe-temp-en",
+        toRecordId: "pipe-zh-c",
+        relation: "related",
+      }),
+    ]);
+    expect(pipeline.assignment.recordClusterKeys["pipe-temp-en"]).not.toBe(
+      pipeline.assignment.recordClusterKeys["pipe-en-a"],
+    );
+    expect(pipeline.assignment.recordClusterKeys["pipe-noise"]).toBeDefined();
+  });
+
+  it("keeps default candidate keys collision-safe", () => {
+    const candidates = buildMemoryRelationCandidates({
+      records: [
+        {
+          id: "colon-left",
+          userId: "eval-user",
+          timestamp: NOW,
+          text: "left",
+          tier: "short",
+          metadata: {
+            a: "b:c",
+          },
+        },
+        {
+          id: "colon-right",
+          userId: "eval-user",
+          timestamp: NOW,
+          text: "right",
+          tier: "short",
+          metadata: {
+            "a:b": "c",
+          },
+        },
+      ],
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("uses the final judgment relation when resolving default edge weight", () => {
+    const pipeline = buildMemoryRelationPipeline({
+      records: [
+        {
+          id: "override-a",
+          userId: "eval-user",
+          timestamp: NOW,
+          text: "first",
+          tier: "short",
+          metadata: {
+            candidateKey: "manual-support",
+          },
+        },
+        {
+          id: "override-b",
+          userId: "eval-user",
+          timestamp: NOW,
+          text: "second",
+          tier: "short",
+          metadata: {
+            candidateKey: "manual-support",
+          },
+        },
+      ],
+      now: NOW,
+      getCandidateKeys: (record) => [
+        String(record.metadata?.candidateKey ?? ""),
+      ],
+      judgment: {
+        judgeCandidate() {
+          return {
+            relation: "support",
+          };
+        },
+      },
+    });
+    const supportRelation = pipeline.relations.find(
+      (relation) => relation.relation === "support",
+    );
+
+    expect(supportRelation?.weight).toBeGreaterThanOrEqual(0.7);
+    expect(pipeline.assignment.recordClusterKeys["override-a"]).toBe(
+      pipeline.assignment.recordClusterKeys["override-b"],
+    );
+  });
+
+  it("runs the relation pipeline through graph assignment, plan, and summary candidates", () => {
+    const pipeline = buildRelationPipelineFixture();
+    const enClusterKey = pipeline.assignment.recordClusterKeys["pipe-en-a"];
+    const zhClusterKey = pipeline.assignment.recordClusterKeys["pipe-zh-a"];
+    const tempClusterKey =
+      pipeline.assignment.recordClusterKeys["pipe-temp-en"];
+    const noiseClusterKey = pipeline.assignment.recordClusterKeys["pipe-noise"];
+
+    expect(pipeline.assignment.getCompetitionKey({ key: enClusterKey })).toBe(
+      pipeline.assignment.getCompetitionKey({ key: zhClusterKey }),
+    );
+    expect(findPlanEntry(pipeline.plan, enClusterKey)).toEqual(
+      expect.objectContaining({
+        action: "preserve",
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+      }),
+    );
+    expect(findPlanEntry(pipeline.plan, zhClusterKey).action).not.toBe(
+      "preserve",
+    );
+    expect(findPlanEntry(pipeline.plan, tempClusterKey).action).not.toBe(
+      "preserve",
+    );
+    expect(findPlanEntry(pipeline.plan, noiseClusterKey)).toEqual(
+      expect.objectContaining({
+        action: "decay",
+        reasonCodes: ["isolated_low_confidence"],
+      }),
+    );
+    expect(pipeline.summaryCandidates).toEqual([
+      expect.objectContaining({
+        clusterKey: enClusterKey,
+        sourceAction: "preserve",
+      }),
+    ]);
   });
 });

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -9,11 +9,14 @@ storage, retrieval, or summarization behavior.
 ## Scope
 
 - Build evidence clusters from `MemoryEvidenceRecord[]` or structurally compatible memory records.
+- Build bounded relation candidates from explicit record keys.
+- Judge relation candidates into `support`, `compete`, `related`, or `uncertain`.
 - Assign graph clusters and competition groups from explicit trace relation edges.
 - Score clusters with evidence, record score, activation, and recency signals.
 - Produce per-record diagnostics for low individual scores inside high-scoring clusters.
 - Build an explainable consolidation plan with `preserve`, `observe`, and `decay`
   recommendations.
+- Build summary candidates from preserved consolidation plan entries.
 
 ## Non-goals
 
@@ -21,6 +24,7 @@ storage, retrieval, or summarization behavior.
 - No storage schema changes.
 - No retrieval behavior changes.
 - No automatic relation generation with embeddings or LLMs.
+- No automatic summary text generation.
 
 ## Consolidation plan
 
@@ -45,3 +49,22 @@ competition groups from strong compete edges, and returns `getClusterKey` /
 `deriveMemoryRelationGraphLifecycle` can then mark preserved graph clusters as
 `consolidated` after a consolidation plan is produced. The relation graph itself
 only assigns `tentative`, `stable`, and `contested` graph states.
+
+## Relation pipeline prototype
+
+`buildMemoryRelationPipeline` wires the pure helpers into a small offline
+prototype:
+
+```text
+records
+  -> buildMemoryRelationCandidates
+  -> judgeMemoryRelationCandidates
+  -> assignMemoryRelationGraph
+  -> buildMemoryConsolidationPlan
+  -> buildMemorySummaryCandidates
+```
+
+The candidate and judgment steps are intentionally lightweight. They can use
+explicit record keys, relation groups, relation values, and caller-provided
+judgment logic, but they do not call embedding models, LLMs, storage, retrieval,
+or runtime memory behavior.

--- a/packages/ai/memory-consolidation/docs/design-zh.md
+++ b/packages/ai/memory-consolidation/docs/design-zh.md
@@ -40,14 +40,31 @@ Summary 是稳定记忆的可读表达
 `@openloomi/memory-consolidation` 目前只提供纯函数能力：
 
 - 构建 evidence clusters。
+- 从显式 record keys 中构建有上限的 relation candidates。
+- 将 relation candidates 裁决为 `support`、`compete`、`related` 或 `uncertain`。
 - 从显式 trace relation 中分配 graph clusters 和 competition groups。
 - 保留 weak related edges 作为观察信号，而不是直接参与合并。
 - 计算 cluster-level score。
 - 输出 per-record diagnostics。
 - 输出 consolidation plan，将记忆簇信号转成 `preserve`、`observe`、`decay` 建议。
+- 从 `preserve` plan entries 输出 summary candidates，但不生成 summary 文本。
 - 支持 eval 场景比较 trace-level signal 和 cluster-level signal。
 
 它不会修改 forgetting decision、storage schema、retrieval behavior 或 summarization behavior。
+
+当前离线原型链路可以表示为：
+
+```text
+records
+  -> buildMemoryRelationCandidates
+  -> judgeMemoryRelationCandidates
+  -> assignMemoryRelationGraph
+  -> buildMemoryConsolidationPlan
+  -> buildMemorySummaryCandidates
+```
+
+其中候选生成和候选裁决都依赖显式 key、relation group、relation value 或调用方传入的
+轻量策略；默认不接 embedding、LLM、storage 或 runtime memory 行为。
 
 ## 决策层设计
 

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./evidence-cluster": "./src/evidence-cluster.ts",
+    "./pipeline": "./src/pipeline.ts",
     "./relation-graph": "./src/relation-graph.ts"
   },
   "devDependencies": {

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./evidence-cluster";
 export * from "./plan";
+export * from "./pipeline";
 export * from "./relation-graph";

--- a/packages/ai/memory-consolidation/src/pipeline.ts
+++ b/packages/ai/memory-consolidation/src/pipeline.ts
@@ -1,0 +1,581 @@
+import type { MemoryEvidenceRecord } from "./evidence-cluster";
+import {
+  buildMemoryConsolidationPlan,
+  type BuildMemoryConsolidationPlanInput,
+  type MemoryConsolidationPlan,
+  type MemoryConsolidationPlanEntry,
+} from "./plan";
+import {
+  assignMemoryRelationGraph,
+  type AssignMemoryRelationGraphInput,
+  type MemoryRelationEdge,
+  type MemoryRelationGraphAssignment,
+  type MemoryRelationKind,
+} from "./relation-graph";
+
+type PrimitiveValue = string | number | boolean;
+
+export type MemoryRelationCandidateReasonCode =
+  | "shared_candidate_key"
+  | "shared_dimension"
+  | "shared_metadata";
+
+export interface MemoryRelationCandidate {
+  id: string;
+  fromRecordId: string;
+  toRecordId: string;
+  candidateKeys: string[];
+  score: number;
+  reasonCodes: MemoryRelationCandidateReasonCode[];
+}
+
+export interface BuildMemoryRelationCandidatesInput {
+  records: MemoryEvidenceRecord[];
+  getCandidateKeys?(
+    record: MemoryEvidenceRecord,
+  ): Iterable<string | undefined | false | null>;
+  maxRecordsPerKey?: number;
+  maxCandidatesPerRecord?: number;
+  scoreNorm?: number;
+}
+
+export type MemoryRelationJudgmentKind = MemoryRelationKind | "uncertain";
+
+export type MemoryRelationJudgmentReasonCode =
+  | "same_relation_value"
+  | "different_relation_value"
+  | "candidate_related"
+  | "uncertain_candidate";
+
+export interface MemoryRelationJudgmentDecision {
+  relation: MemoryRelationJudgmentKind;
+  weight?: number;
+  reasonCodes?: MemoryRelationJudgmentReasonCode[];
+}
+
+export interface MemoryRelationJudgment {
+  candidate: MemoryRelationCandidate;
+  relation: MemoryRelationJudgmentKind;
+  weight: number;
+  reasonCodes: MemoryRelationJudgmentReasonCode[];
+  edge?: MemoryRelationEdge;
+}
+
+export interface MemoryRelationJudgmentThresholds {
+  supportWeight: number;
+  competeWeight: number;
+  relatedWeight: number;
+  relatedScore: number;
+}
+
+export interface JudgeMemoryRelationCandidatesInput {
+  candidates: MemoryRelationCandidate[];
+  records: MemoryEvidenceRecord[];
+  now: number;
+  getRelationGroup?(record: MemoryEvidenceRecord): string | undefined;
+  getRelationValue?(record: MemoryEvidenceRecord): string | undefined;
+  judgeCandidate?(
+    candidate: MemoryRelationCandidate,
+    context: {
+      fromRecord: MemoryEvidenceRecord;
+      toRecord: MemoryEvidenceRecord;
+      defaultDecision: MemoryRelationJudgmentDecision;
+      now: number;
+    },
+  ): MemoryRelationJudgmentDecision | undefined;
+  thresholds?: Partial<MemoryRelationJudgmentThresholds>;
+}
+
+export interface MemoryRelationJudgmentResult {
+  judgments: MemoryRelationJudgment[];
+  relations: MemoryRelationEdge[];
+}
+
+export interface MemorySummaryCandidate {
+  clusterKey: string;
+  competitionKey: string;
+  recordIds: string[];
+  evidenceCount: number;
+  score: number;
+  priority: number;
+  reasonCodes: MemoryConsolidationPlanEntry["reasonCodes"];
+  sourceAction: "preserve";
+}
+
+export interface BuildMemorySummaryCandidatesInput {
+  plan: MemoryConsolidationPlan;
+  maxCandidates?: number;
+}
+
+export interface BuildMemoryRelationPipelineInput extends Omit<
+  BuildMemoryRelationCandidatesInput,
+  "records" | "maxRecordsPerKey" | "maxCandidatesPerRecord" | "scoreNorm"
+> {
+  records: MemoryEvidenceRecord[];
+  now: number;
+  candidate?: Omit<
+    BuildMemoryRelationCandidatesInput,
+    "records" | "getCandidateKeys"
+  >;
+  judgment?: Omit<
+    JudgeMemoryRelationCandidatesInput,
+    "candidates" | "records" | "now"
+  >;
+  graph?: Omit<AssignMemoryRelationGraphInput, "records" | "relations" | "now">;
+  plan?: Omit<
+    BuildMemoryConsolidationPlanInput,
+    "records" | "now" | "getClusterKey" | "getCompetitionKey"
+  >;
+  summary?: Omit<BuildMemorySummaryCandidatesInput, "plan">;
+}
+
+export interface MemoryRelationPipeline {
+  candidates: MemoryRelationCandidate[];
+  judgments: MemoryRelationJudgment[];
+  relations: MemoryRelationEdge[];
+  assignment: MemoryRelationGraphAssignment;
+  plan: MemoryConsolidationPlan;
+  summaryCandidates: MemorySummaryCandidate[];
+}
+
+const DEFAULT_MAX_RECORDS_PER_KEY = 50;
+const DEFAULT_MAX_CANDIDATES_PER_RECORD = 6;
+const DEFAULT_SCORE_NORM = 2;
+
+const DEFAULT_JUDGMENT_THRESHOLDS: MemoryRelationJudgmentThresholds = {
+  supportWeight: 0.78,
+  competeWeight: 0.74,
+  relatedWeight: 0.45,
+  relatedScore: 0.5,
+};
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function isPrimitive(value: unknown): value is PrimitiveValue {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function stablePairId(left: string, right: string): string {
+  const [fromRecordId, toRecordId] = [left, right].sort();
+  return `${encodeURIComponent(fromRecordId)}|${encodeURIComponent(toRecordId)}`;
+}
+
+function candidateId(fromRecordId: string, toRecordId: string): string {
+  return `candidate:${stablePairId(fromRecordId, toRecordId)}`;
+}
+
+function edgeId(
+  relation: MemoryRelationKind,
+  fromRecordId: string,
+  toRecordId: string,
+): string {
+  return `${relation}:${stablePairId(fromRecordId, toRecordId)}`;
+}
+
+function primitiveRecordKeys(
+  prefix: "dimension" | "metadata",
+  values: Record<string, unknown> | undefined,
+): string[] {
+  if (!values) {
+    return [];
+  }
+
+  return Object.entries(values)
+    .filter((entry): entry is [string, PrimitiveValue] => isPrimitive(entry[1]))
+    .map(
+      ([key, value]) =>
+        `${prefix}:${encodeURIComponent(key)}:${encodeURIComponent(String(value))}`,
+    );
+}
+
+function defaultCandidateKeys(record: MemoryEvidenceRecord): string[] {
+  return [
+    ...primitiveRecordKeys("dimension", record.dimensions),
+    ...primitiveRecordKeys("metadata", record.metadata),
+  ];
+}
+
+function resolveCandidateKeys(
+  record: MemoryEvidenceRecord,
+  getCandidateKeys:
+    | BuildMemoryRelationCandidatesInput["getCandidateKeys"]
+    | undefined,
+): string[] {
+  const keys = getCandidateKeys
+    ? [...getCandidateKeys(record)].filter((key): key is string => Boolean(key))
+    : defaultCandidateKeys(record);
+
+  return [...new Set(keys)].sort();
+}
+
+function candidateReasonCodes(
+  keys: string[],
+): MemoryRelationCandidateReasonCode[] {
+  const reasonCodes = new Set<MemoryRelationCandidateReasonCode>();
+
+  for (const key of keys) {
+    reasonCodes.add("shared_candidate_key");
+    if (key.startsWith("dimension:")) {
+      reasonCodes.add("shared_dimension");
+    }
+    if (key.startsWith("metadata:")) {
+      reasonCodes.add("shared_metadata");
+    }
+  }
+
+  return [...reasonCodes];
+}
+
+function sortCandidates(
+  candidates: MemoryRelationCandidate[],
+): MemoryRelationCandidate[] {
+  return [...candidates].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    if (b.candidateKeys.length !== a.candidateKeys.length) {
+      return b.candidateKeys.length - a.candidateKeys.length;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function buildMemoryRelationCandidates(
+  input: BuildMemoryRelationCandidatesInput,
+): MemoryRelationCandidate[] {
+  const maxRecordsPerKey = Math.max(
+    2,
+    input.maxRecordsPerKey ?? DEFAULT_MAX_RECORDS_PER_KEY,
+  );
+  const maxCandidatesPerRecord = Math.max(
+    1,
+    input.maxCandidatesPerRecord ?? DEFAULT_MAX_CANDIDATES_PER_RECORD,
+  );
+  const scoreNorm = Math.max(1, input.scoreNorm ?? DEFAULT_SCORE_NORM);
+  const recordsByKey = new Map<string, MemoryEvidenceRecord[]>();
+  const candidateKeysByPair = new Map<string, Set<string>>();
+
+  for (const record of input.records) {
+    const keys = resolveCandidateKeys(record, input.getCandidateKeys);
+
+    for (const key of keys) {
+      const existing = recordsByKey.get(key) ?? [];
+      existing.push(record);
+      recordsByKey.set(key, existing);
+    }
+  }
+
+  for (const [key, records] of recordsByKey.entries()) {
+    const bucket = [...records]
+      .sort((a, b) => b.timestamp - a.timestamp || a.id.localeCompare(b.id))
+      .slice(0, maxRecordsPerKey);
+
+    for (let leftIndex = 0; leftIndex < bucket.length; leftIndex += 1) {
+      for (
+        let rightIndex = leftIndex + 1;
+        rightIndex < bucket.length;
+        rightIndex += 1
+      ) {
+        const left = bucket[leftIndex]!;
+        const right = bucket[rightIndex]!;
+        const pairId = stablePairId(left.id, right.id);
+        const existing = candidateKeysByPair.get(pairId) ?? new Set<string>();
+        existing.add(key);
+        candidateKeysByPair.set(pairId, existing);
+      }
+    }
+  }
+
+  const candidates = [...candidateKeysByPair.entries()].map(
+    ([pairId, keySet]) => {
+      const [encodedFrom, encodedTo] = pairId.split("|");
+      const fromRecordId = decodeURIComponent(encodedFrom ?? "");
+      const toRecordId = decodeURIComponent(encodedTo ?? "");
+      const candidateKeys = [...keySet].sort();
+
+      return {
+        id: candidateId(fromRecordId, toRecordId),
+        fromRecordId,
+        toRecordId,
+        candidateKeys,
+        score: clamp01(candidateKeys.length / scoreNorm),
+        reasonCodes: candidateReasonCodes(candidateKeys),
+      };
+    },
+  );
+  const selected: MemoryRelationCandidate[] = [];
+  const selectedCountByRecordId = new Map<string, number>();
+
+  for (const candidate of sortCandidates(candidates)) {
+    const fromCount = selectedCountByRecordId.get(candidate.fromRecordId) ?? 0;
+    const toCount = selectedCountByRecordId.get(candidate.toRecordId) ?? 0;
+
+    if (
+      fromCount >= maxCandidatesPerRecord ||
+      toCount >= maxCandidatesPerRecord
+    ) {
+      continue;
+    }
+
+    selected.push(candidate);
+    selectedCountByRecordId.set(candidate.fromRecordId, fromCount + 1);
+    selectedCountByRecordId.set(candidate.toRecordId, toCount + 1);
+  }
+
+  return sortCandidates(selected);
+}
+
+function resolveJudgmentThresholds(
+  thresholds: Partial<MemoryRelationJudgmentThresholds> | undefined,
+): MemoryRelationJudgmentThresholds {
+  return {
+    supportWeight:
+      thresholds?.supportWeight ?? DEFAULT_JUDGMENT_THRESHOLDS.supportWeight,
+    competeWeight:
+      thresholds?.competeWeight ?? DEFAULT_JUDGMENT_THRESHOLDS.competeWeight,
+    relatedWeight:
+      thresholds?.relatedWeight ?? DEFAULT_JUDGMENT_THRESHOLDS.relatedWeight,
+    relatedScore:
+      thresholds?.relatedScore ?? DEFAULT_JUDGMENT_THRESHOLDS.relatedScore,
+  };
+}
+
+function defaultRelationGroup(
+  record: MemoryEvidenceRecord,
+): string | undefined {
+  const value =
+    record.metadata?.relationGroup ?? record.dimensions?.relationGroup;
+  return isPrimitive(value) ? String(value) : undefined;
+}
+
+function defaultRelationValue(
+  record: MemoryEvidenceRecord,
+): string | undefined {
+  const value =
+    record.metadata?.relationValue ?? record.dimensions?.relationValue;
+  return isPrimitive(value) ? String(value) : undefined;
+}
+
+function defaultJudgmentDecision(
+  candidate: MemoryRelationCandidate,
+  fromRecord: MemoryEvidenceRecord,
+  toRecord: MemoryEvidenceRecord,
+  thresholds: MemoryRelationJudgmentThresholds,
+  getRelationGroup: JudgeMemoryRelationCandidatesInput["getRelationGroup"],
+  getRelationValue: JudgeMemoryRelationCandidatesInput["getRelationValue"],
+): MemoryRelationJudgmentDecision {
+  const fromGroup =
+    getRelationGroup?.(fromRecord) ?? defaultRelationGroup(fromRecord);
+  const toGroup =
+    getRelationGroup?.(toRecord) ?? defaultRelationGroup(toRecord);
+  const fromValue =
+    getRelationValue?.(fromRecord) ?? defaultRelationValue(fromRecord);
+  const toValue =
+    getRelationValue?.(toRecord) ?? defaultRelationValue(toRecord);
+
+  if (fromGroup && fromGroup === toGroup && fromValue && toValue) {
+    if (fromValue === toValue) {
+      return {
+        relation: "support",
+        weight: thresholds.supportWeight,
+        reasonCodes: ["same_relation_value"],
+      };
+    }
+
+    return {
+      relation: "compete",
+      weight: thresholds.competeWeight,
+      reasonCodes: ["different_relation_value"],
+    };
+  }
+
+  if (candidate.score >= thresholds.relatedScore) {
+    return {
+      relation: "related",
+      weight: thresholds.relatedWeight,
+      reasonCodes: ["candidate_related"],
+    };
+  }
+
+  return {
+    relation: "uncertain",
+    weight: 0,
+    reasonCodes: ["uncertain_candidate"],
+  };
+}
+
+function latestActivationAt(
+  left: MemoryEvidenceRecord,
+  right: MemoryEvidenceRecord,
+): number | undefined {
+  const timestamps = [left.lastAccessAt, right.lastAccessAt].filter(
+    (value): value is number => value !== undefined,
+  );
+
+  if (timestamps.length === 0) {
+    return undefined;
+  }
+
+  return Math.max(...timestamps);
+}
+
+function defaultWeightForRelation(
+  relation: MemoryRelationJudgmentKind,
+  thresholds: MemoryRelationJudgmentThresholds,
+): number {
+  if (relation === "support") {
+    return thresholds.supportWeight;
+  }
+  if (relation === "compete") {
+    return thresholds.competeWeight;
+  }
+  if (relation === "related") {
+    return thresholds.relatedWeight;
+  }
+  return 0;
+}
+
+export function judgeMemoryRelationCandidates(
+  input: JudgeMemoryRelationCandidatesInput,
+): MemoryRelationJudgmentResult {
+  const thresholds = resolveJudgmentThresholds(input.thresholds);
+  const recordsById = new Map(
+    input.records.map((record) => [record.id, record]),
+  );
+  const judgments: MemoryRelationJudgment[] = [];
+
+  for (const candidate of input.candidates) {
+    const fromRecord = recordsById.get(candidate.fromRecordId);
+    const toRecord = recordsById.get(candidate.toRecordId);
+
+    if (!fromRecord || !toRecord) {
+      continue;
+    }
+
+    const defaultDecision = defaultJudgmentDecision(
+      candidate,
+      fromRecord,
+      toRecord,
+      thresholds,
+      input.getRelationGroup,
+      input.getRelationValue,
+    );
+    const decision =
+      input.judgeCandidate?.(candidate, {
+        fromRecord,
+        toRecord,
+        defaultDecision,
+        now: input.now,
+      }) ?? defaultDecision;
+    const weight = clamp01(
+      decision.weight ??
+        (decision.relation === defaultDecision.relation
+          ? defaultDecision.weight
+          : undefined) ??
+        defaultWeightForRelation(decision.relation, thresholds),
+    );
+    const reasonCodes =
+      decision.reasonCodes ?? defaultDecision.reasonCodes ?? [];
+    const edge =
+      decision.relation === "uncertain"
+        ? undefined
+        : {
+            id: edgeId(
+              decision.relation,
+              candidate.fromRecordId,
+              candidate.toRecordId,
+            ),
+            fromRecordId: candidate.fromRecordId,
+            toRecordId: candidate.toRecordId,
+            relation: decision.relation,
+            weight,
+            evidenceCount: candidate.candidateKeys.length,
+            activationCount:
+              (fromRecord.accessCount ?? 0) + (toRecord.accessCount ?? 0),
+            lastActivatedAt: latestActivationAt(fromRecord, toRecord),
+          };
+
+    judgments.push({
+      candidate,
+      relation: decision.relation,
+      weight,
+      reasonCodes,
+      edge,
+    });
+  }
+
+  return {
+    judgments,
+    relations: judgments.flatMap((judgment) =>
+      judgment.edge ? [judgment.edge] : [],
+    ),
+  };
+}
+
+export function buildMemorySummaryCandidates(
+  input: BuildMemorySummaryCandidatesInput,
+): MemorySummaryCandidate[] {
+  const maxCandidates = Math.max(1, input.maxCandidates ?? 10);
+
+  return input.plan.actions.preserve
+    .map((entry) => ({
+      clusterKey: entry.clusterKey,
+      competitionKey: entry.competitionKey,
+      recordIds: entry.recordIds,
+      evidenceCount: entry.evidenceCount,
+      score: entry.score,
+      priority: entry.score * Math.log1p(entry.evidenceCount),
+      reasonCodes: entry.reasonCodes,
+      sourceAction: "preserve" as const,
+    }))
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, maxCandidates);
+}
+
+export function buildMemoryRelationPipeline(
+  input: BuildMemoryRelationPipelineInput,
+): MemoryRelationPipeline {
+  const candidates = buildMemoryRelationCandidates({
+    ...input.candidate,
+    records: input.records,
+    getCandidateKeys: input.getCandidateKeys,
+  });
+  const judgmentResult = judgeMemoryRelationCandidates({
+    ...input.judgment,
+    candidates,
+    records: input.records,
+    now: input.now,
+  });
+  const assignment = assignMemoryRelationGraph({
+    ...input.graph,
+    records: input.records,
+    relations: judgmentResult.relations,
+    now: input.now,
+  });
+  const plan = buildMemoryConsolidationPlan({
+    ...input.plan,
+    records: input.records,
+    now: input.now,
+    getClusterKey: assignment.getClusterKey,
+    getCompetitionKey: assignment.getCompetitionKey,
+  });
+  const summaryCandidates = buildMemorySummaryCandidates({
+    ...input.summary,
+    plan,
+  });
+
+  return {
+    candidates,
+    judgments: judgmentResult.judgments,
+    relations: judgmentResult.relations,
+    assignment,
+    plan,
+    summaryCandidates,
+  };
+}


### PR DESCRIPTION
Summary
Add a lightweight relation pipeline prototype to @openloomi/memory-consolidation.

This wires the package-local pure helpers into an offline pipeline:

records
-> buildMemoryRelationCandidates
-> judgeMemoryRelationCandidates
-> assignMemoryRelationGraph
-> buildMemoryConsolidationPlan
-> buildMemorySummaryCandidates

Scope
- Adds buildMemoryRelationCandidates for bounded relation candidate generation from explicit record keys
- Adds judgeMemoryRelationCandidates for lightweight support / compete / related / uncertain judgments
- Adds buildMemorySummaryCandidates for summary candidates from preserve plan entries
- Adds buildMemoryRelationPipeline as a convenience wrapper for the offline prototype
- Extends memory-consolidation eval scenarios
- Updates package docs
- Does not change forgetting runtime, storage schema, retrieval, or summarization behavior
- Does not introduce embedding / LLM dependencies

Testing
- corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/pipeline.ts apps/web/tests/unit/memory-consolidation-eval.test.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json packages/ai/memory-consolidation/README.md packages/ai/memory-consolidation/docs/design-zh.md
- corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts
- corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit
- corepack pnpm --filter web tsc
- git diff --check