### PR TITLE
feat(memory): add runtime retrieval diagnostics

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   adaptMemoryRecordsForConsolidation,
+  adaptRuntimeMemoryRecordsForConsolidation,
   analyzeSemanticMemoryDraftReadiness,
   analyzeMemoryEvidenceClusters,
   assignMemoryRelationGraph,
@@ -8,10 +9,15 @@ import {
   buildMemoryConsolidationPlan,
   buildMemoryConsolidationDiagnosticsReport,
   buildMemoryEvidenceClusters,
+  buildMemoryConsolidationDiagnosticsRunReport,
+  buildMemoryConsolidationRuntimeRecordSelectors,
   buildMemoryRelationCandidates,
   buildMemoryRelationPipeline,
   buildMemoryRelationPipelineDiagnostics,
+  buildMemorySemanticRetrievalComparisonReport,
   buildMemorySemanticRetrievalDryRunReport,
+  buildMemorySemanticRetrievalEvalScenarioReport,
+  buildMemorySemanticRetrievalMergedResults,
   buildMemorySemanticRetrievalPlan,
   buildSemanticMemoryArtifactStorageDryRunReport,
   buildSemanticMemoryDraftSummarizerInputContract,
@@ -20,13 +26,19 @@ import {
   deserializeSemanticMemoryArtifactStorageRecord,
   deriveMemoryRelationGraphLifecycle,
   invokeSemanticMemoryDraftSummarizerProvider,
+  logMemoryConsolidationDiagnosticsRun,
   persistSemanticMemoryDrafts,
   runMemoryConsolidationDiagnostics,
   serializeSemanticMemoryArtifactStorageRecord,
   summarizeSemanticMemoryDraftCandidate,
+  resolveMemorySemanticRetrievalConfig,
+  type MemorySemanticRetrievalConfig,
   type MemorySemanticRetrievalCandidate,
+  type MemorySemanticRetrievalComparisonReport,
   type MemorySemanticRetrievalDryRunReport,
   type MemorySemanticRetrievalDraft,
+  type MemorySemanticRetrievalEvalScenarioReport,
+  type MemorySemanticRetrievalMergedResultSet,
   type MemorySemanticRetrievalPlanningInput,
   type MemorySemanticRetrievalPlanningResult,
   type SemanticMemoryArtifactStorageAdapter,
@@ -1005,6 +1017,24 @@ function semanticArtifactStorageFixture() {
       dryRun: true,
     },
   } satisfies SemanticMemoryArtifactStorageRecord;
+}
+
+async function buildDiagnosticsRunFixture() {
+  const input = buildAdapterDiagnosticsInput();
+
+  return runMemoryConsolidationDiagnostics({
+    userId: "adapter-user",
+    now: NOW,
+    dryRun: true,
+    limit: 25,
+    reader: {
+      async listCandidateRecords() {
+        return input.records;
+      },
+    },
+    selectors: adapterSelectors,
+    plan: input.plan,
+  });
 }
 
 describe("memory consolidation evaluation scenarios", () => {
@@ -2318,6 +2348,367 @@ describe("memory consolidation evaluation scenarios", () => {
     });
   });
 
