### PR TITLE
feat(memory): add consolidation diagnostics adapter

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  adaptMemoryRecordsForConsolidation,
   analyzeMemoryEvidenceClusters,
   assignMemoryRelationGraph,
   buildMemoryConsolidationPlan,
+  buildMemoryConsolidationDiagnosticsReport,
   buildMemoryEvidenceClusters,
   buildMemoryRelationCandidates,
   buildMemoryRelationPipeline,
+  buildMemoryRelationPipelineDiagnostics,
   deriveMemoryRelationGraphLifecycle,
 } from "@openloomi/memory-consolidation";
 import {
@@ -609,6 +612,124 @@ function buildRelationPipelineFixture() {
   });
 }
 
+type AdapterSourceRecord = {
+  uid?: string;
+  owner?: string;
+  createdAt?: number;
+  body?: string;
+  reads?: number;
+  fields?: {
+    preference?: string;
+    value?: "zh" | "en";
+  };
+  meta?: {
+    scope?: "temporary" | "long-term";
+  };
+};
+
+function adapterSourceRecord(
+  uid: string,
+  body: string,
+  day: number,
+  value: "zh" | "en",
+  options: {
+    reads?: number;
+    scope?: "temporary" | "long-term";
+  } = {},
+): AdapterSourceRecord {
+  return {
+    uid,
+    owner: "adapter-user",
+    createdAt: day * DAY_MS,
+    body,
+    reads: options.reads,
+    fields: {
+      preference: "answer-language",
+      value,
+    },
+    meta: {
+      scope: options.scope ?? "long-term",
+    },
+  };
+}
+
+const adapterSelectors = {
+  getId: (record: AdapterSourceRecord) => record.uid,
+  getUserId: (record: AdapterSourceRecord) => record.owner,
+  getTimestamp: (record: AdapterSourceRecord) => record.createdAt,
+  getText: (record: AdapterSourceRecord) => record.body,
+  getAccessCount: (record: AdapterSourceRecord) => record.reads,
+  getDimensions: (record: AdapterSourceRecord) =>
+    record.fields ? { ...record.fields } : undefined,
+  getMetadata: (record: AdapterSourceRecord) =>
+    record.meta ? { ...record.meta } : undefined,
+  getRelationGroup: (record: AdapterSourceRecord) => record.fields?.preference,
+  getRelationValue: (record: AdapterSourceRecord) => record.fields?.value,
+  getRelationScope: (record: AdapterSourceRecord) => record.meta?.scope,
+};
+
+function buildAdapterDiagnosticsInput() {
+  return {
+    records: [
+      adapterSourceRecord(
+        "adapter-zh-a",
+        "Use Chinese for repo work.",
+        30,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "adapter-zh-b",
+        "Prefer Chinese technical explanations.",
+        45,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "adapter-zh-c",
+        "Code explanations are easier in Chinese.",
+        60,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "adapter-en-a",
+        "Use English-first answers for this workspace.",
+        115,
+        "en",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "adapter-en-b",
+        "Default to English for this one discussion.",
+        118,
+        "en",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "adapter-temp-en",
+        "For this one reply, use English.",
+        119,
+        "en",
+        { scope: "temporary" },
+      ),
+    ],
+    now: NOW,
+    selectors: adapterSelectors,
+    plan: {
+      thresholds: {
+        preserveScore: 0.5,
+        preserveEvidence: 3,
+        competitionMargin: 0.05,
+      },
+    },
+  };
+}
+
+function buildAdapterDiagnosticsFixture() {
+  return buildMemoryRelationPipelineDiagnostics(buildAdapterDiagnosticsInput());
+}
+
 describe("memory consolidation evaluation scenarios", () => {
   it("keeps expected long-term outcomes backed by repeated evidence", () => {
     for (const scenario of scenarios) {
@@ -1069,6 +1190,203 @@ describe("memory consolidation evaluation scenarios", () => {
       expect.objectContaining({
         clusterKey: enClusterKey,
         sourceAction: "preserve",
+      }),
+    ]);
+  });
+
+  it("adapts structural memory records into relation pipeline diagnostics", () => {
+    const diagnostics = buildAdapterDiagnosticsFixture();
+    const zhDiagnostic = diagnostics.recordDiagnostics.find(
+      (item) => item.recordId === "adapter-zh-a",
+    );
+    const tempDiagnostic = diagnostics.recordDiagnostics.find(
+      (item) => item.recordId === "adapter-temp-en",
+    );
+    const enClusterKey =
+      diagnostics.pipeline.assignment.recordClusterKeys["adapter-en-a"];
+    const tempClusterKey =
+      diagnostics.pipeline.assignment.recordClusterKeys["adapter-temp-en"];
+
+    expect(diagnostics.summary).toEqual(
+      expect.objectContaining({
+        sourceRecordCount: 6,
+        adaptedRecordCount: 6,
+        skippedRecordCount: 0,
+        recordsWithCandidateKeys: 6,
+        recordsWithRelationGroup: 6,
+        recordsWithRelationValue: 6,
+        preserveCount: 1,
+        summaryCandidateCount: 1,
+      }),
+    );
+    expect(zhDiagnostic).toEqual(
+      expect.objectContaining({
+        graphStatus: "contested",
+        planAction: "preserve",
+        selectedForSummary: true,
+      }),
+    );
+    expect(tempDiagnostic).toEqual(
+      expect.objectContaining({
+        graphStatus: "tentative",
+        planAction: "decay",
+        supportRelationCount: 0,
+        selectedForSummary: false,
+      }),
+    );
+    expect(tempDiagnostic?.relatedRelationCount).toBeGreaterThan(0);
+    expect(tempClusterKey).not.toBe(enClusterKey);
+  });
+
+  it("builds a compact diagnostics report from relation pipeline diagnostics", () => {
+    const diagnostics = buildAdapterDiagnosticsFixture();
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+    const zhClusterKey =
+      diagnostics.pipeline.assignment.recordClusterKeys["adapter-zh-a"];
+    const enClusterKey =
+      diagnostics.pipeline.assignment.recordClusterKeys["adapter-en-a"];
+    const tempClusterKey =
+      diagnostics.pipeline.assignment.recordClusterKeys["adapter-temp-en"];
+
+    expect(report.summary).toEqual({
+      sourceRecordCount: 6,
+      adaptedRecordCount: 6,
+      skippedRecordCount: 0,
+      candidateCount: diagnostics.pipeline.candidates.length,
+      relationCount: diagnostics.pipeline.relations.length,
+      clusterCount: diagnostics.pipeline.assignment.clusters.length,
+      competitionGroupCount:
+        diagnostics.pipeline.assignment.competitionGroups.length,
+      preserveCount: 1,
+      observeCount: 1,
+      decayCount: 1,
+      summaryCandidateCount: 1,
+    });
+    expect(report.preservedClusters).toEqual([
+      expect.objectContaining({
+        clusterKey: zhClusterKey,
+        competitionKey:
+          diagnostics.pipeline.assignment.clusterCompetitionKeys[zhClusterKey],
+        recordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        evidenceCount: 3,
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+      }),
+    ]);
+    expect(report.preservedClusters[0]?.summaryPriority).toBeGreaterThan(0);
+    expect(
+      report.contestedClusters.map((cluster) => cluster.clusterKey),
+    ).toEqual([zhClusterKey, enClusterKey]);
+    expect(report.contestedClusters).toContainEqual(
+      expect.objectContaining({
+        clusterKey: enClusterKey,
+        action: "observe",
+        competingClusterKeys: [zhClusterKey],
+        winningClusterKey: zhClusterKey,
+        reasonCodes: ["outscored_by_competitor"],
+      }),
+    );
+    expect(report.decayedRecords).toEqual([
+      {
+        recordId: "adapter-temp-en",
+        sourceIndex: 5,
+        clusterKey: tempClusterKey,
+        reasonCodes: ["isolated_low_confidence"],
+      },
+    ]);
+    expect(report.skippedRecords).toEqual([]);
+    expect(report.recordSignals).toContainEqual(
+      expect.objectContaining({
+        recordId: "adapter-temp-en",
+        sourceIndex: 5,
+        clusterKey: tempClusterKey,
+        graphStatus: "tentative",
+        planAction: "decay",
+        supportRelationCount: 0,
+        selectedForSummary: false,
+      }),
+    );
+  });
+
+  it("skips incomplete source records before running diagnostics", () => {
+    const adapted = adaptMemoryRecordsForConsolidation({
+      records: [
+        {
+          owner: "adapter-user",
+          createdAt: NOW,
+          body: "Missing id.",
+        },
+        {
+          uid: "missing-time",
+          owner: "adapter-user",
+          body: "Missing timestamp.",
+        },
+        adapterSourceRecord(
+          "adapter-valid",
+          "Use Chinese for repo work.",
+          119,
+          "zh",
+        ),
+      ],
+      selectors: adapterSelectors,
+    });
+    const diagnostics = buildMemoryRelationPipelineDiagnostics({
+      records: [
+        {
+          owner: "adapter-user",
+          createdAt: NOW,
+          body: "Missing id.",
+        },
+        {
+          uid: "missing-time",
+          owner: "adapter-user",
+          body: "Missing timestamp.",
+        },
+        adapterSourceRecord(
+          "adapter-valid",
+          "Use Chinese for repo work.",
+          119,
+          "zh",
+        ),
+      ],
+      now: NOW,
+      selectors: adapterSelectors,
+    });
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+
+    expect(adapted.records.map((record) => record.id)).toEqual([
+      "adapter-valid",
+    ]);
+    expect(adapted.skippedRecords).toEqual([
+      {
+        sourceIndex: 0,
+        reasonCodes: ["missing_id"],
+      },
+      {
+        sourceIndex: 1,
+        reasonCodes: ["missing_timestamp"],
+      },
+    ]);
+    expect(diagnostics.summary).toEqual(
+      expect.objectContaining({
+        sourceRecordCount: 3,
+        adaptedRecordCount: 1,
+        skippedRecordCount: 2,
+        candidateCount: 0,
+        relationCount: 0,
+      }),
+    );
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        sourceRecordCount: 3,
+        adaptedRecordCount: 1,
+        skippedRecordCount: 2,
+      }),
+    );
+    expect(report.skippedRecords).toEqual(adapted.skippedRecords);
+    expect(diagnostics.recordDiagnostics).toEqual([
+      expect.objectContaining({
+        recordId: "adapter-valid",
+        graphStatus: "tentative",
       }),
     ]);
   });

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -6,6 +6,29 @@ cluster-level signals, and diagnostics before changing runtime memory behavior.
 This package currently provides pure helpers only. It does not modify forgetting,
 storage, retrieval, or summarization behavior.
 
