### PR TITLE
feat(memory): add relation discovery boundary

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -11,9 +11,11 @@ import {
   buildMemoryGovernanceExplanationReport,
   buildMemoryConsolidationPlan,
   buildMemoryConsolidationDiagnosticsReport,
+  buildCallerProvidedMemoryRelationCandidateDiscoveryReport,
   buildMemoryEvidenceClusters,
   buildMemoryConsolidationDiagnosticsRunReport,
   buildMemoryConsolidationRuntimeRecordSelectors,
+  buildMemoryWeakRelationObservationReport,
   buildMemoryRelationCandidates,
   buildMemoryRelationPipeline,
   buildMemoryRelationPipelineDiagnostics,
@@ -34,7 +36,9 @@ import {
   deriveMemoryRelationGraphLifecycle,
   invokeSemanticMemoryDraftSummarizerProvider,
   logMemoryConsolidationDiagnosticsRun,
+  judgeMemoryRelationCandidates,
   persistSemanticMemoryDrafts,
+  invokeMemoryRelationJudgeProvider,
   runMemoryConsolidationDiagnostics,
   serializeSemanticMemoryArtifactStorageRecord,
   summarizeSemanticMemoryDraftCandidate,
@@ -4545,5 +4549,438 @@ describe("memory consolidation evaluation scenarios", () => {
     expect(report.metadata).toEqual({
       mode: "fixture-only",
     });
+  });
+
+  it("normalizes caller-provided relation candidates before judgment", () => {
+    const records = [
+      {
+        id: "manual-a",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Use Chinese for repo work.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+      {
+        id: "manual-b",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Prefer Chinese technical explanations.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+      {
+        id: "manual-c",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Use English for this one reply.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "en",
+        },
+      },
+    ];
+    const report = buildCallerProvidedMemoryRelationCandidateDiscoveryReport({
+      records,
+      candidates: [
+        {
+          fromRecordId: "manual-b",
+          toRecordId: "manual-a",
+          candidateKeys: ["manual:answer-language", "manual:answer-language"],
+          score: 1.4,
+          reasonCodes: ["manual_review"],
+          metadata: {
+            source: "reviewer",
+          },
+        },
+        {
+          fromRecordId: "manual-a",
+          toRecordId: "manual-b",
+        },
+        {
+          fromRecordId: "manual-a",
+          toRecordId: "missing-record",
+        },
+        {
+          fromRecordId: "manual-c",
+          toRecordId: "manual-c",
+        },
+      ],
+      metadata: {
+        mode: "caller-provided",
+      },
+    });
+
+    expect(report).toEqual({
+      candidates: [
+        {
+          id: "candidate:manual-a|manual-b",
+          fromRecordId: "manual-a",
+          toRecordId: "manual-b",
+          candidateKeys: ["manual:answer-language"],
+          score: 1,
+          reasonCodes: ["caller_provided_candidate", "manual_review"],
+          metadata: {
+            source: "reviewer",
+          },
+        },
+      ],
+      skippedCandidates: [
+        {
+          fromRecordId: "manual-a",
+          toRecordId: "manual-b",
+          reasonCodes: ["duplicate_candidate"],
+          metadata: undefined,
+        },
+        {
+          fromRecordId: "manual-a",
+          toRecordId: "missing-record",
+          reasonCodes: ["missing_record"],
+          metadata: undefined,
+        },
+        {
+          fromRecordId: "manual-c",
+          toRecordId: "manual-c",
+          reasonCodes: ["self_relation_candidate"],
+          metadata: undefined,
+        },
+      ],
+      reasonCodes: [
+        "caller_provided_candidate",
+        "manual_review",
+        "duplicate_candidate",
+        "missing_record",
+        "self_relation_candidate",
+      ],
+      metadata: {
+        mode: "caller-provided",
+      },
+    });
+
+    const judgment = judgeMemoryRelationCandidates({
+      candidates: report.candidates,
+      records,
+      now: NOW,
+    });
+
+    expect(judgment.relations).toEqual([
+      expect.objectContaining({
+        fromRecordId: "manual-a",
+        toRecordId: "manual-b",
+        relation: "support",
+      }),
+    ]);
+  });
+
+  it("keeps weak relation observations from promoting clusters", () => {
+    const records = [
+      {
+        id: "weak-a",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Use Chinese for repo work.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+      {
+        id: "weak-b",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Prefer Chinese technical explanations.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+      {
+        id: "weak-related",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Technical replies should include context.",
+        tier: "short",
+      },
+      {
+        id: "weak-uncertain",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Maybe mention examples.",
+        tier: "short",
+      },
+    ];
+    const discovery = buildCallerProvidedMemoryRelationCandidateDiscoveryReport(
+      {
+        records,
+        candidates: [
+          {
+            fromRecordId: "weak-a",
+            toRecordId: "weak-b",
+            candidateKeys: ["manual:language"],
+            score: 1,
+          },
+          {
+            fromRecordId: "weak-a",
+            toRecordId: "weak-related",
+            candidateKeys: ["manual:style"],
+            score: 0.7,
+            metadata: {
+              source: "weak-discovery",
+            },
+          },
+          {
+            fromRecordId: "weak-a",
+            toRecordId: "weak-uncertain",
+            candidateKeys: ["manual:loose"],
+            score: 0.2,
+          },
+        ],
+      },
+    );
+    const judgment = judgeMemoryRelationCandidates({
+      candidates: discovery.candidates,
+      records,
+      now: NOW,
+    });
+    const report = buildMemoryWeakRelationObservationReport({
+      judgments: judgment.judgments,
+      metadata: {
+        mode: "observation-only",
+      },
+    });
+    const assignment = assignMemoryRelationGraph({
+      records,
+      relations: judgment.relations,
+      now: NOW,
+    });
+
+    expect(report.summary).toEqual({
+      judgmentCount: 3,
+      observationCount: 2,
+      relatedCount: 1,
+      uncertainCount: 1,
+      excludedStrongRelationCount: 1,
+      promotesToCluster: false,
+      mutatesGraph: false,
+    });
+    expect(report.observations).toEqual([
+      expect.objectContaining({
+        fromRecordId: "weak-a",
+        toRecordId: "weak-related",
+        relation: "related",
+        status: "observed",
+        score: 0.7,
+        promotesToCluster: false,
+        mutatesGraph: false,
+        reasonCodes: expect.arrayContaining([
+          "weak_related_relation",
+          "candidate_related",
+          "caller_provided_candidate",
+        ]),
+        metadata: {
+          source: "weak-discovery",
+        },
+      }),
+      expect.objectContaining({
+        fromRecordId: "weak-a",
+        toRecordId: "weak-uncertain",
+        relation: "uncertain",
+        status: "observed",
+        edgeId: undefined,
+        promotesToCluster: false,
+        mutatesGraph: false,
+        reasonCodes: expect.arrayContaining([
+          "uncertain_relation_candidate",
+          "uncertain_candidate",
+          "caller_provided_candidate",
+        ]),
+      }),
+    ]);
+    expect(report.reasonCodes).toEqual(
+      expect.arrayContaining([
+        "weak_related_relation",
+        "uncertain_relation_candidate",
+      ]),
+    );
+    expect(report.metadata).toEqual({
+      mode: "observation-only",
+    });
+    expect(assignment.recordClusterKeys["weak-a"]).toBe(
+      assignment.recordClusterKeys["weak-b"],
+    );
+    expect(assignment.recordClusterKeys["weak-a"]).not.toBe(
+      assignment.recordClusterKeys["weak-related"],
+    );
+  });
+
+  it("invokes an optional relation judge adapter without provider wiring", async () => {
+    const records = [
+      {
+        id: "judge-a",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Use Chinese for repo work.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+      {
+        id: "judge-b",
+        userId: "eval-user",
+        timestamp: NOW,
+        text: "Prefer Chinese technical explanations.",
+        tier: "short",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+        },
+      },
+    ];
+    const discovery = buildCallerProvidedMemoryRelationCandidateDiscoveryReport(
+      {
+        records,
+        candidates: [
+          {
+            fromRecordId: "judge-a",
+            toRecordId: "judge-b",
+            candidateKeys: ["manual:language"],
+            score: 0.9,
+            reasonCodes: ["manual_review"],
+            metadata: {
+              source: "fake-judge-test",
+            },
+          },
+        ],
+      },
+    );
+    const providerInputs: string[] = [];
+    const candidate = discovery.candidates[0];
+    if (!candidate) {
+      throw new Error("Expected relation judge candidate.");
+    }
+    const judged = await invokeMemoryRelationJudgeProvider({
+      candidate,
+      records,
+      now: NOW,
+      metadata: {
+        mode: "fake-judge",
+      },
+      async invoke(input) {
+        providerInputs.push(input.candidate.id);
+        expect(input.defaultDecision).toEqual({
+          relation: "support",
+          weight: expect.any(Number),
+          reasonCodes: ["same_relation_value"],
+        });
+        expect(input.fromRecord.id).toBe("judge-a");
+        expect(input.toRecord.id).toBe("judge-b");
+
+        return {
+          relation: "related",
+          weight: 0.35,
+          reasonCodes: ["candidate_related"],
+        };
+      },
+    });
+    let skippedInvokeCount = 0;
+    const skipped = await invokeMemoryRelationJudgeProvider({
+      candidate: {
+        id: "candidate:judge-a|missing-record",
+        fromRecordId: "judge-a",
+        toRecordId: "missing-record",
+        candidateKeys: ["manual:missing"],
+        score: 0.8,
+        reasonCodes: ["caller_provided_candidate"],
+      },
+      records,
+      now: NOW,
+      async invoke() {
+        skippedInvokeCount += 1;
+        throw new Error("should not be called");
+      },
+    });
+    const failed = await invokeMemoryRelationJudgeProvider({
+      candidate,
+      records,
+      now: NOW,
+      async invoke() {
+        throw new Error("fake judge unavailable");
+      },
+    });
+
+    expect(providerInputs).toEqual(["candidate:judge-a|judge-b"]);
+    expect(judged).toEqual(
+      expect.objectContaining({
+        status: "judged",
+        candidateId: "candidate:judge-a|judge-b",
+        fromRecordId: "judge-a",
+        toRecordId: "judge-b",
+        reasonCodes: [
+          "provider_invoked",
+          "candidate_related",
+          "caller_provided_candidate",
+          "manual_review",
+        ],
+        metadata: {
+          mode: "fake-judge",
+        },
+        decision: {
+          relation: "related",
+          weight: 0.35,
+          reasonCodes: ["candidate_related"],
+        },
+        judgment: expect.objectContaining({
+          relation: "related",
+          weight: 0.35,
+          edge: expect.objectContaining({
+            relation: "related",
+          }),
+        }),
+      }),
+    );
+    expect(judged.input).toEqual(
+      expect.objectContaining({
+        now: NOW,
+        metadata: {
+          mode: "fake-judge",
+        },
+      }),
+    );
+    expect(skippedInvokeCount).toBe(0);
+    expect(skipped).toEqual(
+      expect.objectContaining({
+        status: "skipped",
+        reasonCodes: ["missing_record"],
+      }),
+    );
+    expect(skipped.input).toBeUndefined();
+    expect(skipped.judgment).toBeUndefined();
+    expect(failed).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        reasonCodes: ["provider_error"],
+        error: {
+          name: "Error",
+          message: "fake judge unavailable",
+        },
+      }),
+    );
+    expect(failed.input).toEqual(
+      expect.objectContaining({
+        candidate,
+      }),
+    );
+    expect(failed.judgment).toBeUndefined();
   });
 });

