### PR TITLE
Feat/cli one shot mode

### DIFF
--- a/apps/web/app/api/native/agent/route.ts
+++ b/apps/web/app/api/native/agent/route.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NextRequest } from "next/server";
+import type { Session } from "next-auth";
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
 import { claudePlugin } from "@/lib/ai/extensions";
 
@@ -21,6 +22,7 @@ import type {
 } from "@openloomi/ai/agent/types";
 import type { SandboxConfig } from "@openloomi/ai/agent/sandbox/types";
 import { auth } from "@/app/(auth)/auth";
+import { getAuthUser, type AuthUser } from "@/lib/auth/dual-auth";
 import { promises as fs } from "node:fs";
 import { getUserInsightSettings } from "@/lib/db/queries";
 import path from "node:path";
@@ -39,6 +41,7 @@ interface AgentRequest {
   prompt: string;
   sessionId?: string;
   conversation?: Array<{ role: "user" | "assistant"; content: string }>;
+  platform?: string;
   phase?: "plan" | "execute";
   planId?: string;
   workDir?: string;
@@ -168,6 +171,21 @@ const SSE_HEADERS = {
   Connection: "keep-alive",
   "X-Accel-Buffering": "no",
 };
+
+// Bearer-token callers, such as the one-shot CLI, do not have a full NextAuth
+// session object. Business tools still expect session.user.id/type, so provide
+// the smallest compatible shape here.
+function createSessionFromAuthUser(authUser: AuthUser): Session {
+  return {
+    user: {
+      id: authUser.id,
+      email: authUser.email ?? undefined,
+      name: authUser.name ?? undefined,
+      type: (authUser.type ?? "regular") as Session["user"]["type"],
+    },
+    expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  } as Session;
+}
 
 /**
  * Convert home directory tilde path to absolute path
@@ -338,17 +356,31 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Get user session for business tools
-    const session = await auth();
+    // Authenticate with Bearer token first, then fall back to session cookies.
+    const authUser = await getAuthUser(req);
 
     // Check authentication - unauthenticated users cannot run the agent
-    if (!session?.user?.id) {
+    if (!authUser?.id) {
       console.error("[AgentAPI] ERROR: Unauthorized access attempt");
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Preserve the full NextAuth session for web requests; Bearer-token requests
+    // get a minimal compatible session for business tools.
+    const webSession = await auth();
+    const session: Session & { platform?: string } =
+      webSession?.user?.id === authUser.id
+        ? webSession
+        : createSessionFromAuthUser(authUser);
+    const requestPlatform = body.platform?.trim();
+    if (requestPlatform) {
+      // Let CLI and other scripted callers identify their source to downstream
+      // business tools without changing the web session contract.
+      session.platform = requestPlatform;
+    }
+
     // Get user insight settings (including aiSoulPrompt and language)
-    const userSettings = await getUserInsightSettings(session.user.id);
+    const userSettings = await getUserInsightSettings(authUser.id);
 
     if (!body.prompt) {
       console.error("[AgentAPI] ERROR: prompt is missing or empty!");

--- a/apps/web/scripts/create-dev-standalone.js
+++ b/apps/web/scripts/create-dev-standalone.js
@@ -17,7 +17,20 @@ const mkdir = (p) => {
 };
 
 mkdir(".next/standalone/apps/web");
+mkdir(".next/standalone/apps/web/.next");
+mkdir(".next/standalone/apps/web/public");
+mkdir(".next/standalone/apps/web/lib");
+mkdir(".next/standalone/apps/web/cli-bundle");
 mkdir(".next/standalone/node_modules");
+
+fs.writeFileSync(
+  ".next/standalone/apps/web/server.js",
+  "// Dev placeholder. Next.js serves from source during tauri dev.\n",
+);
+fs.writeFileSync(".next/standalone/apps/web/.next/.placeholder", "");
+fs.writeFileSync(".next/standalone/apps/web/public/.placeholder", "");
+fs.writeFileSync(".next/standalone/apps/web/lib/.placeholder", "");
+fs.writeFileSync(".next/standalone/apps/web/cli-bundle/.placeholder", "");
 
 console.log("Copying native modules for standalone mode...");
 

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ description = "openloomi AI Assistant - Your Personal Productivity Tool"
 authors = ["OpenLoomi Team"]
 edition = "2021"
 autobins = false
+default-run = "openloomi"
 
 [lib]
 name = "openloomi_lib"

--- a/apps/web/src-tauri/src/cli.rs
+++ b/apps/web/src-tauri/src/cli.rs
@@ -5,11 +5,18 @@
 
 //! Non-interactive command-line entry point.
 
-use std::io::Read;
-use std::path::Path;
-use std::process::Command;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::time::Duration;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 // Conservative fallback used when update metadata does not include a file size.
 const DEFAULT_UPDATE_SPACE_BYTES: u64 = 512 * 1024 * 1024;
@@ -17,10 +24,16 @@ const DEFAULT_UPDATE_SPACE_BYTES: u64 = 512 * 1024 * 1024;
 const DEFAULT_ONE_SHOT_PLATFORM: &str = "cli";
 // One-shot agent runs can legitimately take minutes when tools are involved.
 const ONE_SHOT_TIMEOUT_SECS: u64 = 600;
+// Cold-starting Next.js in development can include runtime bundling.
+const ONE_SHOT_SERVER_START_TIMEOUT_SECS: u64 = 300;
+const ONE_SHOT_SERVER_HEALTH_TIMEOUT_SECS: u64 = 2;
 // Test and CI callers can point the CLI at a non-default local API server.
 const OPENLOOMI_API_URL_ENV: &str = "OPENLOOMI_API_URL";
 // CI can provide auth without relying on the desktop token file.
 const OPENLOOMI_AUTH_TOKEN_ENV: &str = "OPENLOOMI_AUTH_TOKEN";
+// Development and tests can point the CLI at a checked-out web app directory.
+#[cfg(debug_assertions)]
+const OPENLOOMI_WEB_DIR_ENV: &str = "OPENLOOMI_WEB_DIR";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CliCommand {
@@ -143,6 +156,36 @@ struct OneShotStreamResult {
     cost: Option<f64>,
     duration_ms: Option<f64>,
     error: Option<String>,
+}
+
+// Owns a headless server process only when the CLI had to start one.
+// If an OpenLoomi server was already running, the guard is empty and drop is a
+// no-op, so a one-shot invocation never shuts down the user's app.
+#[derive(Default)]
+struct OneShotServerGuard {
+    child: Option<Child>,
+    log_path: Option<PathBuf>,
+}
+
+impl OneShotServerGuard {
+    fn started(child: Child, log_path: PathBuf) -> Self {
+        Self {
+            child: Some(child),
+            log_path: Some(log_path),
+        }
+    }
+
+    fn log_path(&self) -> Option<&Path> {
+        self.log_path.as_deref()
+    }
+}
+
+impl Drop for OneShotServerGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            terminate_child_process(&mut child);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -466,9 +509,11 @@ async fn execute_one_shot(
     platform: &str,
     auth_token: &str,
 ) -> Result<OneShotStreamResult, CliError> {
-    // The CLI reuses the already-running local Next.js API instead of starting
-    // its own agent runtime. Later work can decide whether to auto-start it.
     let base_url = one_shot_base_url();
+    // One-shot mode should work without opening the desktop UI. Reuse an
+    // already-running local backend when present; otherwise start a headless one
+    // for the lifetime of this command.
+    let _server_guard = ensure_one_shot_server(&base_url).await?;
     let endpoint = format!("{}/api/native/agent", base_url.trim_end_matches('/'));
     // Use the caller's current directory as the agent workspace so commands
     // launched from CI or scripts operate in the expected project folder.
@@ -547,6 +592,832 @@ fn one_shot_base_url() -> String {
         .map(|url| url.trim().trim_end_matches('/').to_string())
         .filter(|url| !url.is_empty())
         .unwrap_or_else(crate::constants::nextjs_url)
+}
+
+async fn ensure_one_shot_server(base_url: &str) -> Result<OneShotServerGuard, CliError> {
+    if is_one_shot_server_ready(base_url).await {
+        return Ok(OneShotServerGuard::default());
+    }
+
+    if !should_auto_start_server(base_url) {
+        return Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "OpenLoomi agent API is not reachable at {} and auto-start is only supported for local OpenLoomi URLs.",
+                base_url
+            ),
+        ));
+    }
+
+    let mut guard = start_one_shot_server()?;
+    wait_for_one_shot_server(base_url, &mut guard).await?;
+    Ok(guard)
+}
+
+async fn is_one_shot_server_ready(base_url: &str) -> bool {
+    let health_url = format!("{}/api/native/agent", base_url.trim_end_matches('/'));
+    let client = match reqwest::Client::builder()
+        .user_agent("openloomi-cli")
+        .timeout(Duration::from_secs(ONE_SHOT_SERVER_HEALTH_TIMEOUT_SECS))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+
+    match client.get(&health_url).send().await {
+        Ok(response) => matches!(response.status().as_u16(), 200 | 401 | 403 | 405),
+        Err(_) => false,
+    }
+}
+
+fn should_auto_start_server(base_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(base_url) else {
+        return false;
+    };
+    if url.scheme() != "http" {
+        return false;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+        && url.port_or_known_default() == Some(crate::constants::NEXTJS_PORT)
+}
+
+async fn wait_for_one_shot_server(
+    base_url: &str,
+    guard: &mut OneShotServerGuard,
+) -> Result<(), CliError> {
+    let started_at = Instant::now();
+    while started_at.elapsed() < Duration::from_secs(ONE_SHOT_SERVER_START_TIMEOUT_SECS) {
+        if let Some(child) = guard.child.as_mut() {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Err(CliError::new(
+                        "service_unavailable",
+                        format!(
+                            "headless OpenLoomi server exited during startup with status {}. See log: {}",
+                            status,
+                            display_log_path(guard.log_path())
+                        ),
+                    ));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(CliError::new(
+                        "service_unavailable",
+                        format!(
+                            "failed to monitor headless OpenLoomi server during startup: {}. See log: {}",
+                            error,
+                            display_log_path(guard.log_path())
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if is_one_shot_server_ready(base_url).await {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    Err(CliError::new(
+        "service_unavailable",
+        format!(
+            "timed out after {} seconds waiting for headless OpenLoomi server at {}. See log: {}",
+            ONE_SHOT_SERVER_START_TIMEOUT_SECS,
+            base_url,
+            display_log_path(guard.log_path())
+        ),
+    ))
+}
+
+fn start_one_shot_server() -> Result<OneShotServerGuard, CliError> {
+    let log_path = prepare_one_shot_server_log()?;
+
+    #[cfg(debug_assertions)]
+    let child = spawn_dev_one_shot_server(&log_path)?;
+
+    #[cfg(not(debug_assertions))]
+    let child = spawn_packaged_one_shot_server(&log_path)?;
+
+    Ok(OneShotServerGuard::started(child, log_path))
+}
+
+fn prepare_one_shot_server_log() -> Result<PathBuf, CliError> {
+    let log_dir = crate::storage::get_data_dir().join("logs");
+    std::fs::create_dir_all(&log_dir).map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!("failed to create CLI server log directory: {}", error),
+        )
+    })?;
+
+    let log_path = log_dir.join("cli-headless-server.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!("failed to open CLI server log: {}", error),
+            )
+        })?;
+    let _ = writeln!(
+        file,
+        "\n=== alloomi one-shot headless server start: {:?} ===",
+        std::time::SystemTime::now()
+    );
+    Ok(log_path)
+}
+
+fn open_log_stdio(log_path: &Path) -> Result<(File, File), CliError> {
+    let stdout = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!("failed to open CLI server stdout log: {}", error),
+            )
+        })?;
+    let stderr = stdout.try_clone().map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!("failed to clone CLI server log handle: {}", error),
+        )
+    })?;
+    Ok((stdout, stderr))
+}
+
+fn display_log_path(path: Option<&Path>) -> String {
+    path.map(|path| path.display().to_string())
+        .unwrap_or_else(|| "(log unavailable)".to_string())
+}
+
+#[cfg(debug_assertions)]
+fn spawn_dev_one_shot_server(log_path: &Path) -> Result<Child, CliError> {
+    let web_dir = find_web_dir()?;
+    let script = web_dir.join("scripts").join("run-tauri-dev.js");
+    if !script.exists() {
+        return Err(CliError::new(
+            "service_unavailable",
+            format!("dev server script not found at {}", script.display()),
+        ));
+    }
+
+    let (stdout, stderr) = open_log_stdio(log_path)?;
+    let base_url = crate::constants::nextjs_url();
+    let mut command = Command::new("node");
+    command
+        .arg(&script)
+        .current_dir(&web_dir)
+        .env("IS_TAURI", "true")
+        .env("TAURI_MODE", "1")
+        .env("DEPLOYMENT_MODE", "tauri")
+        .env("PORT", crate::constants::NEXTJS_PORT.to_string())
+        .env(
+            "TAURI_SERVER_PORT",
+            crate::constants::NEXTJS_PORT.to_string(),
+        )
+        .env("NEXTAUTH_URL", &base_url)
+        .env("NEXT_PUBLIC_APP_URL", &base_url)
+        .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    command.spawn().map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!(
+                "failed to start development OpenLoomi server with {}: {}. Set {} to the apps/web directory if the repo cannot be found. See log: {}",
+                script.display(),
+                error,
+                OPENLOOMI_WEB_DIR_ENV,
+                log_path.display()
+            ),
+        )
+    })
+}
+
+#[cfg(debug_assertions)]
+fn find_web_dir() -> Result<PathBuf, CliError> {
+    if let Ok(path) = std::env::var(OPENLOOMI_WEB_DIR_ENV) {
+        let path = PathBuf::from(path.trim());
+        if path.join("package.json").exists() && path.join("scripts").exists() {
+            return Ok(path);
+        }
+        return Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "{} does not point to a valid apps/web directory: {}",
+                OPENLOOMI_WEB_DIR_ENV,
+                path.display()
+            ),
+        ));
+    }
+
+    let mut roots = Vec::new();
+    if let Ok(current_dir) = std::env::current_dir() {
+        roots.push(current_dir);
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            roots.push(parent.to_path_buf());
+        }
+    }
+
+    for root in roots {
+        for ancestor in root.ancestors() {
+            let monorepo_web = ancestor.join("apps").join("web");
+            if monorepo_web.join("package.json").exists() && monorepo_web.join("scripts").exists() {
+                return Ok(monorepo_web);
+            }
+
+            if ancestor.join("package.json").exists()
+                && ancestor.join("src-tauri").exists()
+                && ancestor.join("scripts").exists()
+            {
+                return Ok(ancestor.to_path_buf());
+            }
+        }
+    }
+
+    Err(CliError::new(
+        "service_unavailable",
+        format!(
+            "could not locate apps/web for development headless startup. Set {} to the apps/web directory.",
+            OPENLOOMI_WEB_DIR_ENV
+        ),
+    ))
+}
+
+#[cfg(not(debug_assertions))]
+fn spawn_packaged_one_shot_server(log_path: &Path) -> Result<Child, CliError> {
+    let resource_dir = packaged_resource_dir();
+    let standalone_dir = [
+        resource_dir.join("_up_").join(".next").join("standalone"),
+        resource_dir.join(".next").join("standalone"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+    .ok_or_else(|| {
+        CliError::new(
+            "service_unavailable",
+            format!(
+                "packaged Next.js standalone directory not found near {}. See log: {}",
+                resource_dir.display(),
+                log_path.display()
+            ),
+        )
+    })?;
+
+    let server_script = standalone_dir.join("apps").join("web").join("server.js");
+    if !server_script.exists() {
+        return Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "packaged Next.js server not found at {}. See log: {}",
+                server_script.display(),
+                log_path.display()
+            ),
+        ));
+    }
+
+    let env_home = env_home_dir();
+    let node_cmd = find_or_install_node_quiet(&env_home, log_path)?;
+    run_packaged_db_init(&node_cmd, &standalone_dir, log_path);
+
+    let boot_script = standalone_dir
+        .join("apps")
+        .join("web")
+        .join("scripts")
+        .join("boot-with-secrets.js");
+    let use_boot_script = boot_script.exists();
+    let mut args = Vec::new();
+    if use_boot_script {
+        args.push(boot_script);
+        args.push(server_script);
+    } else {
+        args.push(server_script);
+    }
+
+    let (stdout, stderr) = open_log_stdio(log_path)?;
+    let base_url = crate::constants::nextjs_url();
+    let data_dir = crate::storage::get_data_dir();
+    let db_path = data_dir.join("data.db");
+    let code_tmpdir = PathBuf::from(&env_home)
+        .join(".cache")
+        .join("openloomi-tmp");
+    let effective_path = effective_path_with_node(&node_cmd);
+    let mut command = Command::new(&node_cmd);
+    command
+        .args(args)
+        .current_dir(&standalone_dir)
+        .env("PATH", effective_path)
+        .env("HOME", &env_home)
+        .env("USER", std::env::var("USER").unwrap_or_default())
+        .env("SHELL", std::env::var("SHELL").unwrap_or_default())
+        .env("NODE_ENV", "production")
+        .env("WORKERS", "1")
+        .env("PORT", crate::constants::NEXTJS_PORT.to_string())
+        .env("IS_TAURI", "true")
+        .env("TAURI_MODE", "1")
+        .env("DEPLOYMENT_MODE", "tauri")
+        .env("TAURI_DB_PATH", db_path.to_string_lossy().to_string())
+        .env("NEXTAUTH_URL", &base_url)
+        .env("NEXT_PUBLIC_APP_URL", &base_url)
+        .env("API_TIMEOUT_MS", "3000000")
+        .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+        .env(
+            "CLAUDE_CODE_TMPDIR",
+            code_tmpdir.to_string_lossy().to_string(),
+        )
+        .env("CLAUDE_DISABLE_URL_SAFETY_CHECK", "true")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let mut child = command.spawn().map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!(
+                "failed to start packaged OpenLoomi server with {}: {}. See log: {}",
+                node_cmd,
+                error,
+                log_path.display()
+            ),
+        )
+    })?;
+
+    if use_boot_script {
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(b"{}");
+        }
+    }
+
+    Ok(child)
+}
+
+#[cfg(not(debug_assertions))]
+fn effective_path_with_node(node_cmd: &str) -> String {
+    let current_path = std::env::var("PATH").unwrap_or_default();
+    let Some(parent) = Path::new(node_cmd).parent() else {
+        return current_path;
+    };
+    let parent = parent.to_string_lossy();
+    if parent.is_empty() {
+        return current_path;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        format!("{};{}", parent, current_path)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        format!("{}:{}", parent, current_path)
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn packaged_resource_dir() -> PathBuf {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    if exe_dir.ends_with("MacOS") {
+        exe_dir
+            .parent()
+            .map(|path| path.join("Resources"))
+            .unwrap_or(exe_dir)
+    } else {
+        exe_dir
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn run_packaged_db_init(node_cmd: &str, standalone_dir: &Path, log_path: &Path) {
+    let init_db_script = standalone_dir
+        .join("apps")
+        .join("web")
+        .join("scripts")
+        .join("init-db.cjs");
+    if !init_db_script.exists() {
+        return;
+    }
+
+    let Ok((stdout, stderr)) = open_log_stdio(log_path) else {
+        return;
+    };
+    let data_dir = crate::storage::get_data_dir();
+    let db_path = data_dir.join("data.db");
+    let migrations_dir = standalone_dir
+        .join("apps")
+        .join("web")
+        .join("lib")
+        .join("db")
+        .join("migrations-sqlite");
+
+    let mut command = Command::new(node_cmd);
+    command
+        .arg(init_db_script)
+        .current_dir(standalone_dir.join("apps").join("web"))
+        .env("TAURI_DB_PATH", db_path.to_string_lossy().to_string())
+        .env(
+            "TAURI_MIGRATIONS_DIR",
+            migrations_dir.to_string_lossy().to_string(),
+        )
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let _ = command.status();
+}
+
+#[cfg(not(debug_assertions))]
+fn env_home_dir() -> String {
+    #[cfg(windows)]
+    {
+        std::env::var("USERPROFILE")
+            .or_else(|_| std::env::var("APPDATA"))
+            .unwrap_or_default()
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::var("HOME").unwrap_or_default()
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn find_or_install_node_quiet(env_home: &str, log_path: &Path) -> Result<String, CliError> {
+    for candidate in node_candidates(env_home) {
+        if is_cli_node_version_valid(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    install_node_quiet(env_home, log_path)?;
+    let installed = downloaded_node_path(env_home);
+    if is_cli_node_version_valid(&installed) {
+        return Ok(installed);
+    }
+
+    Err(CliError::new(
+        "service_unavailable",
+        format!(
+            "Node.js v22 is required for packaged one-shot mode but was not found or installed. See log: {}",
+            log_path.display()
+        ),
+    ))
+}
+
+#[cfg(not(debug_assertions))]
+fn node_candidates(env_home: &str) -> Vec<String> {
+    let mut candidates = vec![downloaded_node_path(env_home), "node".to_string()];
+
+    #[cfg(target_os = "windows")]
+    {
+        candidates.extend([
+            format!(r"{}\AppData\Roaming\nvm\v22.17.0\node.exe", env_home),
+            r"C:\Program Files\nodejs\node.exe".to_string(),
+            r"C:\Program Files (x86)\nodejs\node.exe".to_string(),
+        ]);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        candidates.extend([
+            "/usr/local/bin/node".to_string(),
+            "/opt/homebrew/bin/node".to_string(),
+            format!("{}/.nvm/versions/node/v22.17.0/bin/node", env_home),
+            format!(
+                "{}/.local/share/fnm/node-versions/v22.17.0/installation/bin/node",
+                env_home
+            ),
+        ]);
+    }
+
+    candidates
+}
+
+#[cfg(not(debug_assertions))]
+fn downloaded_node_path(env_home: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        PathBuf::from(env_home)
+            .join(".openloomi")
+            .join("node")
+            .join("node.exe")
+            .to_string_lossy()
+            .to_string()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        PathBuf::from(env_home)
+            .join(".openloomi")
+            .join("node")
+            .join("bin")
+            .join("node")
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn is_cli_node_version_valid(node_path: &str) -> bool {
+    let output = Command::new(node_path).arg("--version").output();
+    let Ok(output) = output else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let version = String::from_utf8_lossy(&output.stdout);
+    let Some(version) = version.trim().strip_prefix('v') else {
+        return false;
+    };
+    let Some(major) = version.split('.').next() else {
+        return false;
+    };
+    major == "22"
+}
+
+#[cfg(not(debug_assertions))]
+fn install_node_quiet(env_home: &str, log_path: &Path) -> Result<(), CliError> {
+    let install_dir = PathBuf::from(env_home).join(".openloomi").join("node");
+    let node_exe = PathBuf::from(downloaded_node_path(env_home));
+    if node_exe.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(&install_dir).map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!("failed to create Node.js install directory: {}", error),
+        )
+    })?;
+
+    let (url, archive_name) = node_download_spec();
+    append_log_line(log_path, &format!("Downloading Node.js from {}", url));
+    let archive_path = std::env::temp_dir().join(archive_name);
+    let mut response = reqwest::blocking::Client::new()
+        .get(url)
+        .send()
+        .map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!(
+                    "failed to download Node.js for headless one-shot mode: {}. See log: {}",
+                    error,
+                    log_path.display()
+                ),
+            )
+        })?;
+    if !response.status().is_success() {
+        return Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "failed to download Node.js: HTTP {}. See log: {}",
+                response.status(),
+                log_path.display()
+            ),
+        ));
+    }
+
+    let mut file = File::create(&archive_path).map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!("failed to create Node.js archive file: {}", error),
+        )
+    })?;
+    std::io::copy(&mut response, &mut file).map_err(|error| {
+        CliError::new(
+            "service_unavailable",
+            format!("failed to write Node.js archive file: {}", error),
+        )
+    })?;
+
+    let result = extract_node_archive_quiet(&archive_path, &install_dir, log_path);
+    let _ = std::fs::remove_file(&archive_path);
+    result
+}
+
+#[cfg(all(not(debug_assertions), target_os = "windows"))]
+fn node_download_spec() -> (&'static str, &'static str) {
+    (
+        "https://nodejs.org/dist/v22.17.0/node-v22.17.0-win-x64.zip",
+        "node-v22.17.0-win-x64.zip",
+    )
+}
+
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
+fn node_download_spec() -> (&'static str, &'static str) {
+    (
+        "https://nodejs.org/dist/v22.17.0/node-v22.17.0-darwin-arm64.tar.gz",
+        "node-v22.17.0-darwin-arm64.tar.gz",
+    )
+}
+
+#[cfg(all(
+    not(debug_assertions),
+    target_os = "macos",
+    not(target_arch = "aarch64")
+))]
+fn node_download_spec() -> (&'static str, &'static str) {
+    (
+        "https://nodejs.org/dist/v22.17.0/node-v22.17.0-darwin-x64.tar.gz",
+        "node-v22.17.0-darwin-x64.tar.gz",
+    )
+}
+
+#[cfg(all(not(debug_assertions), target_os = "linux", target_arch = "aarch64"))]
+fn node_download_spec() -> (&'static str, &'static str) {
+    (
+        "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-arm64.tar.gz",
+        "node-v22.17.0-linux-arm64.tar.gz",
+    )
+}
+
+#[cfg(all(
+    not(debug_assertions),
+    target_os = "linux",
+    not(target_arch = "aarch64")
+))]
+fn node_download_spec() -> (&'static str, &'static str) {
+    (
+        "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-x64.tar.gz",
+        "node-v22.17.0-linux-x64.tar.gz",
+    )
+}
+
+#[cfg(all(not(debug_assertions), target_os = "windows"))]
+fn extract_node_archive_quiet(
+    archive_path: &Path,
+    install_dir: &Path,
+    log_path: &Path,
+) -> Result<(), CliError> {
+    let output = Command::new("powershell")
+        .args([
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &format!(
+                "Expand-Archive -Path '{}' -DestinationPath '{}' -Force",
+                archive_path.to_string_lossy(),
+                install_dir.to_string_lossy()
+            ),
+        ])
+        .output()
+        .map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!("failed to run PowerShell for Node.js extraction: {}", error),
+            )
+        })?;
+
+    if !output.status.success() {
+        append_log_line(
+            log_path,
+            &String::from_utf8_lossy(&output.stderr).to_string(),
+        );
+        return Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "failed to extract Node.js archive. See log: {}",
+                log_path.display()
+            ),
+        ));
+    }
+
+    let extracted_node = install_dir.join("node-v22.17.0-win-x64").join("node.exe");
+    let final_node = install_dir.join("node.exe");
+    if extracted_node.exists() && !final_node.exists() {
+        std::fs::copy(&extracted_node, &final_node).map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!("failed to install Node.js binary: {}", error),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(all(not(debug_assertions), not(target_os = "windows")))]
+fn extract_node_archive_quiet(
+    archive_path: &Path,
+    install_dir: &Path,
+    log_path: &Path,
+) -> Result<(), CliError> {
+    let Ok((stdout, stderr)) = open_log_stdio(log_path) else {
+        return Err(CliError::new(
+            "service_unavailable",
+            "failed to open log for Node.js extraction",
+        ));
+    };
+    let status = Command::new("tar")
+        .args([
+            "-xzf",
+            archive_path.to_string_lossy().as_ref(),
+            "-C",
+            install_dir.to_string_lossy().as_ref(),
+            "--strip-components=1",
+        ])
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .status()
+        .map_err(|error| {
+            CliError::new(
+                "service_unavailable",
+                format!("failed to run tar for Node.js extraction: {}", error),
+            )
+        })?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CliError::new(
+            "service_unavailable",
+            format!(
+                "failed to extract Node.js archive with tar. See log: {}",
+                log_path.display()
+            ),
+        ))
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn append_log_line(log_path: &Path, line: &str) {
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) {
+        let _ = writeln!(file, "{}", line);
+    }
+}
+
+fn terminate_child_process(child: &mut Child) {
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &child.id().to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(CREATE_NO_WINDOW)
+            .status();
+    }
+
+    #[cfg(unix)]
+    {
+        let pid = child.id().to_string();
+        let _ = Command::new("kill")
+            .args(["-15", &format!("-{}", pid)])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let _ = Command::new("kill")
+            .args(["-15", &pid])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        std::thread::sleep(Duration::from_millis(500));
+        let _ = Command::new("kill")
+            .args(["-9", &format!("-{}", pid)])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let _ = Command::new("kill")
+            .args(["-9", &pid])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn map_one_shot_request_error(error: reqwest::Error, endpoint: &str) -> CliError {
@@ -907,13 +1778,11 @@ async fn check_network_connectivity() -> PreflightCheck {
     // R2 is the primary latest.json source used by the updater.
     let r2_url = "https://pub-7f8ad94cb1444cbebae6bfd55ec52f5d.r2.dev/latest.json";
     match client.get(r2_url).send().await {
-        Ok(response) if response.status().is_success() => {
-            return PreflightCheck {
-                name: "network",
-                ok: true,
-                detail: "R2 latest.json reachable".to_string(),
-            };
-        }
+        Ok(response) if response.status().is_success() => PreflightCheck {
+            name: "network",
+            ok: true,
+            detail: "R2 latest.json reachable".to_string(),
+        },
         Ok(response) => {
             let r2_error = format!("R2 returned HTTP {}", response.status());
             check_github_network_fallback(&client, r2_error).await

--- a/apps/web/src-tauri/src/cli.rs
+++ b/apps/web/src-tauri/src/cli.rs
@@ -3,14 +3,24 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file in the root of this source tree.
 
-//! Non-interactive command-line entry point scaffolding.
+//! Non-interactive command-line entry point.
 
 use std::io::Read;
 use std::path::Path;
 use std::process::Command;
 use std::process::ExitCode;
+use std::time::Duration;
 
+// Conservative fallback used when update metadata does not include a file size.
 const DEFAULT_UPDATE_SPACE_BYTES: u64 = 512 * 1024 * 1024;
+// Downstream business tools can inspect session.platform to distinguish CLI runs.
+const DEFAULT_ONE_SHOT_PLATFORM: &str = "cli";
+// One-shot agent runs can legitimately take minutes when tools are involved.
+const ONE_SHOT_TIMEOUT_SECS: u64 = 600;
+// Test and CI callers can point the CLI at a non-default local API server.
+const OPENLOOMI_API_URL_ENV: &str = "OPENLOOMI_API_URL";
+// CI can provide auth without relying on the desktop token file.
+const OPENLOOMI_AUTH_TOKEN_ENV: &str = "OPENLOOMI_AUTH_TOKEN";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CliCommand {
@@ -20,6 +30,8 @@ enum CliCommand {
     OneShot(OneShotArgs),
 }
 
+// Parsed one-shot inputs stay separate from execution so the parser can be
+// unit-tested without making network calls.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OneShotArgs {
     prompt: Option<String>,
@@ -31,31 +43,34 @@ struct OneShotArgs {
 }
 
 #[derive(Debug, serde::Serialize)]
-struct JsonError<'a> {
-    ok: bool,
-    command: &'a str,
-    error: CliErrorBody,
-}
-
-#[derive(Debug, serde::Serialize)]
 struct CliErrorBody {
     code: String,
     message: String,
 }
 
+// Shape consumed by scripts and CI. Keep fields explicit and nullable instead
+// of omitting them so downstream JSON parsers can stay simple.
 #[derive(Debug, serde::Serialize)]
 struct OneShotJsonOutput {
     ok: bool,
     command: &'static str,
-    implemented: bool,
     prompt_length: usize,
     stdin: bool,
     model: Option<String>,
     provider: Option<String>,
-    platform: Option<String>,
-    error: CliErrorBody,
+    platform: String,
+    response: Option<String>,
+    session_id: Option<String>,
+    event_count: usize,
+    text_event_count: usize,
+    tool_calls: Vec<String>,
+    permission_requests: usize,
+    cost: Option<f64>,
+    duration_ms: Option<f64>,
+    error: Option<CliErrorBody>,
 }
 
+// Structured form of all update --check output, including preflight probes.
 #[derive(Debug, serde::Serialize)]
 struct UpdateCheckJsonOutput {
     ok: bool,
@@ -70,11 +85,64 @@ struct UpdateCheckJsonOutput {
     error: Option<CliErrorBody>,
 }
 
+// A single preflight probe; detail is human-readable but still stable enough
+// to surface in JSON logs.
 #[derive(Debug, serde::Serialize)]
 struct PreflightCheck {
     name: &'static str,
     ok: bool,
     detail: String,
+}
+
+/// Payload expected by /api/native/agent. The serde renames keep this Rust
+/// struct aligned with the existing Next.js route contract.
+#[derive(Debug, serde::Serialize)]
+struct OneShotAgentRequest<'a> {
+    prompt: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<&'a str>,
+    platform: &'a str,
+    #[serde(rename = "workDir", skip_serializing_if = "Option::is_none")]
+    work_dir: Option<String>,
+    #[serde(rename = "modelConfig", skip_serializing_if = "Option::is_none")]
+    model_config: Option<OneShotModelConfig<'a>>,
+    #[serde(rename = "permissionMode")]
+    permission_mode: &'static str,
+    #[serde(rename = "skillsConfig")]
+    skills_config: OneShotFeatureConfig,
+    #[serde(rename = "mcpConfig")]
+    mcp_config: OneShotFeatureConfig,
+    #[serde(rename = "authToken", skip_serializing_if = "Option::is_none")]
+    auth_token: Option<&'a str>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct OneShotModelConfig<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct OneShotFeatureConfig {
+    enabled: bool,
+    #[serde(rename = "userDirEnabled")]
+    user_dir_enabled: bool,
+    #[serde(rename = "appDirEnabled")]
+    app_dir_enabled: bool,
+}
+
+// Accumulated result from the agent SSE stream.
+#[derive(Debug, Default)]
+struct OneShotStreamResult {
+    response: String,
+    session_id: Option<String>,
+    event_count: usize,
+    text_event_count: usize,
+    tool_calls: Vec<String>,
+    permission_requests: usize,
+    cost: Option<f64>,
+    duration_ms: Option<f64>,
+    error: Option<String>,
 }
 
 #[derive(Debug)]
@@ -102,6 +170,8 @@ where
     I: IntoIterator<Item = String>,
 {
     let args: Vec<String> = args.into_iter().collect();
+    // Keep parsing and execution separated so usage errors never partially run
+    // a command.
     match parse_args(&args) {
         Ok(CliCommand::Help) => {
             print_help();
@@ -112,7 +182,7 @@ where
             ExitCode::SUCCESS
         }
         Ok(CliCommand::UpdateCheck { json }) => run_update_check(json).await,
-        Ok(CliCommand::OneShot(options)) => run_one_shot_stub(options),
+        Ok(CliCommand::OneShot(options)) => run_one_shot(options).await,
         Err(error) => {
             eprintln!("error: {}", error.message);
             eprintln!();
@@ -128,6 +198,8 @@ fn parse_args(raw_args: &[String]) -> Result<CliCommand, CliError> {
         return Ok(CliCommand::Help);
     }
 
+    // --json is intentionally command-agnostic: it can be placed before or
+    // after subcommands/options and still affects the final output format.
     let json = args.iter().any(|arg| arg == "--json");
     let args: Vec<String> = args
         .iter()
@@ -206,6 +278,8 @@ fn parse_one_shot_args(args: &[String], json: bool) -> Result<OneShotArgs, CliEr
                     format!("unknown one-shot option: {}", arg),
                 ));
             }
+            // Multiple bare words are joined back into a single prompt so both
+            // quoted and unquoted shell usage behave naturally.
             _ => prompt_parts.push(arg.clone()),
         }
         index += 1;
@@ -244,60 +318,384 @@ fn require_inline_value(arg: &str, prefix: &'static str) -> Result<String, CliEr
     Ok(value.to_string())
 }
 
-fn run_one_shot_stub(options: OneShotArgs) -> ExitCode {
+async fn run_one_shot(options: OneShotArgs) -> ExitCode {
+    let platform = one_shot_platform(&options);
+
+    // Resolve local input and auth before touching the agent API. This keeps
+    // usage/auth failures fast and gives scripts stable exit codes.
     let prompt = match resolve_one_shot_prompt(&options) {
         Ok(prompt) => prompt,
         Err(error) => {
-            if options.json {
-                print_json(&JsonError {
-                    ok: false,
-                    command: "one-shot",
-                    error: CliErrorBody {
-                        code: error.code.to_string(),
-                        message: error.message,
-                    },
-                });
-            } else {
-                eprintln!("error: {}", error.message);
-            }
-            return ExitCode::from(2);
+            return print_one_shot_error(&options, 0, platform, error, 2);
+        }
+    };
+    let prompt_length = prompt.trim().len();
+
+    let auth_token = match load_cli_auth_token() {
+        Ok(token) => token,
+        Err(error) => {
+            return print_one_shot_error(&options, prompt_length, platform, error, 1);
         }
     };
 
-    let error = CliErrorBody {
-        code: "not_implemented".to_string(),
-        message: "one-shot parsing is wired, but agent execution is not implemented yet."
-            .to_string(),
-    };
+    match execute_one_shot(&prompt, &options, &platform, &auth_token).await {
+        Ok(result) => {
+            let ok = result.error.is_none();
+            if options.json {
+                // In JSON mode, all diagnostics belong inside the payload so
+                // stdout remains machine-readable for pipeline consumers.
+                print_json(&OneShotJsonOutput {
+                    ok,
+                    command: "one-shot",
+                    prompt_length,
+                    stdin: options.read_stdin,
+                    model: options.model.clone(),
+                    provider: options.provider.clone(),
+                    platform,
+                    response: Some(result.response.clone()),
+                    session_id: result.session_id,
+                    event_count: result.event_count,
+                    text_event_count: result.text_event_count,
+                    tool_calls: result.tool_calls,
+                    permission_requests: result.permission_requests,
+                    cost: result.cost,
+                    duration_ms: result.duration_ms,
+                    error: result.error.map(|message| CliErrorBody {
+                        code: "agent_error".to_string(),
+                        message,
+                    }),
+                });
+            } else {
+                // Human mode prints only the assistant text to stdout; errors
+                // stay on stderr so shell redirection remains useful.
+                if !result.response.is_empty() {
+                    println!("{}", result.response);
+                }
+                if let Some(error) = result.error {
+                    eprintln!("agent error: {}", error);
+                }
+            }
 
+            if ok {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => print_one_shot_error(&options, prompt_length, platform, error, 1),
+    }
+}
+
+fn print_one_shot_error(
+    options: &OneShotArgs,
+    prompt_length: usize,
+    platform: String,
+    error: CliError,
+    exit_code: u8,
+) -> ExitCode {
     if options.json {
+        // Error payload mirrors the success schema to keep scripted callers
+        // from needing separate parsers for failure cases.
         print_json(&OneShotJsonOutput {
             ok: false,
             command: "one-shot",
-            implemented: false,
-            prompt_length: prompt.trim().len(),
+            prompt_length,
             stdin: options.read_stdin,
-            model: options.model,
-            provider: options.provider,
-            platform: options.platform,
-            error,
+            model: options.model.clone(),
+            provider: options.provider.clone(),
+            platform,
+            response: None,
+            session_id: None,
+            event_count: 0,
+            text_event_count: 0,
+            tool_calls: Vec::new(),
+            permission_requests: 0,
+            cost: None,
+            duration_ms: None,
+            error: Some(CliErrorBody {
+                code: error.code.to_string(),
+                message: error.message,
+            }),
         });
     } else {
-        println!("one-shot mode recognized");
-        println!("prompt length: {}", prompt.trim().len());
-        if let Some(model) = options.model {
-            println!("model: {}", model);
+        eprintln!("error: {}", error.message);
+    }
+    ExitCode::from(exit_code)
+}
+
+fn one_shot_platform(options: &OneShotArgs) -> String {
+    // Default to "cli" even when callers omit --platform, but still allow
+    // tests and future automation surfaces to override it.
+    options
+        .platform
+        .as_deref()
+        .filter(|platform| !platform.trim().is_empty())
+        .unwrap_or(DEFAULT_ONE_SHOT_PLATFORM)
+        .to_string()
+}
+
+fn load_cli_auth_token() -> Result<String, CliError> {
+    // Env override is useful for CI and scripted runs; otherwise reuse the
+    // token saved by the desktop login flow.
+    if let Ok(token) = std::env::var(OPENLOOMI_AUTH_TOKEN_ENV) {
+        let token = token.trim().to_string();
+        if !token.is_empty() {
+            return Ok(token);
         }
-        if let Some(provider) = options.provider {
-            println!("provider: {}", provider);
-        }
-        if let Some(platform) = options.platform {
-            println!("platform: {}", platform);
-        }
-        eprintln!("one-shot agent execution is not implemented yet.");
     }
 
-    ExitCode::from(2)
+    match crate::storage::load_token() {
+        Ok(Some(token)) if !token.trim().is_empty() => Ok(token),
+        Ok(_) => Err(CliError::new(
+            "not_authenticated",
+            format!(
+                "no saved auth token found. Log in to OpenLoomi first, or set {}.",
+                OPENLOOMI_AUTH_TOKEN_ENV
+            ),
+        )),
+        Err(error) => Err(CliError::new(
+            "token",
+            format!("failed to load saved auth token: {}", error),
+        )),
+    }
+}
+
+async fn execute_one_shot(
+    prompt: &str,
+    options: &OneShotArgs,
+    platform: &str,
+    auth_token: &str,
+) -> Result<OneShotStreamResult, CliError> {
+    // The CLI reuses the already-running local Next.js API instead of starting
+    // its own agent runtime. Later work can decide whether to auto-start it.
+    let base_url = one_shot_base_url();
+    let endpoint = format!("{}/api/native/agent", base_url.trim_end_matches('/'));
+    // Use the caller's current directory as the agent workspace so commands
+    // launched from CI or scripts operate in the expected project folder.
+    let work_dir = std::env::current_dir()
+        .ok()
+        .map(|path| path.display().to_string());
+    let request_body = OneShotAgentRequest {
+        prompt,
+        provider: options.provider.as_deref(),
+        platform,
+        work_dir,
+        model_config: options
+            .model
+            .as_deref()
+            .map(|model| OneShotModelConfig { model: Some(model) }),
+        // Non-interactive mode cannot answer permission prompts, so deny
+        // unsafe tool calls instead of waiting on the TUI.
+        permission_mode: "dontAsk",
+        skills_config: OneShotFeatureConfig {
+            enabled: true,
+            user_dir_enabled: true,
+            app_dir_enabled: false,
+        },
+        mcp_config: OneShotFeatureConfig {
+            // Match the existing frontend direct-execution default for now:
+            // skills are available, external MCP servers are not auto-loaded.
+            enabled: false,
+            user_dir_enabled: false,
+            app_dir_enabled: false,
+        },
+        auth_token: Some(auth_token),
+    };
+
+    let client = reqwest::Client::builder()
+        .user_agent("openloomi-cli")
+        .timeout(Duration::from_secs(ONE_SHOT_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| {
+            CliError::new(
+                "http_client",
+                format!("failed to create HTTP client: {}", error),
+            )
+        })?;
+
+    let response = client
+        .post(&endpoint)
+        .header("Accept", "text/event-stream")
+        // Bearer auth gates /api/native/agent; authToken in the JSON body is
+        // kept for existing downstream services that read it from agent options.
+        .bearer_auth(auth_token)
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|error| map_one_shot_request_error(error, &endpoint))?;
+
+    let status = response.status();
+    let response_text = response.text().await.map_err(|error| {
+        CliError::new(
+            "agent_response",
+            format!("failed to read agent response: {}", error),
+        )
+    })?;
+
+    if !status.is_success() {
+        return Err(one_shot_http_error(status, &response_text));
+    }
+
+    parse_agent_sse(&response_text)
+}
+
+fn one_shot_base_url() -> String {
+    // Debug builds default to localhost:3515 and release builds to 3414 through
+    // constants::nextjs_url(); env override makes integration tests flexible.
+    std::env::var(OPENLOOMI_API_URL_ENV)
+        .ok()
+        .map(|url| url.trim().trim_end_matches('/').to_string())
+        .filter(|url| !url.is_empty())
+        .unwrap_or_else(crate::constants::nextjs_url)
+}
+
+fn map_one_shot_request_error(error: reqwest::Error, endpoint: &str) -> CliError {
+    if error.is_timeout() {
+        return CliError::new(
+            "timeout",
+            format!(
+                "agent request timed out after {} seconds: {}",
+                ONE_SHOT_TIMEOUT_SECS, endpoint
+            ),
+        );
+    }
+    if error.is_connect() {
+        return CliError::new(
+            "service_unavailable",
+            format!(
+                "could not connect to OpenLoomi agent API at {}. Start the OpenLoomi app or local web server first.",
+                endpoint
+            ),
+        );
+    }
+    CliError::new("network", format!("agent request failed: {}", error))
+}
+
+fn one_shot_http_error(status: reqwest::StatusCode, body: &str) -> CliError {
+    let detail = extract_error_message(body).unwrap_or_else(|| body.trim().to_string());
+    let message = if detail.is_empty() {
+        format!("agent API returned HTTP {}", status)
+    } else {
+        format!("agent API returned HTTP {}: {}", status, detail)
+    };
+
+    // Map HTTP status codes to stable CLI error codes for automation.
+    let code = match status.as_u16() {
+        401 | 403 => "not_authenticated",
+        404 => "service_unavailable",
+        408 | 504 => "timeout",
+        429 => "rate_limited",
+        _ if status.is_server_error() => "service_unavailable",
+        _ => "agent_http",
+    };
+
+    CliError::new(code, message)
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    if let Some(message) = value.get("message").and_then(serde_json::Value::as_str) {
+        return Some(message.to_string());
+    }
+    match value.get("error") {
+        Some(serde_json::Value::String(message)) => Some(message.clone()),
+        Some(serde_json::Value::Object(error)) => error
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn parse_agent_sse(raw: &str) -> Result<OneShotStreamResult, CliError> {
+    let mut result = OneShotStreamResult::default();
+
+    // /api/native/agent streams Server-Sent Events. For one-shot mode we
+    // collect the stream into one final response object before exiting.
+    for line in raw.lines() {
+        let Some(data) = parse_sse_data_line(line) else {
+            continue;
+        };
+        let data = data.trim();
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+
+        let event = serde_json::from_str::<serde_json::Value>(data).map_err(|error| {
+            CliError::new(
+                "agent_response",
+                format!("failed to parse agent SSE event: {}", error),
+            )
+        })?;
+        record_agent_event(&mut result, &event);
+    }
+
+    if result.event_count == 0 {
+        return Err(CliError::new(
+            "agent_response",
+            "agent API response did not contain any SSE data events.",
+        ));
+    }
+
+    Ok(result)
+}
+
+fn parse_sse_data_line(line: &str) -> Option<&str> {
+    // Ignore comments/heartbeats and only parse SSE data frames.
+    line.strip_prefix("data: ")
+        .or_else(|| line.strip_prefix("data:"))
+}
+
+fn record_agent_event(result: &mut OneShotStreamResult, event: &serde_json::Value) {
+    result.event_count += 1;
+
+    let event_type = event
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    match event_type {
+        // "text" events are streaming deltas; "direct_answer" is used by some
+        // planning paths. Both are user-visible assistant output.
+        "text" | "direct_answer" => {
+            if let Some(content) = event.get("content").and_then(serde_json::Value::as_str) {
+                result.response.push_str(content);
+                result.text_event_count += 1;
+            }
+        }
+        "session" => {
+            // Support both naming styles in case the server-side event shape
+            // changes while keeping backward compatibility.
+            result.session_id = event
+                .get("sessionId")
+                .or_else(|| event.get("session_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+        }
+        "tool_use" => {
+            // Tool names are useful in JSON output for auditing non-interactive
+            // runs without dumping full tool inputs.
+            if let Some(name) = event.get("name").and_then(serde_json::Value::as_str) {
+                result.tool_calls.push(name.to_string());
+            }
+        }
+        "permission_request" => {
+            result.permission_requests += 1;
+        }
+        "result" => {
+            result.cost = event.get("cost").and_then(serde_json::Value::as_f64);
+            result.duration_ms = event.get("duration").and_then(serde_json::Value::as_f64);
+        }
+        "error" => {
+            result.error = event
+                .get("message")
+                .or_else(|| event.get("content"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string)
+                .or_else(|| Some("agent returned an error event".to_string()));
+        }
+        _ => {}
+    }
 }
 
 fn resolve_one_shot_prompt(options: &OneShotArgs) -> Result<String, CliError> {
@@ -331,6 +729,8 @@ fn resolve_one_shot_prompt(options: &OneShotArgs) -> Result<String, CliError> {
 async fn run_update_check(json: bool) -> ExitCode {
     match crate::update::do_check_for_update().await {
         Ok(result) => {
+            // The shared updater tells us what is available; CLI preflight adds
+            // install-readiness checks without performing the update.
             let preflight = run_update_preflight(Some(&result)).await;
             let preflight_ok = preflight.iter().all(|check| check.ok);
 
@@ -373,6 +773,8 @@ async fn run_update_check(json: bool) -> ExitCode {
             }
         }
         Err(error) => {
+            // Even if metadata lookup fails, still run local probes so users can
+            // see whether filesystem/temp/disk prerequisites are healthy.
             let preflight = run_update_preflight(None).await;
 
             if json {
@@ -405,6 +807,8 @@ async fn run_update_preflight(
 ) -> Vec<PreflightCheck> {
     let mut checks = Vec::new();
 
+    // Verify the binary path first; update code needs to know what it is
+    // replacing or wrapping during installer handoff.
     checks.push(match std::env::current_exe() {
         Ok(path) if path.exists() => PreflightCheck {
             name: "current_exe",
@@ -424,6 +828,8 @@ async fn run_update_preflight(
     });
 
     let data_dir = crate::storage::get_data_dir();
+    // Data and backup directories are separate probes because backup support is
+    // opt-in but should fail early when the target is not writable.
     checks.push(check_directory_writable("data_dir_writable", &data_dir));
     checks.push(check_directory_writable(
         "backup_dir_writable",
@@ -433,8 +839,12 @@ async fn run_update_preflight(
     let temp_dir = std::env::temp_dir();
     checks.push(check_directory_writable("temp_dir_writable", &temp_dir));
 
+    // Network is checked independently from update metadata so --check can
+    // distinguish "cannot reach release source" from local machine problems.
     checks.push(check_network_connectivity().await);
 
+    // Prefer update metadata size, then fall back to HEAD content-length, then
+    // fall back to the conservative default in required_update_space_bytes.
     let mut download_size = update_result.and_then(|result| {
         if result.file_size > 0 {
             Some(result.file_size)
@@ -494,6 +904,7 @@ async fn check_network_connectivity() -> PreflightCheck {
         }
     };
 
+    // R2 is the primary latest.json source used by the updater.
     let r2_url = "https://pub-7f8ad94cb1444cbebae6bfd55ec52f5d.r2.dev/latest.json";
     match client.get(r2_url).send().await {
         Ok(response) if response.status().is_success() => {
@@ -515,6 +926,8 @@ async fn check_github_network_fallback(
     client: &reqwest::Client,
     r2_error: String,
 ) -> PreflightCheck {
+    // GitHub tags are a secondary signal; this keeps preflight useful during
+    // transient R2 outages.
     let mut request = client
         .get("https://api.github.com/repos/melandlabs/release/tags")
         .header("Accept", "application/vnd.github+json");
@@ -545,6 +958,8 @@ async fn check_github_network_fallback(
 
 fn check_platform_asset(result: &crate::update::UpdateCheckResult) -> PreflightCheck {
     let latest_tag = format!("v{}", result.latest_version);
+    // Reuse update.rs platform mapping so preflight validates the same asset
+    // name the installer will later try to download.
     match crate::update::get_platform_download_filename(&latest_tag) {
         Some(filename) if result.download_url.contains(&filename) => PreflightCheck {
             name: "platform_asset",
@@ -590,6 +1005,8 @@ async fn check_download_url(download_url: &str) -> (PreflightCheck, Option<u64>)
         );
     }
 
+    // HEAD avoids downloading the installer during --check while still
+    // validating reachability and, when available, content length.
     let client = match reqwest::Client::builder()
         .user_agent("openloomi-cli")
         .timeout(std::time::Duration::from_secs(15))
@@ -669,6 +1086,8 @@ fn check_directory_writable(name: &'static str, dir: &Path) -> PreflightCheck {
         name
     ));
 
+    // Probe by creating and deleting a tiny file instead of trusting directory
+    // existence; ACLs can allow one but not the other.
     match std::fs::write(&probe_path, b"ok").and_then(|_| std::fs::remove_file(&probe_path)) {
         Ok(()) => PreflightCheck {
             name,
@@ -718,6 +1137,8 @@ fn check_disk_space(dir: &Path, download_size: Option<u64>) -> PreflightCheck {
 }
 
 fn required_update_space_bytes(download_size: Option<u64>) -> u64 {
+    // Require roughly double the installer size to leave room for download,
+    // extraction, and backup work. Never go below the conservative default.
     download_size
         .unwrap_or(DEFAULT_UPDATE_SPACE_BYTES)
         .saturating_mul(2)
@@ -726,6 +1147,8 @@ fn required_update_space_bytes(download_size: Option<u64>) -> u64 {
 
 #[cfg(target_os = "windows")]
 fn available_space_bytes(dir: &Path) -> Result<u64, String> {
+    // Use PowerShell/.NET DriveInfo on Windows to avoid extra native
+    // dependencies in the CLI target.
     let script = r#"
 $path = [System.IO.Path]::GetFullPath($env:OPENLOOMI_DISK_PATH)
 $root = [System.IO.Path]::GetPathRoot($path)
@@ -747,6 +1170,8 @@ $root = [System.IO.Path]::GetPathRoot($path)
 
 #[cfg(unix)]
 fn available_space_bytes(dir: &Path) -> Result<u64, String> {
+    // df -Pk is available on the Unix platforms OpenLoomi targets and reports
+    // portable 1 KiB blocks.
     let output = Command::new("df")
         .args(["-Pk"])
         .arg(dir)
@@ -816,6 +1241,8 @@ fn print_preflight(preflight: &[PreflightCheck]) {
 }
 
 fn print_json<T: serde::Serialize>(value: &T) {
+    // Pretty JSON is easier to inspect manually while remaining valid for
+    // pipeline tools such as jq.
     match serde_json::to_string_pretty(value) {
         Ok(json) => println!("{}", json),
         Err(error) => {
@@ -839,7 +1266,7 @@ Usage:
   alloomi --help
 
 Options:
-  -z, --one-shot          Parse a non-interactive one-shot prompt (execution stubbed for now)
+  -z, --one-shot          Execute a non-interactive one-shot prompt
       --stdin             Read the one-shot prompt from standard input
       --json              Emit machine-readable JSON on stdout
       --model <model>     Override the default model for one-shot execution
@@ -918,5 +1345,36 @@ mod tests {
         assert_eq!(format_bytes(42), "42 B");
         assert_eq!(format_bytes(1024), "1.0 KiB");
         assert_eq!(format_bytes(1024 * 1024), "1.0 MiB");
+    }
+
+    #[test]
+    fn parses_agent_sse_text_result_and_tool_events() {
+        let raw = concat!(
+            ": keep-alive\n\n",
+            "data: {\"type\":\"session\",\"sessionId\":\"sess-1\"}\n\n",
+            "data: {\"type\":\"text\",\"content\":\"Hello\"}\n\n",
+            "data: {\"type\":\"tool_use\",\"name\":\"Read\"}\n\n",
+            "data: {\"type\":\"text\",\"content\":\" world\"}\n\n",
+            "data: {\"type\":\"result\",\"cost\":0.12,\"duration\":345}\n\n",
+            "data: {\"type\":\"done\"}\n\n",
+        );
+
+        let result = parse_agent_sse(raw).unwrap();
+        assert_eq!(result.response, "Hello world");
+        assert_eq!(result.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(result.text_event_count, 2);
+        assert_eq!(result.tool_calls, vec!["Read"]);
+        assert_eq!(result.cost, Some(0.12));
+        assert_eq!(result.duration_ms, Some(345.0));
+        assert_eq!(result.error, None);
+    }
+
+    #[test]
+    fn parses_agent_sse_error_event() {
+        let raw = "data: {\"type\":\"error\",\"message\":\"boom\"}\n\n";
+
+        let result = parse_agent_sse(raw).unwrap();
+        assert_eq!(result.event_count, 1);
+        assert_eq!(result.error.as_deref(), Some("boom"));
     }
 }


### PR DESCRIPTION
## Summary

- Auto-start a headless local OpenLoomi server for `alloomi --one-shot` when the local agent API is not already running
- Reuse an existing local server when available, and only clean up the process tree started by the CLI itself
- Keep `--json` output machine-readable by redirecting headless server logs to a log file
- Keep dev standalone placeholder resources in place for Tauri/Cargo resource checks

## Testing

- `cargo build --manifest-path apps/web/src-tauri/Cargo.toml --bin alloomi`
- `apps\web\src-tauri\target\debug\alloomi.exe --one-shot "用一句话介绍 OpenLoomi" --json`
re #46 