+## Design position
+
+Long-term memory should not be treated as an append-only log. A practical memory
+system usually needs an online capture phase and an offline consolidation phase:
+raw events are first kept as traces, then repeated evidence, conflict, recency,
+and activation decide which traces may become stable semantic memory candidates.
+
+This package focuses on the offline consolidation phase:
+
+```text
+episodic traces
+  -> relation diagnostics
+  -> consolidation report
+  -> semantic memory candidates
+```
+
+It helps inspect whether existing traces form stable clusters, compete with
+other clusters, remain weak observations, or should decay instead of being
+promoted. The output is diagnostic: `preservedClusters` are candidates for later
+semantic consolidation, `contestedClusters` show conflicting or changing memory
+patterns, and `decayedRecords` are signals to avoid promotion rather than direct
+delete instructions.
+
 ## Scope
 
 - Build evidence clusters from `MemoryEvidenceRecord[]` or structurally compatible memory records.
@@ -17,14 +40,19 @@ storage, retrieval, or summarization behavior.
 - Build an explainable consolidation plan with `preserve`, `observe`, and `decay`
   recommendations.
 - Build summary candidates from preserved consolidation plan entries.
+- Adapt structurally compatible memory records into an offline relation pipeline
+  diagnostics view.
 
 ## Non-goals
 
 - No runtime integration with the forgetting engine.
 - No storage schema changes.
 - No retrieval behavior changes.
