### PR TITLE
feat(memory): add semantic artifact foundation

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -13,10 +13,16 @@ import {
   buildMemoryRelationPipelineDiagnostics,
   buildMemorySemanticRetrievalDryRunReport,
   buildMemorySemanticRetrievalPlan,
+  buildSemanticMemoryArtifactStorageDryRunReport,
+  buildSemanticMemoryDraftSummarizerInputContract,
+  buildSemanticMemoryDraftSummarizerDiagnostics,
   buildSemanticMemoryDraftCandidates,
+  deserializeSemanticMemoryArtifactStorageRecord,
   deriveMemoryRelationGraphLifecycle,
+  invokeSemanticMemoryDraftSummarizerProvider,
   persistSemanticMemoryDrafts,
   runMemoryConsolidationDiagnostics,
+  serializeSemanticMemoryArtifactStorageRecord,
   summarizeSemanticMemoryDraftCandidate,
   type MemorySemanticRetrievalCandidate,
   type MemorySemanticRetrievalDryRunReport,
@@ -26,6 +32,7 @@ import {
   type SemanticMemoryArtifactStorageAdapter,
   type SemanticMemoryArtifactStorageRecord,
   type SemanticMemoryDraftStore,
+  type SemanticMemoryDraftSummarizerProviderInvoke,
   type SemanticMemoryDraftSummarizer,
 } from "@openloomi/memory-consolidation";
 import {
@@ -954,6 +961,10 @@ function buildSemanticDraftPersistenceFixture() {
   };
 }
 
+function buildSemanticDraftSummarizerFixture() {
+  return buildSemanticDraftPersistenceFixture();
+}
+
 function recordingSemanticDraftStore() {
   const calls: Array<Parameters<SemanticMemoryDraftStore["saveDrafts"]>[0]> =
     [];
@@ -966,6 +977,34 @@ function recordingSemanticDraftStore() {
       },
     } satisfies SemanticMemoryDraftStore,
   };
