### PR TITLE
feat(memory): add semantic retrieval dry-run boundaries

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   adaptMemoryRecordsForConsolidation,
+  analyzeSemanticMemoryDraftReadiness,
   analyzeMemoryEvidenceClusters,
   assignMemoryRelationGraph,
   calculateMemoryConsolidationEvalMetrics,
@@ -10,11 +11,20 @@ import {
   buildMemoryRelationCandidates,
   buildMemoryRelationPipeline,
   buildMemoryRelationPipelineDiagnostics,
+  buildMemorySemanticRetrievalDryRunReport,
+  buildMemorySemanticRetrievalPlan,
   buildSemanticMemoryDraftCandidates,
   deriveMemoryRelationGraphLifecycle,
   persistSemanticMemoryDrafts,
   runMemoryConsolidationDiagnostics,
   summarizeSemanticMemoryDraftCandidate,
+  type MemorySemanticRetrievalCandidate,
+  type MemorySemanticRetrievalDryRunReport,
+  type MemorySemanticRetrievalDraft,
+  type MemorySemanticRetrievalPlanningInput,
+  type MemorySemanticRetrievalPlanningResult,
+  type SemanticMemoryArtifactStorageAdapter,
+  type SemanticMemoryArtifactStorageRecord,
   type SemanticMemoryDraftStore,
   type SemanticMemoryDraftSummarizer,
 } from "@openloomi/memory-consolidation";
@@ -1722,6 +1732,489 @@ describe("memory consolidation evaluation scenarios", () => {
     );
   });
 