+- No online importance scoring at memory-ingest time.
 - No automatic relation generation with embeddings or LLMs.
 - No automatic summary text generation.
+- No final semantic memory generation.
+- No direct deletion or archival of source records.
 
 ## Consolidation plan
 
@@ -68,3 +96,47 @@ The candidate and judgment steps are intentionally lightweight. They can use
 explicit record keys, relation groups, relation values, and caller-provided
 judgment logic, but they do not call embedding models, LLMs, storage, retrieval,
 or runtime memory behavior.
+
+## Diagnostics adapter
+
+`buildMemoryRelationPipelineDiagnostics` is an adapter around the offline
+pipeline. It accepts source records with caller-provided selectors, normalizes
+them into `MemoryEvidenceRecord[]`, runs the relation pipeline, and returns
+per-record diagnostics plus aggregate counts.
+
+The adapter is intentionally observational:
+
+- It skips incomplete source records instead of inventing missing identity or
+  timestamp fields.
+- It uses explicit relation group / value selectors as conservative default
+  candidate keys.
+- It can keep temporary or ephemeral traces as `related` signals instead of
+  promoting them into support or competition edges.
+- It reports cluster keys, competition keys, graph status, plan action, relation
+  counts, and summary-candidate selection without changing runtime memory
+  behavior.
+
+`buildMemoryConsolidationDiagnosticsReport` can then format the raw diagnostics
+into a compact report with summary counts, preserved clusters, contested
+clusters, decayed records, skipped records, and per-record signals. It is a view
+over `MemoryRelationPipelineDiagnostics`; it does not rerun the pipeline or make
+new consolidation decisions.
+
+Callers can keep the full diagnostics for debugging and derive the compact
+report for review or logging:
+
+```ts
+const diagnostics = buildMemoryRelationPipelineDiagnostics({
+  records,
+  now,
+  selectors: {
+    getId: (record) => record.id,
+    getTimestamp: (record) => record.timestamp,
+    getText: (record) => record.text,
+    getRelationGroup: (record) => record.metadata?.relationGroup,
+    getRelationValue: (record) => record.metadata?.relationValue,
+    getRelationScope: (record) => record.metadata?.relationScope,
+  },
+});
+const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+```

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./adapter": "./src/adapter.ts",
     "./evidence-cluster": "./src/evidence-cluster.ts",
     "./pipeline": "./src/pipeline.ts",
     "./relation-graph": "./src/relation-graph.ts"