+}
+
+function semanticArtifactStorageFixture() {
+  return {
+    artifactId: "artifact:semantic-draft:answer-language-zh",
+    userId: "adapter-user",
+    type: "preference",
+    content: "User prefers Chinese explanations for technical repo work.",
+    status: "draft",
+    confidence: 0.82,
+    sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+    sourceClusterKey: "answer-language:zh",
+    competitionKey: "answer-language",
+    reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+    createdAt: NOW,
+    updatedAt: NOW,
+    rollback: {
+      operationId: "memory-consolidation-dry-run",
+      sourceArtifactId: "artifact:previous",
+      reason: "semantic artifact storage test",
+      metadata: {
+        packageLocal: true,
+      },
+    },
+    metadata: {
+      dryRun: true,
+    },
+  } satisfies SemanticMemoryArtifactStorageRecord;
 }
 
 describe("memory consolidation evaluation scenarios", () => {
@@ -1817,6 +1856,333 @@ describe("memory consolidation evaluation scenarios", () => {
     );
   });
 
+  it("builds summarizer request diagnostics from semantic draft readiness", () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const report = buildSemanticMemoryDraftSummarizerDiagnostics({
+      candidate,
+      records: diagnostics.records,
+      minConfidence: 0.5,
+    });
+
+    expect(report).toEqual({
+      request: {
+        draftId: candidate.draftId,
+        sourceClusterKey: candidate.sourceClusterKey,
+        competitionKey: candidate.competitionKey,
+        suggestedType: candidate.suggestedType,
+        confidence: candidate.confidence,
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        availableSourceRecordIds: [
+          "adapter-zh-a",
+          "adapter-zh-b",
+          "adapter-zh-c",
+        ],
+        missingSourceRecordIds: [],
+        recordsMissingTextIds: [],
+        ready: true,
+        reasonCodes: [],
+      },
+      response: undefined,
+    });
+  });
+
+  it("reports summarizer response provenance mismatches without provider calls", () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const report = buildSemanticMemoryDraftSummarizerDiagnostics({
+      candidate,
+      records: diagnostics.records,
+      draft: {
+        type: "unknown",
+        content: "",
+        sourceRecordIds: ["adapter-zh-a"],
+        confidence: Number.NaN,
+      },
+    });
+
+    expect(report.response).toEqual({
+      draftId: candidate.draftId,
+      outputType: "unknown",
+      outputConfidence: Number.NaN,
+      outputSourceRecordIds: ["adapter-zh-a"],
+      preservesType: false,
+      preservesSourceRecordIds: false,
+      hasContent: false,
+      reasonCodes: [
+        "missing_output_content",
+        "output_source_record_mismatch",
+        "output_type_mismatch",
+        "invalid_output_confidence",
+      ],
+    });
+    expect(report.request.ready).toBe(true);
+
+    const duplicateSourceReport = buildSemanticMemoryDraftSummarizerDiagnostics(
+      {
+        candidate,
+        records: diagnostics.records,
+        draft: {
+          type: candidate.suggestedType,
+          content: "Duplicated source ids should not hide missing provenance.",
+          sourceRecordIds: ["adapter-zh-a", "adapter-zh-a", "adapter-zh-b"],
+          confidence: candidate.confidence,
+        },
+      },
+    );
+
+    expect(duplicateSourceReport.response).toEqual(
+      expect.objectContaining({
+        preservesSourceRecordIds: false,
+        reasonCodes: ["output_source_record_mismatch"],
+      }),
+    );
+  });
+
+  it("builds a stable summarizer input contract from candidate source records", () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const inputContract = buildSemanticMemoryDraftSummarizerInputContract({
+      candidate,
+      records: diagnostics.records,
+      context: {
+        now: NOW,
+        metadata: {
+          locale: "zh-CN",
+        },
+      },
+      minConfidence: 0.5,
+    });
+
+    expect(inputContract).toEqual({
+      candidate: {
+        draftId: candidate.draftId,
+        sourceClusterKey: candidate.sourceClusterKey,
+        competitionKey: candidate.competitionKey,
+        suggestedType: "preference",
+        confidence: candidate.confidence,
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+        needsSummary: true,
+        summaryPriority: candidate.summaryPriority,
+      },
+      request: {
+        draftId: candidate.draftId,
+        sourceClusterKey: candidate.sourceClusterKey,
+        competitionKey: candidate.competitionKey,
+        suggestedType: "preference",
+        confidence: candidate.confidence,
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        availableSourceRecordIds: [
+          "adapter-zh-a",
+          "adapter-zh-b",
+          "adapter-zh-c",
+        ],
+        missingSourceRecordIds: [],
+        recordsMissingTextIds: [],
+        ready: true,
+        reasonCodes: [],
+      },
+      sourceRecords: [
+        {
+          recordId: "adapter-zh-a",
+          text: "Use Chinese for repo work.",
+          timestamp: 30 * DAY_MS,
+          metadata: {
+            relationGroup: "answer-language",
+            relationScope: "long-term",
+            relationValue: "zh",
+            scope: "long-term",
+          },
+        },
+        {
+          recordId: "adapter-zh-b",
+          text: "Prefer Chinese technical explanations.",
+          timestamp: 45 * DAY_MS,
+          metadata: {
+            relationGroup: "answer-language",
+            relationScope: "long-term",
+            relationValue: "zh",
+            scope: "long-term",
+          },
+        },
+        {
+          recordId: "adapter-zh-c",
+          text: "Code explanations are easier in Chinese.",
+          timestamp: 60 * DAY_MS,
+          metadata: {
+            relationGroup: "answer-language",
+            relationScope: "long-term",
+            relationValue: "zh",
+            scope: "long-term",
+          },
+        },
+      ],
+      context: {
+        now: NOW,
+        metadata: {
+          locale: "zh-CN",
+        },
+      },
+    });
+    expect(
+      inputContract.sourceRecords.map((record) => record.recordId),
+    ).toEqual(candidate.sourceRecordIds);
+  });
+
+  it("lets a fake provider consume the summarizer input contract deterministically", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const inputContract = buildSemanticMemoryDraftSummarizerInputContract({
+      candidate,
+      records: diagnostics.records,
+      context: {
+        metadata: {
+          source: "golden-test",
+        },
+      },
+    });
+    const fakeProvider = async (
+      input: ReturnType<typeof buildSemanticMemoryDraftSummarizerInputContract>,
+    ) => ({
+      type: input.candidate.suggestedType,
+      content: input.sourceRecords.map((record) => record.text).join(" "),
+      sourceRecordIds: [...input.candidate.sourceRecordIds],
+      confidence: input.candidate.confidence,
+      metadata: {
+        sourceClusterKey: input.candidate.sourceClusterKey,
+        competitionKey: input.candidate.competitionKey,
+        reasonCodes: [...input.candidate.reasonCodes],
+        requestReady: input.request.ready,
+        source: input.context?.metadata?.source,
+      },
+    });
+
+    const draft = await fakeProvider(inputContract);
+
+    expect(draft).toEqual({
+      type: "preference",
+      content:
+        "Use Chinese for repo work. Prefer Chinese technical explanations. Code explanations are easier in Chinese.",
+      sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+      confidence: candidate.confidence,
+      metadata: {
+        sourceClusterKey: candidate.sourceClusterKey,
+        competitionKey: candidate.competitionKey,
+        reasonCodes: ["strong_repeated_evidence", "wins_competition"],
+        requestReady: true,
+        source: "golden-test",
+      },
+    });
+    expect(draft.sourceRecordIds).not.toContain("adapter-temp-en");
+  });
+
+  it("invokes a caller-provided summarizer provider through the adapter boundary", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const receivedDraftIds: string[] = [];
+    const invoke: SemanticMemoryDraftSummarizerProviderInvoke = async (
+      input,
+    ) => {
+      receivedDraftIds.push(input.candidate.draftId);
+
+      return {
+        type: input.candidate.suggestedType,
+        content: input.sourceRecords.map((record) => record.text).join(" "),
+        sourceRecordIds: [...input.candidate.sourceRecordIds],
+        confidence: input.candidate.confidence,
+        metadata: {
+          sourceClusterKey: input.candidate.sourceClusterKey,
+          competitionKey: input.candidate.competitionKey,
+          inputReady: input.request.ready,
+          sourceRecordCount: input.sourceRecords.length,
+        },
+      };
+    };
+
+    const result = await invokeSemanticMemoryDraftSummarizerProvider({
+      candidate,
+      records: diagnostics.records,
+      invoke,
+      minConfidence: 0.5,
+    });
+
+    expect(receivedDraftIds).toEqual([candidate.draftId]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "summarized",
+        reasonCodes: [],
+        draft: expect.objectContaining({
+          type: "preference",
+          sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+          confidence: candidate.confidence,
+          metadata: expect.objectContaining({
+            sourceClusterKey: candidate.sourceClusterKey,
+            competitionKey: candidate.competitionKey,
+            inputReady: true,
+            sourceRecordCount: 3,
+          }),
+        }),
+      }),
+    );
+    expect(result.input.sourceRecords.map((record) => record.recordId)).toEqual(
+      ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+    );
+    expect(result.diagnostics.response).toEqual(
+      expect.objectContaining({
+        preservesType: true,
+        preservesSourceRecordIds: true,
+        hasContent: true,
+        reasonCodes: [],
+      }),
+    );
+  });
+
+  it("keeps provider adapter failure paths observable without real provider calls", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    let skippedInvokeCount = 0;
+    const skipped = await invokeSemanticMemoryDraftSummarizerProvider({
+      candidate: {
+        ...candidate,
+        confidence: 0.2,
+      },
+      records: diagnostics.records,
+      minConfidence: 0.5,
+      invoke: async () => {
+        skippedInvokeCount += 1;
+        throw new Error("should not be called");
+      },
+    });
+
+    expect(skippedInvokeCount).toBe(0);
+    expect(skipped).toEqual(
+      expect.objectContaining({
+        status: "skipped",
+        reasonCodes: ["request_not_ready", "low_confidence"],
+      }),
+    );
+    expect(skipped.draft).toBeUndefined();
+    expect(skipped.error).toBeUndefined();
+    expect(skipped.diagnostics.request.ready).toBe(false);
+
+    const failed = await invokeSemanticMemoryDraftSummarizerProvider({
+      candidate,
+      records: diagnostics.records,
+      invoke: async () => {
+        throw new Error("fake provider unavailable");
+      },
+    });
+
+    expect(failed).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: {
+          name: "Error",
+          message: "fake provider unavailable",
+        },
+        reasonCodes: ["provider_error"],
+      }),
+    );
+    expect(failed.draft).toBeUndefined();
+    expect(failed.diagnostics.request.ready).toBe(true);
+    expect(failed.diagnostics.response).toBeUndefined();
+  });
+
   it("documents fake summarizer failure cases without adding a real provider", async () => {
     const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
     const fakeSummarizer: SemanticMemoryDraftSummarizer = {
@@ -2396,6 +2762,158 @@ describe("memory consolidation evaluation scenarios", () => {
         ],
       }),
     ]);
