### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openloomi"
-version = "0.6.1"
+version = "0.6.2"
 description = "openloomi AI Assistant - Your Personal Productivity Tool"
 authors = ["OpenLoomi Team"]
 edition = "2021"

--- a/apps/web/src-tauri/tauri.conf.dev.json
+++ b/apps/web/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "openloomi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.openloomi.app",
   "build": {
     "beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "openloomi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.openloomi.app",
   "build": {
     "beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openloomi-monorepo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai/mcp/package.json
+++ b/packages/ai/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/memory-consolidation",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/ai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ai/rag/package.json
+++ b/packages/ai/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rag",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/audit",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/config",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/hooks",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/i18n",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/indexeddb",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/insights",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/asana/package.json
+++ b/packages/integrations/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-asana",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/calendar/package.json
+++ b/packages/integrations/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-calendar",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/channels/package.json
+++ b/packages/integrations/channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-channels",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/composio/package.json
+++ b/packages/integrations/composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-composio",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/dingtalk/package.json
+++ b/packages/integrations/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-dingtalk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/facebook-messenger/package.json
+++ b/packages/integrations/facebook-messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-facebook-messenger",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/feishu/package.json
+++ b/packages/integrations/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-feishu",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/gmail/package.json
+++ b/packages/integrations/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-gmail",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/google-docs/package.json
+++ b/packages/integrations/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-docs",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/google-meet/package.json
+++ b/packages/integrations/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-meet",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/hubspot/package.json
+++ b/packages/integrations/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-hubspot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/imessage/package.json
+++ b/packages/integrations/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-imessage",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/instagram/package.json
+++ b/packages/integrations/instagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-instagram",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/jira/package.json
+++ b/packages/integrations/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-jira",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/linkedin/package.json
+++ b/packages/integrations/linkedin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-linkedin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "description": "Unified package for alloo mi integration packages",

--- a/packages/integrations/qqbot/package.json
+++ b/packages/integrations/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-qqbot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/rss/package.json
+++ b/packages/integrations/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rss",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/telegram/package.json
+++ b/packages/integrations/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-telegram",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/weixin/package.json
+++ b/packages/integrations/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-weixin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/whatsapp/package.json
+++ b/packages/integrations/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-whatsapp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/integrations/x/package.json
+++ b/packages/integrations/x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-x",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rag",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "type": "module",
   "exports": {

--- a/packages/rss/package.json
+++ b/packages/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rss",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "type": "module",
   "exports": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/search",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/security",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/shared",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/sqlite",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/storage",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice-kokoro/package.json
+++ b/packages/voice-kokoro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/voice-kokoro",
-  "version": "0.1.0",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice-whisper/package.json
+++ b/packages/voice-whisper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/voice-whisper",
-  "version": "0.1.0",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/skills/openloomi-api/SKILL.md
+++ b/skills/openloomi-api/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-api
 description: "openloomi API documentation and reference. Use when working with openloomi backend APIs, AI, authentication, characters, messages, files, integrations, billing, or any server-side functionality. Triggers: API endpoints, backend routes, authentication, cloud API, integrations"
 metadata:
-  version: 0.6.1
+  version: 0.6.2
 ---
 
 > **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.

--- a/skills/openloomi-connectors/SKILL.md
+++ b/skills/openloomi-connectors/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-connectors
 description: "openloomi Connectors tools - manage platform integrations (OAuth connections, list accounts, check status). Triggers: connect platform, integration status, list accounts, disconnect"
 metadata:
-  version: 0.6.1
+  version: 0.6.2
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
 ---
 

--- a/skills/openloomi-feature-guide/SKILL.md
+++ b/skills/openloomi-feature-guide/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-feature-guide
 description: "Use this when users ask about openloomi features, capabilities, or how to use it. Examples: 'openloomi 怎么用', '你能做什么', 'What can you do?', 'How does openloomi work?', 'Tell me about openloomi features', 'What platforms does openloomi support?', 'How do I use scheduled tasks?', 'What is Insights system?', 'How do I connect Telegram?', 'How to create automation?', '什么是 openloomi 事件?'
 metadata:
-  version: 0.6.1
+  version: 0.6.2
 ---
 
 > **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.

--- a/skills/openloomi-loop/SKILL.md
+++ b/skills/openloomi-loop/SKILL.md
@@ -3,7 +3,7 @@ name: openloomi-loop
 description: "Use this when the user asks about openloomi's Loop — openloomi's proactive execution brain. It actively and continuously pulls external signals (Gmail, Calendar, GitHub, Slack) via Composio MCP, enriches them through openloomi-memory, classifies them into typed decisions, and executes via Claude Code. Triggers: 'openloomi loop', 'loop tick', 'loop schedule', 'loop inbox', 'loop run', 'proactive decisions', 'context → decision → execute', 'pull signals', 'decision queue', 'loop serve'"
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-loop.cjs *), Bash(node $SKILL_DIR/scripts/loop-tick.cjs *), Bash(node ../../openloomi-memory/scripts/openloomi-memory.cjs *), Bash(claude -p *), Bash(tail -f $SKILL_DIR/data/daemon.log), Bash(cat >> $SKILL_DIR/data/signals.jsonl), Bash(echo *), Bash(ls *)
 metadata:
-  version: 0.6.1
+  version: 0.6.2
 ---
 
 > **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.


### PR DESCRIPTION
## Summary

Bump the version of every workspace package from `0.6.1` to `0.6.2` to keep the monorepo release tags in lockstep.

## Changes

- `package.json` (root)
- `apps/web/package.json`, `apps/web/src-tauri/Cargo.toml`, `apps/web/src-tauri/tauri.conf.json`, `apps/web/src-tauri/tauri.conf.dev.json`
- All 42 packages under `packages/` (including `packages/ai/*`, `packages/integrations/*`, and the two voice packages that were still on `0.1.0` — now aligned at `0.6.2`)
- Skill metadata in `skills/openloomi-{api,connectors,feature-guide,loop}/SKILL.md`

51 files changed, 51 insertions(+), 51 deletions(-).

## Notes

- No source code or runtime behavior is affected; this is a release-version-only bump.
- Follows the same pattern as the previous `chore: bump version to 0.6.1` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)