--- a/packages/ai/memory-consolidation/src/adapter.ts
+++ b/packages/ai/memory-consolidation/src/adapter.ts
@@ -1,0 +1,763 @@
+import type {
+  MemoryEvidenceRecord,
+  MemoryEvidenceTier,
+} from "./evidence-cluster";
+import {
+  buildMemoryRelationPipeline,
+  type BuildMemoryRelationPipelineInput,
+  type MemoryRelationPipeline,
+} from "./pipeline";
+import type {
+  MemoryConsolidationAction,
+  MemoryConsolidationReasonCode,
+} from "./plan";
+import type { MemoryGraphClusterStatus } from "./relation-graph";
+
+type PrimitiveValue = string | number | boolean;
+
+export interface MemoryConsolidationSourceRecord {
+  id?: string;
+  userId?: string;
+  timestamp?: number;
+  text?: string;
+  mediaRefs?: string[];
+  tier?: MemoryEvidenceTier;
+  accessCount?: number;
+  lastAccessAt?: number;
+  importanceScore?: number;
+  isPinned?: boolean;
+  archivedAt?: number;
+  dimensions?: Record<string, PrimitiveValue | undefined>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryConsolidationRecordSelectors<
+  TRecord = MemoryConsolidationSourceRecord,
+> {
+  getId?(record: TRecord): string | undefined;
+  getUserId?(record: TRecord): string | undefined;
+  getTimestamp?(record: TRecord): number | undefined;
+  getText?(record: TRecord): string | undefined;
+  getMediaRefs?(record: TRecord): string[] | undefined;
+  getTier?(record: TRecord): MemoryEvidenceTier | undefined;
+  getAccessCount?(record: TRecord): number | undefined;
+  getLastAccessAt?(record: TRecord): number | undefined;
+  getImportanceScore?(record: TRecord): number | undefined;
+  getIsPinned?(record: TRecord): boolean | undefined;
+  getArchivedAt?(record: TRecord): number | undefined;
+  getDimensions?(
+    record: TRecord,
+  ): Record<string, PrimitiveValue | undefined> | undefined;
+  getMetadata?(record: TRecord): Record<string, unknown> | undefined;
+  getRelationGroup?(record: TRecord): string | undefined;
+  getRelationValue?(record: TRecord): string | undefined;
+  getRelationScope?(record: TRecord): string | undefined;
+}
+
+export type MemoryConsolidationAdapterSkipReason =
+  | "missing_id"
+  | "missing_timestamp";
+
+export interface MemoryConsolidationSkippedRecord {
+  sourceIndex: number;
+  reasonCodes: MemoryConsolidationAdapterSkipReason[];
+}
+
+export interface AdaptMemoryRecordsForConsolidationInput<
+  TRecord = MemoryConsolidationSourceRecord,
+> {
+  records: TRecord[];
+  defaultUserId?: string;
+  defaultTier?: MemoryEvidenceTier;
+  selectors?: MemoryConsolidationRecordSelectors<TRecord>;
+}
+
+export interface AdaptMemoryRecordsForConsolidationResult {
+  records: MemoryEvidenceRecord[];
+  skippedRecords: MemoryConsolidationSkippedRecord[];
+  sourceIndexesByRecordId: Record<string, number>;
+}
+
+export type MemoryRelationPipelineTemporaryScopeBehavior =
+  | "related"
+  | "default";
+
+export interface BuildMemoryRelationPipelineDiagnosticsInput<
+  TRecord = MemoryConsolidationSourceRecord,
+> extends Omit<
+  BuildMemoryRelationPipelineInput,
+  "records" | "getCandidateKeys"
+> {
+  records: TRecord[];
+  defaultUserId?: string;
+  defaultTier?: MemoryEvidenceTier;
+  selectors?: MemoryConsolidationRecordSelectors<TRecord>;
+  temporaryScopeBehavior?: MemoryRelationPipelineTemporaryScopeBehavior;
+  getCandidateKeys?(
+    record: MemoryEvidenceRecord,
+    context: {
+      sourceRecord: TRecord;
+      sourceIndex: number;
+    },
+  ): Iterable<string | undefined | false | null>;
+}
+
+export interface MemoryRelationRecordDiagnostic {
+  recordId: string;
+  sourceIndex: number;
+  clusterKey?: string;
+  competitionKey?: string;
+  graphStatus?: MemoryGraphClusterStatus;
+  planAction?: MemoryConsolidationAction;
+  planReasonCodes: MemoryConsolidationReasonCode[];
+  relationCandidateCount: number;
+  supportRelationCount: number;
+  competeRelationCount: number;
+  relatedRelationCount: number;
+  selectedForSummary: boolean;
+  summaryPriority?: number;
+}
+
+export interface MemoryRelationPipelineDiagnosticSummary {
+  sourceRecordCount: number;
+  adaptedRecordCount: number;
+  skippedRecordCount: number;
+  recordsWithCandidateKeys: number;
+  recordsWithRelationGroup: number;
+  recordsWithRelationValue: number;
+  candidateCount: number;
+  relationCount: number;
+  supportRelationCount: number;
+  competeRelationCount: number;
+  relatedRelationCount: number;
+  clusterCount: number;
+  competitionGroupCount: number;
+  preserveCount: number;
+  observeCount: number;
+  decayCount: number;
+  summaryCandidateCount: number;
+}
+
+export interface MemoryRelationPipelineDiagnostics {
+  records: MemoryEvidenceRecord[];
+  skippedRecords: MemoryConsolidationSkippedRecord[];
+  pipeline: MemoryRelationPipeline;
+  recordDiagnostics: MemoryRelationRecordDiagnostic[];
+  summary: MemoryRelationPipelineDiagnosticSummary;
+}
+
+export interface MemoryConsolidationDiagnosticsReportSummary {
+  sourceRecordCount: number;
+  adaptedRecordCount: number;
+  skippedRecordCount: number;
+  candidateCount: number;
+  relationCount: number;
+  clusterCount: number;
+  competitionGroupCount: number;
+  preserveCount: number;
+  observeCount: number;
+  decayCount: number;
+  summaryCandidateCount: number;
+}
+
+export interface MemoryConsolidationPreservedClusterReport {
+  clusterKey: string;
+  competitionKey: string;
+  recordIds: string[];
+  evidenceCount: number;
+  score: number;
+  reasonCodes: MemoryConsolidationReasonCode[];
+  summaryPriority?: number;
+}
+
+export interface MemoryConsolidationContestedClusterReport {
+  clusterKey: string;
+  competitionKey: string;
+  recordIds: string[];
+  action: MemoryConsolidationAction;
+  competingClusterKeys: string[];
+  winningClusterKey: string;
+  scoreMargin: number;
+  reasonCodes: MemoryConsolidationReasonCode[];
+}
+
+export interface MemoryConsolidationDecayedRecordReport {
+  recordId: string;
+  sourceIndex: number;
+  clusterKey?: string;
+  reasonCodes: MemoryConsolidationReasonCode[];
+}
+
+export interface MemoryConsolidationRecordSignalReport {
+  recordId: string;
+  sourceIndex: number;
+  clusterKey?: string;
+  graphStatus?: MemoryGraphClusterStatus;
+  planAction?: MemoryConsolidationAction;
+  relationCandidateCount: number;
+  supportRelationCount: number;
+  competeRelationCount: number;
+  relatedRelationCount: number;
+  selectedForSummary: boolean;
+}
+
+export interface MemoryConsolidationDiagnosticsReport {
+  summary: MemoryConsolidationDiagnosticsReportSummary;
+  preservedClusters: MemoryConsolidationPreservedClusterReport[];
+  contestedClusters: MemoryConsolidationContestedClusterReport[];
+  decayedRecords: MemoryConsolidationDecayedRecordReport[];
+  skippedRecords: MemoryConsolidationSkippedRecord[];
+  recordSignals: MemoryConsolidationRecordSignalReport[];
+}
+
+const DEFAULT_TIER: MemoryEvidenceTier = "short";
+const DEFAULT_TEMPORARY_SCOPE_BEHAVIOR: MemoryRelationPipelineTemporaryScopeBehavior =
+  "related";
+
+function fallbackRecord(
+  record: unknown,
+): Partial<MemoryConsolidationSourceRecord> {
+  return typeof record === "object" && record !== null
+    ? (record as Partial<MemoryConsolidationSourceRecord>)
+    : {};
+}
+
+function isPrimitive(value: unknown): value is PrimitiveValue {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function booleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function stringArrayOrUndefined(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function tierOrUndefined(value: unknown): MemoryEvidenceTier | undefined {
+  return value === "short" || value === "mid" || value === "long"
+    ? value
+    : undefined;
+}
+
+function dimensionsOrUndefined(
+  value: unknown,
+): Record<string, PrimitiveValue | undefined> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const dimensions: Record<string, PrimitiveValue | undefined> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined || isPrimitive(entry)) {
+      dimensions[key] = entry;
+    }
+  }
+
+  return dimensions;
+}
+
+function metadataOrUndefined(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return { ...(value as Record<string, unknown>) };
+}
+
+function pickWithFallback<TRecord, TValue>(
+  record: TRecord,
+  selector: ((record: TRecord) => TValue | undefined) | undefined,
+  fallback: TValue | undefined,
+): TValue | undefined {
+  return selector?.(record) ?? fallback;
+}
+
+function relationMetadata(
+  metadata: Record<string, unknown> | undefined,
+  relationGroup: string | undefined,
+  relationValue: string | undefined,
+  relationScope: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!metadata && !relationGroup && !relationValue && !relationScope) {
+    return undefined;
+  }
+
+  return {
+    ...(metadata ?? {}),
+    ...(relationGroup ? { relationGroup } : {}),
+    ...(relationValue ? { relationValue } : {}),
+    ...(relationScope ? { relationScope } : {}),
+  };
+}
+
+function relationStringFromRecord(
+  record: MemoryEvidenceRecord,
+  key: "relationGroup" | "relationValue" | "relationScope",
+): string | undefined {
+  const value = record.metadata?.[key] ?? record.dimensions?.[key];
+  return isPrimitive(value) ? String(value) : undefined;
+}
+
+function defaultAdapterCandidateKeys(record: MemoryEvidenceRecord): string[] {
+  const relationGroup = relationStringFromRecord(record, "relationGroup");
+
+  if (!relationGroup) {
+    return [];
+  }
+
+  return [`relation-group:${encodeURIComponent(relationGroup)}`];
+}
+
+function isTemporaryScope(scope: string | undefined): boolean {
+  return scope === "temporary" || scope === "ephemeral";
+}
+
+function addCount(
+  countsByRecordId: Map<string, number>,
+  recordId: string,
+  increment = 1,
+): void {
+  countsByRecordId.set(
+    recordId,
+    (countsByRecordId.get(recordId) ?? 0) + increment,
+  );
+}
+
+function countCandidateLinks(
+  pipeline: MemoryRelationPipeline,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const candidate of pipeline.candidates) {
+    addCount(counts, candidate.fromRecordId);
+    addCount(counts, candidate.toRecordId);
+  }
+
+  return counts;
+}
+
+function countRelationsByKind(
+  pipeline: MemoryRelationPipeline,
+  relation: "support" | "compete" | "related",
+): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const edge of pipeline.relations) {
+    if (edge.relation !== relation) {
+      continue;
+    }
+
+    addCount(counts, edge.fromRecordId);
+    addCount(counts, edge.toRecordId);
+  }
+
+  return counts;
+}
+
+export function adaptMemoryRecordsForConsolidation<TRecord>(
+  input: AdaptMemoryRecordsForConsolidationInput<TRecord>,
+): AdaptMemoryRecordsForConsolidationResult {
+  const records: MemoryEvidenceRecord[] = [];
+  const skippedRecords: MemoryConsolidationSkippedRecord[] = [];
+  const sourceIndexesByRecordId: Record<string, number> = {};
+
+  input.records.forEach((sourceRecord, sourceIndex) => {
+    const fallback = fallbackRecord(sourceRecord);
+    const id = pickWithFallback(
+      sourceRecord,
+      input.selectors?.getId,
+      stringOrUndefined(fallback.id),
+    );
+    const timestamp = pickWithFallback(
+      sourceRecord,
+      input.selectors?.getTimestamp,
+      numberOrUndefined(fallback.timestamp),
+    );
+    const reasonCodes: MemoryConsolidationAdapterSkipReason[] = [];
+
+    if (!id) {
+      reasonCodes.push("missing_id");
+    }
+    if (timestamp === undefined) {
+      reasonCodes.push("missing_timestamp");
+    }
+    if (!id || timestamp === undefined) {
+      skippedRecords.push({ sourceIndex, reasonCodes });
+      return;
+    }
+
+    const recordId: string = id;
+    const recordTimestamp: number = timestamp;
+    const relationGroup = pickWithFallback(
+      sourceRecord,
+      input.selectors?.getRelationGroup,
+      undefined,
+    );
+    const relationValue = pickWithFallback(
+      sourceRecord,
+      input.selectors?.getRelationValue,
+      undefined,
+    );
+    const relationScope = pickWithFallback(
+      sourceRecord,
+      input.selectors?.getRelationScope,
+      undefined,
+    );
+    const metadata = relationMetadata(
+      pickWithFallback(
+        sourceRecord,
+        input.selectors?.getMetadata,
+        metadataOrUndefined(fallback.metadata),
+      ),
+      relationGroup,
+      relationValue,
+      relationScope,
+    );
+
+    records.push({
+      id: recordId,
+      userId:
+        pickWithFallback(
+          sourceRecord,
+          input.selectors?.getUserId,
+          stringOrUndefined(fallback.userId),
+        ) ??
+        input.defaultUserId ??
+        "unknown",
+      timestamp: recordTimestamp,
+      text: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getText,
+        stringOrUndefined(fallback.text),
+      ),
+      mediaRefs: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getMediaRefs,
+        stringArrayOrUndefined(fallback.mediaRefs),
+      ),
+      tier:
+        pickWithFallback(
+          sourceRecord,
+          input.selectors?.getTier,
+          tierOrUndefined(fallback.tier),
+        ) ??
+        input.defaultTier ??
+        DEFAULT_TIER,
+      accessCount: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getAccessCount,
+        numberOrUndefined(fallback.accessCount),
+      ),
+      lastAccessAt: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getLastAccessAt,
+        numberOrUndefined(fallback.lastAccessAt),
+      ),
+      importanceScore: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getImportanceScore,
+        numberOrUndefined(fallback.importanceScore),
+      ),
+      isPinned: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getIsPinned,
+        booleanOrUndefined(fallback.isPinned),
+      ),
+      archivedAt: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getArchivedAt,
+        numberOrUndefined(fallback.archivedAt),
+      ),
+      dimensions: pickWithFallback(
+        sourceRecord,
+        input.selectors?.getDimensions,
+        dimensionsOrUndefined(fallback.dimensions),
+      ),
+      metadata,
+    });
+    sourceIndexesByRecordId[recordId] = sourceIndex;
+  });
+
+  return {
+    records,
+    skippedRecords,
+    sourceIndexesByRecordId,
+  };
+}
+
+export function buildMemoryRelationPipelineDiagnostics<TRecord>(
+  input: BuildMemoryRelationPipelineDiagnosticsInput<TRecord>,
+): MemoryRelationPipelineDiagnostics {
+  const adapted = adaptMemoryRecordsForConsolidation({
+    records: input.records,
+    defaultUserId: input.defaultUserId,
+    defaultTier: input.defaultTier,
+    selectors: input.selectors,
+  });
+  const sourceRecordById = new Map(
+    adapted.records.map((record) => {
+      const sourceIndex = adapted.sourceIndexesByRecordId[record.id] ?? -1;
+      return [
+        record.id,
+        {
+          sourceRecord: input.records[sourceIndex]!,
+          sourceIndex,
+        },
+      ];
+    }),
+  );
+  const candidateKeysByRecordId = new Map<string, string[]>();
+  const temporaryScopeBehavior =
+    input.temporaryScopeBehavior ?? DEFAULT_TEMPORARY_SCOPE_BEHAVIOR;
+  const pipeline = buildMemoryRelationPipeline({
+    ...input,
+    records: adapted.records,
+    getCandidateKeys(record) {
+      const source = sourceRecordById.get(record.id);
+      const keys = source
+        ? [
+            ...(input.getCandidateKeys?.(record, source) ??
+              defaultAdapterCandidateKeys(record)),
+          ].filter((key): key is string => Boolean(key))
+        : defaultAdapterCandidateKeys(record);
+
+      candidateKeysByRecordId.set(record.id, [...new Set(keys)].sort());
+      return keys;
+    },
+    judgment: {
+      ...input.judgment,
+      judgeCandidate(candidate, context) {
+        const callerDecision = input.judgment?.judgeCandidate?.(
+          candidate,
+          context,
+        );
+
+        if (callerDecision) {
+          return callerDecision;
+        }
+
+        if (temporaryScopeBehavior === "related") {
+          const fromScope = relationStringFromRecord(
+            context.fromRecord,
+            "relationScope",
+          );
+          const toScope = relationStringFromRecord(
+            context.toRecord,
+            "relationScope",
+          );
+
+          if (isTemporaryScope(fromScope) || isTemporaryScope(toScope)) {
+            return {
+              relation: "related",
+              weight: 0.45,
+              reasonCodes: ["candidate_related"],
+            };
+          }
+        }
+
+        return context.defaultDecision;
+      },
+    },
+  });
+  const candidateCounts = countCandidateLinks(pipeline);
+  const supportCounts = countRelationsByKind(pipeline, "support");
+  const competeCounts = countRelationsByKind(pipeline, "compete");
+  const relatedCounts = countRelationsByKind(pipeline, "related");
+  const clusterByKey = new Map(
+    pipeline.assignment.clusters.map((cluster) => [cluster.clusterId, cluster]),
+  );
+  const planEntryByClusterKey = new Map(
+    pipeline.plan.entries.map((entry) => [entry.clusterKey, entry]),
+  );
+  const summaryCandidateByClusterKey = new Map(
+    pipeline.summaryCandidates.map((candidate) => [
+      candidate.clusterKey,
+      candidate,
+    ]),
+  );
+
+  const recordDiagnostics = adapted.records.map((record) => {
+    const clusterKey = pipeline.assignment.recordClusterKeys[record.id];
+    const cluster = clusterKey ? clusterByKey.get(clusterKey) : undefined;
+    const planEntry = clusterKey
+      ? planEntryByClusterKey.get(clusterKey)
+      : undefined;
+    const summaryCandidate = clusterKey
+      ? summaryCandidateByClusterKey.get(clusterKey)
+      : undefined;
+
+    return {
+      recordId: record.id,
+      sourceIndex: adapted.sourceIndexesByRecordId[record.id] ?? -1,
+      clusterKey,
+      competitionKey: clusterKey
+        ? pipeline.assignment.clusterCompetitionKeys[clusterKey]
+        : undefined,
+      graphStatus: cluster?.status,
+      planAction: planEntry?.action,
+      planReasonCodes: planEntry?.reasonCodes ?? [],
+      relationCandidateCount: candidateCounts.get(record.id) ?? 0,
+      supportRelationCount: supportCounts.get(record.id) ?? 0,
+      competeRelationCount: competeCounts.get(record.id) ?? 0,
+      relatedRelationCount: relatedCounts.get(record.id) ?? 0,
+      selectedForSummary: summaryCandidate !== undefined,
+      summaryPriority: summaryCandidate?.priority,
+    };
+  });
+
+  return {
+    records: adapted.records,
+    skippedRecords: adapted.skippedRecords,
+    pipeline,
+    recordDiagnostics,
+    summary: {
+      sourceRecordCount: input.records.length,
+      adaptedRecordCount: adapted.records.length,
+      skippedRecordCount: adapted.skippedRecords.length,
+      recordsWithCandidateKeys: adapted.records.filter(
+        (record) => (candidateKeysByRecordId.get(record.id)?.length ?? 0) > 0,
+      ).length,
+      recordsWithRelationGroup: adapted.records.filter((record) =>
+        Boolean(relationStringFromRecord(record, "relationGroup")),
+      ).length,
+      recordsWithRelationValue: adapted.records.filter((record) =>
+        Boolean(relationStringFromRecord(record, "relationValue")),
+      ).length,
+      candidateCount: pipeline.candidates.length,
+      relationCount: pipeline.relations.length,
+      supportRelationCount: pipeline.relations.filter(
+        (edge) => edge.relation === "support",
+      ).length,
+      competeRelationCount: pipeline.relations.filter(
+        (edge) => edge.relation === "compete",
+      ).length,
+      relatedRelationCount: pipeline.relations.filter(
+        (edge) => edge.relation === "related",
+      ).length,
+      clusterCount: pipeline.assignment.clusters.length,
+      competitionGroupCount: pipeline.assignment.competitionGroups.length,
+      preserveCount: pipeline.plan.actions.preserve.length,
+      observeCount: pipeline.plan.actions.observe.length,
+      decayCount: pipeline.plan.actions.decay.length,
+      summaryCandidateCount: pipeline.summaryCandidates.length,
+    },
+  };
+}
+
+export function buildMemoryConsolidationDiagnosticsReport(
+  diagnostics: MemoryRelationPipelineDiagnostics,
+): MemoryConsolidationDiagnosticsReport {
+  const summaryCandidateByClusterKey = new Map(
+    diagnostics.pipeline.summaryCandidates.map((candidate) => [
+      candidate.clusterKey,
+      candidate,
+    ]),
+  );
+  const graphStatusByClusterKey = new Map(
+    diagnostics.pipeline.assignment.clusters.map((cluster) => [
+      cluster.clusterId,
+      cluster.status,
+    ]),
+  );
+
+  const preservedClusters = diagnostics.pipeline.plan.actions.preserve
+    .map((entry) => ({
+      clusterKey: entry.clusterKey,
+      competitionKey: entry.competitionKey,
+      recordIds: [...entry.recordIds],
+      evidenceCount: entry.evidenceCount,
+      score: entry.score,
+      reasonCodes: [...entry.reasonCodes],
+      summaryPriority: summaryCandidateByClusterKey.get(entry.clusterKey)
+        ?.priority,
+    }))
+    .sort((a, b) => {
+      const priorityDelta = (b.summaryPriority ?? 0) - (a.summaryPriority ?? 0);
+      return priorityDelta || b.score - a.score;
+    });
+  const contestedClusters = diagnostics.pipeline.plan.entries
+    .filter(
+      (entry) =>
+        entry.competingClusterKeys.length > 0 ||
+        graphStatusByClusterKey.get(entry.clusterKey) === "contested",
+    )
+    .map((entry) => ({
+      clusterKey: entry.clusterKey,
+      competitionKey: entry.competitionKey,
+      recordIds: [...entry.recordIds],
+      action: entry.action,
+      competingClusterKeys: [...entry.competingClusterKeys],
+      winningClusterKey: entry.winningClusterKey,
+      scoreMargin: entry.scoreMargin,
+      reasonCodes: [...entry.reasonCodes],
+    }));
+  const decayedRecords = diagnostics.recordDiagnostics
+    .filter((signal) => signal.planAction === "decay")
+    .map((signal) => ({
+      recordId: signal.recordId,
+      sourceIndex: signal.sourceIndex,
+      clusterKey: signal.clusterKey,
+      reasonCodes: [...signal.planReasonCodes],
+    }))
+    .sort((a, b) => a.sourceIndex - b.sourceIndex);
+  const recordSignals = diagnostics.recordDiagnostics
+    .map((signal) => ({
+      recordId: signal.recordId,
+      sourceIndex: signal.sourceIndex,
+      clusterKey: signal.clusterKey,
+      graphStatus: signal.graphStatus,
+      planAction: signal.planAction,
+      relationCandidateCount: signal.relationCandidateCount,
+      supportRelationCount: signal.supportRelationCount,
+      competeRelationCount: signal.competeRelationCount,
+      relatedRelationCount: signal.relatedRelationCount,
+      selectedForSummary: signal.selectedForSummary,
+    }))
+    .sort((a, b) => a.sourceIndex - b.sourceIndex);
+
+  return {
+    summary: {
+      sourceRecordCount: diagnostics.summary.sourceRecordCount,
+      adaptedRecordCount: diagnostics.summary.adaptedRecordCount,
+      skippedRecordCount: diagnostics.summary.skippedRecordCount,
+      candidateCount: diagnostics.summary.candidateCount,
+      relationCount: diagnostics.summary.relationCount,
+      clusterCount: diagnostics.summary.clusterCount,
+      competitionGroupCount: diagnostics.summary.competitionGroupCount,
+      preserveCount: diagnostics.summary.preserveCount,
+      observeCount: diagnostics.summary.observeCount,
+      decayCount: diagnostics.summary.decayCount,
+      summaryCandidateCount: diagnostics.summary.summaryCandidateCount,
+    },
+    preservedClusters,
+    contestedClusters,
+    decayedRecords,
+    skippedRecords: diagnostics.skippedRecords.map((record) => ({
+      sourceIndex: record.sourceIndex,
+      reasonCodes: [...record.reasonCodes],
+    })),
+    recordSignals,
+  };
+}

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./adapter";
 export * from "./evidence-cluster";
 export * from "./plan";
 export * from "./pipeline";