+  });
+
+  it("serializes and deserializes semantic memory artifacts with rollback provenance", () => {
+    const artifact = semanticArtifactStorageFixture();
+    artifact.confidence = 1.4;
+    const serialized = serializeSemanticMemoryArtifactStorageRecord(artifact);
+    const deserialized =
+      deserializeSemanticMemoryArtifactStorageRecord(serialized);
+
+    artifact.sourceRecordIds.push("mutated-after-serialize");
+    artifact.rollback.metadata = {
+      packageLocal: false,
+    };
+
+    expect(serialized).toEqual({
+      schemaVersion: 1,
+      artifact: expect.objectContaining({
+        artifactId: "artifact:semantic-draft:answer-language-zh",
+        userId: "adapter-user",
+        status: "draft",
+        confidence: 1,
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        rollback: expect.objectContaining({
+          operationId: "memory-consolidation-dry-run",
+          sourceArtifactId: "artifact:previous",
+          metadata: {
+            packageLocal: true,
+          },
+        }),
+      }),
+    });
+    expect(deserialized).toEqual({
+      valid: true,
+      artifact: expect.objectContaining({
+        artifactId: "artifact:semantic-draft:answer-language-zh",
+        userId: "adapter-user",
+        status: "draft",
+        confidence: 1,
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        rollback: expect.objectContaining({
+          operationId: "memory-consolidation-dry-run",
+          sourceArtifactId: "artifact:previous",
+          metadata: {
+            packageLocal: true,
+          },
+        }),
+      }),
+      reasonCodes: [],
+    });
+  });
+
+  it("reports invalid semantic memory artifact payloads without storage writes", () => {
+    const result = deserializeSemanticMemoryArtifactStorageRecord({
+      schemaVersion: 1,
+      artifact: {
+        artifactId: "",
+        userId: "",
+        type: "",
+        content: "",
+        status: "",
+        confidence: Number.NaN,
+        sourceRecordIds: [],
+        sourceClusterKey: "",
+        competitionKey: "",
+        reasonCodes: [],
+      },
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      reasonCodes: [
+        "missing_artifact_id",
+        "missing_user_id",
+        "missing_type",
+        "missing_content",
+        "missing_status",
+        "invalid_confidence",
+        "missing_source_record_ids",
+        "missing_source_cluster_key",
+        "missing_competition_key",
+        "missing_timestamps",
+        "missing_rollback_metadata",
+      ],
+    });
+    expect(
+      deserializeSemanticMemoryArtifactStorageRecord({
+        schemaVersion: 2,
+        artifact: {},
+      }),
+    ).toEqual({
+      valid: false,
+      reasonCodes: ["unsupported_schema_version"],
+    });
+  });
+
+  it("builds semantic artifact storage write reports without performing writes", () => {
+    const disabledArtifact = semanticArtifactStorageFixture();
+    const disabledReport = buildSemanticMemoryArtifactStorageDryRunReport({
+      userId: "adapter-user",
+      artifacts: [disabledArtifact],
+      enabled: false,
+      dryRun: false,
+    });
+    const writeReadyArtifact = semanticArtifactStorageFixture();
+    const writeReadyReport = buildSemanticMemoryArtifactStorageDryRunReport({
+      userId: "adapter-user",
+      artifacts: [writeReadyArtifact],
+      enabled: true,
+      dryRun: false,
+    });
+
+    disabledArtifact.sourceRecordIds.push("mutated-after-report");
+    writeReadyArtifact.sourceRecordIds.push("mutated-after-report");
+
+    expect(disabledReport.summary).toEqual({
+      userId: "adapter-user",
+      status: "disabled",
+      dryRun: true,
+      artifactCount: 1,
+      wouldWriteCount: 1,
+      actualWriteCount: 0,
+      skippedWriteCount: 1,
+    });
+    expect(disabledReport.reasonCodes).toEqual([
+      "artifact_storage_candidate",
+      "persistence_disabled",
+    ]);
+    expect(disabledReport.artifacts[0]).toEqual(
+      expect.objectContaining({
+        artifactId: "artifact:semantic-draft:answer-language-zh",
+        sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+        rollbackOperationId: "memory-consolidation-dry-run",
+        rollbackSourceArtifactId: "artifact:previous",
+        reasonCodes: ["artifact_storage_candidate", "persistence_disabled"],
+      }),
+    );
+    expect(writeReadyReport.summary).toEqual({
+      userId: "adapter-user",
+      status: "write-ready",
+      dryRun: false,
+      artifactCount: 1,
+      wouldWriteCount: 1,
+      actualWriteCount: 0,
+      skippedWriteCount: 0,
+    });
+    expect(writeReadyReport.reasonCodes).toEqual([
+      "artifact_storage_candidate",
+      "write_ready",
+    ]);
+    expect(
+      writeReadyReport.serializedArtifacts[0]?.artifact.sourceRecordIds,
+    ).toEqual(["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"]);
   });
 
   it("runs opt-in memory consolidation diagnostics as a dry-run", async () => {

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -142,6 +142,10 @@ result.
 enough source records, text, confidence, and provenance before it is sent to a
 summarizer.
 
+The summarizer provider boundary can format request/response diagnostics, build a
+stable caller-provided input contract, and wrap fake or external adapters with
+readiness checks. It still does not ship or call a concrete model provider.
+
 `calculateMemoryConsolidationEvalMetrics` provides a small scenario metrics
 helper for comparing expected preservation, temporary/noise leakage, contested
 cluster coverage, and decay precision proxies in focused eval suites.
@@ -155,6 +159,13 @@ retrieval behavior.
 semantic drafts. It only writes through a caller-provided draft store when
 explicitly enabled with `dryRun: false`; otherwise it returns the planned draft
 artifacts for review without changing storage or retrieval behavior.
+
+`serializeSemanticMemoryArtifactStorageRecord` and
+`deserializeSemanticMemoryArtifactStorageRecord` provide a package-local artifact
+round-trip boundary for future storage adapters.
+
+`buildSemanticMemoryArtifactStorageDryRunReport` describes planned semantic
+artifact writes without calling a storage adapter.
 
 `buildMemorySemanticRetrievalPlan` and
 `buildMemorySemanticRetrievalDryRunReport` describe how semantic drafts can be

--- a/packages/ai/memory-consolidation/docs/storage-schema.md
+++ b/packages/ai/memory-consolidation/docs/storage-schema.md
@@ -3,6 +3,9 @@
 This note sketches storage boundaries for future semantic memory work. It does
 not define a migration and does not require runtime writes.
 
+The schema goal is to make semantic memory artifacts durable and auditable
+without replacing raw traces or changing retrieval behavior by default.
+
 ## Layers
 
 ```text
@@ -20,22 +23,73 @@ deprecated memories
 - Deprecated memories preserve old beliefs or preferences after they are
   superseded.
 
-## Required Fields
+## Artifact Shape
 
-Every stored semantic artifact should preserve:
+A durable semantic artifact should be shaped around provenance first:
 
-- artifact id
-- user id
-- content
-- type
-- status
-- confidence
-- source record ids
-- source cluster key
-- competition key
-- reason codes
-- created / updated timestamps
-- rollback metadata
+```ts
+{
+  artifactId: string;
+  userId: string;
+  type: "preference" | "project_state" | "decision" | "constraint" | "unknown" | string;
+  content: string;
+  status: "draft" | "consolidated" | "deprecated" | "conflicted" | string;
+  confidence: number;
+  sourceRecordIds: string[];
+  sourceClusterKey: string;
+  competitionKey: string;
+  reasonCodes: string[];
+  createdAt: number;
+  updatedAt: number;
+  rollback: {
+    sourceArtifactId?: string;
+    operationId?: string;
+    createdBy?: string;
+    reason?: string;
+    metadata?: Record<string, unknown>;
+  };
+  metadata?: Record<string, unknown>;
+}
+```
+
+This mirrors the package-local storage adapter contract, but it is still a
+schema note rather than a migration.
+
+## Field Semantics
+
+- `artifactId` identifies the semantic artifact, not the raw trace.
+- `userId` scopes the artifact to one memory owner.
+- `type` keeps semantic category separate from storage status.
+- `content` stores the compact semantic memory text.
+- `status` records lifecycle state without deleting older artifacts.
+- `confidence` should be clamped to `0..1` before storage.
+- `sourceRecordIds` preserve trace fallback and auditability.
+- `sourceClusterKey` and `competitionKey` preserve consolidation context.
+- `reasonCodes` explain why the artifact was produced or retained.
+- `createdAt` and `updatedAt` support temporal revision later.
+- `rollback` records how to reverse or inspect the operation.
+- `metadata` is reserved for non-schema extension data.
+
+## Status Semantics
+
+- `draft`: produced from semantic draft consolidation but not active memory.
+- `consolidated`: reviewed or promoted semantic memory artifact.
+- `deprecated`: superseded by newer evidence but still auditable.
+- `conflicted`: competing evidence exists and should remain observable.
+
+Status transitions should be additive and explainable. A newer artifact can
+supersede an older one, but the older artifact should remain inspectable until a
+separate retention policy says otherwise.
+
+## Invariants
+
+- A semantic artifact must keep at least one `sourceRecordId`.
+- Raw source traces remain the fallback evidence.
+- Semantic artifacts should be removable without deleting source traces.
+- Persisted drafts must not become retrieval results by default.
+- Deprecated or conflicted artifacts should not be silently overwritten.
+- Rollback metadata should identify the operation or artifact that introduced
+  the current state whenever possible.
 
 ## Retention and Rollback
 
@@ -43,6 +97,56 @@ Source traces should remain available until a separate retention policy exists.
 Semantic drafts and consolidated memories should be removable without deleting
 their supporting traces. Rollback should be able to identify which artifact was
 created from which source records, cluster, and consolidation decision.
+
+## Migration Proposal
+
+A future migration should be staged and reversible:
+
+1. Add a separate semantic artifact storage area for the shape above.
+2. Keep raw traces in their existing storage area and reference them through
+   `sourceRecordIds`.
+3. Backfill no artifacts by default; use dry-run reports first to inspect what
+   would be written.
+4. Gate writes behind an explicit opt-in flag after dry-run output is reviewed.
+5. Keep retrieval disabled for stored artifacts until a later retrieval opt-in
+   task enables it.
+
+The migration should prefer separate semantic artifact storage over mutating raw
+trace records. This keeps raw evidence available, makes rollback simpler, and
+lets semantic memory remain an auditable derived layer.
+
+Suggested indexes:
+
+- `userId` for owner-scoped inspection.
+- `status` for draft, consolidated, deprecated, and conflicted views.
+- `competitionKey` for conflict and replacement workflows.
+- `sourceRecordIds` or a join table for trace-level audit and rollback.
+
+## Rollback Plan
+
+Rollback should not delete raw traces. It should be able to disable or remove
+derived artifacts while keeping their evidence available:
+
+1. Disable semantic artifact writes through the opt-in flag.
+2. Mark affected artifacts as `deprecated` or remove them from the semantic
+   artifact storage area.
+3. Use `rollback.operationId` or `rollback.sourceArtifactId` to find artifacts
+   created by the same operation.
+4. Keep `sourceRecordIds`, `sourceClusterKey`, `competitionKey`, and
+   `reasonCodes` available for audit after rollback.
+5. Leave retrieval behavior unchanged unless a later opt-in retrieval task has
+   explicitly enabled semantic artifacts.
+
+Rollback should be treated as metadata-driven state correction first, and as
+physical deletion only after a separate retention policy exists.
+
+## Deferred Questions
+
+The next storage task should decide:
+
+- how package-local serialization should validate this shape
+- how dry-run write reports should expose planned artifact changes
+- when a separate retention policy may physically delete old artifacts
 
 ## Non-Goals
 

--- a/packages/ai/memory-consolidation/src/persistence.ts
+++ b/packages/ai/memory-consolidation/src/persistence.ts
@@ -73,6 +73,82 @@ export interface SemanticMemoryArtifactStorageAdapter {
   ): Promise<SemanticMemoryArtifactStorageAdapterSaveResult>;
 }
 
+export type SerializedSemanticMemoryArtifactStorageRecordSchemaVersion = 1;
+
+export interface SerializedSemanticMemoryArtifactStorageRecord {
+  schemaVersion: SerializedSemanticMemoryArtifactStorageRecordSchemaVersion;
+  artifact: SemanticMemoryArtifactStorageRecord;
+}
+
+export type SemanticMemoryArtifactDeserializationReasonCode =
+  | "invalid_payload"
+  | "unsupported_schema_version"
+  | "missing_artifact_id"
+  | "missing_user_id"
+  | "missing_type"
+  | "missing_content"
+  | "missing_status"
+  | "invalid_confidence"
+  | "missing_source_record_ids"
+  | "missing_source_cluster_key"
+  | "missing_competition_key"
+  | "missing_timestamps"
+  | "missing_rollback_metadata"
+  | (string & {});
+
+export interface DeserializeSemanticMemoryArtifactStorageRecordResult {
+  valid: boolean;
+  artifact?: SemanticMemoryArtifactStorageRecord;
+  reasonCodes: SemanticMemoryArtifactDeserializationReasonCode[];
+}
+
+export type SemanticMemoryArtifactStorageDryRunReportStatus =
+  | "disabled"
+  | "dry-run"
+  | "write-ready";
+
+export type SemanticMemoryArtifactStorageDryRunReportReasonCode =
+  | "artifact_storage_candidate"
+  | "persistence_disabled"
+  | "dry_run"
+  | "write_ready"
+  | (string & {});
+
+export interface SemanticMemoryArtifactStorageDryRunReportSummary {
+  userId: string;
+  status: SemanticMemoryArtifactStorageDryRunReportStatus;
+  dryRun: boolean;
+  artifactCount: number;
+  wouldWriteCount: number;
+  actualWriteCount: 0;
+  skippedWriteCount: number;
+}
+
+export interface SemanticMemoryArtifactStorageDryRunReportArtifact {
+  artifactId: string;
+  status: SemanticMemoryArtifactStatus;
+  sourceRecordIds: string[];
+  sourceClusterKey: string;
+  competitionKey: string;
+  rollbackOperationId?: string;
+  rollbackSourceArtifactId?: string;
+  reasonCodes: SemanticMemoryArtifactStorageDryRunReportReasonCode[];
+}
+
+export interface SemanticMemoryArtifactStorageDryRunReport {
+  summary: SemanticMemoryArtifactStorageDryRunReportSummary;
+  artifacts: SemanticMemoryArtifactStorageDryRunReportArtifact[];
+  serializedArtifacts: SerializedSemanticMemoryArtifactStorageRecord[];
+  reasonCodes: SemanticMemoryArtifactStorageDryRunReportReasonCode[];
+}
+
+export interface BuildSemanticMemoryArtifactStorageDryRunReportInput {
+  userId: string;
+  artifacts: SemanticMemoryArtifactStorageRecord[];
+  enabled?: boolean;
+  dryRun?: boolean;
+}
+
 export interface SemanticMemoryDraftStoreSaveInput {
   userId: string;
   drafts: PersistedSemanticMemoryDraft[];
@@ -106,6 +182,32 @@ function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
+function copyRecord(
+  record: SemanticMemoryArtifactStorageRecord,
+): SemanticMemoryArtifactStorageRecord {
+  return {
+    ...record,
+    confidence: clamp01(record.confidence),
+    sourceRecordIds: [...record.sourceRecordIds],
+    reasonCodes: [...record.reasonCodes],
+    rollback: {
+      ...record.rollback,
+      metadata: record.rollback.metadata
+        ? { ...record.rollback.metadata }
+        : undefined,
+    },
+    metadata: record.metadata ? { ...record.metadata } : undefined,
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function buildPersistedDraft(
   item: SemanticMemoryDraftPersistenceItem,
   createdAt: number,
@@ -123,6 +225,168 @@ function buildPersistedDraft(
     score: item.candidate.score,
     reasonCodes: [...item.candidate.reasonCodes],
     createdAt,
+  };
+}
+
+function storageDryRunStatus(input: {
+  enabled?: boolean;
+  dryRun?: boolean;
+}): SemanticMemoryArtifactStorageDryRunReportStatus {
+  if (input.enabled !== true) {
+    return "disabled";
+  }
+
+  return input.dryRun === false ? "write-ready" : "dry-run";
+}
+
+function storageDryRunReasonCode(
+  status: SemanticMemoryArtifactStorageDryRunReportStatus,
+): SemanticMemoryArtifactStorageDryRunReportReasonCode {
+  if (status === "disabled") {
+    return "persistence_disabled";
+  }
+
+  return status === "dry-run" ? "dry_run" : "write_ready";
+}
+
+export function serializeSemanticMemoryArtifactStorageRecord(
+  artifact: SemanticMemoryArtifactStorageRecord,
+): SerializedSemanticMemoryArtifactStorageRecord {
+  return {
+    schemaVersion: 1,
+    artifact: copyRecord(artifact),
+  };
+}
+
+export function deserializeSemanticMemoryArtifactStorageRecord(
+  value: unknown,
+): DeserializeSemanticMemoryArtifactStorageRecordResult {
+  if (!isObject(value)) {
+    return {
+      valid: false,
+      reasonCodes: ["invalid_payload"],
+    };
+  }
+
+  if (value.schemaVersion !== 1) {
+    return {
+      valid: false,
+      reasonCodes: ["unsupported_schema_version"],
+    };
+  }
+
+  if (!isObject(value.artifact)) {
+    return {
+      valid: false,
+      reasonCodes: ["invalid_payload"],
+    };
+  }
+
+  const artifact =
+    value.artifact as unknown as SemanticMemoryArtifactStorageRecord;
+  const reasonCodes: SemanticMemoryArtifactDeserializationReasonCode[] = [];
+
+  if (!hasText(artifact.artifactId)) {
+    reasonCodes.push("missing_artifact_id");
+  }
+
+  if (!hasText(artifact.userId)) {
+    reasonCodes.push("missing_user_id");
+  }
+
+  if (!hasText(artifact.type)) {
+    reasonCodes.push("missing_type");
+  }
+
+  if (!hasText(artifact.content)) {
+    reasonCodes.push("missing_content");
+  }
+
+  if (!hasText(artifact.status)) {
+    reasonCodes.push("missing_status");
+  }
+
+  if (!Number.isFinite(artifact.confidence)) {
+    reasonCodes.push("invalid_confidence");
+  }
+
+  if (
+    !Array.isArray(artifact.sourceRecordIds) ||
+    artifact.sourceRecordIds.length === 0 ||
+    !artifact.sourceRecordIds.every(hasText)
+  ) {
+    reasonCodes.push("missing_source_record_ids");
+  }
+
+  if (!hasText(artifact.sourceClusterKey)) {
+    reasonCodes.push("missing_source_cluster_key");
+  }
+
+  if (!hasText(artifact.competitionKey)) {
+    reasonCodes.push("missing_competition_key");
+  }
+
+  if (
+    !Number.isFinite(artifact.createdAt) ||
+    !Number.isFinite(artifact.updatedAt)
+  ) {
+    reasonCodes.push("missing_timestamps");
+  }
+
+  if (!isObject(artifact.rollback)) {
+    reasonCodes.push("missing_rollback_metadata");
+  }
+
+  if (!Array.isArray(artifact.reasonCodes)) {
+    reasonCodes.push("invalid_payload");
+  }
+
+  if (reasonCodes.length > 0) {
+    return {
+      valid: false,
+      reasonCodes,
+    };
+  }
+
+  return {
+    valid: true,
+    artifact: copyRecord(artifact),
+    reasonCodes: [],
+  };
+}
+
+export function buildSemanticMemoryArtifactStorageDryRunReport(
+  input: BuildSemanticMemoryArtifactStorageDryRunReportInput,
+): SemanticMemoryArtifactStorageDryRunReport {
+  const status = storageDryRunStatus(input);
+  const runReason = storageDryRunReasonCode(status);
+  const wouldWriteCount = input.artifacts.length;
+  const skippedWriteCount = status === "write-ready" ? 0 : wouldWriteCount;
+
+  return {
+    summary: {
+      userId: input.userId,
+      status,
+      dryRun: status !== "write-ready",
+      artifactCount: input.artifacts.length,
+      wouldWriteCount,
+      actualWriteCount: 0,
+      skippedWriteCount,
+    },
+    artifacts: input.artifacts.map((artifact) => ({
+      artifactId: artifact.artifactId,
+      status: artifact.status,
+      sourceRecordIds: [...artifact.sourceRecordIds],
+      sourceClusterKey: artifact.sourceClusterKey,
+      competitionKey: artifact.competitionKey,
+      rollbackOperationId: artifact.rollback.operationId,
+      rollbackSourceArtifactId: artifact.rollback.sourceArtifactId,
+      reasonCodes: ["artifact_storage_candidate", runReason],
+    })),
+    serializedArtifacts: input.artifacts.map((artifact) =>
+      serializeSemanticMemoryArtifactStorageRecord(artifact),
+    ),
+    reasonCodes: ["artifact_storage_candidate", runReason],
   };
 }
 

--- a/packages/ai/memory-consolidation/src/semantic-draft.ts
+++ b/packages/ai/memory-consolidation/src/semantic-draft.ts
@@ -91,6 +91,119 @@ export interface SemanticMemoryDraftReadinessDiagnostics {
   reasonCodes: SemanticMemoryDraftReadinessReasonCode[];
 }
 
+export interface SemanticMemoryDraftSummarizerRequestDiagnostics {
+  draftId: string;
+  sourceClusterKey: string;
+  competitionKey: string;
+  suggestedType: MemorySemanticDraftSuggestedType;
+  confidence: number;
+  sourceRecordIds: string[];
+  availableSourceRecordIds: string[];
+  missingSourceRecordIds: string[];
+  recordsMissingTextIds: string[];
+  ready: boolean;
+  reasonCodes: SemanticMemoryDraftReadinessReasonCode[];
+}
+
+export type SemanticMemoryDraftSummarizerResponseReasonCode =
+  | "missing_output_content"
+  | "output_source_record_mismatch"
+  | "output_type_mismatch"
+  | "invalid_output_confidence"
+  | (string & {});
+
+export interface SemanticMemoryDraftSummarizerResponseDiagnostics {
+  draftId: string;
+  outputType: MemorySemanticDraftSuggestedType;
+  outputConfidence: number;
+  outputSourceRecordIds: string[];
+  preservesType: boolean;
+  preservesSourceRecordIds: boolean;
+  hasContent: boolean;
+  reasonCodes: SemanticMemoryDraftSummarizerResponseReasonCode[];
+}
+
+export interface SemanticMemoryDraftSummarizerDiagnostics {
+  request: SemanticMemoryDraftSummarizerRequestDiagnostics;
+  response?: SemanticMemoryDraftSummarizerResponseDiagnostics;
+}
+
+export interface SemanticMemoryDraftSummarizerSourceRecordInput {
+  recordId: string;
+  text: string;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SemanticMemoryDraftSummarizerCandidateInput {
+  draftId: string;
+  sourceClusterKey: string;
+  competitionKey: string;
+  suggestedType: MemorySemanticDraftSuggestedType;
+  confidence: number;
+  sourceRecordIds: string[];
+  reasonCodes: MemoryConsolidationReasonCode[];
+  needsSummary: true;
+  summaryPriority?: number;
+}
+
+export interface SemanticMemoryDraftSummarizerInputContract {
+  candidate: SemanticMemoryDraftSummarizerCandidateInput;
+  request: SemanticMemoryDraftSummarizerRequestDiagnostics;
+  sourceRecords: SemanticMemoryDraftSummarizerSourceRecordInput[];
+  context?: SemanticMemoryDraftSummarizerContext;
+}
+
+export interface SemanticMemoryDraftSummarizerProviderInvoke {
+  (
+    input: SemanticMemoryDraftSummarizerInputContract,
+  ): Promise<SemanticMemoryDraft>;
+}
+
+export type SemanticMemoryDraftSummarizerProviderAdapterStatus =
+  | "summarized"
+  | "skipped"
+  | "failed";
+
+export type SemanticMemoryDraftSummarizerProviderAdapterReasonCode =
+  | "request_not_ready"
+  | "provider_error"
+  | SemanticMemoryDraftReadinessReasonCode
+  | SemanticMemoryDraftSummarizerResponseReasonCode
+  | (string & {});
+
+export interface SemanticMemoryDraftSummarizerProviderAdapterError {
+  name?: string;
+  message: string;
+}
+
+export interface SemanticMemoryDraftSummarizerProviderAdapterResult {
+  status: SemanticMemoryDraftSummarizerProviderAdapterStatus;
+  input: SemanticMemoryDraftSummarizerInputContract;
+  diagnostics: SemanticMemoryDraftSummarizerDiagnostics;
+  draft?: SemanticMemoryDraft;
+  error?: SemanticMemoryDraftSummarizerProviderAdapterError;
+  reasonCodes: SemanticMemoryDraftSummarizerProviderAdapterReasonCode[];
+}
+
+export interface BuildSemanticMemoryDraftSummarizerDiagnosticsInput {
+  candidate: MemorySemanticDraftCandidate;
+  records: MemoryEvidenceRecord[];
+  minConfidence?: number;
+  draft?: SemanticMemoryDraft;
+}
+
+export interface BuildSemanticMemoryDraftSummarizerInputContractInput {
+  candidate: MemorySemanticDraftCandidate;
+  records: MemoryEvidenceRecord[];
+  context?: SemanticMemoryDraftSummarizerContext;
+  minConfidence?: number;
+}
+
+export interface InvokeSemanticMemoryDraftSummarizerProviderInput extends BuildSemanticMemoryDraftSummarizerInputContractInput {
+  invoke: SemanticMemoryDraftSummarizerProviderInvoke;
+}
+
 function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
@@ -224,6 +337,85 @@ function resolveMaxCandidates(value: number | undefined): number {
   return Math.max(0, Math.floor(value));
 }
 
+function sameStringSet(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+function copyContext(
+  context: SemanticMemoryDraftSummarizerContext | undefined,
+): SemanticMemoryDraftSummarizerContext | undefined {
+  if (!context) {
+    return undefined;
+  }
+
+  return {
+    now: context.now,
+    metadata: context.metadata ? { ...context.metadata } : undefined,
+  };
+}
+
+function toProviderAdapterError(
+  error: unknown,
+): SemanticMemoryDraftSummarizerProviderAdapterError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
+function buildSummarizerResponseDiagnostics(
+  candidate: MemorySemanticDraftCandidate,
+  draft: SemanticMemoryDraft,
+): SemanticMemoryDraftSummarizerResponseDiagnostics {
+  const hasContent = draft.content.trim().length > 0;
+  const preservesType = draft.type === candidate.suggestedType;
+  const preservesSourceRecordIds = sameStringSet(
+    draft.sourceRecordIds,
+    candidate.sourceRecordIds,
+  );
+  const reasonCodes: SemanticMemoryDraftSummarizerResponseReasonCode[] = [];
+
+  if (!hasContent) {
+    reasonCodes.push("missing_output_content");
+  }
+
+  if (!preservesSourceRecordIds) {
+    reasonCodes.push("output_source_record_mismatch");
+  }
+
+  if (!preservesType) {
+    reasonCodes.push("output_type_mismatch");
+  }
+
+  if (!Number.isFinite(draft.confidence)) {
+    reasonCodes.push("invalid_output_confidence");
+  }
+
+  return {
+    draftId: candidate.draftId,
+    outputType: draft.type,
+    outputConfidence: draft.confidence,
+    outputSourceRecordIds: [...draft.sourceRecordIds],
+    preservesType,
+    preservesSourceRecordIds,
+    hasContent,
+    reasonCodes,
+  };
+}
+
 export function buildSemanticMemoryDraftCandidates(
   input: BuildSemanticMemoryDraftCandidatesInput,
 ): MemorySemanticDraftCandidate[] {
@@ -346,4 +538,128 @@ export function analyzeSemanticMemoryDraftReadiness(
     recordsMissingTextIds,
     reasonCodes,
   };
+}
+
+export function buildSemanticMemoryDraftSummarizerDiagnostics(
+  input: BuildSemanticMemoryDraftSummarizerDiagnosticsInput,
+): SemanticMemoryDraftSummarizerDiagnostics {
+  const readiness = analyzeSemanticMemoryDraftReadiness({
+    candidate: input.candidate,
+    records: input.records,
+    minConfidence: input.minConfidence,
+  });
+  const request: SemanticMemoryDraftSummarizerRequestDiagnostics = {
+    draftId: input.candidate.draftId,
+    sourceClusterKey: input.candidate.sourceClusterKey,
+    competitionKey: input.candidate.competitionKey,
+    suggestedType: input.candidate.suggestedType,
+    confidence: input.candidate.confidence,
+    sourceRecordIds: [...readiness.sourceRecordIds],
+    availableSourceRecordIds: [...readiness.availableSourceRecordIds],
+    missingSourceRecordIds: [...readiness.missingSourceRecordIds],
+    recordsMissingTextIds: [...readiness.recordsMissingTextIds],
+    ready: readiness.ready,
+    reasonCodes: [...readiness.reasonCodes],
+  };
+
+  return {
+    request,
+    response: input.draft
+      ? buildSummarizerResponseDiagnostics(input.candidate, input.draft)
+      : undefined,
+  };
+}
+
+export function buildSemanticMemoryDraftSummarizerInputContract(
+  input: BuildSemanticMemoryDraftSummarizerInputContractInput,
+): SemanticMemoryDraftSummarizerInputContract {
+  const recordsById = new Map(
+    input.records.map((record) => [record.id, record]),
+  );
+  const diagnostics = buildSemanticMemoryDraftSummarizerDiagnostics({
+    candidate: input.candidate,
+    records: input.records,
+    minConfidence: input.minConfidence,
+  });
+  const sourceRecords =
+    diagnostics.request.sourceRecordIds.flatMap<SemanticMemoryDraftSummarizerSourceRecordInput>(
+      (recordId) => {
+        const record = recordsById.get(recordId);
+
+        if (!record) {
+          return [];
+        }
+
+        return [
+          {
+            recordId,
+            text: record.text ?? "",
+            timestamp: record.timestamp,
+            metadata: record.metadata ? { ...record.metadata } : undefined,
+          },
+        ];
+      },
+    );
+
+  return {
+    candidate: {
+      draftId: input.candidate.draftId,
+      sourceClusterKey: input.candidate.sourceClusterKey,
+      competitionKey: input.candidate.competitionKey,
+      suggestedType: input.candidate.suggestedType,
+      confidence: input.candidate.confidence,
+      sourceRecordIds: [...input.candidate.sourceRecordIds],
+      reasonCodes: [...input.candidate.reasonCodes],
+      needsSummary: true,
+      summaryPriority: input.candidate.summaryPriority,
+    },
+    request: diagnostics.request,
+    sourceRecords,
+    context: copyContext(input.context),
+  };
+}
+
+export async function invokeSemanticMemoryDraftSummarizerProvider(
+  input: InvokeSemanticMemoryDraftSummarizerProviderInput,
+): Promise<SemanticMemoryDraftSummarizerProviderAdapterResult> {
+  const inputContract = buildSemanticMemoryDraftSummarizerInputContract(input);
+
+  if (!inputContract.request.ready) {
+    return {
+      status: "skipped",
+      input: inputContract,
+      diagnostics: {
+        request: inputContract.request,
+      },
+      reasonCodes: ["request_not_ready", ...inputContract.request.reasonCodes],
+    };
+  }
+
+  try {
+    const draft = await input.invoke(inputContract);
+    const diagnostics = buildSemanticMemoryDraftSummarizerDiagnostics({
+      candidate: input.candidate,
+      records: input.records,
+      minConfidence: input.minConfidence,
+      draft,
+    });
+
+    return {
+      status: "summarized",
+      input: inputContract,
+      diagnostics,
+      draft,
+      reasonCodes: [...(diagnostics.response?.reasonCodes ?? [])],
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      input: inputContract,
+      diagnostics: {
+        request: inputContract.request,
+      },
+      error: toProviderAdapterError(error),
+      reasonCodes: ["provider_error"],
+    };
+  }
 }


### PR DESCRIPTION
## Summary
Add the semantic artifact foundation for the memory-consolidation package.

This PR keeps the implementation package-local and reviewable:
- add semantic memory draft candidate and summarizer boundary helpers
- add semantic artifact serialization and validation helpers
- add controlled persistence dry-run reports and caller-provided store boundary
- document the future storage shape as a schema note, not a migration

## Scope
- Does not change forgetting runtime behavior
- Does not change retrieval ranking or retrieval defaults
- Does not add a storage migration or write to a database
- Does not introduce an LLM, embedding provider, network provider, scheduler, or UI
- Persistence remains disabled/dry-run by default and requires an explicit caller-provided store

## Testing
- `corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/semantic-draft.ts packages/ai/memory-consolidation/src/persistence.ts packages/ai/memory-consolidation/README.md packages/ai/memory-consolidation/docs/storage-schema.md apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `git diff --check`