### PR TITLE
feat(files): add .tsv and .tgz to FILE_TYPE_CONFIG

### DIFF
--- a/apps/web/components/file/file-icon-src.ts
+++ b/apps/web/components/file/file-icon-src.ts
@@ -88,6 +88,7 @@ export function getLibraryFileIconSrc(extRaw: string): string {
     markdown: "txt",
     log: "txt",
     rtf: "txt",
+    tsv: "csv",
     ods: "spreadsheets",
     odp: "pptx",
     // Apple iWork suite - reuse the closest existing icon so users can tell
@@ -204,6 +205,7 @@ export function getUploadFileIconSrc(extRaw: string): string {
     "text/plain": "txt",
     "text/markdown": "txt",
     "text/csv": "excel",
+    "text/tab-separated-values": "excel",
     "text/html": "html",
     "application/json": "file",
     "application/zip": "zip",
@@ -255,6 +257,7 @@ export function getUploadFileIconSrc(extRaw: string): string {
     xls: "excel",
     xlsx: "excel",
     csv: "excel",
+    tsv: "excel",
     ods: "excel",
     numbers: "excel",
     ppt: "ppt",
@@ -284,6 +287,7 @@ export function getUploadFileIconSrc(extRaw: string): string {
     "7z": "zip",
     tar: "zip",
     gz: "zip",
+    tgz: "zip",
     bz2: "zip",
     json: "file",
   };

--- a/apps/web/lib/files/config.ts
+++ b/apps/web/lib/files/config.ts
@@ -55,6 +55,11 @@ export const FILE_TYPE_CONFIG = {
   txt: { mime: "text/plain", extensions: [".txt"], label: "TXT" },
   md: { mime: "text/markdown", extensions: [".md"], label: "Markdown" },
   csv: { mime: "text/csv", extensions: [".csv"], label: "CSV" },
+  tsv: {
+    mime: "text/tab-separated-values",
+    extensions: [".tsv"],
+    label: "TSV",
+  },
   json: { mime: "application/json", extensions: [".json"], label: "JSON" },
   html: { mime: "text/html", extensions: [".html", ".htm"], label: "HTML" },
   // Apple office suite formats
@@ -83,6 +88,11 @@ export const FILE_TYPE_CONFIG = {
   },
   tar: { mime: "application/x-tar", extensions: [".tar"], label: "TAR" },
   gz: { mime: "application/gzip", extensions: [".gz"], label: "GZIP" },
+  tgz: {
+    mime: "application/gzip",
+    extensions: [".tgz"],
+    label: "TGZ",
+  },
   bz2: {
     mime: "application/x-bzip2",
     extensions: [".bz2"],
@@ -149,6 +159,7 @@ export const SUPPORTED_ATTACHMENT_MIME_TYPES = [
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "text/plain",
   "text/markdown",
+  "text/tab-separated-values",
   "text/html",
   // Apple office suite formats (new version)
   "application/vnd.apple.pages",

--- a/apps/web/tests/unit/files-config.test.ts
+++ b/apps/web/tests/unit/files-config.test.ts
@@ -1,0 +1,86 @@
+/**
+ * File type config unit tests.
+ *
+ * Covers the .tsv and .tgz formats added to FILE_TYPE_CONFIG so the
+ * MIME/extension lookups, attachment allowlist, and supported-extension
+ * list stay in sync.
+ */
+import { describe, test, expect } from "vitest";
+
+import {
+  FILE_TYPE_CONFIG,
+  SUPPORTED_ATTACHMENT_MIME_TYPES,
+  SUPPORTED_FILE_EXTENSIONS,
+  getMimeTypeFromExtension,
+  getExtensionsFromMimeType,
+} from "@/lib/files/config";
+import {
+  getLibraryFileIconSrc,
+  getUploadFileIconSrc,
+} from "@/components/file/file-icon-src";
+
+describe("FILE_TYPE_CONFIG tsv/tgz support", () => {
+  test("declares tsv with the tab-separated MIME type", () => {
+    expect(FILE_TYPE_CONFIG.tsv).toEqual({
+      mime: "text/tab-separated-values",
+      extensions: [".tsv"],
+      label: "TSV",
+    });
+  });
+
+  test("declares tgz mapped to gzip", () => {
+    expect(FILE_TYPE_CONFIG.tgz).toEqual({
+      mime: "application/gzip",
+      extensions: [".tgz"],
+      label: "TGZ",
+    });
+  });
+
+  test("resolves MIME types from the new extensions", () => {
+    expect(getMimeTypeFromExtension(".tsv")).toBe("text/tab-separated-values");
+    expect(getMimeTypeFromExtension("tsv")).toBe("text/tab-separated-values");
+    // .tgz shares the gzip MIME with .gz; both extensions resolve to it.
+    expect(getMimeTypeFromExtension(".tgz")).toBe("application/gzip");
+  });
+
+  test("maps the tab-separated MIME back to its extension", () => {
+    expect(getExtensionsFromMimeType("text/tab-separated-values")).toEqual([
+      ".tsv",
+    ]);
+  });
+
+  test("includes the new extensions in the supported list", () => {
+    expect(SUPPORTED_FILE_EXTENSIONS).toContain(".tsv");
+    expect(SUPPORTED_FILE_EXTENSIONS).toContain(".tgz");
+  });
+
+  test("allows tab-separated uploads as attachments", () => {
+    expect(SUPPORTED_ATTACHMENT_MIME_TYPES).toContain(
+      "text/tab-separated-values",
+    );
+    // gzip is already permitted, which also covers .tgz uploads.
+    expect(SUPPORTED_ATTACHMENT_MIME_TYPES).toContain("application/gzip");
+  });
+});
+
+describe("file icon resolution for tsv/tgz", () => {
+  test("library icons reuse spreadsheet/archive artwork", () => {
+    expect(getLibraryFileIconSrc(".tsv")).toBe("/images/file/csv.svg");
+    expect(getLibraryFileIconSrc("tgz")).toBe("/images/file/zip.svg");
+  });
+
+  test("upload icons reuse excel/zip artwork by extension", () => {
+    expect(getUploadFileIconSrc(".tsv")).toBe(
+      "/images/file/upload/icon_excel.svg",
+    );
+    expect(getUploadFileIconSrc("tgz")).toBe(
+      "/images/file/upload/icon_zip.svg",
+    );
+  });
+
+  test("upload icons resolve the tab-separated MIME type", () => {
+    expect(getUploadFileIconSrc("text/tab-separated-values")).toBe(
+      "/images/file/upload/icon_excel.svg",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #217.

`.tsv` and `.tgz` already worked as generic attachments but lacked dedicated definitions, so they showed up without proper MIME types, labels, or icons. This adds them to `FILE_TYPE_CONFIG` and wires them through the existing helpers, matching the experience for `.csv` and `.zip`.

## Changes

- **`apps/web/lib/files/config.ts`**
  - `tsv` → `text/tab-separated-values`, label `TSV`
  - `tgz` → `application/gzip`, label `TGZ`
  - Added `text/tab-separated-values` to `SUPPORTED_ATTACHMENT_MIME_TYPES` (gzip is already allowed, which also covers `.tgz`)
- **`apps/web/components/file/file-icon-src.ts`**
  - `getLibraryFileIconSrc`: `tsv` reuses the CSV icon (`tgz` alias was already present)
  - `getUploadFileIconSrc`: `text/tab-separated-values` and the `tsv`/`tgz` extensions reuse the excel/zip upload icons
- **`apps/web/tests/unit/files-config.test.ts`** (new)
  - Covers MIME/extension lookups, the attachment allowlist, the supported-extension list, and icon resolution for both formats

### Notes on MIME choices

- `.tsv` uses the registered `text/tab-separated-values` type.
- `.tgz` uses `application/gzip`, matching the existing `.gz` entry and the issue's suggested fix, since a `.tgz` is processed as a gzip-compressed tar. This keeps it inside the already-allowed gzip MIME type.

## Validation

Run from `apps/web`:

- `npx vitest run tests/unit/files-config.test.ts` → 9 passed
- `biome lint` on changed files → clean
- `prettier --check` on changed files → clean
- `tsc --noEmit` (full project) → 0 errors