### PR TITLE
docs(marketing): expand proactive-decisions copy with capture inputs and follow-up plan

### DIFF
--- a/apps/marketing/content/use-cases/proactive-decisions.mdx
+++ b/apps/marketing/content/use-cases/proactive-decisions.mdx
@@ -1,23 +1,23 @@
 ---
-title: "Proactive Execution Brain — Decisions Surface Before You Ask"
-description: "Let OpenLoomi watch Gmail, Calendar, GitHub, and Slack 24/7 and surface typed decisions (RSVPs, draft replies, PR reviews) the moment they appear — you only act when it matters."
+title: "Proactive Execution Brain — Decisions Surface, and the Plan Checks Back In"
+description: "Let OpenLoomi watch Gmail, Calendar, GitHub, and Slack 24/7, capture tasks from voice, screenshots, links, and notes, and surface typed decisions (RSVPs, draft replies, PR reviews, structured to-dos) — then check back so nothing gets forgotten."
 icon: "FaBrain"
 ---
 
 # Proactive Execution Brain — Decisions Surface Before You Ask
 
-## Four Streams of Inbound, One Decision Queue
+## Four Streams of Inbound + Whatever You Throw At It, One Decision Queue
 
-The average professional has 4 streams of inbound — Gmail, Calendar, GitHub, Slack — and no single place where "what should I do next" lives. You tab-switch all day, re-read the same thread three times, and miss the calendar RSVP until it's already started. OpenLoomi's **Proactive Execution Brain** (`openloomi-loop`) runs inside the desktop app, watches all four in the background, enriches every new signal through your local memory, and turns each one into a typed decision card ready for a one-keystroke action.
+The average professional has 4 streams of inbound — Gmail, Calendar, GitHub, Slack — and no single place where "what should I do next" lives. You tab-switch all day, re-read the same thread three times, and miss the calendar RSVP until it's already started. Just as often, the real work isn't inbound at all — it's the half-formed thought on your walk, the screenshot of a deadline you noticed in passing, the article you bookmarked for later, the Slack thread someone pinged you about. OpenLoomi's **Proactive Execution Brain** (`openloomi-loop`) runs inside the desktop app, watches every channel in the background, enriches every new signal through your local memory, and turns each one into a typed decision card ready for a one-keystroke action — or, when you point it at messy input, a structured daily plan that checks back in.
 
 **What it does:**
 
-| Step            | Action                                                                                                            |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| 👀 **Watch**    | Pulls new signals from Gmail, Calendar, GitHub, and Slack via Composio MCP — every tick, in parallel              |
-| 🧠 **Enrich**   | Looks up each sender / organizer / repo through `openloomi-memory` so the card arrives with full context attached |
-| 🏷️ **Classify** | Maps each signal to a typed decision: `rsvp`, `draft_reply`, `review_pr`, `todo`, `slack_reply`                   |
-| ✅ **Pick**     | Review the queue in OpenLoomi's Loop panel, the local web UI, or the REPL — one keystroke to execute              |
+| Step            | Action                                                                                                                                                         |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 👀 **Watch**    | Pulls new signals from Gmail, Calendar, GitHub, and Slack via Composio MCP and accepts voice memos, screenshots, links, pasted notes — every tick, in parallel |
+| 🧠 **Enrich**   | Looks up each sender / organizer / repo through `openloomi-memory` so the card arrives with full context attached                                              |
+| 🏷️ **Classify** | Maps each signal to a typed decision: `rsvp`, `draft_reply`, `review_pr`, `todo`, `slack_reply`                                                                |
+| ✅ **Pick**     | Review the queue in OpenLoomi's Loop panel, the local web UI, or the REPL — one keystroke to execute                                                           |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `apps/marketing/content/use-cases/proactive-decisions.mdx` so the
Proactive Execution Brain use case reflects the broader capture surface and
follow-up behavior:

- Title and meta description now mention voice, screenshot, link, and note
  capture, plus the "plan that checks back in" outcome.
- The "Four Streams of Inbound" heading and intro paragraph acknowledge that
  real work often comes from messy, outbound input (a walk-thought, a
  screenshot of a deadline, a bookmarked article, a Slack ping) — not just
  the four inbound channels — and frame OpenLoomi as handling both.
- The `Watch` row in the "What it does" table now lists voice memos,
  screenshots, links, and pasted notes alongside the Composio MCP signals.
