### PR TITLE
fix: prevent text messages from splitting tool calls into separate messages

### DIFF
--- a/apps/web/lib/cron/executor.ts
+++ b/apps/web/lib/cron/executor.ts
@@ -982,7 +982,6 @@ ${characterContextSection}`,
             currentParts.push({ type: "text", text: sanitizedText });
           }
           await saveCurrentAssistantMessage();
-          resetCurrentMessage();
         } else if (message.type === "tool_use") {
           // Don't save here - let tool calls accumulate in the same message
           // Only save when we have text content that user needs to see


### PR DESCRIPTION
## Summary

- Remove `resetCurrentMessage()` call after saving text events in `executor.ts`
- Text messages between tool calls were causing a new `currentMessageId` to be generated
- This resulted in Tool A, Text C, Tool B appearing as separate messages instead of one combined message

## Root Cause

After saving a `text` event, `resetCurrentMessage()` was called which generates a new `currentMessageId`. The next `tool_use` would then create a separate message instead of staying in the same message.

## Flow (Before)
```
Tool A → messageId: X, saves
Text C → messageId: X, saves, RESET → currentMessageId = Y
Tool B → messageId: Y (NEW message)
```

## Flow (After)
```
Tool A → messageId: X, saves
Text C → messageId: X, saves  (no reset)
Tool B → messageId: X  (same message)
```

## Test Plan

- [ ] Create a scheduled job that calls a tool, returns text, then calls another tool
- [ ] Execute the job and verify all three appear in the same message

🤖 Generated with [Claude Code](https://claude.com/claude-code)