### PR TITLE
feat(mcp): sync saveUserMemory tool from alloomi

### DIFF
--- a/apps/web/lib/ai/mcp/tools/index.ts
+++ b/apps/web/lib/ai/mcp/tools/index.ts
@@ -23,9 +23,11 @@ import { createRawMessagesTools } from "./raw-messages";
 import { createUnifiedMemorySearchTool } from "./unified-memory";
 import { createMemoryPathTool } from "./memory-path";
 import { createSchedulerTools } from "./scheduler";
+import { createUserMemoryTool, type MemoryUpdateCallback } from "./user-memory";
 
 export type BusinessToolsMcpOptions = {
   excludeTools?: string[];
+  onMemoryUpdate?: MemoryUpdateCallback;
 };
 
 /**
@@ -83,6 +85,9 @@ export function createBusinessToolsMcpServer(
 
     // Scheduler tools
     ...createSchedulerTools(session, embeddingsAuthToken),
+
+    // User memory tool
+    createUserMemoryTool(session, options?.onMemoryUpdate),
   ];
 
   const excludeSet = new Set(options?.excludeTools ?? []);
@@ -104,3 +109,4 @@ export function createBusinessToolsMcpServer(
 // Re-export shared types for external use
 export type { InsightChangeCallback, TaskInput } from "./shared";
 export { INSIGHT_FILTER_KINDS } from "./shared";
+export type { MemoryUpdateCallback } from "./user-memory";

--- a/apps/web/lib/ai/mcp/tools/user-memory.ts
+++ b/apps/web/lib/ai/mcp/tools/user-memory.ts
@@ -1,0 +1,171 @@
+/**
+ * User memory tool - persists explicit durable facts the user asks to
+ * remember. This complements raw file tools with a narrow, user-facing path.
+ */
+
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Session } from "next-auth";
+import { getUserMemoryPath } from "@/lib/utils/path";
+
+export type MemoryUpdatePayload = {
+  category: string;
+  fileName: string;
+  displayLabel: string;
+  action: "create" | "update";
+  description?: string;
+  filePath: string;
+};
+export type MemoryUpdateCallback = (data: MemoryUpdatePayload) => void;
+
+const MEMORY_CATEGORIES = ["people", "projects", "notes", "strategy"] as const;
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .normalize("NFKC")
+    .trim()
+    .toLowerCase()
+    .replace(/[\\/:*?"<>|#]+/g, " ")
+    .replace(/[^\p{L}\p{N}._-]+/gu, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+  return slug || `memory-${Date.now()}`;
+}
+
+function ensureMarkdown(title: string, content: string): string {
+  const trimmed = content.trim();
+  if (/^#{1,6}\s+\S/m.test(trimmed)) {
+    return `${trimmed}\n`;
+  }
+  return `# ${title.trim()}\n\n${trimmed}\n`;
+}
+
+function compactDescription(content: string): string | undefined {
+  const lines = content
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^#{1,6}\s+/.test(line))
+    .filter((line) => !/^[-*_]{3,}$/.test(line));
+
+  const first = lines[0]?.replace(/^[-*]\s+/, "").trim();
+  if (!first) return undefined;
+  return first.length > 120 ? `${first.slice(0, 117)}...` : first;
+}
+
+export function createUserMemoryTool(
+  session: Session,
+  onMemoryUpdate?: MemoryUpdateCallback,
+) {
+  return tool(
+    "saveUserMemory",
+    [
+      "Save a durable user fact when the user EXPLICITLY asks you to remember, save, or update information about them.",
+      "",
+      "**WHEN TO USE:**",
+      "- User says 'remember that...', 'note that...', 'save this to memory', or asks to update a persistent fact.",
+      "- The information is useful in future conversations, such as people, projects, personal notes, or strategy.",
+      "",
+      "**WHEN NOT TO USE:**",
+      "- Do NOT infer memories silently from ordinary conversation.",
+      "- Do NOT save secrets, passwords, tokens, or highly sensitive information.",
+      "- Do NOT use this for reminders or tracked events; use insight/task tools instead.",
+      "",
+      "**CATEGORIES:**",
+      "- people: person profiles, relationships, contacts",
+      "- projects: ongoing work, project context, decisions",
+      "- notes: general personal notes and durable facts",
+      "- strategy: planning, goals, positioning, long-term strategy",
+    ].join("\n"),
+    {
+      category: z
+        .enum(MEMORY_CATEGORIES)
+        .describe("The memory category that best matches the fact."),
+      title: z
+        .string()
+        .min(1)
+        .max(120)
+        .describe("A concise user-facing title for the memory."),
+      content: z
+        .string()
+        .min(1)
+        .max(4000)
+        .describe(
+          "The durable memory content in concise Markdown. Keep it factual and useful.",
+        ),
+    },
+    async ({ category, title, content }) => {
+      try {
+        // Validate user session for security/isolation
+        if (!session?.user?.id) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Unauthorized: invalid user session",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const userId = session.user.id;
+        const memoryRoot = getUserMemoryPath(userId);
+        const categoryDir = path.join(memoryRoot, category);
+        await fs.mkdir(categoryDir, { recursive: true });
+
+        const fileName = `${slugifyTitle(title)}.md`;
+        const filePath = path.join(categoryDir, fileName);
+        const action: MemoryUpdatePayload["action"] = await fs
+          .access(filePath)
+          .then(() => "update" as const)
+          .catch(() => "create" as const);
+        const markdown = ensureMarkdown(title, content);
+
+        await fs.writeFile(filePath, markdown, "utf8");
+
+        const payload: MemoryUpdatePayload = {
+          category,
+          fileName,
+          displayLabel: title.trim(),
+          action,
+          description: compactDescription(markdown),
+          filePath,
+        };
+
+        onMemoryUpdate?.(payload);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                success: true,
+                ...payload,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                success: false,
+                message: `Failed to save memory: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `saveUserMemory` MCP tool that allows the agent to persist durable user facts (people, projects, notes, strategy) as markdown files
- Files stored at `~/.openloomi/data/memory/{userId}/{category}/{slug}.md`
- Export `MemoryUpdateCallback` type and add `onMemoryUpdate` option to `BusinessToolsMcpOptions`
- Tool is synced from alloomi implementation

## Test plan

- [ ] Verify `saveUserMemory` tool appears in MCP business-tools server
- [ ] Test saving a memory in each category (people, projects, notes, strategy)
- [ ] Verify memory files are correctly written to `~/.openloomi/data/memory/`
- [ ] Test `onMemoryUpdate` callback is fired when a memory is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)