### PR TITLE
feat(memory): add consolidation diagnostics bundle

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -10,6 +10,7 @@ import {
   buildMemoryGovernanceCommandDryRunReport,
   buildMemoryGovernanceExplanationReport,
   buildMemoryConsolidationPlan,
+  buildMemoryConsolidationDiagnosticsBundle,
   buildMemoryConsolidationDiagnosticsReport,
   buildCallerProvidedMemoryRelationCandidateDiscoveryReport,
   buildMemoryEvidenceClusters,
@@ -4820,6 +4821,140 @@ describe("memory consolidation evaluation scenarios", () => {
     );
     expect(assignment.recordClusterKeys["weak-a"]).not.toBe(
       assignment.recordClusterKeys["weak-related"],
+    );
+  });
+
+  it("bundles end-to-end memory consolidation diagnostics without runtime mutation", () => {
+    const { diagnostics, candidate } = buildSemanticDraftPersistenceFixture();
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+    const draftCandidates = buildSemanticMemoryDraftCandidates({
+      report,
+      records: diagnostics.records,
+    });
+    const relationDiscovery =
+      buildCallerProvidedMemoryRelationCandidateDiscoveryReport({
+        records: diagnostics.records,
+        candidates: [
+          {
+            fromRecordId: "adapter-zh-a",
+            toRecordId: "adapter-zh-b",
+            candidateKeys: ["manual:language"],
+            score: 1,
+          },
+        ],
+      });
+    const weakRelationObservation = buildMemoryWeakRelationObservationReport({
+      judgments: diagnostics.pipeline.judgments,
+    });
+    const artifact = semanticArtifactStorageFixture();
+    const storageDryRunReport = buildSemanticMemoryArtifactStorageDryRunReport({
+      userId: artifact.userId,
+      artifacts: [artifact],
+      enabled: true,
+      dryRun: true,
+    });
+    const revisionMemory = buildSemanticMemoryRevisionStatusSignal({
+      artifactId: artifact.artifactId,
+      artifactStatus: artifact.status,
+      sourceRecordIds: artifact.sourceRecordIds,
+      confidence: artifact.confidence,
+      reasonCodes: artifact.reasonCodes,
+      rollback: artifact.rollback,
+      metadata: artifact.metadata,
+    });
+    const revisionExplanation = buildSemanticMemoryRevisionExplanationReport({
+      memories: [revisionMemory],
+    });
+    const governanceExplanation = buildMemoryGovernanceExplanationReport({
+      memories: [revisionMemory],
+      sourceRecords: diagnostics.records,
+    });
+    const bundle = buildMemoryConsolidationDiagnosticsBundle({
+      diagnostics,
+      relationDiscoveryReport: relationDiscovery,
+      weakRelationObservationReport: weakRelationObservation,
+      consolidationReport: report,
+      semanticDraftCandidates: draftCandidates,
+      storageDryRunReport,
+      revisionExplanationReport: revisionExplanation,
+      governanceExplanationReport: governanceExplanation,
+      metadata: {
+        mode: "end-to-end-diagnostics",
+      },
+    });
+
+    expect(bundle.summary).toEqual({
+      sourceRecordCount: report.summary.sourceRecordCount,
+      adaptedRecordCount: report.summary.adaptedRecordCount,
+      skippedRecordCount: report.summary.skippedRecordCount,
+      relationCandidateCount: report.summary.candidateCount,
+      discoveredRelationCandidateCount: 1,
+      skippedDiscoveredRelationCandidateCount: 0,
+      relationCount: report.summary.relationCount,
+      weakObservationCount: weakRelationObservation.summary.observationCount,
+      preservedClusterCount: report.preservedClusters.length,
+      contestedClusterCount: report.contestedClusters.length,
+      decayedRecordCount: report.decayedRecords.length,
+      semanticDraftCandidateCount: draftCandidates.length,
+      storageArtifactCount: 1,
+      storageWouldWriteCount: 1,
+      revisionMemoryCount: 1,
+      governanceMemoryCount: 1,
+      dryRunOnly: true,
+      mutatesRuntime: false,
+      mutatesStorage: false,
+      mutatesRetrieval: false,
+    });
+    expect(bundle.stages.consolidationReport).toBe(report);
+    expect(bundle.stages.semanticDraftCandidates[0]).toEqual(candidate);
+    expect(bundle.stages.storageDryRunReport?.summary.dryRun).toBe(true);
+    expect(bundle.stages.revisionExplanationReport?.summary.activeCount).toBe(
+      1,
+    );
+    expect(bundle.stages.governanceExplanationReport?.memories[0]).toEqual(
+      expect.objectContaining({
+        artifactId: artifact.artifactId,
+        rollbackAvailable: true,
+      }),
+    );
+    expect(bundle.reasonCodes).toEqual(
+      expect.arrayContaining([
+        "diagnostics_bundle",
+        "dry_run_only",
+        "runtime_unchanged",
+        "storage_unchanged",
+        "retrieval_unchanged",
+        "relation_discovery_attached",
+        "semantic_draft_candidates_found",
+        "storage_dry_run_attached",
+        "revision_report_attached",
+        "governance_report_attached",
+      ]),
+    );
+    expect(bundle.metadata).toEqual({
+      mode: "end-to-end-diagnostics",
+    });
+
+    const storageWriteReadyReport =
+      buildSemanticMemoryArtifactStorageDryRunReport({
+        userId: artifact.userId,
+        artifacts: [artifact],
+        enabled: true,
+        dryRun: false,
+      });
+    const writeReadyBundle = buildMemoryConsolidationDiagnosticsBundle({
+      diagnostics,
+      storageDryRunReport: storageWriteReadyReport,
+    });
+
+    expect(writeReadyBundle.summary.dryRunOnly).toBe(false);
+    expect(writeReadyBundle.summary.mutatesStorage).toBe(false);
+    expect(writeReadyBundle.reasonCodes).toEqual(
+      expect.arrayContaining(["storage_write_ready_attached"]),
+    );
+    expect(writeReadyBundle.reasonCodes).not.toContain("dry_run_only");
+    expect(writeReadyBundle.reasonCodes).not.toContain(
+      "storage_dry_run_attached",
     );
   });
 

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -192,6 +192,11 @@ recency-aware competition without applying replacements or changing retrieval.
 Governance helpers turn revision signals into explanation reports, correction
 command dry-runs, and polluted-memory audit fixtures without applying changes.
 
