### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openloomi"
-version = "0.6.0"
+version = "0.6.1"
 description = "openloomi AI Assistant - Your Personal Productivity Tool"
 authors = ["OpenLoomi Team"]
 edition = "2021"

--- a/apps/web/src-tauri/tauri.conf.dev.json
+++ b/apps/web/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "openloomi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.openloomi.app",
   "build": {
     "beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "openloomi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.openloomi.app",
   "build": {
     "beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openloomi-monorepo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai/mcp/package.json
+++ b/packages/ai/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/memory-consolidation",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/rag/package.json
+++ b/packages/ai/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rag",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/audit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/hooks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/i18n",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/indexeddb",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/insights",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/asana/package.json
+++ b/packages/integrations/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-asana",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/calendar/package.json
+++ b/packages/integrations/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-calendar",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/channels/package.json
+++ b/packages/integrations/channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-channels",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/composio/package.json
+++ b/packages/integrations/composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-composio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/dingtalk/package.json
+++ b/packages/integrations/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-dingtalk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/facebook-messenger/package.json
+++ b/packages/integrations/facebook-messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-facebook-messenger",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/feishu/package.json
+++ b/packages/integrations/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-feishu",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/gmail/package.json
+++ b/packages/integrations/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-gmail",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/google-docs/package.json
+++ b/packages/integrations/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-docs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/google-meet/package.json
+++ b/packages/integrations/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-meet",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/hubspot/package.json
+++ b/packages/integrations/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-hubspot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/imessage/package.json
+++ b/packages/integrations/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-imessage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/instagram/package.json
+++ b/packages/integrations/instagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-instagram",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/jira/package.json
+++ b/packages/integrations/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-jira",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/linkedin/package.json
+++ b/packages/integrations/linkedin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-linkedin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "description": "Unified package for alloo mi integration packages",

--- a/packages/integrations/qqbot/package.json
+++ b/packages/integrations/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-qqbot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/rss/package.json
+++ b/packages/integrations/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rss",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/telegram/package.json
+++ b/packages/integrations/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-telegram",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/weixin/package.json
+++ b/packages/integrations/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-weixin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/whatsapp/package.json
+++ b/packages/integrations/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-whatsapp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/x/package.json
+++ b/packages/integrations/x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-x",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rag",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "exports": {

--- a/packages/rss/package.json
+++ b/packages/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rss",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "exports": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/search",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/security",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/sqlite",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/storage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump version across all packages in the monorepo from `0.6.0` to `0.6.1`
- Includes root `package.json`, `apps/web`, and all `packages/*` directories

## Test plan

- [ ] Verify all 45 package.json files reflect version `0.6.1`
- [ ] Run build to confirm no version-related issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)