### PR TITLE
fix(web): New Chat button not updating chatId in router

### DIFF
--- a/apps/web/components/agent/chat-header-panel.tsx
+++ b/apps/web/components/agent/chat-header-panel.tsx
@@ -208,13 +208,6 @@ export function ChatHeaderPanel({
    * Handle new chat
    */
   const handleNewChat = () => {
-    if (chatContextOptional) {
-      chatContextOptional.setMessages([]);
-      chatContextOptional.clearFocusedInsights();
-      chatContextOptional.switchChatId(null);
-      setTimeout(scrollToRight, 150);
-      return;
-    }
     if (onChatIdChange) {
       onChatIdChange(null);
       setTimeout(scrollToRight, 150);


### PR DESCRIPTION
Fix top-right `+` New Chat button
Before, if I select chat A, then click the top-right `+` New Chat button, the router `chatId` is not updated
Then when I click chat A again, it does not open correctly
Now the top-right `+` button also calls parent `handleChatIdChange`, same as New Chat in `chat-history-side-panel`