+  it("keeps semantic retrieval integration disabled by default", () => {
+    const config =
+      resolveMemorySemanticRetrievalConfig() satisfies MemorySemanticRetrievalConfig;
+
+    expect(config).toEqual({
+      enabled: false,
+      status: "disabled",
+      minConfidence: 0,
+      allowContested: false,
+      maxCandidates: undefined,
+      reasonCodes: ["semantic_retrieval_disabled"],
+      metadata: undefined,
+    });
+  });
+
+  it("resolves explicit semantic retrieval opt-in config without ranking changes", () => {
+    const config = resolveMemorySemanticRetrievalConfig({
+      enabled: true,
+      minConfidence: 1.5,
+      allowContested: true,
+      maxCandidates: 2.8,
+      reasonCodes: ["semantic_draft_candidate"],
+      metadata: {
+        source: "unit-test",
+      },
+    });
+
+    expect(config).toEqual({
+      enabled: true,
+      status: "enabled",
+      minConfidence: 1,
+      allowContested: true,
+      maxCandidates: 2,
+      reasonCodes: ["semantic_draft_candidate", "semantic_retrieval_enabled"],
+      metadata: {
+        source: "unit-test",
+      },
+    });
+  });
+
+  it("keeps raw trace fallback when semantic retrieval merge is disabled", () => {
+    const plan = buildMemorySemanticRetrievalPlan({
+      query: "Which preference is relevant?",
+      drafts: [
+        {
+          draftId: "semantic-draft:selected",
+          type: "preference",
+          content: "User prefers Chinese technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          confidence: 0.88,
+        },
+      ],
+      existingRecordIds: ["raw-trace:zh-a"],
+      getDraftRelevance: () => 0.9,
+    });
+    const merged = buildMemorySemanticRetrievalMergedResults({
+      plan,
+      sourceResults: [
+        {
+          recordId: "raw-trace:zh-a",
+          content: "Prefer Chinese technical explanations.",
+          reasonCodes: ["query_relevance"],
+        },
+      ],
+    }) satisfies MemorySemanticRetrievalMergedResultSet;
+
+    expect(merged.enabled).toBe(false);
+    expect(merged.results).toEqual([
+      expect.objectContaining({
+        resultId: "raw-trace:zh-a",
+        kind: "source-trace",
+        status: "fallback",
+        sourceRecordIds: ["raw-trace:zh-a"],
+        reasonCodes: [
+          "source_trace_fallback",
+          "semantic_retrieval_disabled",
+          "query_relevance",
+        ],
+      }),
+    ]);
+    expect(merged.semanticResults).toEqual([]);
+    expect(merged.suppressedDrafts).toEqual([
+      expect.objectContaining({
+        draftId: "semantic-draft:selected",
+        status: "suppressed",
+        reasonCodes: [
+          "semantic_draft_candidate",
+          "query_relevance",
+          "semantic_retrieval_disabled",
+        ],
+      }),
+    ]);
+  });
+
+  it("merges raw trace fallback with eligible semantic drafts only after opt-in", () => {
+    const plan = buildMemorySemanticRetrievalPlan({
+      query: "Which long-term preference should guide this answer?",
+      minConfidence: 0.7,
+      drafts: [
+        {
+          draftId: "semantic-draft:selected",
+          type: "preference",
+          content: "User prefers Chinese technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          confidence: 0.88,
+          metadata: {
+            sourceClusterKey: "answer-language:zh",
+          },
+        },
+        {
+          draftId: "semantic-draft:low-confidence",
+          type: "preference",
+          content: "User might prefer terse answers.",
+          sourceRecordIds: ["raw-trace:style-a"],
+          confidence: 0.4,
+        },
+      ],
+      existingRecordIds: ["raw-trace:zh-a"],
+      getDraftRelevance: () => 0.9,
+    });
+    const merged = buildMemorySemanticRetrievalMergedResults({
+      plan,
+      config: {
+        enabled: true,
+        reasonCodes: ["semantic_draft_candidate"],
+      },
+    });
+
+    expect(merged.enabled).toBe(true);
+    expect(merged.results).toEqual([
+      expect.objectContaining({
+        resultId: "raw-trace:zh-a",
+        kind: "source-trace",
+        status: "fallback",
+        sourceRecordIds: ["raw-trace:zh-a"],
+        reasonCodes: expect.arrayContaining([
+          "source_trace_fallback",
+          "semantic_retrieval_enabled",
+        ]),
+      }),
+      expect.objectContaining({
+        resultId: "semantic-draft:selected",
+        kind: "semantic-draft",
+        draftId: "semantic-draft:selected",
+        status: "eligible",
+        confidence: 0.88,
+        queryRelevance: 0.9,
+        sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+        reasonCodes: expect.arrayContaining([
+          "semantic_draft_candidate",
+          "query_relevance",
+          "semantic_retrieval_enabled",
+        ]),
+        metadata: {
+          sourceClusterKey: "answer-language:zh",
+        },
+      }),
+    ]);
+    expect(merged.suppressedDrafts).toEqual([
+      expect.objectContaining({
+        draftId: "semantic-draft:low-confidence",
+        status: "suppressed",
+        reasonCodes: expect.arrayContaining([
+          "semantic_draft_candidate",
+          "query_relevance",
+          "low_confidence",
+          "semantic_retrieval_enabled",
+        ]),
+      }),
+    ]);
+    expect(plan.fallbackRecordIds).toEqual(["raw-trace:zh-a"]);
+  });
+
+  it("reports opt-in semantic retrieval eval scenarios for selected, suppressed, and fallback results", () => {
+    const plan = buildMemorySemanticRetrievalPlan({
+      query: "Which language preference should guide this answer?",
+      minConfidence: 0.7,
+      drafts: [
+        {
+          draftId: "semantic-draft:selected-zh",
+          type: "preference",
+          content: "User prefers Chinese for technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          confidence: 0.9,
+        },
+        {
+          draftId: "semantic-draft:temporary-en",
+          type: "preference",
+          content: "User once asked for English in a temporary reply.",
+          sourceRecordIds: ["raw-trace:en-temp"],
+          confidence: 0.5,
+        },
+      ],
+      existingRecordIds: ["raw-trace:zh-a"],
+      getDraftRelevance({ draft }) {
+        return draft.draftId === "semantic-draft:selected-zh" ? 0.95 : 0.8;
+      },
+    });
+    const merged = buildMemorySemanticRetrievalMergedResults({
+      plan,
+      config: {
+        enabled: true,
+      },
+      sourceResults: [
+        {
+          recordId: "raw-trace:zh-a",
+          content: "Prefer Chinese technical explanations.",
+          reasonCodes: ["query_relevance"],
+        },
+      ],
+    });
+    const report = buildMemorySemanticRetrievalEvalScenarioReport({
+      scenarioId: "retrieval-opt-in-language-preference",
+      merged,
+      expectations: {
+        selectedDraftIds: ["semantic-draft:selected-zh"],
+        suppressedDraftIds: ["semantic-draft:temporary-en"],
+        fallbackRecordIds: ["raw-trace:zh-a"],
+      },
+      metadata: {
+        category: "opt-in-retrieval",
+      },
+    }) satisfies MemorySemanticRetrievalEvalScenarioReport;
+
+    expect(report).toEqual({
+      scenarioId: "retrieval-opt-in-language-preference",
+      query: "Which language preference should guide this answer?",
+      enabled: true,
+      selectedDraftIds: ["semantic-draft:selected-zh"],
+      suppressedDraftIds: ["semantic-draft:temporary-en"],
+      fallbackRecordIds: ["raw-trace:zh-a"],
+      missingSelectedDraftIds: [],
+      missingSuppressedDraftIds: [],
+      missingFallbackRecordIds: [],
+      selectedPassed: true,
+      suppressedPassed: true,
+      fallbackPassed: true,
+      passed: true,
+      reasonCodes: expect.arrayContaining([
+        "semantic_retrieval_enabled",
+        "semantic_draft_candidate",
+        "query_relevance",
+        "source_trace_fallback",
+        "low_confidence",
+      ]),
+      metadata: {
+        category: "opt-in-retrieval",
+      },
+    });
+    expect(merged.results.map((result) => result.kind)).toEqual([
+      "source-trace",
+      "semantic-draft",
+    ]);
+  });
+
+  it("builds a log-only semantic retrieval comparison report without mutating snapshots", () => {
+    const plan = buildMemorySemanticRetrievalPlan({
+      query: "Which language preference should guide this answer?",
+      minConfidence: 0.7,
+      drafts: [
+        {
+          draftId: "semantic-draft:selected-zh",
+          type: "preference",
+          content: "User prefers Chinese for technical explanations.",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          confidence: 0.9,
+        },
+        {
+          draftId: "semantic-draft:low-confidence",
+          type: "preference",
+          content: "User might prefer terse answers.",
+          sourceRecordIds: ["raw-trace:style-a"],
+          confidence: 0.4,
+        },
+      ],
+      existingRecordIds: ["raw-trace:zh-a"],
+      getDraftRelevance: () => 0.9,
+    });
+    const baseline = buildMemorySemanticRetrievalMergedResults({
+      plan,
+      sourceResults: [
+        {
+          recordId: "raw-trace:zh-a",
+          content: "Prefer Chinese technical explanations.",
+        },
+      ],
+    });
+    const candidate = buildMemorySemanticRetrievalMergedResults({
+      plan,
+      config: {
+        enabled: true,
+      },
+      sourceResults: [
+        {
+          recordId: "raw-trace:zh-a",
+          content: "Prefer Chinese technical explanations.",
+        },
+      ],
+    });
+    const baselineSnapshot = JSON.stringify(baseline);
+    const candidateSnapshot = JSON.stringify(candidate);
+    const report = buildMemorySemanticRetrievalComparisonReport({
+      baseline,
+      candidate,
+      metadata: {
+        mode: "log-only",
+      },
+    }) satisfies MemorySemanticRetrievalComparisonReport;
+
+    expect(report).toEqual({
+      summary: {
+        query: "Which language preference should guide this answer?",
+        baselineResultCount: 1,
+        candidateResultCount: 2,
+        addedSemanticDraftCount: 1,
+        retainedFallbackRecordCount: 1,
+        suppressedDraftCount: 1,
+      },
+      query: "Which language preference should guide this answer?",
+      baselineEnabled: false,
+      candidateEnabled: true,
+      baselineResultIds: ["raw-trace:zh-a"],
+      candidateResultIds: ["raw-trace:zh-a", "semantic-draft:selected-zh"],
+      retainedFallbackRecordIds: ["raw-trace:zh-a"],
+      addedSemanticDrafts: [
+        {
+          draftId: "semantic-draft:selected-zh",
+          sourceRecordIds: ["raw-trace:zh-a", "raw-trace:zh-b"],
+          reasonCodes: [
+            "semantic_draft_candidate",
+            "query_relevance",
+            "semantic_retrieval_enabled",
+          ],
+        },
+      ],
+      suppressedDrafts: [
+        {
+          draftId: "semantic-draft:low-confidence",
+          sourceRecordIds: ["raw-trace:style-a"],
+          reasonCodes: [
+            "semantic_draft_candidate",
+            "query_relevance",
+            "low_confidence",
+            "semantic_retrieval_enabled",
+          ],
+        },
+      ],
+      reasonCodes: expect.arrayContaining([
+        "semantic_retrieval_comparison",
+        "semantic_retrieval_log_only",
+        "semantic_retrieval_disabled",
+        "semantic_retrieval_enabled",
+      ]),
+      metadata: {
+        mode: "log-only",
+      },
+    });
+    expect(JSON.stringify(baseline)).toBe(baselineSnapshot);
+    expect(JSON.stringify(candidate)).toBe(candidateSnapshot);
+  });
+
   it("plans semantic draft retrieval candidates with caller-provided relevance", () => {
     const drafts: MemorySemanticRetrievalDraft[] = [
       {
@@ -2965,6 +3356,280 @@ describe("memory consolidation evaluation scenarios", () => {
         suggestedType: "preference",
         sourceRecordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
         needsSummary: true,
+      }),
+    ]);
+  });
+
+  it("adapts structurally compatible runtime memory records for consolidation", () => {
+    const records: MemoryRecord[] = [
+      {
+        ...relationPipelineRecord(
+          "runtime-zh-a",
+          "Use Chinese for repo work.",
+          119,
+          "zh",
+          { accessCount: 2 },
+        ),
+        importanceScore: 0.8,
+        dimensions: {
+          project: "openloomi",
+        },
+      },
+    ];
+    const adapted = adaptRuntimeMemoryRecordsForConsolidation({ records });
+
+    expect(adapted).toEqual({
+      records: [
+        expect.objectContaining({
+          id: "runtime-zh-a",
+          userId: "eval-user",
+          timestamp: 119 * DAY_MS,
+          text: "Use Chinese for repo work.",
+          tier: "short",
+          accessCount: 2,
+          importanceScore: 0.8,
+          dimensions: {
+            project: "openloomi",
+          },
+          metadata: expect.objectContaining({
+            relationGroup: "answer-language",
+            relationValue: "zh",
+            relationScope: "long-term",
+          }),
+        }),
+      ],
+      skippedRecords: [],
+      sourceIndexesByRecordId: {
+        "runtime-zh-a": 0,
+      },
+    });
+  });
+
+  it("uses runtime memory record selectors in diagnostics without storage writes", () => {
+    const records: MemoryRecord[] = [
+      relationPipelineRecord(
+        "runtime-zh-a",
+        "Use Chinese for repo work.",
+        30,
+        "zh",
+        { accessCount: 1 },
+      ),
+      relationPipelineRecord(
+        "runtime-zh-b",
+        "Prefer Chinese technical explanations.",
+        45,
+        "zh",
+        { accessCount: 1 },
+      ),
+      relationPipelineRecord(
+        "runtime-zh-c",
+        "Code explanations are easier in Chinese.",
+        60,
+        "zh",
+        { accessCount: 1 },
+      ),
+      relationPipelineRecord(
+        "runtime-temp-en",
+        "Use English for this one reply.",
+        119,
+        "en",
+        { scope: "temporary" },
+      ),
+    ];
+    const diagnostics = buildMemoryRelationPipelineDiagnostics({
+      records,
+      now: NOW,
+      selectors: buildMemoryConsolidationRuntimeRecordSelectors<MemoryRecord>(),
+      plan: {
+        thresholds: {
+          preserveScore: 0.5,
+          preserveEvidence: 3,
+          competitionMargin: 0.05,
+        },
+      },
+    });
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        sourceRecordCount: 4,
+        adaptedRecordCount: 4,
+        skippedRecordCount: 0,
+        preserveCount: 1,
+        decayCount: 1,
+      }),
+    );
+    expect(report.preservedClusters).toEqual([
+      expect.objectContaining({
+        recordIds: ["runtime-zh-a", "runtime-zh-b", "runtime-zh-c"],
+        reasonCodes: ["strong_repeated_evidence"],
+      }),
+    ]);
+    expect(report.decayedRecords).toEqual([
+      expect.objectContaining({
+        recordId: "runtime-temp-en",
+      }),
+    ]);
+  });
+
+  it("builds a compact diagnostics run report for real-record batches", async () => {
+    const records = [
+      {
+        owner: "adapter-user",
+        createdAt: NOW,
+        body: "Missing id.",
+      },
+      adapterSourceRecord(
+        "runtime-report-zh-a",
+        "Use Chinese for repo work.",
+        30,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "runtime-report-zh-b",
+        "Prefer Chinese technical explanations.",
+        45,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "runtime-report-zh-c",
+        "Code explanations are easier in Chinese.",
+        60,
+        "zh",
+        { reads: 1 },
+      ),
+      adapterSourceRecord(
+        "runtime-report-temp-en",
+        "Use English for this one reply.",
+        119,
+        "en",
+        { scope: "temporary" },
+      ),
+    ];
+    const result = await runMemoryConsolidationDiagnostics({
+      userId: "adapter-user",
+      now: NOW,
+      dryRun: true,
+      reader: {
+        async listCandidateRecords() {
+          return records;
+        },
+      },
+      selectors: adapterSelectors,
+      plan: {
+        thresholds: {
+          preserveScore: 0.5,
+          preserveEvidence: 3,
+          competitionMargin: 0.05,
+        },
+      },
+    });
+    const report = buildMemoryConsolidationDiagnosticsRunReport(result);
+
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        status: "success",
+        dryRun: true,
+        userId: "adapter-user",
+        scannedRecordCount: 5,
+        adaptedRecordCount: 4,
+        skippedRecordCount: 1,
+        preservedClusterCount: 1,
+        suppressedRecordCount: 1,
+        semanticDraftCandidateCount: 1,
+      }),
+    );
+    expect(report.skippedRecords).toEqual([
+      {
+        sourceIndex: 0,
+        reasonCodes: ["missing_id"],
+      },
+    ]);
+    expect(report.preservedClusters).toEqual([
+      expect.objectContaining({
+        recordIds: [
+          "runtime-report-zh-a",
+          "runtime-report-zh-b",
+          "runtime-report-zh-c",
+        ],
+        reasonCodes: ["strong_repeated_evidence"],
+        semanticDraftCandidateIds: [expect.stringContaining("semantic-draft:")],
+      }),
+    ]);
+    expect(report.suppressedRecords).toEqual([
+      expect.objectContaining({
+        recordId: "runtime-report-temp-en",
+        reasonCodes: ["isolated_low_confidence"],
+      }),
+    ]);
+    expect(report.semanticDraftCandidateIds).toEqual([
+      expect.stringContaining("semantic-draft:"),
+    ]);
+  });
+
+  it("logs diagnostics run reports only through an explicitly enabled caller sink", async () => {
+    const result = await buildDiagnosticsRunFixture();
+    const disabledSinkCalls: unknown[] = [];
+    const disabled = await logMemoryConsolidationDiagnosticsRun({
+      result,
+      sink: {
+        logDiagnosticsRun(report) {
+          disabledSinkCalls.push(report);
+        },
+      },
+    });
+    const enabledSinkCalls: ReturnType<
+      typeof buildMemoryConsolidationDiagnosticsRunReport
+    >[] = [];
+    const logged = await logMemoryConsolidationDiagnosticsRun({
+      result,
+      enabled: true,
+      sink: {
+        logDiagnosticsRun(report) {
+          enabledSinkCalls.push(report);
+        },
+      },
+    });
+
+    expect(disabledSinkCalls).toEqual([]);
+    expect(disabled).toEqual(
+      expect.objectContaining({
+        status: "disabled",
+        reasonCodes: ["log_disabled"],
+      }),
+    );
+    await expect(
+      logMemoryConsolidationDiagnosticsRun({
+        result,
+        enabled: true,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: "disabled",
+        reasonCodes: ["log_sink_missing"],
+      }),
+    );
+    expect(logged).toEqual(
+      expect.objectContaining({
+        status: "logged",
+        reasonCodes: ["log_only"],
+      }),
+    );
+    expect(enabledSinkCalls).toEqual([
+      expect.objectContaining({
+        summary: expect.objectContaining({
+          dryRun: true,
+          userId: "adapter-user",
+          preservedClusterCount: 1,
+          suppressedRecordCount: 1,
+        }),
+        preservedClusters: [
+          expect.objectContaining({
+            recordIds: ["adapter-zh-a", "adapter-zh-b", "adapter-zh-c"],
+          }),
+        ],
       }),
     ]);
   });

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -155,6 +155,17 @@ a record reader, and the runner returns diagnostics, a compact report, and draft
 candidates without writing semantic memory, archiving source records, or changing
 retrieval behavior.
 