--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -43,6 +43,7 @@ import {
   serializeSemanticMemoryArtifactStorageRecord,
   summarizeSemanticMemoryDraftCandidate,
   resolveMemorySemanticRetrievalConfig,
+  type MemoryEvidenceRecord,
   type MemorySemanticRetrievalConfig,
   type MemorySemanticRetrievalCandidate,
   type MemorySemanticRetrievalComparisonReport,
@@ -3488,7 +3489,7 @@ describe("memory consolidation evaluation scenarios", () => {
   });
 
   it("builds a compact diagnostics run report for real-record batches", async () => {
-    const records = [
+    const records: AdapterSourceRecord[] = [
       {
         owner: "adapter-user",
         createdAt: NOW,
@@ -4552,7 +4553,7 @@ describe("memory consolidation evaluation scenarios", () => {
   });
 
   it("normalizes caller-provided relation candidates before judgment", () => {
-    const records = [
+    const records: MemoryEvidenceRecord[] = [
       {
         id: "manual-a",
         userId: "eval-user",
@@ -4680,7 +4681,7 @@ describe("memory consolidation evaluation scenarios", () => {
   });
 
   it("keeps weak relation observations from promoting clusters", () => {
-    const records = [
+    const records: MemoryEvidenceRecord[] = [
       {
         id: "weak-a",
         userId: "eval-user",
@@ -4823,7 +4824,7 @@ describe("memory consolidation evaluation scenarios", () => {
   });
 
   it("invokes an optional relation judge adapter without provider wiring", async () => {
-    const records = [
+    const records: MemoryEvidenceRecord[] = [
       {
         id: "judge-a",
         userId: "eval-user",

--- a/packages/ai/memory-consolidation/src/pipeline.ts
+++ b/packages/ai/memory-consolidation/src/pipeline.ts
@@ -18,7 +18,9 @@ type PrimitiveValue = string | number | boolean;
 export type MemoryRelationCandidateReasonCode =
   | "shared_candidate_key"
   | "shared_dimension"
-  | "shared_metadata";
+  | "shared_metadata"
+  | "caller_provided_candidate"
+  | (string & {});
 
 export interface MemoryRelationCandidate {
   id: string;
@@ -27,6 +29,7 @@ export interface MemoryRelationCandidate {
   candidateKeys: string[];
   score: number;
   reasonCodes: MemoryRelationCandidateReasonCode[];
+  metadata?: Record<string, unknown>;
 }
 
 export interface BuildMemoryRelationCandidatesInput {
@@ -37,6 +40,42 @@ export interface BuildMemoryRelationCandidatesInput {
   maxRecordsPerKey?: number;
   maxCandidatesPerRecord?: number;
   scoreNorm?: number;
+}
+
+export type MemoryRelationDiscoveryReasonCode =
+  | MemoryRelationCandidateReasonCode
+  | "duplicate_candidate"
+  | "missing_record"
+  | "self_relation_candidate"
+  | (string & {});
+
+export interface CallerProvidedMemoryRelationCandidate {
+  fromRecordId: string;
+  toRecordId: string;
+  candidateKeys?: string[];
+  score?: number;
+  reasonCodes?: MemoryRelationCandidateReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildCallerProvidedMemoryRelationCandidateDiscoveryReportInput {
+  records: MemoryEvidenceRecord[];
+  candidates: CallerProvidedMemoryRelationCandidate[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface SkippedMemoryRelationCandidateDiscoveryEntry {
+  fromRecordId?: string;
+  toRecordId?: string;
+  reasonCodes: MemoryRelationDiscoveryReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryRelationCandidateDiscoveryReport {
+  candidates: MemoryRelationCandidate[];
+  skippedCandidates: SkippedMemoryRelationCandidateDiscoveryEntry[];
+  reasonCodes: MemoryRelationDiscoveryReasonCode[];
+  metadata?: Record<string, unknown>;
 }
 
 export type MemoryRelationJudgmentKind = MemoryRelationKind | "uncertain";
@@ -89,6 +128,101 @@ export interface JudgeMemoryRelationCandidatesInput {
 export interface MemoryRelationJudgmentResult {
   judgments: MemoryRelationJudgment[];
   relations: MemoryRelationEdge[];
+}
+
+export type MemoryRelationJudgeProviderReasonCode =
+  | "provider_invoked"
+  | "provider_error"
+  | "missing_record"
+  | "default_decision_used"
+  | MemoryRelationJudgmentReasonCode
+  | MemoryRelationCandidateReasonCode
+  | (string & {});
+
+export interface MemoryRelationJudgeProviderInput {
+  candidate: MemoryRelationCandidate;
+  fromRecord: MemoryEvidenceRecord;
+  toRecord: MemoryEvidenceRecord;
+  defaultDecision: MemoryRelationJudgmentDecision;
+  now: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type MemoryRelationJudgeProviderInvoke = (
+  input: MemoryRelationJudgeProviderInput,
+) =>
+  | Promise<MemoryRelationJudgmentDecision | undefined>
+  | MemoryRelationJudgmentDecision
+  | undefined;
+
+export interface InvokeMemoryRelationJudgeProviderInput {
+  candidate: MemoryRelationCandidate;
+  records: MemoryEvidenceRecord[];
+  now: number;
+  invoke: MemoryRelationJudgeProviderInvoke;
+  getRelationGroup?: JudgeMemoryRelationCandidatesInput["getRelationGroup"];
+  getRelationValue?: JudgeMemoryRelationCandidatesInput["getRelationValue"];
+  thresholds?: Partial<MemoryRelationJudgmentThresholds>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryRelationJudgeProviderResult {
+  status: "judged" | "skipped" | "failed";
+  candidateId: string;
+  fromRecordId: string;
+  toRecordId: string;
+  input?: MemoryRelationJudgeProviderInput;
+  decision?: MemoryRelationJudgmentDecision;
+  judgment?: MemoryRelationJudgment;
+  error?: {
+    name: string;
+    message: string;
+  };
+  reasonCodes: MemoryRelationJudgeProviderReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export type MemoryWeakRelationObservationReasonCode =
+  | "weak_related_relation"
+  | "uncertain_relation_candidate"
+  | MemoryRelationJudgmentReasonCode
+  | MemoryRelationCandidateReasonCode
+  | (string & {});
+
+export interface MemoryWeakRelationObservation {
+  candidateId: string;
+  fromRecordId: string;
+  toRecordId: string;
+  relation: Extract<MemoryRelationJudgmentKind, "related" | "uncertain">;
+  status: "observed";
+  score: number;
+  weight: number;
+  candidateKeys: string[];
+  edgeId?: string;
+  promotesToCluster: false;
+  mutatesGraph: false;
+  reasonCodes: MemoryWeakRelationObservationReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildMemoryWeakRelationObservationReportInput {
+  judgments: MemoryRelationJudgment[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryWeakRelationObservationReport {
+  summary: {
+    judgmentCount: number;
+    observationCount: number;
+    relatedCount: number;
+    uncertainCount: number;
+    excludedStrongRelationCount: number;
+    promotesToCluster: false;
+    mutatesGraph: false;
+  };
+  observations: MemoryWeakRelationObservation[];
+  reasonCodes: MemoryWeakRelationObservationReasonCode[];
+  metadata?: Record<string, unknown>;
 }
 
 export interface MemorySummaryCandidate {
@@ -164,6 +298,18 @@ function isPrimitive(value: unknown): value is PrimitiveValue {
 function stablePairId(left: string, right: string): string {
   const [fromRecordId, toRecordId] = [left, right].sort();
   return `${encodeURIComponent(fromRecordId)}|${encodeURIComponent(toRecordId)}`;
+}
+
+function stableRecordPair(
+  left: string,
+  right: string,
+): {
+  fromRecordId: string;
+  toRecordId: string;
+} {
+  return left <= right
+    ? { fromRecordId: left, toRecordId: right }
+    : { fromRecordId: right, toRecordId: left };
 }
 
 function candidateId(fromRecordId: string, toRecordId: string): string {
@@ -329,6 +475,79 @@ export function buildMemoryRelationCandidates(
   }
 
   return sortCandidates(selected);
+}
+
+export function buildCallerProvidedMemoryRelationCandidateDiscoveryReport(
+  input: BuildCallerProvidedMemoryRelationCandidateDiscoveryReportInput,
+): MemoryRelationCandidateDiscoveryReport {
+  const recordsById = new Set(input.records.map((record) => record.id));
+  const candidates: MemoryRelationCandidate[] = [];
+  const skippedCandidates: SkippedMemoryRelationCandidateDiscoveryEntry[] = [];
+  const seenPairIds = new Set<string>();
+  const reasonCodes = new Set<MemoryRelationDiscoveryReasonCode>();
+
+  for (const candidate of input.candidates) {
+    const pairReasonCodes = new Set<MemoryRelationDiscoveryReasonCode>();
+
+    if (
+      !recordsById.has(candidate.fromRecordId) ||
+      !recordsById.has(candidate.toRecordId)
+    ) {
+      pairReasonCodes.add("missing_record");
+    }
+
+    if (candidate.fromRecordId === candidate.toRecordId) {
+      pairReasonCodes.add("self_relation_candidate");
+    }
+
+    const pairId = stablePairId(candidate.fromRecordId, candidate.toRecordId);
+    if (seenPairIds.has(pairId)) {
+      pairReasonCodes.add("duplicate_candidate");
+    }
+
+    if (pairReasonCodes.size > 0) {
+      for (const reasonCode of pairReasonCodes) {
+        reasonCodes.add(reasonCode);
+      }
+      skippedCandidates.push({
+        fromRecordId: candidate.fromRecordId,
+        toRecordId: candidate.toRecordId,
+        reasonCodes: [...pairReasonCodes],
+        metadata: candidate.metadata,
+      });
+      continue;
+    }
+
+    seenPairIds.add(pairId);
+    reasonCodes.add("caller_provided_candidate");
+    for (const reasonCode of candidate.reasonCodes ?? []) {
+      reasonCodes.add(reasonCode);
+    }
+
+    const pair = stableRecordPair(candidate.fromRecordId, candidate.toRecordId);
+    const candidateKeys = [...new Set(candidate.candidateKeys ?? [])].sort();
+    const candidateReasonCodes: MemoryRelationCandidateReasonCode[] = [
+      "caller_provided_candidate",
+      ...(candidate.reasonCodes ?? []),
+    ];
+
+    candidates.push({
+      id: candidateId(pair.fromRecordId, pair.toRecordId),
+      fromRecordId: pair.fromRecordId,
+      toRecordId: pair.toRecordId,
+      candidateKeys,
+      score: clamp01(candidate.score ?? 1),
+      reasonCodes: [...new Set(candidateReasonCodes)],
+      metadata: candidate.metadata,
+    });
+  }
+
+  return {
+    candidates: sortCandidates(candidates),
+    skippedCandidates,
+    reasonCodes: [...reasonCodes],
+    metadata: input.metadata,
+  };
 }
 
 function resolveJudgmentThresholds(
@@ -515,6 +734,184 @@ export function judgeMemoryRelationCandidates(
     relations: judgments.flatMap((judgment) =>
       judgment.edge ? [judgment.edge] : [],
     ),
+  };
+}
+
+function errorInfo(error: unknown): { name: string; message: string } {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return {
+    name: "Error",
+    message: String(error),
+  };
+}
+
+export async function invokeMemoryRelationJudgeProvider(
+  input: InvokeMemoryRelationJudgeProviderInput,
+): Promise<MemoryRelationJudgeProviderResult> {
+  const recordsById = new Map(
+    input.records.map((record) => [record.id, record]),
+  );
+  const fromRecord = recordsById.get(input.candidate.fromRecordId);
+  const toRecord = recordsById.get(input.candidate.toRecordId);
+
+  if (!fromRecord || !toRecord) {
+    return {
+      status: "skipped",
+      candidateId: input.candidate.id,
+      fromRecordId: input.candidate.fromRecordId,
+      toRecordId: input.candidate.toRecordId,
+      reasonCodes: ["missing_record"],
+      metadata: input.metadata,
+    };
+  }
+
+  const thresholds = resolveJudgmentThresholds(input.thresholds);
+  const defaultDecision = defaultJudgmentDecision(
+    input.candidate,
+    fromRecord,
+    toRecord,
+    thresholds,
+    input.getRelationGroup,
+    input.getRelationValue,
+  );
+  const providerInput: MemoryRelationJudgeProviderInput = {
+    candidate: input.candidate,
+    fromRecord,
+    toRecord,
+    defaultDecision,
+    now: input.now,
+    metadata: input.metadata,
+  };
+
+  try {
+    const providerDecision = await input.invoke(providerInput);
+    const decision = providerDecision ?? defaultDecision;
+    const judgmentResult = judgeMemoryRelationCandidates({
+      candidates: [input.candidate],
+      records: input.records,
+      now: input.now,
+      getRelationGroup: input.getRelationGroup,
+      getRelationValue: input.getRelationValue,
+      thresholds: input.thresholds,
+      judgeCandidate: () => decision,
+    });
+    const reasonCodes = new Set<MemoryRelationJudgeProviderReasonCode>();
+    reasonCodes.add("provider_invoked");
+    if (!providerDecision) {
+      reasonCodes.add("default_decision_used");
+    }
+    for (const reasonCode of decision.reasonCodes ?? []) {
+      reasonCodes.add(reasonCode);
+    }
+    for (const reasonCode of input.candidate.reasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
+
+    return {
+      status: "judged",
+      candidateId: input.candidate.id,
+      fromRecordId: input.candidate.fromRecordId,
+      toRecordId: input.candidate.toRecordId,
+      input: providerInput,
+      decision,
+      judgment: judgmentResult.judgments[0],
+      reasonCodes: [...reasonCodes],
+      metadata: input.metadata,
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      candidateId: input.candidate.id,
+      fromRecordId: input.candidate.fromRecordId,
+      toRecordId: input.candidate.toRecordId,
+      input: providerInput,
+      error: errorInfo(error),
+      reasonCodes: ["provider_error"],
+      metadata: input.metadata,
+    };
+  }
+}
+
+function weakRelationReasonCode(
+  relation: Extract<MemoryRelationJudgmentKind, "related" | "uncertain">,
+): MemoryWeakRelationObservationReasonCode {
+  return relation === "related"
+    ? "weak_related_relation"
+    : "uncertain_relation_candidate";
+}
+
+export function buildMemoryWeakRelationObservationReport(
+  input: BuildMemoryWeakRelationObservationReportInput,
+): MemoryWeakRelationObservationReport {
+  const observations: MemoryWeakRelationObservation[] = [];
+  const reasonCodes = new Set<MemoryWeakRelationObservationReasonCode>();
+  let excludedStrongRelationCount = 0;
+
+  for (const judgment of input.judgments) {
+    if (judgment.relation !== "related" && judgment.relation !== "uncertain") {
+      excludedStrongRelationCount += 1;
+      continue;
+    }
+
+    const observationReasonCodes: MemoryWeakRelationObservationReasonCode[] = [
+      weakRelationReasonCode(judgment.relation),
+      ...judgment.reasonCodes,
+      ...judgment.candidate.reasonCodes,
+    ];
+    for (const reasonCode of observationReasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
+
+    observations.push({
+      candidateId: judgment.candidate.id,
+      fromRecordId: judgment.candidate.fromRecordId,
+      toRecordId: judgment.candidate.toRecordId,
+      relation: judgment.relation,
+      status: "observed",
+      score: judgment.candidate.score,
+      weight: judgment.weight,
+      candidateKeys: [...judgment.candidate.candidateKeys],
+      edgeId: judgment.edge?.id,
+      promotesToCluster: false,
+      mutatesGraph: false,
+      reasonCodes: [...new Set(observationReasonCodes)],
+      metadata: judgment.candidate.metadata,
+    });
+  }
+
+  observations.sort((a, b) => {
+    if (b.weight !== a.weight) {
+      return b.weight - a.weight;
+    }
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.candidateId.localeCompare(b.candidateId);
+  });
+
+  return {
+    summary: {
+      judgmentCount: input.judgments.length,
+      observationCount: observations.length,
+      relatedCount: observations.filter(
+        (observation) => observation.relation === "related",
+      ).length,
+      uncertainCount: observations.filter(
+        (observation) => observation.relation === "uncertain",
+      ).length,
+      excludedStrongRelationCount,
+      promotesToCluster: false,
+      mutatesGraph: false,
+    },
+    observations,
+    reasonCodes: [...reasonCodes],
+    metadata: input.metadata,
   };
 }
 


### PR DESCRIPTION
## Summary
Add a relation discovery boundary for the memory-consolidation package.

This PR keeps relation discovery caller-provided and observation-only:
- add a helper for normalizing caller-provided relation candidates
- add a relation judge adapter boundary that invokes only a caller-provided function
- add weak relation observation reports for related / uncertain judgments
- add focused tests for candidate normalization, weak observations, and fake judge adapter behavior

## Scope
- Does not introduce a real LLM, embedding provider, network provider, database, scheduler, or UI
- Does not change forgetting runtime behavior
- Does not change retrieval ranking or retrieval defaults
- Does not mutate storage or add a migration
- Weak relation observations are report-only and keep `mutatesGraph: false`
- The optional judge adapter only calls the provided `invoke` function and does not wire any provider

## Testing
- `corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/pipeline.ts apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm -C apps/web lint`
- `git diff --check`