### PR TITLE
feat(memory): add consolidation shadow diagnostics boundary

### DIFF
--- a/apps/web/tests/unit/memory-consolidation-eval.test.ts
+++ b/apps/web/tests/unit/memory-consolidation-eval.test.ts
@@ -25,7 +25,9 @@ import {
   buildMemorySemanticRetrievalEvalScenarioReport,
   buildMemorySemanticRetrievalMergedResults,
   buildMemorySemanticRetrievalPlan,
+  buildMemoryConsolidationShadowReport,
   buildSemanticMemoryArtifactStorageDryRunReport,
+  buildSemanticMemoryDraftPersistencePreparationReport,
   buildSemanticMemoryRevisionCompetitionDiagnostics,
   buildSemanticMemoryRevisionExplanationReport,
   buildSemanticMemoryRevisionRelationPlan,
@@ -35,12 +37,14 @@ import {
   buildSemanticMemoryDraftCandidates,
   deserializeSemanticMemoryArtifactStorageRecord,
   deriveMemoryRelationGraphLifecycle,
+  invokeSemanticMemoryDraftSummarizerProviderBatch,
   invokeSemanticMemoryDraftSummarizerProvider,
   logMemoryConsolidationDiagnosticsRun,
   judgeMemoryRelationCandidates,
   persistSemanticMemoryDrafts,
   invokeMemoryRelationJudgeProvider,
   runMemoryConsolidationDiagnostics,
+  runMemoryConsolidationShadowDiagnostics,
   serializeSemanticMemoryArtifactStorageRecord,
   summarizeSemanticMemoryDraftCandidate,
   resolveMemorySemanticRetrievalConfig,
@@ -721,6 +725,63 @@ function adapterSourceRecords(
   return specs.map(([uid, body, day, value, options]) =>
     adapterSourceRecord(uid, body, day, value, options),
   );
+}
+
+function buildTraceToPersistencePrototypeRecords(): AdapterSourceRecord[] {
+  return adapterSourceRecords([
+    [
+      "prototype-zh-a",
+      "Use Chinese for technical repository work.",
+      86,
+      "zh",
+      { reads: 1 },
+    ],
+    [
+      "prototype-zh-b",
+      "Prefer Chinese explanations when reviewing code.",
+      98,
+      "zh",
+      { reads: 1 },
+    ],
+    [
+      "prototype-zh-c",
+      "Chinese answers are easier to use for repo debugging.",
+      112,
+      "zh",
+      { reads: 1 },
+    ],
+    [
+      "prototype-temp-en",
+      "For this one reply, use English.",
+      118,
+      "en",
+      { reads: 9, scope: "temporary" },
+    ],
+    [
+      "prototype-noise",
+      "The editor sidebar was blue during this session.",
+      119,
+      "blue-sidebar",
+      { preference: "scratch-note", reads: 9 },
+    ],
+  ]);
+}
+
+function adapterSourceRecordToMemoryRecord(
+  record: AdapterSourceRecord,
+): MemoryRecord {
+  return {
+    id: record.uid ?? "unknown",
+    userId: record.owner ?? "adapter-user",
+    timestamp: record.createdAt ?? 0,
+    text: record.body ?? "",
+    tier: "short",
+    accessCount: record.reads,
+    metadata: {
+      ...record.fields,
+      ...record.meta,
+    },
+  };
 }
 
 const adapterSelectors = {
@@ -2228,6 +2289,527 @@ describe("memory consolidation evaluation scenarios", () => {
     expect(failed.draft).toBeUndefined();
     expect(failed.diagnostics.request.ready).toBe(true);
     expect(failed.diagnostics.response).toBeUndefined();
+  });
+
+  it("summarizes provider adapter batches with skipped and failed candidates", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const lowConfidenceCandidate = {
+      ...candidate,
+      draftId: `${candidate.draftId}:low-confidence`,
+      confidence: 0.2,
+    };
+    const providerFailureCandidate = {
+      ...candidate,
+      draftId: `${candidate.draftId}:provider-failure`,
+    };
+    const invokedDraftIds: string[] = [];
+    const report = await invokeSemanticMemoryDraftSummarizerProviderBatch({
+      candidates: [candidate, lowConfidenceCandidate, providerFailureCandidate],
+      records: diagnostics.records,
+      minConfidence: 0.5,
+      async invoke(input) {
+        invokedDraftIds.push(input.candidate.draftId);
+
+        if (input.candidate.draftId === providerFailureCandidate.draftId) {
+          throw new Error("batch provider unavailable");
+        }
+
+        return {
+          type: input.candidate.suggestedType,
+          content: input.sourceRecords.map((record) => record.text).join(" "),
+          sourceRecordIds: [...input.candidate.sourceRecordIds],
+          confidence: input.candidate.confidence,
+        };
+      },
+    });
+
+    expect(invokedDraftIds).toEqual([
+      candidate.draftId,
+      providerFailureCandidate.draftId,
+    ]);
+    expect(report.summary).toEqual({
+      candidateCount: 3,
+      summarizedCount: 1,
+      skippedCount: 1,
+      failedCount: 1,
+      responseIssueCount: 0,
+    });
+    expect(report.results.map((result) => result.status)).toEqual([
+      "summarized",
+      "skipped",
+      "failed",
+    ]);
+    expect(report.results[1]).toEqual(
+      expect.objectContaining({
+        reasonCodes: ["request_not_ready", "low_confidence"],
+      }),
+    );
+    expect(report.results[2]).toEqual(
+      expect.objectContaining({
+        reasonCodes: ["provider_error"],
+        error: {
+          name: "Error",
+          message: "batch provider unavailable",
+        },
+      }),
+    );
+    expect(report.reasonCodes).toEqual([
+      "request_not_ready",
+      "low_confidence",
+      "provider_error",
+    ]);
+  });
+
+  it("prepares persistence items from safe provider batch results only", async () => {
+    const { diagnostics, candidate } = buildSemanticDraftSummarizerFixture();
+    const lowConfidenceCandidate = {
+      ...candidate,
+      draftId: `${candidate.draftId}:low-confidence`,
+      confidence: 0.2,
+    };
+    const providerFailureCandidate = {
+      ...candidate,
+      draftId: `${candidate.draftId}:provider-failure`,
+    };
+    const responseIssueCandidate = {
+      ...candidate,
+      draftId: `${candidate.draftId}:response-issue`,
+    };
+    const providerBatchReport =
+      await invokeSemanticMemoryDraftSummarizerProviderBatch({
+        candidates: [
+          candidate,
+          lowConfidenceCandidate,
+          providerFailureCandidate,
+          responseIssueCandidate,
+        ],
+        records: diagnostics.records,
+        minConfidence: 0.5,
+        async invoke(input) {
+          if (input.candidate.draftId === providerFailureCandidate.draftId) {
+            throw new Error("batch provider unavailable");
+          }
+
+          return {
+            type: input.candidate.suggestedType,
+            content:
+              input.candidate.draftId === responseIssueCandidate.draftId
+                ? ""
+                : input.sourceRecords.map((record) => record.text).join(" "),
+            sourceRecordIds: [...input.candidate.sourceRecordIds],
+            confidence: input.candidate.confidence,
+          };
+        },
+      });
+    const report = buildSemanticMemoryDraftPersistencePreparationReport({
+      providerBatchReport,
+    });
+
+    expect(report.summary).toEqual({
+      resultCount: 4,
+      persistenceItemCount: 1,
+      skippedResultCount: 3,
+      responseIssueCount: 1,
+    });
+    expect(report.items).toEqual([
+      expect.objectContaining({
+        candidate,
+        draft: expect.objectContaining({
+          sourceRecordIds: candidate.sourceRecordIds,
+          confidence: candidate.confidence,
+        }),
+      }),
+    ]);
+    expect(report.skippedResults).toEqual([
+      {
+        draftId: lowConfidenceCandidate.draftId,
+        status: "skipped",
+        reasonCodes: [
+          "provider_result_skipped",
+          "request_not_ready",
+          "low_confidence",
+        ],
+      },
+      {
+        draftId: providerFailureCandidate.draftId,
+        status: "failed",
+        reasonCodes: ["provider_result_failed", "provider_error"],
+      },
+      {
+        draftId: responseIssueCandidate.draftId,
+        status: "summarized",
+        reasonCodes: [
+          "provider_result_has_response_issues",
+          "missing_output_content",
+        ],
+      },
+    ]);
+    expect(report.reasonCodes).toEqual([
+      "provider_result_ready",
+      "provider_result_skipped",
+      "request_not_ready",
+      "low_confidence",
+      "provider_result_failed",
+      "provider_error",
+      "provider_result_has_response_issues",
+      "missing_output_content",
+    ]);
+  });
+
+  it("validates the trace-to-persistence prototype without a coupled pipeline API", async () => {
+    const sourceRecords = buildTraceToPersistencePrototypeRecords();
+    const diagnostics = buildAdapterDiagnosticsForRecords(sourceRecords);
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+    const candidates = buildSemanticMemoryDraftCandidates({
+      report,
+      records: diagnostics.records,
+    });
+    const sourceIds = ["prototype-zh-a", "prototype-zh-b", "prototype-zh-c"];
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toEqual(
+      expect.objectContaining({
+        suggestedType: "preference",
+        sourceRecordIds: sourceIds,
+        needsSummary: true,
+      }),
+    );
+    expect(report.decayedRecords.map((record) => record.recordId)).toEqual(
+      expect.arrayContaining(["prototype-temp-en", "prototype-noise"]),
+    );
+
+    const providerSourceIds: string[][] = [];
+    const providerBatchReport =
+      await invokeSemanticMemoryDraftSummarizerProviderBatch({
+        candidates,
+        records: diagnostics.records,
+        minConfidence: 0.5,
+        async invoke(input) {
+          providerSourceIds.push(
+            input.sourceRecords.map((record) => record.recordId),
+          );
+
+          return {
+            type: input.candidate.suggestedType,
+            content:
+              "User prefers Chinese explanations for technical repository work.",
+            sourceRecordIds: [...input.candidate.sourceRecordIds],
+            confidence: input.candidate.confidence,
+            metadata: {
+              sourceClusterKey: input.candidate.sourceClusterKey,
+              competitionKey: input.candidate.competitionKey,
+              reasonCodes: [...input.candidate.reasonCodes],
+            },
+          };
+        },
+      });
+    const preparationReport =
+      buildSemanticMemoryDraftPersistencePreparationReport({
+        providerBatchReport,
+      });
+    const candidate = candidates[0];
+
+    expect(candidate).toBeDefined();
+    expect(providerSourceIds).toEqual([sourceIds]);
+    expect(providerBatchReport.summary.summarizedCount).toBe(1);
+    expect(preparationReport.summary.persistenceItemCount).toBe(1);
+    expect(preparationReport.skippedResults).toEqual([]);
+    expect(preparationReport.items).toEqual([
+      expect.objectContaining({
+        candidate: expect.objectContaining({
+          sourceRecordIds: sourceIds,
+          reasonCodes: expect.arrayContaining(["strong_repeated_evidence"]),
+        }),
+        draft: expect.objectContaining({
+          type: "preference",
+          sourceRecordIds: sourceIds,
+          confidence: candidate?.confidence,
+          metadata: expect.objectContaining({
+            sourceClusterKey: candidate?.sourceClusterKey,
+            competitionKey: candidate?.competitionKey,
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("shows the prototype reduces trace-level noise before persistence", async () => {
+    const sourceRecords = buildTraceToPersistencePrototypeRecords();
+    const scorer = new DefaultMemoryRecordScorer();
+    const baselineTopIds = sourceRecords
+      .map((record) => ({
+        id: record.uid,
+        score: scorer.score(adapterSourceRecordToMemoryRecord(record), {
+          now: NOW,
+        }),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 2)
+      .map((record) => record.id);
+    const diagnostics = buildAdapterDiagnosticsForRecords(sourceRecords);
+    const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+    const candidates = buildSemanticMemoryDraftCandidates({
+      report,
+      records: diagnostics.records,
+    });
+    const providerBatchReport =
+      await invokeSemanticMemoryDraftSummarizerProviderBatch({
+        candidates,
+        records: diagnostics.records,
+        async invoke(input) {
+          return {
+            type: input.candidate.suggestedType,
+            content:
+              "User prefers Chinese explanations for technical repository work.",
+            sourceRecordIds: [...input.candidate.sourceRecordIds],
+            confidence: input.candidate.confidence,
+          };
+        },
+      });
+    const preparationReport =
+      buildSemanticMemoryDraftPersistencePreparationReport({
+        providerBatchReport,
+      });
+
+    expect(baselineTopIds).toEqual(
+      expect.arrayContaining(["prototype-temp-en", "prototype-noise"]),
+    );
+    expect(preparationReport.items).toHaveLength(1);
+    expect(preparationReport.items[0]?.candidate.sourceRecordIds).toEqual([
+      "prototype-zh-a",
+      "prototype-zh-b",
+      "prototype-zh-c",
+    ]);
+    expect(preparationReport.items[0]?.candidate.sourceRecordIds).not.toEqual(
+      expect.arrayContaining(baselineTopIds),
+    );
+  });
+
+  it("builds a report-only consolidation shadow report without a provider", async () => {
+    const report = await buildMemoryConsolidationShadowReport({
+      ...buildAdapterDiagnosticsInput(),
+      records: buildTraceToPersistencePrototypeRecords(),
+    });
+
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        semanticDraftCandidateCount: 1,
+        providerResultCount: 0,
+        persistenceItemCount: 0,
+      }),
+    );
+    expect(report.providerBatchReport).toBeUndefined();
+    expect(report.persistencePreparationReport).toBeUndefined();
+    expect(report.reasonCodes).toEqual(
+      expect.arrayContaining(["shadow_report_only", "provider_not_configured"]),
+    );
+    expect(report.mutatesRuntime).toBe(false);
+    expect(report.mutatesStorage).toBe(false);
+    expect(report.mutatesRetrieval).toBe(false);
+  });
+
+  it("extends the shadow report through a fake provider and preparation boundary", async () => {
+    const sourceIds = ["prototype-zh-a", "prototype-zh-b", "prototype-zh-c"];
+    const report = await buildMemoryConsolidationShadowReport({
+      ...buildAdapterDiagnosticsInput(),
+      records: buildTraceToPersistencePrototypeRecords(),
+      async summarizerProvider(input) {
+        return {
+          type: input.candidate.suggestedType,
+          content:
+            "User prefers Chinese explanations for technical repository work.",
+          sourceRecordIds: [...input.candidate.sourceRecordIds],
+          confidence: input.candidate.confidence,
+        };
+      },
+    });
+
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        semanticDraftCandidateCount: 1,
+        summarizedCount: 1,
+        persistenceItemCount: 1,
+        skippedPersistenceResultCount: 0,
+      }),
+    );
+    expect(
+      report.persistencePreparationReport?.items[0]?.candidate.sourceRecordIds,
+    ).toEqual(sourceIds);
+    expect(report.reasonCodes).toEqual(
+      expect.arrayContaining([
+        "provider_batch_attached",
+        "persistence_preparation_attached",
+        "provider_result_ready",
+      ]),
+    );
+  });
+
+  it("keeps shadow provider failures observable without throwing the batch", async () => {
+    const report = await buildMemoryConsolidationShadowReport({
+      ...buildAdapterDiagnosticsInput(),
+      records: buildTraceToPersistencePrototypeRecords(),
+      async summarizerProvider() {
+        throw new Error("shadow provider unavailable");
+      },
+    });
+
+    expect(report.summary).toEqual(
+      expect.objectContaining({
+        failedProviderCount: 1,
+        persistenceItemCount: 0,
+        skippedPersistenceResultCount: 1,
+      }),
+    );
+    expect(report.providerBatchReport?.results[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        reasonCodes: ["provider_error"],
+      }),
+    );
+    expect(report.reasonCodes).toEqual(
+      expect.arrayContaining(["provider_error", "provider_result_failed"]),
+    );
+  });
+
+  it("does not load records when shadow diagnostics are disabled", async () => {
+    let loaded = false;
+    const result = await runMemoryConsolidationShadowDiagnostics({
+      ...buildAdapterDiagnosticsInput(),
+      enabled: false,
+      dryRun: true,
+      async loadRecords() {
+        loaded = true;
+        return buildTraceToPersistencePrototypeRecords();
+      },
+    });
+
+    expect(loaded).toBe(false);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "disabled",
+        scannedRecordCount: 0,
+        reasonCodes: ["shadow_disabled"],
+        mutatesRuntime: false,
+        mutatesStorage: false,
+        mutatesRetrieval: false,
+      }),
+    );
+  });
+
+  it("runs shadow diagnostics as an enabled dry-run with caller logging", async () => {
+    const loggedReports: unknown[] = [];
+    const result = await runMemoryConsolidationShadowDiagnostics({
+      ...buildAdapterDiagnosticsInput(),
+      enabled: true,
+      dryRun: true,
+      async loadRecords() {
+        return buildTraceToPersistencePrototypeRecords();
+      },
+      async summarizerProvider(input) {
+        return {
+          type: input.candidate.suggestedType,
+          content:
+            "User prefers Chinese explanations for technical repository work.",
+          sourceRecordIds: [...input.candidate.sourceRecordIds],
+          confidence: input.candidate.confidence,
+        };
+      },
+      async logReport(report) {
+        loggedReports.push(report);
+      },
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.scannedRecordCount).toBe(5);
+    expect(result.report?.summary.persistenceItemCount).toBe(1);
+    expect(result.log.status).toBe("logged");
+    expect(loggedReports).toHaveLength(1);
+    expect(result.reasonCodes).toEqual(
+      expect.arrayContaining(["shadow_log_success"]),
+    );
+  });
+
+  it("keeps shadow log failures observable without failing diagnostics", async () => {
+    const result = await runMemoryConsolidationShadowDiagnostics({
+      ...buildAdapterDiagnosticsInput(),
+      enabled: true,
+      dryRun: true,
+      async loadRecords() {
+        return buildTraceToPersistencePrototypeRecords();
+      },
+      async logReport() {
+        throw new Error("shadow log unavailable");
+      },
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.report?.summary.semanticDraftCandidateCount).toBe(1);
+    expect(result.log).toEqual({
+      status: "failed",
+      error: {
+        name: "Error",
+        message: "shadow log unavailable",
+      },
+    });
+    expect(result.reasonCodes).toEqual(
+      expect.arrayContaining(["shadow_log_failed"]),
+    );
+  });
+
+  it("keeps shadow record loading failures observable without throwing", async () => {
+    let logged = false;
+    const result = await runMemoryConsolidationShadowDiagnostics({
+      ...buildAdapterDiagnosticsInput(),
+      enabled: true,
+      dryRun: true,
+      async loadRecords() {
+        throw new Error("shadow reader unavailable");
+      },
+      async logReport() {
+        logged = true;
+      },
+    });
+
+    expect(logged).toBe(false);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        dryRun: true,
+        scannedRecordCount: 0,
+        log: { status: "disabled" },
+        error: {
+          name: "Error",
+          message: "shadow reader unavailable",
+        },
+        reasonCodes: ["shadow_run_failed"],
+        mutatesRuntime: false,
+        mutatesStorage: false,
+        mutatesRetrieval: false,
+      }),
+    );
+  });
+
+  it("rejects non-dry-run shadow diagnostics before loading records", async () => {
+    let loaded = false;
+    const result = await runMemoryConsolidationShadowDiagnostics({
+      ...buildAdapterDiagnosticsInput(),
+      enabled: true,
+      dryRun: false,
+      async loadRecords() {
+        loaded = true;
+        return buildTraceToPersistencePrototypeRecords();
+      },
+    });
+
+    expect(loaded).toBe(false);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "unsupported",
+        dryRun: false,
+        scannedRecordCount: 0,
+        reasonCodes: ["shadow_dry_run_required"],
+      }),
+    );
   });
 
   it("documents fake summarizer failure cases without adding a real provider", async () => {

--- a/packages/ai/memory-consolidation/README.md
+++ b/packages/ai/memory-consolidation/README.md
@@ -145,6 +145,19 @@ summarizer.
 The summarizer provider boundary can format request/response diagnostics, build a
 stable caller-provided input contract, and wrap fake or external adapters with
 readiness checks. It still does not ship or call a concrete model provider.
+Batch provider reports can invoke the same caller-provided adapter across
+multiple draft candidates and summarize `summarized`, `skipped`, and `failed`
+results without adding provider wiring.
+Persistence preparation reports can then select safe summarized drafts from a
+provider batch while keeping skipped, failed, or response-issue results
+observable before any storage write.
+
+`buildMemoryConsolidationShadowReport` composes diagnostics, semantic draft
+candidates, optional caller-provided summarizer batches, and persistence
+preparation into a report-only shadow result before runtime integration.
+`runMemoryConsolidationShadowDiagnostics` adds the smallest runtime-facing
+enabled/dry-run/log boundary while still avoiding runtime, storage, and retrieval
+mutation.
 
 `calculateMemoryConsolidationEvalMetrics` provides a small scenario metrics
 helper for comparing expected preservation, temporary/noise leakage, contested

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -16,7 +16,8 @@
     "./retrieval": "./src/retrieval.ts",
     "./revision": "./src/revision.ts",
     "./runtime": "./src/runtime.ts",
-    "./semantic-draft": "./src/semantic-draft.ts"
+    "./semantic-draft": "./src/semantic-draft.ts",
+    "./shadow": "./src/shadow.ts"
   },
   "devDependencies": {
     "@openloomi/config": "workspace:*",

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -11,3 +11,4 @@ export * from "./retrieval";
 export * from "./revision";
 export * from "./runtime";
 export * from "./semantic-draft";
+export * from "./shadow";

--- a/packages/ai/memory-consolidation/src/persistence.ts
+++ b/packages/ai/memory-consolidation/src/persistence.ts
@@ -1,11 +1,46 @@
 import type {
   MemorySemanticDraftCandidate,
   SemanticMemoryDraft,
+  SemanticMemoryDraftSummarizerProviderAdapterReasonCode,
+  SemanticMemoryDraftSummarizerProviderAdapterResult,
+  SemanticMemoryDraftSummarizerProviderBatchReport,
 } from "./semantic-draft";
 
 export interface SemanticMemoryDraftPersistenceItem {
   candidate: MemorySemanticDraftCandidate;
   draft: SemanticMemoryDraft;
+}
+
+export type SemanticMemoryDraftPersistencePreparationReasonCode =
+  | "provider_result_ready"
+  | "provider_result_skipped"
+  | "provider_result_failed"
+  | "provider_result_has_response_issues"
+  | SemanticMemoryDraftSummarizerProviderAdapterReasonCode
+  | (string & {});
+
+export interface SemanticMemoryDraftPersistenceSkippedProviderResult {
+  draftId: string;
+  status: SemanticMemoryDraftSummarizerProviderAdapterResult["status"];
+  reasonCodes: SemanticMemoryDraftPersistencePreparationReasonCode[];
+}
+
+export interface SemanticMemoryDraftPersistencePreparationSummary {
+  resultCount: number;
+  persistenceItemCount: number;
+  skippedResultCount: number;
+  responseIssueCount: number;
+}
+
+export interface SemanticMemoryDraftPersistencePreparationReport {
+  summary: SemanticMemoryDraftPersistencePreparationSummary;
+  items: SemanticMemoryDraftPersistenceItem[];
+  skippedResults: SemanticMemoryDraftPersistenceSkippedProviderResult[];
+  reasonCodes: SemanticMemoryDraftPersistencePreparationReasonCode[];
+}
+
+export interface BuildSemanticMemoryDraftPersistencePreparationReportInput {
+  providerBatchReport: SemanticMemoryDraftSummarizerProviderBatchReport;
 }
 
 export interface PersistedSemanticMemoryDraft {
@@ -225,6 +260,76 @@ function buildPersistedDraft(
     score: item.candidate.score,
     reasonCodes: [...item.candidate.reasonCodes],
     createdAt,
+  };
+}
+
+function candidateDraftId(
+  result: SemanticMemoryDraftSummarizerProviderAdapterResult,
+): string {
+  return result.candidate.draftId;
+}
+
+function skippedProviderReasonCodes(
+  result: SemanticMemoryDraftSummarizerProviderAdapterResult,
+): SemanticMemoryDraftPersistencePreparationReasonCode[] {
+  if (result.status === "skipped") {
+    return ["provider_result_skipped", ...result.reasonCodes];
+  }
+
+  if (result.status === "failed") {
+    return ["provider_result_failed", ...result.reasonCodes];
+  }
+
+  return ["provider_result_has_response_issues", ...result.reasonCodes];
+}
+
+export function buildSemanticMemoryDraftPersistencePreparationReport(
+  input: BuildSemanticMemoryDraftPersistencePreparationReportInput,
+): SemanticMemoryDraftPersistencePreparationReport {
+  const items: SemanticMemoryDraftPersistenceItem[] = [];
+  const skippedResults: SemanticMemoryDraftPersistenceSkippedProviderResult[] =
+    [];
+  const reasonCodes =
+    new Set<SemanticMemoryDraftPersistencePreparationReasonCode>();
+  let responseIssueCount = 0;
+
+  for (const result of input.providerBatchReport.results) {
+    const hasResponseIssues = result.reasonCodes.length > 0;
+
+    if (result.status === "summarized" && hasResponseIssues) {
+      responseIssueCount += 1;
+    }
+
+    if (result.status === "summarized" && result.draft && !hasResponseIssues) {
+      items.push({
+        candidate: result.candidate,
+        draft: result.draft,
+      });
+      reasonCodes.add("provider_result_ready");
+      continue;
+    }
+
+    const skippedReasonCodes = skippedProviderReasonCodes(result);
+    for (const reasonCode of skippedReasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
+    skippedResults.push({
+      draftId: candidateDraftId(result),
+      status: result.status,
+      reasonCodes: skippedReasonCodes,
+    });
+  }
+
+  return {
+    summary: {
+      resultCount: input.providerBatchReport.results.length,
+      persistenceItemCount: items.length,
+      skippedResultCount: skippedResults.length,
+      responseIssueCount,
+    },
+    items,
+    skippedResults,
+    reasonCodes: [...reasonCodes],
   };
 }
 

--- a/packages/ai/memory-consolidation/src/semantic-draft.ts
+++ b/packages/ai/memory-consolidation/src/semantic-draft.ts
@@ -179,6 +179,7 @@ export interface SemanticMemoryDraftSummarizerProviderAdapterError {
 
 export interface SemanticMemoryDraftSummarizerProviderAdapterResult {
   status: SemanticMemoryDraftSummarizerProviderAdapterStatus;
+  candidate: MemorySemanticDraftCandidate;
   input: SemanticMemoryDraftSummarizerInputContract;
   diagnostics: SemanticMemoryDraftSummarizerDiagnostics;
   draft?: SemanticMemoryDraft;
@@ -202,6 +203,27 @@ export interface BuildSemanticMemoryDraftSummarizerInputContractInput {
 
 export interface InvokeSemanticMemoryDraftSummarizerProviderInput extends BuildSemanticMemoryDraftSummarizerInputContractInput {
   invoke: SemanticMemoryDraftSummarizerProviderInvoke;
+}
+
+export interface InvokeSemanticMemoryDraftSummarizerProviderBatchInput extends Omit<
+  InvokeSemanticMemoryDraftSummarizerProviderInput,
+  "candidate"
+> {
+  candidates: MemorySemanticDraftCandidate[];
+}
+
+export interface SemanticMemoryDraftSummarizerProviderBatchSummary {
+  candidateCount: number;
+  summarizedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  responseIssueCount: number;
+}
+
+export interface SemanticMemoryDraftSummarizerProviderBatchReport {
+  summary: SemanticMemoryDraftSummarizerProviderBatchSummary;
+  results: SemanticMemoryDraftSummarizerProviderAdapterResult[];
+  reasonCodes: SemanticMemoryDraftSummarizerProviderAdapterReasonCode[];
 }
 
 function clamp01(value: number): number {
@@ -627,6 +649,7 @@ export async function invokeSemanticMemoryDraftSummarizerProvider(
   if (!inputContract.request.ready) {
     return {
       status: "skipped",
+      candidate: input.candidate,
       input: inputContract,
       diagnostics: {
         request: inputContract.request,
@@ -646,6 +669,7 @@ export async function invokeSemanticMemoryDraftSummarizerProvider(
 
     return {
       status: "summarized",
+      candidate: input.candidate,
       input: inputContract,
       diagnostics,
       draft,
@@ -654,6 +678,7 @@ export async function invokeSemanticMemoryDraftSummarizerProvider(
   } catch (error) {
     return {
       status: "failed",
+      candidate: input.candidate,
       input: inputContract,
       diagnostics: {
         request: inputContract.request,
@@ -662,4 +687,41 @@ export async function invokeSemanticMemoryDraftSummarizerProvider(
       reasonCodes: ["provider_error"],
     };
   }
+}
+
+export async function invokeSemanticMemoryDraftSummarizerProviderBatch(
+  input: InvokeSemanticMemoryDraftSummarizerProviderBatchInput,
+): Promise<SemanticMemoryDraftSummarizerProviderBatchReport> {
+  const results: SemanticMemoryDraftSummarizerProviderAdapterResult[] = [];
+
+  for (const candidate of input.candidates) {
+    results.push(
+      await invokeSemanticMemoryDraftSummarizerProvider({
+        candidate,
+        records: input.records,
+        context: input.context,
+        minConfidence: input.minConfidence,
+        invoke: input.invoke,
+      }),
+    );
+  }
+
+  return {
+    summary: {
+      candidateCount: input.candidates.length,
+      summarizedCount: results.filter(
+        (result) => result.status === "summarized",
+      ).length,
+      skippedCount: results.filter((result) => result.status === "skipped")
+        .length,
+      failedCount: results.filter((result) => result.status === "failed")
+        .length,
+      responseIssueCount: results.filter(
+        (result) =>
+          result.status === "summarized" && result.reasonCodes.length > 0,
+      ).length,
+    },
+    results,
+    reasonCodes: [...new Set(results.flatMap((result) => result.reasonCodes))],
+  };
 }

--- a/packages/ai/memory-consolidation/src/shadow.ts
+++ b/packages/ai/memory-consolidation/src/shadow.ts
@@ -1,0 +1,297 @@
+import {
+  buildMemoryConsolidationDiagnosticsReport,
+  buildMemoryRelationPipelineDiagnostics,
+  type BuildMemoryRelationPipelineDiagnosticsInput,
+  type MemoryConsolidationDiagnosticsReport,
+  type MemoryConsolidationSourceRecord,
+  type MemoryRelationPipelineDiagnostics,
+} from "./adapter";
+import {
+  buildSemanticMemoryDraftPersistencePreparationReport,
+  type SemanticMemoryDraftPersistencePreparationReport,
+} from "./persistence";
+import {
+  buildSemanticMemoryDraftCandidates,
+  invokeSemanticMemoryDraftSummarizerProviderBatch,
+  type BuildSemanticMemoryDraftCandidatesInput,
+  type MemorySemanticDraftCandidate,
+  type SemanticMemoryDraftSummarizerContext,
+  type SemanticMemoryDraftSummarizerProviderBatchReport,
+  type SemanticMemoryDraftSummarizerProviderInvoke,
+} from "./semantic-draft";
+
+export type MemoryConsolidationShadowReasonCode =
+  | "shadow_report_only"
+  | "provider_not_configured"
+  | "provider_batch_attached"
+  | "persistence_preparation_attached"
+  | "shadow_disabled"
+  | "shadow_dry_run_required"
+  | "shadow_run_failed"
+  | "shadow_log_disabled"
+  | "shadow_log_success"
+  | "shadow_log_failed"
+  | (string & {});
+
+export interface BuildMemoryConsolidationShadowReportInput<
+  TRecord = MemoryConsolidationSourceRecord,
+> extends BuildMemoryRelationPipelineDiagnosticsInput<TRecord> {
+  semanticDraftCandidates?: Omit<
+    BuildSemanticMemoryDraftCandidatesInput,
+    "report" | "records"
+  >;
+  summarizerProvider?: SemanticMemoryDraftSummarizerProviderInvoke;
+  summarizerContext?: SemanticMemoryDraftSummarizerContext;
+  minConfidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryConsolidationShadowReportSummary {
+  sourceRecordCount: number;
+  adaptedRecordCount: number;
+  skippedRecordCount: number;
+  semanticDraftCandidateCount: number;
+  providerResultCount: number;
+  summarizedCount: number;
+  failedProviderCount: number;
+  persistenceItemCount: number;
+  skippedPersistenceResultCount: number;
+}
+
+export interface MemoryConsolidationShadowReport {
+  summary: MemoryConsolidationShadowReportSummary;
+  diagnostics: MemoryRelationPipelineDiagnostics;
+  report: MemoryConsolidationDiagnosticsReport;
+  semanticDraftCandidates: MemorySemanticDraftCandidate[];
+  providerBatchReport?: SemanticMemoryDraftSummarizerProviderBatchReport;
+  persistencePreparationReport?: SemanticMemoryDraftPersistencePreparationReport;
+  reasonCodes: MemoryConsolidationShadowReasonCode[];
+  metadata?: Record<string, unknown>;
+  mutatesRuntime: false;
+  mutatesStorage: false;
+  mutatesRetrieval: false;
+}
+
+export interface RunMemoryConsolidationShadowDiagnosticsInput<
+  TRecord = MemoryConsolidationSourceRecord,
+> extends Omit<
+  BuildMemoryConsolidationShadowReportInput<TRecord>,
+  "records" | "now"
+> {
+  enabled?: boolean;
+  dryRun?: boolean;
+  now?: number;
+  limit?: number;
+  loadRecords(input: {
+    now: number;
+    limit?: number;
+  }): Promise<TRecord[]> | TRecord[];
+  logReport?(report: MemoryConsolidationShadowReport): Promise<void> | void;
+}
+
+export interface MemoryConsolidationShadowLogResult {
+  status: "disabled" | "logged" | "failed";
+  error?: {
+    name?: string;
+    message: string;
+  };
+}
+
+export interface MemoryConsolidationShadowDiagnosticsRunResult {
+  status: "disabled" | "success" | "unsupported" | "failed";
+  dryRun: boolean;
+  startedAt: number;
+  finishedAt: number;
+  scannedRecordCount: number;
+  report?: MemoryConsolidationShadowReport;
+  log: MemoryConsolidationShadowLogResult;
+  error?: {
+    name?: string;
+    message: string;
+  };
+  reasonCodes: MemoryConsolidationShadowReasonCode[];
+  mutatesRuntime: false;
+  mutatesStorage: false;
+  mutatesRetrieval: false;
+}
+
+function adapterError(error: unknown): { name?: string; message: string } {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
+export async function buildMemoryConsolidationShadowReport<TRecord>(
+  input: BuildMemoryConsolidationShadowReportInput<TRecord>,
+): Promise<MemoryConsolidationShadowReport> {
+  const diagnostics = buildMemoryRelationPipelineDiagnostics(input);
+  const report = buildMemoryConsolidationDiagnosticsReport(diagnostics);
+  const semanticDraftCandidates = buildSemanticMemoryDraftCandidates({
+    ...input.semanticDraftCandidates,
+    report,
+    records: diagnostics.records,
+  });
+  const reasonCodes = new Set<MemoryConsolidationShadowReasonCode>([
+    "shadow_report_only",
+  ]);
+  let providerBatchReport:
+    | SemanticMemoryDraftSummarizerProviderBatchReport
+    | undefined;
+  let persistencePreparationReport:
+    | SemanticMemoryDraftPersistencePreparationReport
+    | undefined;
+
+  if (input.summarizerProvider) {
+    providerBatchReport =
+      await invokeSemanticMemoryDraftSummarizerProviderBatch({
+        candidates: semanticDraftCandidates,
+        records: diagnostics.records,
+        context: input.summarizerContext,
+        minConfidence: input.minConfidence,
+        invoke: input.summarizerProvider,
+      });
+    reasonCodes.add("provider_batch_attached");
+    for (const reasonCode of providerBatchReport.reasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
+
+    persistencePreparationReport =
+      buildSemanticMemoryDraftPersistencePreparationReport({
+        providerBatchReport,
+      });
+    reasonCodes.add("persistence_preparation_attached");
+    for (const reasonCode of persistencePreparationReport.reasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
+  } else {
+    reasonCodes.add("provider_not_configured");
+  }
+
+  return {
+    summary: {
+      sourceRecordCount: input.records.length,
+      adaptedRecordCount: diagnostics.records.length,
+      skippedRecordCount: diagnostics.skippedRecords.length,
+      semanticDraftCandidateCount: semanticDraftCandidates.length,
+      providerResultCount: providerBatchReport?.results.length ?? 0,
+      summarizedCount: providerBatchReport?.summary.summarizedCount ?? 0,
+      failedProviderCount: providerBatchReport?.summary.failedCount ?? 0,
+      persistenceItemCount:
+        persistencePreparationReport?.summary.persistenceItemCount ?? 0,
+      skippedPersistenceResultCount:
+        persistencePreparationReport?.summary.skippedResultCount ?? 0,
+    },
+    diagnostics,
+    report,
+    semanticDraftCandidates,
+    providerBatchReport,
+    persistencePreparationReport,
+    reasonCodes: [...reasonCodes],
+    metadata: input.metadata ? { ...input.metadata } : undefined,
+    mutatesRuntime: false,
+    mutatesStorage: false,
+    mutatesRetrieval: false,
+  };
+}
+
+export async function runMemoryConsolidationShadowDiagnostics<TRecord>(
+  input: RunMemoryConsolidationShadowDiagnosticsInput<TRecord>,
+): Promise<MemoryConsolidationShadowDiagnosticsRunResult> {
+  const startedAt = Date.now();
+  const now = input.now ?? startedAt;
+  const base = {
+    mutatesRuntime: false as const,
+    mutatesStorage: false as const,
+    mutatesRetrieval: false as const,
+  };
+
+  if (input.enabled !== true) {
+    return {
+      status: "disabled",
+      dryRun: input.dryRun !== false,
+      startedAt,
+      finishedAt: Date.now(),
+      scannedRecordCount: 0,
+      log: { status: "disabled" },
+      reasonCodes: ["shadow_disabled"],
+      ...base,
+    };
+  }
+
+  if (input.dryRun !== true) {
+    return {
+      status: "unsupported",
+      dryRun: false,
+      startedAt,
+      finishedAt: Date.now(),
+      scannedRecordCount: 0,
+      log: { status: "disabled" },
+      reasonCodes: ["shadow_dry_run_required"],
+      ...base,
+    };
+  }
+
+  let records: TRecord[];
+  let report: MemoryConsolidationShadowReport;
+
+  try {
+    records = await input.loadRecords({ now, limit: input.limit });
+    report = await buildMemoryConsolidationShadowReport({
+      ...input,
+      records,
+      now,
+    });
+  } catch (error) {
+    return {
+      status: "failed",
+      dryRun: true,
+      startedAt,
+      finishedAt: Date.now(),
+      scannedRecordCount: 0,
+      log: { status: "disabled" },
+      error: adapterError(error),
+      reasonCodes: ["shadow_run_failed"],
+      ...base,
+    };
+  }
+
+  const reasonCodes = new Set<MemoryConsolidationShadowReasonCode>([
+    ...report.reasonCodes,
+  ]);
+  let log: MemoryConsolidationShadowLogResult = { status: "disabled" };
+
+  if (input.logReport) {
+    try {
+      await input.logReport(report);
+      log = { status: "logged" };
+      reasonCodes.add("shadow_log_success");
+    } catch (error) {
+      log = {
+        status: "failed",
+        error: adapterError(error),
+      };
+      reasonCodes.add("shadow_log_failed");
+    }
+  } else {
+    reasonCodes.add("shadow_log_disabled");
+  }
+
+  return {
+    status: "success",
+    dryRun: true,
+    startedAt,
+    finishedAt: Date.now(),
+    scannedRecordCount: records.length,
+    report,
+    log,
+    reasonCodes: [...reasonCodes],
+    ...base,
+  };
+}


### PR DESCRIPTION
## Summary

Add a report-only shadow boundary for memory consolidation before runtime activation.

This PR extends the semantic draft flow with:

- batch invocation for caller-provided summarizer providers
- persistence preparation reports that admit only safe summarized drafts
- a consolidation shadow report that composes diagnostics, semantic draft candidates, optional provider batches, and preparation results
- a runtime-facing dry-run helper that supports disabled / dry-run / log-only shadow diagnostics

## Why

The previous diagnostics and bundle helpers made consolidation observable, but callers still had to stitch together semantic draft provider calls and persistence preparation manually. This PR adds the next safe layer: a shadow-mode report boundary that can be used before any runtime storage or retrieval behavior changes.

The focused eval also compares trace-level baseline scoring with the prototype flow. In the scenario, high-recency temporary/noisy traces can rank highly under the baseline, while the shadow consolidation path only prepares the repeated stable preference for persistence.

## Scope

- Adds `buildMemoryConsolidationShadowReport`
- Adds `runMemoryConsolidationShadowDiagnostics`
- Adds `invokeSemanticMemoryDraftSummarizerProviderBatch`
- Adds `buildSemanticMemoryDraftPersistencePreparationReport`
- Exports the new `./shadow` package entry
- Extends focused memory consolidation eval coverage

## Non-goals

- Does not change forgetting runtime behavior
- Does not write storage
- Does not change retrieval ranking
- Does not add a real LLM provider
- Does not add scheduler, UI, DB migration, or API route wiring

## Testing

- `corepack pnpm exec prettier --check packages/ai/memory-consolidation/src/semantic-draft.ts packages/ai/memory-consolidation/src/persistence.ts packages/ai/memory-consolidation/src/shadow.ts packages/ai/memory-consolidation/src/index.ts packages/ai/memory-consolidation/package.json packages/ai/memory-consolidation/README.md apps/web/tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm --filter @openloomi/memory-consolidation exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm -C apps/web lint`
- `corepack pnpm tsc`
- `git diff --check`