+`adaptRuntimeMemoryRecordsForConsolidation` and
+`buildMemoryConsolidationRuntimeRecordSelectors` adapt structurally compatible
+runtime memory records into the dry-run diagnostics pipeline.
+
+`buildMemoryConsolidationDiagnosticsRunReport` turns a diagnostics dry-run
+result into a compact batch report for skipped, preserved, and suppressed
+records.
+
+`logMemoryConsolidationDiagnosticsRun` can pass that report to a caller-provided
+log sink only when explicitly enabled.
+
 `persistSemanticMemoryDrafts` defines a controlled persistence boundary for
 semantic drafts. It only writes through a caller-provided draft store when
 explicitly enabled with `dryRun: false`; otherwise it returns the planned draft
@@ -170,6 +181,9 @@ artifact writes without calling a storage adapter.
 `buildMemorySemanticRetrievalPlan` and
 `buildMemorySemanticRetrievalDryRunReport` describe how semantic drafts can be
 inspected for retrieval impact without changing production retrieval ranking.
+Opt-in retrieval helpers can merge raw trace fallback with eligible semantic
+drafts, evaluate selected or suppressed drafts, and produce log-only comparison
+reports without injecting results into runtime context.
 
 Callers can keep the full diagnostics for debugging and derive the compact
 report for review or logging:

--- a/packages/ai/memory-consolidation/src/retrieval.ts
+++ b/packages/ai/memory-consolidation/src/retrieval.ts
@@ -5,6 +5,10 @@ export type MemorySemanticRetrievalCandidateStatus =
   | "suppressed"
   | "fallback";
 
+export type MemorySemanticRetrievalResultKind =
+  | "source-trace"
+  | "semantic-draft";
+
 export type MemorySemanticRetrievalDraftStatus =
   | "active"
   | "contested"
@@ -14,12 +18,37 @@ export type MemorySemanticRetrievalDraftStatus =
 
 export type MemorySemanticRetrievalReasonCode =
   | "semantic_draft_candidate"
+  | "semantic_retrieval_comparison"
+  | "semantic_retrieval_disabled"
+  | "semantic_retrieval_enabled"
+  | "semantic_retrieval_log_only"
   | "source_trace_fallback"
   | "low_confidence"
   | "contested_memory"
   | "max_candidates"
   | "query_relevance"
   | (string & {});
+
+export type MemorySemanticRetrievalConfigStatus = "disabled" | "enabled";
+
+export interface MemorySemanticRetrievalConfigInput {
+  enabled?: boolean;
+  minConfidence?: number;
+  allowContested?: boolean;
+  maxCandidates?: number;
+  reasonCodes?: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalConfig {
+  enabled: boolean;
+  status: MemorySemanticRetrievalConfigStatus;
+  minConfidence: number;
+  allowContested: boolean;
+  maxCandidates?: number;
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
 
 export interface MemorySemanticRetrievalDraft {
   draftId: string;
@@ -41,6 +70,30 @@ export interface MemorySemanticRetrievalCandidate {
   draftStatus: MemorySemanticRetrievalDraftStatus;
   status: MemorySemanticRetrievalCandidateStatus;
   reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalSourceResult {
+  recordId: string;
+  content?: string;
+  score?: number;
+  reasonCodes?: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalMergedResult {
+  resultId: string;
+  kind: MemorySemanticRetrievalResultKind;
+  status: MemorySemanticRetrievalCandidateStatus;
+  sourceRecordIds: string[];
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  recordId?: string;
+  draftId?: string;
+  type?: MemorySemanticDraftSuggestedType;
+  content?: string;
+  score?: number;
+  confidence?: number;
+  queryRelevance?: number;
   metadata?: Record<string, unknown>;
 }
 
@@ -72,6 +125,70 @@ export interface MemorySemanticRetrievalPlanningResult {
   metadata?: Record<string, unknown>;
 }
 
+export interface MemorySemanticRetrievalMergedResultSet {
+  query: string;
+  enabled: boolean;
+  results: MemorySemanticRetrievalMergedResult[];
+  sourceResults: MemorySemanticRetrievalMergedResult[];
+  semanticResults: MemorySemanticRetrievalMergedResult[];
+  suppressedDrafts: MemorySemanticRetrievalCandidate[];
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalEvalExpectations {
+  selectedDraftIds?: string[];
+  suppressedDraftIds?: string[];
+  fallbackRecordIds?: string[];
+}
+
+export interface MemorySemanticRetrievalEvalScenarioReport {
+  scenarioId: string;
+  query: string;
+  enabled: boolean;
+  selectedDraftIds: string[];
+  suppressedDraftIds: string[];
+  fallbackRecordIds: string[];
+  missingSelectedDraftIds: string[];
+  missingSuppressedDraftIds: string[];
+  missingFallbackRecordIds: string[];
+  selectedPassed: boolean;
+  suppressedPassed: boolean;
+  fallbackPassed: boolean;
+  passed: boolean;
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemorySemanticRetrievalComparisonDraft {
+  draftId: string;
+  sourceRecordIds: string[];
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+}
+
+export interface MemorySemanticRetrievalComparisonReportSummary {
+  query: string;
+  baselineResultCount: number;
+  candidateResultCount: number;
+  addedSemanticDraftCount: number;
+  retainedFallbackRecordCount: number;
+  suppressedDraftCount: number;
+}
+
+export interface MemorySemanticRetrievalComparisonReport {
+  summary: MemorySemanticRetrievalComparisonReportSummary;
+  query: string;
+  baselineEnabled: boolean;
+  candidateEnabled: boolean;
+  baselineResultIds: string[];
+  candidateResultIds: string[];
+  retainedFallbackRecordIds: string[];
+  addedSemanticDrafts: MemorySemanticRetrievalComparisonDraft[];
+  suppressedDrafts: MemorySemanticRetrievalComparisonDraft[];
+  reasonCodes: MemorySemanticRetrievalReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
 export interface MemorySemanticRetrievalDryRunReportSummary {
   query: string;
   existingRecordCount: number;
@@ -99,6 +216,26 @@ export interface BuildMemorySemanticRetrievalDryRunReportInput {
   metadata?: Record<string, unknown>;
 }
 
+export interface BuildMemorySemanticRetrievalMergedResultsInput {
+  plan: MemorySemanticRetrievalPlanningResult;
+  config?: MemorySemanticRetrievalConfigInput;
+  sourceResults?: MemorySemanticRetrievalSourceResult[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildMemorySemanticRetrievalEvalScenarioReportInput {
+  scenarioId: string;
+  merged: MemorySemanticRetrievalMergedResultSet;
+  expectations?: MemorySemanticRetrievalEvalExpectations;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildMemorySemanticRetrievalComparisonReportInput {
+  baseline: MemorySemanticRetrievalMergedResultSet;
+  candidate: MemorySemanticRetrievalMergedResultSet;
+  metadata?: Record<string, unknown>;
+}
+
 function clamp01(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value)) {
     return 0;
@@ -121,6 +258,117 @@ function resolveMaxCandidates(value: number | undefined): number {
   }
 
   return Math.max(0, Math.floor(value));
+}
+
+function resolveOptionalMaxCandidates(
+  value: number | undefined,
+): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+function uniqueReasonCodes(
+  reasonCodes: MemorySemanticRetrievalReasonCode[],
+): MemorySemanticRetrievalReasonCode[] {
+  return [...new Set(reasonCodes)];
+}
+
+function missingIds(
+  actual: string[],
+  expected: string[] | undefined,
+): string[] {
+  const actualSet = new Set(actual);
+
+  return (expected ?? []).filter((id) => !actualSet.has(id));
+}
+
+function resultRecordIds(
+  results: MemorySemanticRetrievalMergedResult[],
+): string[] {
+  return results.flatMap((result) =>
+    result.recordId ? [result.recordId] : result.sourceRecordIds,
+  );
+}
+
+export function resolveMemorySemanticRetrievalConfig(
+  input: MemorySemanticRetrievalConfigInput = {},
+): MemorySemanticRetrievalConfig {
+  const enabled = input.enabled === true;
+
+  return {
+    enabled,
+    status: enabled ? "enabled" : "disabled",
+    minConfidence: clamp01(input.minConfidence),
+    allowContested: input.allowContested === true,
+    maxCandidates: resolveOptionalMaxCandidates(input.maxCandidates),
+    reasonCodes: [
+      ...(input.reasonCodes ?? []),
+      enabled ? "semantic_retrieval_enabled" : "semantic_retrieval_disabled",
+    ],
+    metadata: input.metadata ? { ...input.metadata } : undefined,
+  };
+}
+
+function toSourceMergedResult(
+  source: MemorySemanticRetrievalSourceResult,
+  config: MemorySemanticRetrievalConfig,
+): MemorySemanticRetrievalMergedResult {
+  return {
+    resultId: source.recordId,
+    kind: "source-trace",
+    recordId: source.recordId,
+    status: "fallback",
+    sourceRecordIds: [source.recordId],
+    content: source.content,
+    score: source.score,
+    reasonCodes: uniqueReasonCodes([
+      "source_trace_fallback",
+      ...config.reasonCodes,
+      ...(source.reasonCodes ?? []),
+    ]),
+    metadata: source.metadata ? { ...source.metadata } : undefined,
+  };
+}
+
+function toSemanticMergedResult(
+  candidate: MemorySemanticRetrievalCandidate,
+  config: MemorySemanticRetrievalConfig,
+): MemorySemanticRetrievalMergedResult {
+  return {
+    resultId: candidate.draftId,
+    kind: "semantic-draft",
+    draftId: candidate.draftId,
+    type: candidate.type,
+    content: candidate.content,
+    status: candidate.status,
+    sourceRecordIds: [...candidate.sourceRecordIds],
+    confidence: candidate.confidence,
+    queryRelevance: candidate.queryRelevance,
+    reasonCodes: uniqueReasonCodes([
+      ...candidate.reasonCodes,
+      ...config.reasonCodes,
+    ]),
+    metadata: candidate.metadata ? { ...candidate.metadata } : undefined,
+  };
+}
+
+function suppressSemanticCandidateForConfig(
+  candidate: MemorySemanticRetrievalCandidate,
+  config: MemorySemanticRetrievalConfig,
+): MemorySemanticRetrievalCandidate {
+  return {
+    ...candidate,
+    sourceRecordIds: [...candidate.sourceRecordIds],
+    status: "suppressed",
+    reasonCodes: uniqueReasonCodes([
+      ...candidate.reasonCodes,
+      ...config.reasonCodes,
+    ]),
+    metadata: candidate.metadata ? { ...candidate.metadata } : undefined,
+  };
 }
 
 function toRetrievalCandidate(
@@ -210,6 +458,169 @@ export function buildMemorySemanticRetrievalPlan(
     candidates: applyRetrievalFilters(candidates, input),
     fallbackRecordIds: [...(input.existingRecordIds ?? [])],
     metadata: input.metadata ? { ...input.metadata } : undefined,
+  };
+}
+
+export function buildMemorySemanticRetrievalMergedResults(
+  input: BuildMemorySemanticRetrievalMergedResultsInput,
+): MemorySemanticRetrievalMergedResultSet {
+  const config = resolveMemorySemanticRetrievalConfig(input.config);
+  const sourceResults = (
+    input.sourceResults ??
+    input.plan.fallbackRecordIds.map((recordId) => ({ recordId }))
+  ).map((source) => toSourceMergedResult(source, config));
+  const semanticCandidates = config.enabled
+    ? input.plan.candidates.filter(
+        (candidate) => candidate.status === "eligible",
+      )
+    : [];
+  const semanticResults = semanticCandidates.map((candidate) =>
+    toSemanticMergedResult(candidate, config),
+  );
+  const suppressedDrafts = config.enabled
+    ? input.plan.candidates
+        .filter((candidate) => candidate.status !== "eligible")
+        .map((candidate) => ({
+          ...candidate,
+          sourceRecordIds: [...candidate.sourceRecordIds],
+          reasonCodes: uniqueReasonCodes([
+            ...candidate.reasonCodes,
+            ...config.reasonCodes,
+          ]),
+          metadata: candidate.metadata ? { ...candidate.metadata } : undefined,
+        }))
+    : input.plan.candidates.map((candidate) =>
+        suppressSemanticCandidateForConfig(candidate, config),
+      );
+  const results = [...sourceResults, ...semanticResults];
+
+  return {
+    query: input.plan.query,
+    enabled: config.enabled,
+    results,
+    sourceResults,
+    semanticResults,
+    suppressedDrafts,
+    reasonCodes: uniqueReasonCodes([
+      ...config.reasonCodes,
+      ...results.flatMap((result) => result.reasonCodes),
+      ...suppressedDrafts.flatMap((candidate) => candidate.reasonCodes),
+    ]),
+    metadata: input.metadata ?? input.plan.metadata ?? config.metadata,
+  };
+}
+
+export function buildMemorySemanticRetrievalEvalScenarioReport(
+  input: BuildMemorySemanticRetrievalEvalScenarioReportInput,
+): MemorySemanticRetrievalEvalScenarioReport {
+  const selectedDraftIds = input.merged.semanticResults.flatMap((result) =>
+    result.draftId ? [result.draftId] : [],
+  );
+  const suppressedDraftIds = input.merged.suppressedDrafts.map(
+    (candidate) => candidate.draftId,
+  );
+  const fallbackRecordIds = input.merged.sourceResults.flatMap((result) =>
+    result.recordId ? [result.recordId] : result.sourceRecordIds,
+  );
+  const missingSelectedDraftIds = missingIds(
+    selectedDraftIds,
+    input.expectations?.selectedDraftIds,
+  );
+  const missingSuppressedDraftIds = missingIds(
+    suppressedDraftIds,
+    input.expectations?.suppressedDraftIds,
+  );
+  const missingFallbackRecordIds = missingIds(
+    fallbackRecordIds,
+    input.expectations?.fallbackRecordIds,
+  );
+  const selectedPassed = missingSelectedDraftIds.length === 0;
+  const suppressedPassed = missingSuppressedDraftIds.length === 0;
+  const fallbackPassed = missingFallbackRecordIds.length === 0;
+
+  return {
+    scenarioId: input.scenarioId,
+    query: input.merged.query,
+    enabled: input.merged.enabled,
+    selectedDraftIds,
+    suppressedDraftIds,
+    fallbackRecordIds,
+    missingSelectedDraftIds,
+    missingSuppressedDraftIds,
+    missingFallbackRecordIds,
+    selectedPassed,
+    suppressedPassed,
+    fallbackPassed,
+    passed: selectedPassed && suppressedPassed && fallbackPassed,
+    reasonCodes: [...input.merged.reasonCodes],
+    metadata: input.metadata ?? input.merged.metadata,
+  };
+}
+
+export function buildMemorySemanticRetrievalComparisonReport(
+  input: BuildMemorySemanticRetrievalComparisonReportInput,
+): MemorySemanticRetrievalComparisonReport {
+  const baselineResultIds = input.baseline.results.map(
+    (result) => result.resultId,
+  );
+  const candidateResultIds = input.candidate.results.map(
+    (result) => result.resultId,
+  );
+  const baselineFallbackRecordIds = new Set(
+    resultRecordIds(input.baseline.sourceResults),
+  );
+  const retainedFallbackRecordIds = resultRecordIds(
+    input.candidate.sourceResults,
+  ).filter((recordId) => baselineFallbackRecordIds.has(recordId));
+  const baselineSemanticDraftIds = new Set(
+    input.baseline.semanticResults.flatMap((result) =>
+      result.draftId ? [result.draftId] : [],
+    ),
+  );
+  const addedSemanticDrafts = input.candidate.semanticResults
+    .filter(
+      (result) =>
+        result.draftId && !baselineSemanticDraftIds.has(result.draftId),
+    )
+    .map((result) => ({
+      draftId: result.draftId as string,
+      sourceRecordIds: [...result.sourceRecordIds],
+      reasonCodes: [...result.reasonCodes],
+    }));
+  const suppressedDrafts = input.candidate.suppressedDrafts.map(
+    (candidate) => ({
+      draftId: candidate.draftId,
+      sourceRecordIds: [...candidate.sourceRecordIds],
+      reasonCodes: [...candidate.reasonCodes],
+    }),
+  );
+  const reasonCodes = uniqueReasonCodes([
+    "semantic_retrieval_comparison",
+    "semantic_retrieval_log_only",
+    ...input.baseline.reasonCodes,
+    ...input.candidate.reasonCodes,
+  ]);
+
+  return {
+    summary: {
+      query: input.candidate.query,
+      baselineResultCount: input.baseline.results.length,
+      candidateResultCount: input.candidate.results.length,
+      addedSemanticDraftCount: addedSemanticDrafts.length,
+      retainedFallbackRecordCount: retainedFallbackRecordIds.length,
+      suppressedDraftCount: suppressedDrafts.length,
+    },
+    query: input.candidate.query,
+    baselineEnabled: input.baseline.enabled,
+    candidateEnabled: input.candidate.enabled,
+    baselineResultIds,
+    candidateResultIds,
+    retainedFallbackRecordIds,
+    addedSemanticDrafts,
+    suppressedDrafts,
+    reasonCodes,
+    metadata:
+      input.metadata ?? input.candidate.metadata ?? input.baseline.metadata,
   };
 }
 

--- a/packages/ai/memory-consolidation/src/runtime.ts
+++ b/packages/ai/memory-consolidation/src/runtime.ts
@@ -1,11 +1,19 @@
 import {
+  adaptMemoryRecordsForConsolidation,
   buildMemoryConsolidationDiagnosticsReport,
   buildMemoryRelationPipelineDiagnostics,
+  type AdaptMemoryRecordsForConsolidationResult,
   type BuildMemoryRelationPipelineDiagnosticsInput,
+  type MemoryConsolidationContestedClusterReport,
+  type MemoryConsolidationDecayedRecordReport,
   type MemoryConsolidationDiagnosticsReport,
+  type MemoryConsolidationPreservedClusterReport,
+  type MemoryConsolidationRecordSelectors,
+  type MemoryConsolidationSkippedRecord,
   type MemoryConsolidationSourceRecord,
   type MemoryRelationPipelineDiagnostics,
 } from "./adapter";
+import type { MemoryEvidenceTier } from "./evidence-cluster";
 import {
   buildSemanticMemoryDraftCandidates,
   type BuildSemanticMemoryDraftCandidatesInput,
@@ -13,6 +21,44 @@ import {
 } from "./semantic-draft";
 
 const DEFAULT_DIAGNOSTICS_LIMIT = 500;
+
+type RuntimeDimensionValue = string | number | boolean;
+
+export interface MemoryConsolidationRuntimeMemoryRecord {
+  id?: string;
+  userId?: string;
+  timestamp?: number;
+  text?: string;
+  mediaRefs?: string[];
+  tier?: MemoryEvidenceTier;
+  accessCount?: number;
+  lastAccessAt?: number;
+  importanceScore?: number;
+  isPinned?: boolean;
+  archivedAt?: number;
+  dimensions?: Record<string, RuntimeDimensionValue | undefined>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryConsolidationRuntimeRelationKeys {
+  relationGroup?: string;
+  relationValue?: string;
+  relationScope?: string;
+}
+
+export interface BuildMemoryConsolidationRuntimeRecordSelectorsInput {
+  relationKeys?: MemoryConsolidationRuntimeRelationKeys;
+}
+
+export interface AdaptRuntimeMemoryRecordsForConsolidationInput<
+  TRecord extends MemoryConsolidationRuntimeMemoryRecord =
+    MemoryConsolidationRuntimeMemoryRecord,
+> {
+  records: TRecord[];
+  defaultUserId?: string;
+  defaultTier?: MemoryEvidenceTier;
+  relationKeys?: MemoryConsolidationRuntimeRelationKeys;
+}
 
 export interface MemoryConsolidationDiagnosticsRecordReader<
   TRecord = MemoryConsolidationSourceRecord,
@@ -51,6 +97,215 @@ export interface MemoryConsolidationDiagnosticsRunResult {
   diagnostics: MemoryRelationPipelineDiagnostics;
   report: MemoryConsolidationDiagnosticsReport;
   semanticDraftCandidates: MemorySemanticDraftCandidate[];
+}
+
+export interface MemoryConsolidationDiagnosticsRunReportSummary {
+  status: MemoryConsolidationDiagnosticsRunResult["status"];
+  dryRun: true;
+  userId: string;
+  startedAt: number;
+  finishedAt: number;
+  scannedRecordCount: number;
+  adaptedRecordCount: number;
+  skippedRecordCount: number;
+  preservedClusterCount: number;
+  contestedClusterCount: number;
+  suppressedRecordCount: number;
+  semanticDraftCandidateCount: number;
+}
+
+export interface MemoryConsolidationDiagnosticsRunReportPreservedCluster extends MemoryConsolidationPreservedClusterReport {
+  semanticDraftCandidateIds: string[];
+}
+
+export interface MemoryConsolidationDiagnosticsRunReport {
+  summary: MemoryConsolidationDiagnosticsRunReportSummary;
+  skippedRecords: MemoryConsolidationSkippedRecord[];
+  preservedClusters: MemoryConsolidationDiagnosticsRunReportPreservedCluster[];
+  contestedClusters: MemoryConsolidationContestedClusterReport[];
+  suppressedRecords: MemoryConsolidationDecayedRecordReport[];
+  semanticDraftCandidateIds: string[];
+}
+
+export interface MemoryConsolidationDiagnosticsLogSink {
+  logDiagnosticsRun(
+    report: MemoryConsolidationDiagnosticsRunReport,
+  ): Promise<void> | void;
+}
+
+export interface LogMemoryConsolidationDiagnosticsRunInput {
+  result: MemoryConsolidationDiagnosticsRunResult;
+  enabled?: boolean;
+  sink?: MemoryConsolidationDiagnosticsLogSink;
+}
+
+export type MemoryConsolidationDiagnosticsLogStatus = "disabled" | "logged";
+
+export type MemoryConsolidationDiagnosticsLogReasonCode =
+  | "log_disabled"
+  | "log_sink_missing"
+  | "log_only";
+
+export interface LogMemoryConsolidationDiagnosticsRunResult {
+  status: MemoryConsolidationDiagnosticsLogStatus;
+  report: MemoryConsolidationDiagnosticsRunReport;
+  reasonCodes: MemoryConsolidationDiagnosticsLogReasonCode[];
+}
+
+function runtimePrimitiveString(value: unknown): string | undefined {
+  if (
+    typeof value !== "string" &&
+    typeof value !== "number" &&
+    typeof value !== "boolean"
+  ) {
+    return undefined;
+  }
+
+  const text = String(value).trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function runtimeRelationValue(
+  record: MemoryConsolidationRuntimeMemoryRecord,
+  key: string,
+): string | undefined {
+  return runtimePrimitiveString(
+    record.metadata?.[key] ?? record.dimensions?.[key],
+  );
+}
+
+export function buildMemoryConsolidationRuntimeRecordSelectors<
+  TRecord extends MemoryConsolidationRuntimeMemoryRecord =
+    MemoryConsolidationRuntimeMemoryRecord,
+>(
+  input: BuildMemoryConsolidationRuntimeRecordSelectorsInput = {},
+): MemoryConsolidationRecordSelectors<TRecord> {
+  const relationGroupKey = input.relationKeys?.relationGroup ?? "relationGroup";
+  const relationValueKey = input.relationKeys?.relationValue ?? "relationValue";
+  const relationScopeKey = input.relationKeys?.relationScope ?? "relationScope";
+
+  return {
+    getId: (record) => record.id,
+    getUserId: (record) => record.userId,
+    getTimestamp: (record) => record.timestamp,
+    getText: (record) => record.text,
+    getMediaRefs: (record) => record.mediaRefs,
+    getTier: (record) => record.tier,
+    getAccessCount: (record) => record.accessCount,
+    getLastAccessAt: (record) => record.lastAccessAt,
+    getImportanceScore: (record) => record.importanceScore,
+    getIsPinned: (record) => record.isPinned,
+    getArchivedAt: (record) => record.archivedAt,
+    getDimensions: (record) => record.dimensions,
+    getMetadata: (record) => record.metadata,
+    getRelationGroup: (record) =>
+      runtimeRelationValue(record, relationGroupKey),
+    getRelationValue: (record) =>
+      runtimeRelationValue(record, relationValueKey),
+    getRelationScope: (record) =>
+      runtimeRelationValue(record, relationScopeKey),
+  };
+}
+
+export function adaptRuntimeMemoryRecordsForConsolidation<
+  TRecord extends MemoryConsolidationRuntimeMemoryRecord,
+>(
+  input: AdaptRuntimeMemoryRecordsForConsolidationInput<TRecord>,
+): AdaptMemoryRecordsForConsolidationResult {
+  return adaptMemoryRecordsForConsolidation({
+    records: input.records,
+    defaultUserId: input.defaultUserId,
+    defaultTier: input.defaultTier,
+    selectors: buildMemoryConsolidationRuntimeRecordSelectors<TRecord>({
+      relationKeys: input.relationKeys,
+    }),
+  });
+}
+
+export function buildMemoryConsolidationDiagnosticsRunReport(
+  result: MemoryConsolidationDiagnosticsRunResult,
+): MemoryConsolidationDiagnosticsRunReport {
+  const draftIdsByClusterKey = new Map<string, string[]>();
+
+  for (const candidate of result.semanticDraftCandidates) {
+    const ids = draftIdsByClusterKey.get(candidate.sourceClusterKey) ?? [];
+    ids.push(candidate.draftId);
+    draftIdsByClusterKey.set(candidate.sourceClusterKey, ids);
+  }
+
+  return {
+    summary: {
+      status: result.status,
+      dryRun: true,
+      userId: result.userId,
+      startedAt: result.startedAt,
+      finishedAt: result.finishedAt,
+      scannedRecordCount: result.scannedRecords,
+      adaptedRecordCount: result.report.summary.adaptedRecordCount,
+      skippedRecordCount: result.report.summary.skippedRecordCount,
+      preservedClusterCount: result.report.preservedClusters.length,
+      contestedClusterCount: result.report.contestedClusters.length,
+      suppressedRecordCount: result.report.decayedRecords.length,
+      semanticDraftCandidateCount: result.semanticDraftCandidates.length,
+    },
+    skippedRecords: result.report.skippedRecords.map((record) => ({
+      sourceIndex: record.sourceIndex,
+      reasonCodes: [...record.reasonCodes],
+    })),
+    preservedClusters: result.report.preservedClusters.map((cluster) => ({
+      ...cluster,
+      recordIds: [...cluster.recordIds],
+      reasonCodes: [...cluster.reasonCodes],
+      semanticDraftCandidateIds: [
+        ...(draftIdsByClusterKey.get(cluster.clusterKey) ?? []),
+      ],
+    })),
+    contestedClusters: result.report.contestedClusters.map((cluster) => ({
+      ...cluster,
+      recordIds: [...cluster.recordIds],
+      competingClusterKeys: [...cluster.competingClusterKeys],
+      reasonCodes: [...cluster.reasonCodes],
+    })),
+    suppressedRecords: result.report.decayedRecords.map((record) => ({
+      recordId: record.recordId,
+      sourceIndex: record.sourceIndex,
+      clusterKey: record.clusterKey,
+      reasonCodes: [...record.reasonCodes],
+    })),
+    semanticDraftCandidateIds: result.semanticDraftCandidates.map(
+      (candidate) => candidate.draftId,
+    ),
+  };
+}
+
+export async function logMemoryConsolidationDiagnosticsRun(
+  input: LogMemoryConsolidationDiagnosticsRunInput,
+): Promise<LogMemoryConsolidationDiagnosticsRunResult> {
+  const report = buildMemoryConsolidationDiagnosticsRunReport(input.result);
+
+  if (input.enabled !== true) {
+    return {
+      status: "disabled",
+      report,
+      reasonCodes: ["log_disabled"],
+    };
+  }
+
+  if (!input.sink) {
+    return {
+      status: "disabled",
+      report,
+      reasonCodes: ["log_sink_missing"],
+    };
+  }
+
+  await input.sink.logDiagnosticsRun(report);
+
+  return {
+    status: "logged",
+    report,
+    reasonCodes: ["log_only"],
+  };
 }
 
 function resolveLimit(limit: number | undefined): number {


### PR DESCRIPTION
## Summary
Add runtime and retrieval diagnostics boundaries for the memory-consolidation package.

This PR builds on the semantic artifact foundation and keeps the new behavior observational:
- add a dry-run memory consolidation diagnostics runner
- add a log-only diagnostics sink boundary
- add opt-in semantic retrieval planning and comparison helpers
- add focused scenarios that verify raw fallback, suppressed drafts, and dry-run reports

## Scope
- Does not change production forgetting runtime behavior
- Does not change default retrieval ranking or retrieval defaults
- Does not write to storage or introduce a scheduler
- Does not introduce an LLM, embedding provider, database, network provider, migration, or UI
- Retrieval diagnostics remain opt-in and compare semantic draft candidates without replacing raw trace fallback by default

## Testing
- `corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/runtime.ts packages/ai/memory-consolidation/src/retrieval.ts packages/ai/memory-consolidation/README.md apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `git diff --check`