### PR DESCRIPTION
Summary
Add a package-local diagnostics adapter for the memory consolidation pipeline.

This introduces an offline observation layer for structurally compatible memory records:

source records
-> adaptMemoryRecordsForConsolidation
-> buildMemoryRelationPipelineDiagnostics
-> buildMemoryConsolidationDiagnosticsReport

The goal is to inspect whether existing traces form stable clusters, compete with other clusters, remain weak observations, or should decay instead of being promoted.

Scope
- Adds adaptMemoryRecordsForConsolidation for selector-based source record normalization
- Adds buildMemoryRelationPipelineDiagnostics for per-record diagnostics over the existing relation pipeline
- Adds buildMemoryConsolidationDiagnosticsReport for a compact reviewer/caller-friendly report shape
- Reports preserved clusters, contested clusters, decayed records, skipped records, and record-level signals
- Documents the package as an offline consolidation diagnostics layer
- Extends focused memory-consolidation eval coverage
- Does not change forgetting runtime behavior
- Does not change storage schema
- Does not change retrieval behavior
- Does not introduce embedding / LLM dependencies
- Does not generate final semantic memory or summary text

Testing
- corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/adapter.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json packages/ai/memory-consolidation/README.md apps/web/tests/unit/memory-consolidation-eval.test.ts
- corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts
- corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit
- git diff --check