+`buildMemoryConsolidationDiagnosticsBundle` can stitch the existing diagnostics,
+weak relation observations, draft candidates, storage dry-runs, and
+revision/governance reports into one offline review bundle. It is still
+report-only and marks runtime, storage, and retrieval mutation as disabled.
+
 Callers can keep the full diagnostics for debugging and derive the compact
 report for review or logging:
 

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./adapter": "./src/adapter.ts",
+    "./diagnostics-bundle": "./src/diagnostics-bundle.ts",
     "./evaluation": "./src/evaluation.ts",
     "./evidence-cluster": "./src/evidence-cluster.ts",
     "./governance": "./src/governance.ts",

--- a/packages/ai/memory-consolidation/src/diagnostics-bundle.ts
+++ b/packages/ai/memory-consolidation/src/diagnostics-bundle.ts
@@ -1,0 +1,193 @@
+import {
+  buildMemoryConsolidationDiagnosticsReport,
+  type MemoryConsolidationDiagnosticsReport,
+  type MemoryRelationPipelineDiagnostics,
+} from "./adapter";
+import type { MemoryGovernanceExplanationReport } from "./governance";
+import type { SemanticMemoryArtifactStorageDryRunReport } from "./persistence";
+import {
+  buildMemoryWeakRelationObservationReport,
+  type MemoryRelationCandidateDiscoveryReport,
+  type MemoryWeakRelationObservationReport,
+} from "./pipeline";
+import type { SemanticMemoryRevisionExplanationReport } from "./revision";
+import {
+  buildSemanticMemoryDraftCandidates,
+  type MemorySemanticDraftCandidate,
+} from "./semantic-draft";
+
+export type MemoryConsolidationDiagnosticsBundleReasonCode =
+  | "diagnostics_bundle"
+  | "dry_run_only"
+  | "storage_write_ready_attached"
+  | "runtime_unchanged"
+  | "storage_unchanged"
+  | "retrieval_unchanged"
+  | "relation_discovery_attached"
+  | "weak_relations_observed"
+  | "semantic_draft_candidates_found"
+  | "storage_dry_run_attached"
+  | "revision_report_attached"
+  | "governance_report_attached"
+  | (string & {});
+
+export interface BuildMemoryConsolidationDiagnosticsBundleInput {
+  diagnostics: MemoryRelationPipelineDiagnostics;
+  relationDiscoveryReport?: MemoryRelationCandidateDiscoveryReport;
+  weakRelationObservationReport?: MemoryWeakRelationObservationReport;
+  consolidationReport?: MemoryConsolidationDiagnosticsReport;
+  semanticDraftCandidates?: MemorySemanticDraftCandidate[];
+  storageDryRunReport?: SemanticMemoryArtifactStorageDryRunReport;
+  revisionExplanationReport?: SemanticMemoryRevisionExplanationReport;
+  governanceExplanationReport?: MemoryGovernanceExplanationReport;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryConsolidationDiagnosticsBundleSummary {
+  sourceRecordCount: number;
+  adaptedRecordCount: number;
+  skippedRecordCount: number;
+  relationCandidateCount: number;
+  discoveredRelationCandidateCount?: number;
+  skippedDiscoveredRelationCandidateCount?: number;
+  relationCount: number;
+  weakObservationCount: number;
+  preservedClusterCount: number;
+  contestedClusterCount: number;
+  decayedRecordCount: number;
+  semanticDraftCandidateCount: number;
+  storageArtifactCount?: number;
+  storageWouldWriteCount?: number;
+  revisionMemoryCount?: number;
+  governanceMemoryCount?: number;
+  dryRunOnly: boolean;
+  mutatesRuntime: false;
+  mutatesStorage: false;
+  mutatesRetrieval: false;
+}
+
+export interface MemoryConsolidationDiagnosticsBundle {
+  summary: MemoryConsolidationDiagnosticsBundleSummary;
+  stages: {
+    relationDiscovery?: MemoryRelationCandidateDiscoveryReport;
+    weakRelationObservation: MemoryWeakRelationObservationReport;
+    diagnostics: MemoryRelationPipelineDiagnostics;
+    consolidationReport: MemoryConsolidationDiagnosticsReport;
+    semanticDraftCandidates: MemorySemanticDraftCandidate[];
+    storageDryRunReport?: SemanticMemoryArtifactStorageDryRunReport;
+    revisionExplanationReport?: SemanticMemoryRevisionExplanationReport;
+    governanceExplanationReport?: MemoryGovernanceExplanationReport;
+  };
+  reasonCodes: MemoryConsolidationDiagnosticsBundleReasonCode[];
+  metadata?: Record<string, unknown>;
+}
+
+function addIf(
+  reasonCodes: Set<MemoryConsolidationDiagnosticsBundleReasonCode>,
+  condition: boolean,
+  reasonCode: MemoryConsolidationDiagnosticsBundleReasonCode,
+): void {
+  if (condition) {
+    reasonCodes.add(reasonCode);
+  }
+}
+
+export function buildMemoryConsolidationDiagnosticsBundle(
+  input: BuildMemoryConsolidationDiagnosticsBundleInput,
+): MemoryConsolidationDiagnosticsBundle {
+  const consolidationReport =
+    input.consolidationReport ??
+    buildMemoryConsolidationDiagnosticsReport(input.diagnostics);
+  const semanticDraftCandidates =
+    input.semanticDraftCandidates ??
+    buildSemanticMemoryDraftCandidates({
+      report: consolidationReport,
+      records: input.diagnostics.records,
+    });
+  const weakRelationObservation =
+    input.weakRelationObservationReport ??
+    buildMemoryWeakRelationObservationReport({
+      judgments: input.diagnostics.pipeline.judgments,
+    });
+  const dryRunOnly = input.storageDryRunReport?.summary.dryRun ?? true;
+  const reasonCodes = new Set<MemoryConsolidationDiagnosticsBundleReasonCode>([
+    "diagnostics_bundle",
+    "runtime_unchanged",
+    "storage_unchanged",
+    "retrieval_unchanged",
+  ]);
+
+  reasonCodes.add(dryRunOnly ? "dry_run_only" : "storage_write_ready_attached");
+
+  addIf(
+    reasonCodes,
+    Boolean(input.relationDiscoveryReport),
+    "relation_discovery_attached",
+  );
+  addIf(
+    reasonCodes,
+    weakRelationObservation.summary.observationCount > 0,
+    "weak_relations_observed",
+  );
+  addIf(
+    reasonCodes,
+    semanticDraftCandidates.length > 0,
+    "semantic_draft_candidates_found",
+  );
+  addIf(
+    reasonCodes,
+    input.storageDryRunReport?.summary.dryRun === true,
+    "storage_dry_run_attached",
+  );
+  addIf(
+    reasonCodes,
+    Boolean(input.revisionExplanationReport),
+    "revision_report_attached",
+  );
+  addIf(
+    reasonCodes,
+    Boolean(input.governanceExplanationReport),
+    "governance_report_attached",
+  );
+
+  return {
+    summary: {
+      sourceRecordCount: consolidationReport.summary.sourceRecordCount,
+      adaptedRecordCount: consolidationReport.summary.adaptedRecordCount,
+      skippedRecordCount: consolidationReport.summary.skippedRecordCount,
+      relationCandidateCount: consolidationReport.summary.candidateCount,
+      discoveredRelationCandidateCount:
+        input.relationDiscoveryReport?.candidates.length,
+      skippedDiscoveredRelationCandidateCount:
+        input.relationDiscoveryReport?.skippedCandidates.length,
+      relationCount: consolidationReport.summary.relationCount,
+      weakObservationCount: weakRelationObservation.summary.observationCount,
+      preservedClusterCount: consolidationReport.preservedClusters.length,
+      contestedClusterCount: consolidationReport.contestedClusters.length,
+      decayedRecordCount: consolidationReport.decayedRecords.length,
+      semanticDraftCandidateCount: semanticDraftCandidates.length,
+      storageArtifactCount: input.storageDryRunReport?.summary.artifactCount,
+      storageWouldWriteCount:
+        input.storageDryRunReport?.summary.wouldWriteCount,
+      revisionMemoryCount: input.revisionExplanationReport?.summary.memoryCount,
+      governanceMemoryCount:
+        input.governanceExplanationReport?.summary.memoryCount,
+      dryRunOnly,
+      mutatesRuntime: false,
+      mutatesStorage: false,
+      mutatesRetrieval: false,
+    },
+    stages: {
+      relationDiscovery: input.relationDiscoveryReport,
+      weakRelationObservation,
+      diagnostics: input.diagnostics,
+      consolidationReport,
+      semanticDraftCandidates,
+      storageDryRunReport: input.storageDryRunReport,
+      revisionExplanationReport: input.revisionExplanationReport,
+      governanceExplanationReport: input.governanceExplanationReport,
+    },
+    reasonCodes: [...reasonCodes],
+    metadata: input.metadata ? { ...input.metadata } : undefined,
+  };
+}

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./adapter";
+export * from "./diagnostics-bundle";
 export * from "./evaluation";
 export * from "./evidence-cluster";
 export * from "./governance";


### PR DESCRIPTION
## Summary

Add a small offline diagnostics bundle helper for `@openloomi/memory-consolidation`.

The new `buildMemoryConsolidationDiagnosticsBundle` stitches together existing package-local outputs into one review-friendly report:

- relation discovery report
- weak relation observation report
- relation pipeline diagnostics
- compact consolidation report
- semantic draft candidates
- optional storage dry-run report
- optional revision explanation report
- optional governance explanation report

## Why

The previous memory-consolidation helpers expose useful diagnostics boundaries, but callers still need to inspect each stage separately. This helper provides a single offline bundle for reviewing how memory traces move through the consolidation pipeline without changing runtime behavior.

## Scope

- Adds `buildMemoryConsolidationDiagnosticsBundle`
- Exports it from the package root and `./diagnostics-bundle`
- Adds a focused end-to-end eval test
- Adds a short README note

## Safety

This remains report-only:

- no runtime behavior changes
- no storage writes
- no retrieval ranking changes
- no forgetting engine changes
- no LLM, embedding, database, network, scheduler, or UI dependency

The bundle explicitly reports:

- `mutatesRuntime: false`
- `mutatesStorage: false`
- `mutatesRetrieval: false`

It also distinguishes dry-run storage reports from write-ready storage reports so the top-level bundle summary does not contradict attached stage reports.

## Testing

```bash
corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/diagnostics-bundle.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json packages/ai/memory-consolidation/README.md apps/web/tests/unit/memory-consolidation-eval.test.ts
corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts
corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit
corepack pnpm -C apps/web lint
corepack pnpm tsc
git diff --check
```