### PR TITLE
fix(web): guest login failed in browser

### DIFF
--- a/apps/web/app/(auth)/auth.ts
+++ b/apps/web/app/(auth)/auth.ts
@@ -248,7 +248,6 @@ function createProductionAuthModule() {
                   ? `https://avatar.vercel.sh/${latestUser.email}`
                   : null);
               token.avatarUrl = resolvedAvatar;
-              token.sessionVersion = latestUser.sessionVersion ?? 1;
             }
             const latestSurvey = await getLatestSurveyByUserId(token.id);
             if (latestSurvey) {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -102,7 +102,6 @@ export async function proxy(request: NextRequest) {
 
   // ========== Original permission logic (compatible with file-read token) ==========
   const publicPaths = new Set([
-    "/",
     "/login",
     "/guest-login",
     "/register",


### PR DESCRIPTION
Before, `/` was public. Guest login could fail in the browser.

Tauri runtime also did not do guest login automatically on homepage.

Now new users go to `/guest-login` first.

I also keep `token.sessionVersion` as `authSessionVersion` to avoid a login loop.