+  it("reports when a semantic draft candidate is ready for summarization", () => {
+    const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
+    const readiness = analyzeSemanticMemoryDraftReadiness({
+      candidate,
+      records: diagnostics.records,
+      minConfidence: 0.5,
+    });
+
+    expect(readiness).toEqual({
+      draftId: candidate.draftId,
+      ready: true,
+      confidence: candidate.confidence,
+      minConfidence: 0.5,
+      sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+      availableSourceRecordIds: [
+        "adapter-zh-a",
+        "adapter-zh-b",
+        "adapter-zh-c",
+      ],
+      missingSourceRecordIds: [],
+      recordsMissingTextIds: [],
+      reasonCodes: [],
+    });
+  });
+
+  it("explains why a semantic draft candidate is not ready for summarization", () => {
+    const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
+    const incompleteCandidate = {
+      ...candidate,
+      confidence: 0.2,
+      sourceClusterKey: "",
+      sourceRecordIds: ["adapter-zh-a", "missing-source", "adapter-no-text"],
+      reasonCodes: [],
+    };
+    const readiness = analyzeSemanticMemoryDraftReadiness({
+      candidate: incompleteCandidate,
+      records: [
+        ...diagnostics.records,
+        {
+          id: "adapter-no-text",
+          userId: "adapter-user",
+          timestamp: NOW,
+          tier: "short",
+        },
+      ],
+      minConfidence: 0.5,
+    });
+
+    expect(readiness).toEqual(
+      expect.objectContaining({
+        ready: false,
+        confidence: 0.2,
+        availableSourceRecordIds: ["adapter-zh-a", "adapter-no-text"],
+        missingSourceRecordIds: ["missing-source"],
+        recordsMissingTextIds: ["adapter-no-text"],
+        reasonCodes: [
+          "low_confidence",
+          "missing_provenance",
+          "missing_source_records",
+          "missing_source_text",
+        ],
+      }),
+    );
+  });
+
+  it("rejects semantic draft readiness when confidence is not finite", () => {
+    const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
+    const readiness = analyzeSemanticMemoryDraftReadiness({
+      candidate: {
+        ...candidate,
+        confidence: Number.NaN,
+      },
+      records: diagnostics.records,
+      minConfidence: 0.5,
+    });
+
+    expect(readiness).toEqual(
+      expect.objectContaining({
+        ready: false,
+        confidence: Number.NaN,
+        reasonCodes: ["invalid_confidence"],
+      }),
+    );
+  });
+
+  it("documents fake summarizer failure cases without adding a real provider", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
+    const fakeSummarizer: SemanticMemoryDraftSummarizer = {
+      async summarizeDraft(candidate, records, context) {
+        if (context?.metadata?.emptyOutput === true) {
+          return {
+            type: candidate.suggestedType,
+            content: "",
+            sourceRecordIds: [...candidate.sourceRecordIds],
+            confidence: candidate.confidence,
+          };
+        }
+
+        if (records.length === 0) {
+          throw new Error("missing source records");
+        }
+
+        if (candidate.confidence < 0.5) {
+          throw new Error("low confidence draft");
+        }
+
+        if (context?.metadata?.graphStatus === "contested") {
+          throw new Error("contested draft");
+        }
+
+        return {
+          type: candidate.suggestedType,
+          content: records
+            .map((record) => record.text)
+            .filter((text): text is string => Boolean(text))
+            .join("\n"),
+          sourceRecordIds: [...candidate.sourceRecordIds],
+          confidence: candidate.confidence,
+        };
+      },
+    };
+
+    await expect(
+      summarizeSemanticMemoryDraftCandidate({
+        candidate: {
+          ...candidate,
+          sourceRecordIds: ["missing-source"],
+        },
+        records: diagnostics.records,
+        summarizer: fakeSummarizer,
+      }),
+    ).rejects.toThrow("missing source records");
+    await expect(
+      summarizeSemanticMemoryDraftCandidate({
+        candidate: {
+          ...candidate,
+          confidence: 0.2,
+        },
+        records: diagnostics.records,
+        summarizer: fakeSummarizer,
+      }),
+    ).rejects.toThrow("low confidence draft");
+    await expect(
+      summarizeSemanticMemoryDraftCandidate({
+        candidate,
+        records: diagnostics.records,
+        summarizer: fakeSummarizer,
+        context: {
+          metadata: {
+            graphStatus: "contested",
+          },
+        },
+      }),
+    ).rejects.toThrow("contested draft");
+
+    const emptyDraft = await summarizeSemanticMemoryDraftCandidate({
+      candidate,
+      records: diagnostics.records,
+      summarizer: fakeSummarizer,
+      context: {
+        metadata: {
+          emptyOutput: true,
+        },
+      },
+    });
+
+    expect(emptyDraft).toEqual(
+      expect.objectContaining({
+        content: "",
+        sourceRecordIds: candidate.sourceRecordIds,
+      }),
+    );
+  });
+
+  it("describes semantic draft retrieval candidates without planning logic", () => {
+    const draft = {
+      draftId: "semantic-draft:answer-language-zh",
+      type: "preference",
+      content: "User prefers Chinese explanations for technical repo work.",
+      sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+      confidence: 0.82,
+      metadata: {
+        sourceClusterKey: "answer-language:zh",
+      },
+    } satisfies MemorySemanticRetrievalDraft;
+    const planningInput = {
+      query: "How should replies be written?",
+      drafts: [draft],
+      existingRecordIds: ["adapter-zh-a"],
+      now: NOW,
+    } satisfies MemorySemanticRetrievalPlanningInput;
+    const retrievalCandidate = {
+      ...draft,
+      queryRelevance: 0.7,
+      draftStatus: "active",
+      status: "eligible",
+      reasonCodes: ["semantic_draft_candidate"],
+    } satisfies MemorySemanticRetrievalCandidate;
+    const planningResult = {
+      query: planningInput.query,
+      candidates: [retrievalCandidate],
+      fallbackRecordIds: planningInput.existingRecordIds,
+    } satisfies MemorySemanticRetrievalPlanningResult;
+
+    expect(planningResult).toEqual({
+      query: "How should replies be written?",
+      candidates: [
+        expect.objectContaining({
+          draftId: "semantic-draft:answer-language-zh",
+          queryRelevance: 0.7,
+          draftStatus: "active",
+          status: "eligible",
+          reasonCodes: ["semantic_draft_candidate"],
+          sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        }),
+      ],
+      fallbackRecordIds: ["adapter-zh-a"],
+    });
+  });
+
+  it("plans semantic draft retrieval candidates with caller-provided relevance", () => {
+    const drafts: MemorySemanticRetrievalDraft[] = [
+      {
+        draftId: "semantic-draft:low-relevance",
+        type: "preference",
+        content: "User prefers compact answers.",
+        sourceRecordIds: ["adapter-style-a"],
+        confidence: 0.99,
+      },
+      {
+        draftId: "semantic-draft:answer-language-zh",
+        type: "preference",
+        content: "User prefers Chinese explanations for technical repo work.",
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b"],
+        confidence: 0.82,
+      },
+      {
+        draftId: "semantic-draft:answer-language-en",
+        type: "preference",
+        content: "User once asked for English in one reply.",
+        sourceRecordIds: ["adapter-en-a"],
+        confidence: 0.72,
+      },
+    ];
+    const result = buildMemorySemanticRetrievalPlan({
+      query: "What language should technical replies use?",
+      drafts,
+      existingRecordIds: ["adapter-zh-a"],
+      now: NOW,
+      getDraftRelevance({ draft }) {
+        if (draft.draftId.endsWith("answer-language-zh")) {
+          return 0.9;
+        }
+
+        if (draft.draftId.endsWith("answer-language-en")) {
+          return 0.9;
+        }
+
+        return 0.2;
+      },
+    });
+
+    expect(result.candidates.map((candidate) => candidate.draftId)).toEqual([
+      "semantic-draft:answer-language-zh",
+      "semantic-draft:answer-language-en",
+      "semantic-draft:low-relevance",
+    ]);
+    expect(result.candidates[0]).toEqual(
+      expect.objectContaining({
+        queryRelevance: 0.9,
+        confidence: 0.82,
+        status: "eligible",
+        reasonCodes: ["semantic_draft_candidate", "query_relevance"],
+      }),
+    );
+    expect(result.fallbackRecordIds).toEqual(["adapter-zh-a"]);
+    expect(drafts[0]?.sourceRecordIds).toEqual(["adapter-style-a"]);
+  });
+
+  it("suppresses semantic retrieval candidates conservatively", () => {
+    const result = buildMemorySemanticRetrievalPlan({
+      query: "What should be recalled?",
+      minConfidence: 0.7,
+      maxCandidates: 1,
+      drafts: [
+        {
+          draftId: "semantic-draft:strong",
+          type: "preference",
+          content: "User prefers Chinese technical explanations.",
+          sourceRecordIds: ["adapter-zh-a"],
+          confidence: 0.9,
+          status: "active",
+        },
+        {
+          draftId: "semantic-draft:contested",
+          type: "preference",
+          content: "User may prefer English.",
+          sourceRecordIds: ["adapter-en-a"],
+          confidence: 0.95,
+          status: "contested",
+        },
+        {
+          draftId: "semantic-draft:low-confidence",
+          type: "preference",
+          content: "User may prefer very short answers.",
+          sourceRecordIds: ["adapter-style-a"],
+          confidence: 0.4,
+          status: "active",
+        },
+        {
+          draftId: "semantic-draft:extra",
+          type: "preference",
+          content: "User prefers detailed citations.",
+          sourceRecordIds: ["adapter-citation-a"],
+          confidence: 0.85,
+          status: "active",
+        },
+      ],
+      getDraftRelevance({ draft }) {
+        return draft.draftId === "semantic-draft:low-confidence" ? 0.6 : 0.9;
+      },
+    });
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        draftId: "semantic-draft:contested",
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "contested_memory",
+        ],
+      }),
+      expect.objectContaining({
+        draftId: "semantic-draft:strong",
+        status: "eligible",
+      }),
+      expect.objectContaining({
+        draftId: "semantic-draft:extra",
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "max_candidates",
+        ],
+      }),
+      expect.objectContaining({
+        draftId: "semantic-draft:low-confidence",
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "low_confidence",
+        ],
+      }),
+    ]);
+  });
+
+  it("covers semantic retrieval eval scenarios for selected, suppressed, contested, and fallback candidates", () => {
+    const result = buildMemorySemanticRetrievalPlan({
+      query: "Which long-term preference should guide this answer?",
+      minConfidence: 0.7,
+      existingRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+      drafts: [
+        {
+          draftId: "semantic-draft:selected",
+          type: "preference",
+          content: "User prefers Chinese for technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          confidence: 0.88,
+          status: "active",
+        },
+        {
+          draftId: "semantic-draft:low-confidence",
+          type: "preference",
+          content: "User might prefer terse answers.",
+          sourceRecordIds: ["raw-trace:style-a"],
+          confidence: 0.4,
+          status: "active",
+        },
+        {
+          draftId: "semantic-draft:contested",
+          type: "preference",
+          content: "User may prefer English now.",
+          sourceRecordIds: ["raw-trace:en-a"],
+          confidence: 0.91,
+          status: "contested",
+        },
+      ],
+      getDraftRelevance({ draft }) {
+        return draft.draftId === "semantic-draft:selected" ? 0.9 : 0.8;
+      },
+    });
+    const candidatesById = new Map(
+      result.candidates.map((candidate) => [candidate.draftId, candidate]),
+    );
+
+    expect(candidatesById.get("semantic-draft:selected")).toEqual(
+      expect.objectContaining({
+        status: "eligible",
+        reasonCodes: ["semantic_draft_candidate", "query_relevance"],
+      }),
+    );
+    expect(candidatesById.get("semantic-draft:low-confidence")).toEqual(
+      expect.objectContaining({
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "low_confidence",
+        ],
+      }),
+    );
+    expect(candidatesById.get("semantic-draft:contested")).toEqual(
+      expect.objectContaining({
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "contested_memory",
+        ],
+      }),
+    );
+    expect(result.fallbackRecordIds).toEqual([
+      "raw-trace:zh-a",
+      "raw-trace:zh-b",
+    ]);
+  });
+
+  it("builds a semantic retrieval dry-run report without changing retrieval results", () => {
+    const result = buildMemorySemanticRetrievalPlan({
+      query: "Which preference is relevant?",
+      existingRecordIds: ["raw-trace:zh-a"],
+      minConfidence: 0.7,
+      drafts: [
+        {
+          draftId: "semantic-draft:selected",
+          type: "preference",
+          content: "User prefers Chinese technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a"],
+          confidence: 0.88,
+        },
+        {
+          draftId: "semantic-draft:low-confidence",
+          type: "preference",
+          content: "User may prefer terse answers.",
+          sourceRecordIds: ["raw-trace:style-a"],
+          confidence: 0.4,
+        },
+      ],
+      getDraftRelevance: () => 0.8,
+    });
+    const report = buildMemorySemanticRetrievalDryRunReport({
+      plan: result,
+      existingRecordIds: ["raw-trace:zh-a"],
+    }) satisfies MemorySemanticRetrievalDryRunReport;
+
+    expect(report).toEqual(
+      expect.objectContaining({
+        summary: {
+          query: "Which preference is relevant?",
+          existingRecordCount: 1,
+          draftCandidateCount: 2,
+          addedDraftCount: 1,
+          suppressedDraftCount: 1,
+          fallbackRecordCount: 1,
+        },
+        existingRecordIds: ["raw-trace:zh-a"],
+        draftCandidateIds: [
+          "semantic-draft:selected",
+          "semantic-draft:low-confidence",
+        ],
+        reasonCodes: expect.arrayContaining([
+          "semantic_draft_candidate",
+          "query_relevance",
+          "low_confidence",
+          "source_trace_fallback",
+        ]),
+      }),
+    );
+    expect(result.fallbackRecordIds).toEqual(["raw-trace:zh-a"]);
+  });
+
   it("does not persist semantic drafts when persistence is disabled", async () => {
     const { item } = buildSemanticDraftPersistenceFixture();
     const result = await persistSemanticMemoryDrafts({
@@ -1838,6 +2331,71 @@ describe("memory consolidation evaluation scenarios", () => {
     expect(diagnostics.records.map((record) => record.id)).toEqual(
       originalRecordIds,
     );
+  });
+
+  it("describes a caller-provided semantic memory artifact storage adapter contract", async () => {
+    const artifact = {
+      artifactId: "artifact:semantic-draft:answer-language-zh",
+      userId: "adapter-user",
+      type: "preference",
+      content: "User prefers Chinese explanations for technical repo work.",
+      status: "draft",
+      confidence: 0.82,
+      sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+      sourceClusterKey: "answer-language:zh",
+      competitionKey: "answer-language",
+      reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+      createdAt: NOW,
+      updatedAt: NOW,
+      rollback: {
+        operationId: "memory-consolidation-dry-run",
+        reason: "semantic draft storage contract test",
+      },
+      metadata: {
+        packageLocal: true,
+      },
+    } satisfies SemanticMemoryArtifactStorageRecord;
+    const saveCalls: Array<{
+      userId: string;
+      artifacts: SemanticMemoryArtifactStorageRecord[];
+      now: number;
+      dryRun: boolean;
+    }> = [];
+    const adapter = {
+      async saveArtifacts(input) {
+        saveCalls.push(input);
+
+        return {
+          artifactIds: input.artifacts.map((artifact) => artifact.artifactId),
+          dryRun: input.dryRun,
+        };
+      },
+    } satisfies SemanticMemoryArtifactStorageAdapter;
+    const result = await adapter.saveArtifacts({
+      userId: "adapter-user",
+      artifacts: [artifact],
+      now: NOW,
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      artifactIds: ["artifact:semantic-draft:answer-language-zh"],
+      dryRun: true,
+    });
+    expect(saveCalls).toEqual([
+      expect.objectContaining({
+        userId: "adapter-user",
+        dryRun: true,
+        artifacts: [
+          expect.objectContaining({
+            sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+            rollback: expect.objectContaining({
+              operationId: "memory-consolidation-dry-run",
+            }),
+          }),
+        ],
+      }),
+    ]);
   });
 
   it("runs opt-in memory consolidation diagnostics as a dry-run", async () => {

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -138,6 +138,10 @@ single draft candidate and its source records to a caller-provided summarizer.
 The package still does not provide a concrete LLM summarizer or persist the
 result.
 
+`analyzeSemanticMemoryDraftReadiness` can inspect whether a draft candidate has
+enough source records, text, confidence, and provenance before it is sent to a
+summarizer.
+
 `calculateMemoryConsolidationEvalMetrics` provides a small scenario metrics
 helper for comparing expected preservation, temporary/noise leakage, contested
 cluster coverage, and decay precision proxies in focused eval suites.
@@ -151,6 +155,10 @@ retrieval behavior.
 semantic drafts. It only writes through a caller-provided draft store when
 explicitly enabled with `dryRun: false`; otherwise it returns the planned draft
 artifacts for review without changing storage or retrieval behavior.
+
+`buildMemorySemanticRetrievalPlan` and
+`buildMemorySemanticRetrievalDryRunReport` describe how semantic drafts can be
+inspected for retrieval impact without changing production retrieval ranking.
 
 Callers can keep the full diagnostics for debugging and derive the compact
 report for review or logging:

--- a/packages/ai/memory-consolidation/docs/execution-plan.md
+++ b/packages/ai/memory-consolidation/docs/execution-plan.md
@@ -1,0 +1,39 @@
+# Memory Consolidation Execution Plan
+
+This file turns the roadmap into one-round implementation tasks. Each task should
+produce one small helper, report shape, or design note with focused tests or a
+format check. Runtime behavior must stay unchanged unless a task explicitly says
+otherwise.
+
+## Rules
+
+- Package-local first; runtime integration later.
+- One task, one primary artifact.
+- Prefer caller-provided signals over embeddings or LLMs.
+- Keep raw trace fallback and provenance visible.
+- Do not change production retrieval ranking by default.
+- Do not write storage unless the task is explicitly about a storage boundary.
+
+## Task Queue
+
+| Task                                | Deliverable                                                                                                  | Verification                                              | Out of scope                                   |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- | ---------------------------------------------- |
+| D1 Retrieval Candidate Types        | Export minimal semantic-draft retrieval candidate and planning result types.                                 | TypeScript check and focused type/unit coverage.          | Scoring, filtering, runtime retrieval.         |
+| D2 Retrieval Candidate Planner      | Pure helper that maps query + semantic drafts + caller-provided relevance into deterministic candidates.     | Relevant high-confidence drafts rank above weaker drafts. | Embeddings, tokenizer, LLM relevance judge.    |
+| D3 Retrieval Candidate Filters      | Conservative filters for confidence, contested status, max candidates, and suppression reason codes.         | Tests for low confidence, contested, and cap behavior.    | Production ranking, feature flag wiring.       |
+| D4 Retrieval Eval Scenarios         | Focused scenarios for selected, suppressed, contested, and fallback candidates.                              | Eval tests describe expected retrieval behavior.          | Full benchmark suite, real user data.          |
+| E1 Retrieval Dry-Run Report Shape   | Export report types for existing ids, draft ids, added drafts, suppressed drafts, fallback ids, and reasons. | TypeScript check and README/roadmap note.                 | Diff algorithm, runtime integration.           |
+| E2 Existing-vs-Draft Diff Helper    | Pure helper that compares existing retrieval results with planned draft candidates.                          | Tests show inspection without changing results.           | Context injection, ranking changes.            |
+| F1 Summarizer Readiness Diagnostics | Pure diagnostics for missing content, source coverage, provenance, and confidence.                           | Tests explain why a candidate is or is not ready.         | Real LLM provider, prompt design.              |
+| F2 Fake Provider Failure Cases      | Fake-provider tests for empty output, missing sources, low confidence, and contested metadata.               | Focused async summarizer tests.                           | Network calls, concrete model integration.     |
+| G1 Storage Schema Design Note       | Short design note for raw traces, semantic drafts, consolidated memories, deprecated memories, rollback.     | Markdown format check.                                    | Migration, database writes.                    |
+| G2 Persistence Adapter Contract     | Interface-only adapter contract for future storage, preserving source ids and rollback metadata.             | TypeScript check and focused interface tests.             | Concrete DB implementation, default-on writes. |
+
+## Recommended Order
+
+```text
+D1 -> D2 -> D3 -> D4 -> E1 -> E2 -> F1 -> F2 -> G1 -> G2
+```
+
+Stop after each task to review the diff. If a task starts requiring runtime,
+storage, retrieval, LLM, or migration details, split it again before coding.

--- a/packages/ai/memory-consolidation/docs/roadmap.md
+++ b/packages/ai/memory-consolidation/docs/roadmap.md
@@ -18,13 +18,15 @@ episodic traces
   -> summarization boundary
   -> runtime dry-run
   -> controlled persistence
-  -> retrieval integration
+  -> retrieval dry-run
+  -> opt-in runtime usage
+  -> temporal memory and belief revision
 ```
 
 The package should not be responsible for online writes, immediate salience
 scoring, final semantic memory generation, real forgetting execution, or
-retrieval ranking yet. These capabilities should be introduced gradually, always
-behind dry-run modes, feature flags, and rollback-friendly boundaries.
+retrieval ranking by default. These capabilities should be introduced gradually,
+always behind dry-run modes, feature flags, and rollback-friendly boundaries.
 
 ## Current Foundation
 
@@ -38,15 +40,21 @@ The package currently provides package-local pure helpers for:
 - relation pipeline execution
 - diagnostics adaptation
 - compact diagnostics reporting
+- semantic draft candidate generation
+- semantic draft summarizer boundary
+- consolidation evaluation metrics
+- dry-run diagnostics runner
+- controlled semantic draft persistence boundary
 
 Together, these helpers can turn existing memory traces into an explainable
-offline diagnostics result:
+offline consolidation result:
 
 ```text
 source records
   -> adaptMemoryRecordsForConsolidation
   -> buildMemoryRelationPipelineDiagnostics
   -> buildMemoryConsolidationDiagnosticsReport
+  -> buildSemanticMemoryDraftCandidates
 ```
 
 The diagnostics can answer:
@@ -56,173 +64,44 @@ The diagnostics can answer:
 - which records are only temporary or weak signals
 - which clusters may become semantic memory candidates later
 - which records should not be promoted into long-term memory
+- which semantic draft artifacts would be produced or persisted in dry-run mode
 
 ## Staged Roadmap
 
-### Phase 1: Semantic Memory Draft Candidates
+### Completed Foundation: Phases 1-5
 
-Goal: turn `preservedClusters` into draft candidates that are closer to
-long-term semantic memory.
+The first five phases establish the semantic draft pipeline without changing
+runtime memory behavior.
 
-Suggested pure helper:
+Implemented capabilities:
 
-```ts
-buildSemanticMemoryDraftCandidates(report, records);
+- turn preserved diagnostics clusters into semantic draft candidates
+- define a caller-provided summarizer boundary without adding an LLM provider
+- compare consolidation behavior with focused scenario metrics
+- run diagnostics through an opt-in dry-run runner
+- define a controlled persistence boundary for semantic drafts
+
+Current boundary:
+
+- no forgetting runtime changes
+- no storage schema changes
+- no retrieval behavior changes
+- no concrete LLM provider
+- no automatic deletion, archival, or replacement of source traces
+
+### Phase 6: Retrieval Dry-Run Integration
+
+Goal: evaluate how semantic drafts would affect memory retrieval before changing
+real retrieval results.
+
+Suggested flow:
+
+```text
+query
+  -> existing retrieval result
+  -> semantic draft retrieval candidates
+  -> dry-run diff report
 ```
-
-Candidate shape:
-
-```ts
-{
-  draftId,
-  sourceClusterKey,
-  sourceRecordIds,
-  suggestedType,
-  confidence,
-  evidenceCount,
-  reasonCodes,
-  needsSummary: true
-}
-```
-
-Boundaries:
-
-- Do not call an LLM.
-- Do not generate summary text.
-- Do not write to storage.
-- Do not change the forgetting runtime.
-- Do not change retrieval behavior.
-
-Value: moves `preserve` from a diagnostics action into a consumable candidate
-for later semantic memory summarization.
-
-### Phase 2: Summarizer Boundary
-
-Goal: define the boundary for summarizing semantic memory drafts without
-binding the package to a specific model provider.
-
-Suggested interface:
-
-```ts
-interface SemanticMemoryDraftSummarizer {
-  summarizeDraft(candidate, records, context): Promise<SemanticMemoryDraft>;
-}
-```
-
-Possible output:
-
-```ts
-const draft: SemanticMemoryDraft = {
-  type,
-  content,
-  sourceRecordIds,
-  confidence,
-  metadata,
-};
-```
-
-Boundaries:
-
-- Define only the interface and a test fake summarizer.
-- Do not integrate a concrete LLM provider.
-- Do not write to the database.
-- Do not connect to a runtime scheduler.
-
-Value: gives future LLM summarization a clear boundary without polluting the
-consolidation core.
-
-### Phase 3: Evaluation Suite
-
-Goal: turn long-term memory behavior into comparable scenarios instead of
-advancing the design only by intuition.
-
-Suggested scenarios:
-
-- temporary instructions should not pollute long-term preferences
-- repeated preferences should become semantic draft candidates
-- repeated recent evidence should allow a new preference to compete with an old
-  one
-- isolated noise should naturally decay
-- project state updates should replace stale state
-- conflicting facts should remain contested
-- expired events should not become semantic memory
-
-Observable metrics:
-
-- expected candidate accuracy
-- temporary override leakage rate
-- noise promotion rate
-- adaptation accuracy
-- contested cluster coverage
-- decay precision proxy
-
-Boundaries:
-
-- Continue using focused tests or scenario evals.
-- Do not use real user data.
-- Do not connect to runtime behavior.
-
-Value: helps prove whether consolidation improves long-term memory quality over
-single-trace scoring alone.
-
-### Phase 4: Runtime Opt-in Diagnostics
-
-Goal: connect the package to runtime for the first time, but only as dry-run
-diagnostics.
-
-Suggested entry point:
-
-```ts
-runMemoryConsolidationDiagnostics({
-  userId,
-  now,
-  dryRun: true,
-});
-```
-
-Behavior:
-
-- read candidate records from existing storage
-- call the memory-consolidation package
-- output a diagnostics report
-- do not write semantic memory
-- do not archive or delete source records
-
-Boundaries:
-
-- Must be dry-run.
-- Must be opt-in.
-- Must not change forgetting engine decisions.
-- Must not change retrieval results.
-
-Value: verifies whether package helpers can consume real memory record shapes and
-creates an observation point before persistence.
-
-### Phase 5: Controlled Semantic Draft Persistence
-
-Goal: persist semantic memory drafts under explicit configuration without
-directly changing long-term memory retrieval.
-
-Suggested policy:
-
-- guard persistence with a feature flag
-- persist drafts first, not final consolidated memory
-- preserve source record ids
-- do not delete source records
-- keep rollback possible
-
-Boundaries:
-
-- Do not directly enter retrieval ranking.
-- Do not directly replace existing summaries.
-- Do not automatically delete source traces.
-
-Value: lets offline consolidation produce auditable artifacts.
-
-### Phase 6: Retrieval Integration
-
-Goal: allow retrieval to use semantic drafts or consolidated memory under
-controlled conditions.
 
 Concerns:
 
@@ -238,10 +117,95 @@ Boundaries:
 - Must have evaluation support.
 - Must be switchable.
 - Must keep raw trace fallback.
+- Must not change default retrieval ranking.
+- Must report what would change before enabling it.
 
-Value: makes consolidated long-term memory useful for task-relevant recall.
+Value: proves whether semantic drafts improve task-relevant recall without
+polluting the active context.
 
-### Phase 7: Temporal Memory and Belief Revision
+### Phase 7: Real Summarizer Provider
+
+Goal: add a concrete summarizer behind the existing
+`SemanticMemoryDraftSummarizer` boundary.
+
+The provider should transform a draft candidate and its source records into a
+semantic draft while preserving provenance:
+
+- source record ids
+- confidence
+- memory type
+- competition metadata
+- reason codes
+- temporal metadata
+
+Boundaries:
+
+- Keep provider integration replaceable.
+- Keep prompt and model behavior testable through fakes.
+- Do not persist final consolidated memory automatically.
+- Do not enter retrieval ranking directly.
+
+Value: turns repeated trace evidence into compact semantic memory text while
+keeping the output explainable and reversible.
+
+### Phase 8: Controlled Storage Schema
+
+Goal: persist memory artifacts with a schema that separates raw traces from
+semantic drafts and future consolidated memories.
+
+Suggested storage layers:
+
+```text
+raw traces
+semantic drafts
+consolidated memories
+deprecated memories
+```
+
+Required fields:
+
+- source record ids
+- confidence
+- status
+- created / updated timestamps
+- provenance metadata
+- rollback metadata
+
+Boundaries:
+
+- Introduce migrations carefully.
+- Keep source traces available.
+- Do not make persisted drafts active retrieval results by default.
+- Keep rollback possible.
+
+Value: gives consolidation artifacts a durable, inspectable home without turning
+them into irreversible memory facts.
+
+### Phase 9: Opt-In Runtime Activation
+
+Goal: let semantic memory participate in runtime behavior only through explicit
+activation stages.
+
+Suggested rollout stages:
+
+```text
+off
+dry-run
+log-only
+developer opt-in
+limited rollout
+default-on
+```
+
+Boundaries:
+
+- Every stage must be switchable.
+- Every behavior change must be observable.
+- Retrieval and forgetting effects should be measured before broad rollout.
+
+Value: moves from diagnostics to product behavior without losing reversibility.
+
+### Phase 10: Temporal Memory and Belief Revision
 
 Goal: handle preference changes, stale facts, and project-state evolution.
 
@@ -271,60 +235,58 @@ Required capabilities:
 Boundaries:
 
 - Should come after retrieval integration.
-- Should not be implemented in early PRs.
+- Should not be implemented before storage and retrieval are observable.
 
 Value: turns long-term memory from a static fact store into an updateable memory
 system.
 
-## Near-term PR Plan
+### Phase 11: Automatic Relation Discovery
 
-The near-term implementation should focus only on the first three phases while
-keeping the package-local and pure-helper style.
+Goal: reduce dependence on explicit relation keys by adding controlled relation
+discovery.
 
-### PR A: Semantic Memory Draft Candidates
+Possible inputs:
 
-Scope:
+- embedding similarity
+- LLM relation judgment
+- entity extraction
+- graph expansion
+- weak relation observation
 
-- add draft candidate types
-- generate candidates from `preservedClusters` in diagnostics reports
-- include confidence, suggested type, and source record ids
-- add focused eval coverage
-- update the README
+Boundaries:
 
-Out of scope:
+- Add only after evaluation and rollback paths are mature.
+- Keep uncertain relations observable instead of immediately merging clusters.
+- Do not let weak inferred relations override explicit evidence.
 
-- no summary text generation
-- no LLM integration
-- no storage writes
-- no runtime integration
+Value: lets clusters emerge from repeated evidence and relation signals instead
+of relying only on manually provided grouping fields.
 
-### PR B: Draft Summarizer Boundary
+### Phase 12: Memory Governance
 
-Scope:
+Goal: make long-term memory understandable, correctable, and reversible.
 
-- define a summarizer interface
-- define the `SemanticMemoryDraft` output shape
-- add fake summarizer tests
-- document that real LLM summarization is future work
+Required questions:
 
-Out of scope:
+- Why was this memory formed?
+- Which traces support it?
+- Why was an older memory deprecated?
+- Can users inspect, delete, or correct it?
+- How can polluted memories be rolled back?
+- How are low-confidence memories isolated?
 
-- no concrete provider integration
-- no API route integration
-- no persistence
+Boundaries:
 
-### PR C: Expanded Consolidation Eval
+- Governance should be designed before memory becomes default-on.
+- User-visible controls should not depend on internal implementation details.
 
-Scope:
+Value: prevents long-term memory from becoming an opaque append-only system.
 
-- organize the existing eval into a clearer scenario suite
-- add project state, conflict, and stale-memory scenarios
-- output a small metrics helper
+## Execution Plan
 
-Out of scope:
-
-- no full benchmark infrastructure
-- no real user data
+See [execution-plan.md](./execution-plan.md) for small reviewable tasks. The
+roadmap intentionally stays high-level; the execution plan breaks the next work
+into one-round implementation units.
 
 ## Integration Principles
 
@@ -335,6 +297,8 @@ Future changes should follow these principles:
 - dry-run first, opt-in execution later
 - evaluation first, retrieval changes later
 - every runtime behavior change must be switchable, explainable, and reversible
+- preserve provenance before summarizing or retrieving
+- keep raw trace fallback until semantic memory is proven reliable
 
 The core direction is not to remember more. It is to gradually build a long-term
 memory formation process that can explain, compete, consolidate, and forget.

--- a/packages/ai/memory-consolidation/docs/storage-schema.md
+++ b/packages/ai/memory-consolidation/docs/storage-schema.md
@@ -1,0 +1,52 @@
+# Memory Consolidation Storage Schema Notes
+
+This note sketches storage boundaries for future semantic memory work. It does
+not define a migration and does not require runtime writes.
+
+## Layers
+
+```text
+raw traces
+semantic drafts
+consolidated memories
+deprecated memories
+```
+
+- Raw traces remain the source of evidence and should not be deleted by
+  consolidation.
+- Semantic drafts are auditable artifacts produced from preserved clusters.
+- Consolidated memories are future active memory records derived from reviewed
+  drafts.
+- Deprecated memories preserve old beliefs or preferences after they are
+  superseded.
+
+## Required Fields
+
+Every stored semantic artifact should preserve:
+
+- artifact id
+- user id
+- content
+- type
+- status
+- confidence
+- source record ids
+- source cluster key
+- competition key
+- reason codes
+- created / updated timestamps
+- rollback metadata
+
+## Retention and Rollback
+
+Source traces should remain available until a separate retention policy exists.
+Semantic drafts and consolidated memories should be removable without deleting
+their supporting traces. Rollback should be able to identify which artifact was
+created from which source records, cluster, and consolidation decision.
+
+## Non-Goals
+
+- No database migration in this package.
+- No default-on persistence.
+- No deletion or archival of source traces.
+- No retrieval activation from persisted drafts by default.

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -11,6 +11,7 @@
     "./persistence": "./src/persistence.ts",
     "./pipeline": "./src/pipeline.ts",
     "./relation-graph": "./src/relation-graph.ts",
+    "./retrieval": "./src/retrieval.ts",
     "./runtime": "./src/runtime.ts",
     "./semantic-draft": "./src/semantic-draft.ts"
   },

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -5,5 +5,6 @@ export * from "./plan";
 export * from "./persistence";
 export * from "./pipeline";
 export * from "./relation-graph";
+export * from "./retrieval";
 export * from "./runtime";
 export * from "./semantic-draft";

--- a/packages/ai/memory-consolidation/src/persistence.ts
+++ b/packages/ai/memory-consolidation/src/persistence.ts
@@ -23,6 +23,56 @@ export interface PersistedSemanticMemoryDraft {
   createdAt: number;
 }
 
+export type SemanticMemoryArtifactStatus =
+  | "draft"
+  | "consolidated"
+  | "deprecated"
+  | "conflicted"
+  | (string & {});
+
+export interface SemanticMemoryArtifactRollbackMetadata {
+  sourceArtifactId?: string;
+  operationId?: string;
+  createdBy?: string;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SemanticMemoryArtifactStorageRecord {
+  artifactId: string;
+  userId: string;
+  type: SemanticMemoryDraft["type"];
+  content: string;
+  status: SemanticMemoryArtifactStatus;
+  confidence: number;
+  sourceRecordIds: string[];
+  sourceClusterKey: string;
+  competitionKey: string;
+  reasonCodes: MemorySemanticDraftCandidate["reasonCodes"];
+  createdAt: number;
+  updatedAt: number;
+  rollback: SemanticMemoryArtifactRollbackMetadata;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SemanticMemoryArtifactStorageAdapterSaveInput {
+  userId: string;
+  artifacts: SemanticMemoryArtifactStorageRecord[];
+  now: number;
+  dryRun: boolean;
+}
+
+export interface SemanticMemoryArtifactStorageAdapterSaveResult {
+  artifactIds: string[];
+  dryRun: boolean;
+}
+
+export interface SemanticMemoryArtifactStorageAdapter {
+  saveArtifacts(
+    input: SemanticMemoryArtifactStorageAdapterSaveInput,
+  ): Promise<SemanticMemoryArtifactStorageAdapterSaveResult>;
+}
+
 export interface SemanticMemoryDraftStoreSaveInput {
   userId: string;
   drafts: PersistedSemanticMemoryDraft[];

--- a/packages/ai/memory-consolidation/src/retrieval.ts
+++ b/packages/ai/memory-consolidation/src/retrieval.ts
@@ -1,0 +1,258 @@
+import type { MemorySemanticDraftSuggestedType } from "./semantic-draft";
+
+export type MemorySemanticRetrievalCandidateStatus =
+  | "eligible"
+  | "suppressed"
+  | "fallback";
+
+export type MemorySemanticRetrievalDraftStatus =
+  | "active"
+  | "contested"
+  | "deprecated"
+  | "unknown"
+  | (string & {});
+
+export type MemorySemanticRetrievalReasonCode =
+  | "semantic_draft_candidate"
+  | "source_trace_fallback"
+  | "low_confidence"
+  | "contested_memory"
+  | "max_candidates"
+  | "query_relevance"
+  | (string & {});
+
+export interface MemorySemanticRetrievalDraft {
+  draftId: string;
+  type: MemorySemanticDraftSuggestedType;
+  content: string;
+  sourceRecordIds: string[];
+  confidence: number;
+  status?: MemorySemanticRetrievalDraftStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalCandidate {
+  draftId: string;
+  type: MemorySemanticDraftSuggestedType;
+  content: string;
+  sourceRecordIds: string[];
+  confidence: number;
+  queryRelevance: number;
+  draftStatus: MemorySemanticRetrievalDraftStatus;
+  status: MemorySemanticRetrievalCandidateStatus;
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalRelevanceContext {
+  query: string;
+  draft: MemorySemanticRetrievalDraft;
+  now?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalPlanningInput {
+  query: string;
+  drafts: MemorySemanticRetrievalDraft[];
+  existingRecordIds?: string[];
+  now?: number;
+  metadata?: Record<string, unknown>;
+  minConfidence?: number;
+  allowContested?: boolean;
+  maxCandidates?: number;
+  getDraftRelevance?(
+    context: MemorySemanticRetrievalRelevanceContext,
+  ): number | undefined;
+}
+
+export interface MemorySemanticRetrievalPlanningResult {
+  query: string;
+  candidates: MemorySemanticRetrievalCandidate[];
+  fallbackRecordIds: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalDryRunReportSummary {
+  query: string;
+  existingRecordCount: number;
+  draftCandidateCount: number;
+  addedDraftCount: number;
+  suppressedDraftCount: number;
+  fallbackRecordCount: number;
+}
+
+export interface MemorySemanticRetrievalDryRunReport {
+  summary: MemorySemanticRetrievalDryRunReportSummary;
+  query: string;
+  existingRecordIds: string[];
+  draftCandidateIds: string[];
+  addedDrafts: MemorySemanticRetrievalCandidate[];
+  suppressedDrafts: MemorySemanticRetrievalCandidate[];
+  fallbackRecordIds: string[];
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildMemorySemanticRetrievalDryRunReportInput {
+  plan: MemorySemanticRetrievalPlanningResult;
+  existingRecordIds?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+function clamp01(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function retrievalReasonCodes(
+  queryRelevance: number,
+): MemorySemanticRetrievalReasonCode[] {
+  return queryRelevance > 0
+    ? ["semantic_draft_candidate", "query_relevance"]
+    : ["semantic_draft_candidate"];
+}
+
+function resolveMaxCandidates(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+function toRetrievalCandidate(
+  input: MemorySemanticRetrievalPlanningInput,
+  draft: MemorySemanticRetrievalDraft,
+): MemorySemanticRetrievalCandidate {
+  const queryRelevance = clamp01(
+    input.getDraftRelevance?.({
+      query: input.query,
+      draft,
+      now: input.now,
+      metadata: input.metadata,
+    }),
+  );
+
+  return {
+    draftId: draft.draftId,
+    type: draft.type,
+    content: draft.content,
+    sourceRecordIds: [...draft.sourceRecordIds],
+    confidence: clamp01(draft.confidence),
+    queryRelevance,
+    draftStatus: draft.status ?? "active",
+    status: "eligible",
+    reasonCodes: retrievalReasonCodes(queryRelevance),
+    metadata: draft.metadata ? { ...draft.metadata } : undefined,
+  };
+}
+
+function applyRetrievalFilters(
+  candidates: MemorySemanticRetrievalCandidate[],
+  input: MemorySemanticRetrievalPlanningInput,
+): MemorySemanticRetrievalCandidate[] {
+  const minConfidence = clamp01(input.minConfidence);
+  const maxCandidates = resolveMaxCandidates(input.maxCandidates);
+  let eligibleCount = 0;
+
+  return candidates.map((candidate) => {
+    const reasonCodes = [...candidate.reasonCodes];
+    let suppressed = false;
+
+    if (candidate.confidence < minConfidence) {
+      reasonCodes.push("low_confidence");
+      suppressed = true;
+    }
+
+    if (
+      input.allowContested !== true &&
+      candidate.draftStatus === "contested"
+    ) {
+      reasonCodes.push("contested_memory");
+      suppressed = true;
+    }
+
+    if (!suppressed) {
+      if (eligibleCount >= maxCandidates) {
+        reasonCodes.push("max_candidates");
+        suppressed = true;
+      } else {
+        eligibleCount += 1;
+      }
+    }
+
+    return {
+      ...candidate,
+      status: suppressed ? "suppressed" : "eligible",
+      reasonCodes,
+    };
+  });
+}
+
+export function buildMemorySemanticRetrievalPlan(
+  input: MemorySemanticRetrievalPlanningInput,
+): MemorySemanticRetrievalPlanningResult {
+  const candidates = input.drafts
+    .map((draft) => toRetrievalCandidate(input, draft))
+    .sort((a, b) => {
+      return (
+        b.queryRelevance - a.queryRelevance ||
+        b.confidence - a.confidence ||
+        a.draftId.localeCompare(b.draftId)
+      );
+    });
+
+  return {
+    query: input.query,
+    candidates: applyRetrievalFilters(candidates, input),
+    fallbackRecordIds: [...(input.existingRecordIds ?? [])],
+    metadata: input.metadata ? { ...input.metadata } : undefined,
+  };
+}
+
+export function buildMemorySemanticRetrievalDryRunReport(
+  input: BuildMemorySemanticRetrievalDryRunReportInput,
+): MemorySemanticRetrievalDryRunReport {
+  const existingRecordIds = [
+    ...(input.existingRecordIds ?? input.plan.fallbackRecordIds),
+  ];
+  const addedDrafts = input.plan.candidates.filter(
+    (candidate) => candidate.status === "eligible",
+  );
+  const suppressedDrafts = input.plan.candidates.filter(
+    (candidate) => candidate.status === "suppressed",
+  );
+  const reasonCodes = [
+    ...new Set([
+      ...input.plan.candidates.flatMap((candidate) => candidate.reasonCodes),
+      ...(input.plan.fallbackRecordIds.length > 0
+        ? (["source_trace_fallback"] as const)
+        : []),
+    ]),
+  ];
+  const metadata = input.metadata ?? input.plan.metadata;
+
+  return {
+    summary: {
+      query: input.plan.query,
+      existingRecordCount: existingRecordIds.length,
+      draftCandidateCount: input.plan.candidates.length,
+      addedDraftCount: addedDrafts.length,
+      suppressedDraftCount: suppressedDrafts.length,
+      fallbackRecordCount: input.plan.fallbackRecordIds.length,
+    },
+    query: input.plan.query,
+    existingRecordIds,
+    draftCandidateIds: input.plan.candidates.map(
+      (candidate) => candidate.draftId,
+    ),
+    addedDrafts,
+    suppressedDrafts,
+    fallbackRecordIds: [...input.plan.fallbackRecordIds],
+    reasonCodes,
+    metadata: metadata ? { ...metadata } : undefined,
+  };
+}

--- a/packages/ai/memory-consolidation/src/semantic-draft.ts
+++ b/packages/ai/memory-consolidation/src/semantic-draft.ts
@@ -65,6 +65,32 @@ export interface SummarizeSemanticMemoryDraftCandidateInput {
   context?: SemanticMemoryDraftSummarizerContext;
 }
 
+export type SemanticMemoryDraftReadinessReasonCode =
+  | "invalid_confidence"
+  | "low_confidence"
+  | "missing_provenance"
+  | "missing_source_records"
+  | "missing_source_text"
+  | (string & {});
+
+export interface AnalyzeSemanticMemoryDraftReadinessInput {
+  candidate: MemorySemanticDraftCandidate;
+  records: MemoryEvidenceRecord[];
+  minConfidence?: number;
+}
+
+export interface SemanticMemoryDraftReadinessDiagnostics {
+  draftId: string;
+  ready: boolean;
+  confidence: number;
+  minConfidence: number;
+  sourceRecordIds: string[];
+  availableSourceRecordIds: string[];
+  missingSourceRecordIds: string[];
+  recordsMissingTextIds: string[];
+  reasonCodes: SemanticMemoryDraftReadinessReasonCode[];
+}
+
 function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
@@ -257,4 +283,67 @@ export async function summarizeSemanticMemoryDraftCandidate(
     sourceRecords,
     input.context,
   );
+}
+
+export function analyzeSemanticMemoryDraftReadiness(
+  input: AnalyzeSemanticMemoryDraftReadinessInput,
+): SemanticMemoryDraftReadinessDiagnostics {
+  const recordsById = new Map(
+    input.records.map((record) => [record.id, record]),
+  );
+  const minConfidence = clamp01(input.minConfidence ?? 0);
+  const sourceRecordIds = [...input.candidate.sourceRecordIds];
+  const availableSourceRecordIds: string[] = [];
+  const missingSourceRecordIds: string[] = [];
+  const recordsMissingTextIds: string[] = [];
+  const reasonCodes: SemanticMemoryDraftReadinessReasonCode[] = [];
+
+  for (const recordId of sourceRecordIds) {
+    const record = recordsById.get(recordId);
+
+    if (!record) {
+      missingSourceRecordIds.push(recordId);
+      continue;
+    }
+
+    availableSourceRecordIds.push(recordId);
+
+    if (!record.text?.trim()) {
+      recordsMissingTextIds.push(recordId);
+    }
+  }
+
+  if (!Number.isFinite(input.candidate.confidence)) {
+    reasonCodes.push("invalid_confidence");
+  } else if (input.candidate.confidence < minConfidence) {
+    reasonCodes.push("low_confidence");
+  }
+
+  if (
+    !input.candidate.sourceClusterKey ||
+    !input.candidate.competitionKey ||
+    input.candidate.reasonCodes.length === 0
+  ) {
+    reasonCodes.push("missing_provenance");
+  }
+
+  if (missingSourceRecordIds.length > 0 || sourceRecordIds.length === 0) {
+    reasonCodes.push("missing_source_records");
+  }
+
+  if (recordsMissingTextIds.length > 0) {
+    reasonCodes.push("missing_source_text");
+  }
+
+  return {
+    draftId: input.candidate.draftId,
+    ready: reasonCodes.length === 0,
+    confidence: input.candidate.confidence,
+    minConfidence,
+    sourceRecordIds,
+    availableSourceRecordIds,
+    missingSourceRecordIds,
+    recordsMissingTextIds,
+    reasonCodes,
+  };
 }


### PR DESCRIPTION
## Summary

Add package-local dry-run boundaries for semantic memory retrieval and future storage.

This PR continues the memory-consolidation roadmap after semantic draft generation by adding:

- semantic draft retrieval candidate and planning types
- a pure retrieval planning helper driven by caller-provided relevance
- conservative suppression signals for low confidence, contested drafts, and max-candidate caps
- a dry-run retrieval report that keeps existing raw trace fallback visible
- semantic draft readiness diagnostics before calling a summarizer
- an interface-only semantic memory artifact storage adapter contract
- short roadmap, execution-plan, and storage-schema notes

## Scope

This remains observational and package-local:

- no production retrieval ranking changes
- no forgetting runtime changes
- no storage schema or migration changes
- no concrete DB implementation
- no LLM, embedding, tokenizer, or external service integration
- no default-on persistence or retrieval activation

## Testing

- `./node_modules/.bin/prettier.cmd --check packages/ai/memory-consolidation/src/persistence.ts packages/ai/memory-consolidation/src/semantic-draft.ts packages/ai/memory-consolidation/src/retrieval.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json apps/web/tests/unit/memory-consolidation-eval.test.ts packages/ai/memory-consolidation/README.md packages/ai/memory-consolidation/docs/roadmap.md packages/ai/memory-consolidation/docs/execution-plan.md packages/ai/memory-consolidation/docs/storage-schema.md`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `git diff --check`