### PR TITLE
docs: update minimum macOS version to 13+

### DIFF
--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -10,7 +10,7 @@ icon: "FaRocket"
 
 | OS          | Minimum Version                                  | Processor                            | RAM  | Disk Space |
 | ----------- | ------------------------------------------------ | ------------------------------------ | ---- | ---------- |
-| **macOS**   | macOS 12 (Monterey) or later                     | Apple Silicon (M1/M2/M3/M4) or Intel | 4 GB | 500 MB     |
+| **macOS**   | macOS 13+                                        | Apple Silicon (M1/M2/M3/M4) or Intel | 4 GB | 500 MB     |
 | **Windows** | Windows 10 (64-bit) or later                     | x86_64 / AMD64                       | 4 GB | 500 MB     |
 | **Linux**   | Ubuntu 20.04 / Debian 11 or later, or equivalent | x86_64 or ARM64                      | 4 GB | 500 MB     |
 


### PR DESCRIPTION
## Summary
- Update minimum macOS version from 12 (Monterey) to 13+ in the getting-started documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)