### PR TITLE
feat(memory): add forgetting-cycle shadow diagnostics hook

### DIFF
--- a/apps/web/tests/unit/indexeddb-forgetting.test.ts
+++ b/apps/web/tests/unit/indexeddb-forgetting.test.ts
@@ -208,6 +208,7 @@ function createRaw(input: {
   embeddingContentHash?: string;
   embeddingDimensions?: number;
   embeddingUpdatedAt?: number;
+  metadata?: Record<string, unknown>;
 }): RawMessage {
   return {
     messageId: input.messageId,
@@ -228,6 +229,7 @@ function createRaw(input: {
     accessCount: 0,
     importanceScore: 0,
     isPinned: false,
+    metadata: input.metadata,
   };
 }
 
@@ -305,6 +307,208 @@ describe("indexeddb forgetting bridge", () => {
     );
     expect(shortToMid.length).toBe(3);
     expect(manager.summaries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps consolidation shadow diagnostics disabled by default", async () => {
+    const now = Date.now();
+    const manager = new InMemoryManager();
+
+    manager.rawMessages = [
+      createRaw({
+        messageId: "default-shadow-off",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 10 * DAY_MS) / 1000),
+        text: "stable preference evidence",
+      }),
+    ];
+
+    const result = await runMemoryForgettingCycle(
+      manager as unknown as IndexedDBManager,
+      "u1",
+      {
+        now,
+        dryRun: true,
+      },
+    );
+
+    expect(result.shadowDiagnostics).toBeUndefined();
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("attaches opt-in consolidation shadow diagnostics without mutating storage", async () => {
+    const now = Date.now();
+    const manager = new InMemoryManager();
+
+    manager.rawMessages = [
+      createRaw({
+        messageId: "lang-zh-1",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 10 * DAY_MS) / 1000),
+        text: "User prefers Chinese answers by default",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+          relationScope: "long-term",
+        },
+      }),
+      createRaw({
+        messageId: "lang-zh-2",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 9 * DAY_MS) / 1000),
+        text: "User repeats that Chinese technical discussion is easier",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+          relationScope: "long-term",
+        },
+      }),
+      createRaw({
+        messageId: "lang-zh-3",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 8 * DAY_MS) / 1000),
+        text: "User wants code explanations in Chinese first",
+        metadata: {
+          relationGroup: "answer-language",
+          relationValue: "zh",
+          relationScope: "long-term",
+        },
+      }),
+    ];
+
+    const result = await runMemoryForgettingCycle(
+      manager as unknown as IndexedDBManager,
+      "u1",
+      {
+        now,
+        dryRun: true,
+        shadowDiagnostics: {
+          enabled: true,
+          dryRun: true,
+          limit: 20,
+        },
+      },
+    );
+
+    expect(result.shadowDiagnostics?.status).toBe("success");
+    expect(result.shadowDiagnostics?.mutatesRuntime).toBe(false);
+    expect(result.shadowDiagnostics?.mutatesStorage).toBe(false);
+    expect(result.shadowDiagnostics?.mutatesRetrieval).toBe(false);
+    expect(result.shadowDiagnostics?.report?.summary.sourceRecordCount).toBe(3);
+    expect(
+      result.shadowDiagnostics?.report?.diagnostics.pipeline.candidates.length,
+    ).toBeGreaterThan(0);
+    expect(
+      result.shadowDiagnostics?.report?.diagnostics.pipeline.plan.entries,
+    ).toContainEqual(
+      expect.objectContaining({
+        recordIds: ["lang-zh-1", "lang-zh-2", "lang-zh-3"],
+      }),
+    );
+    expect(manager.rawMessages.map((item) => item.memoryStage)).toEqual([
+      "short",
+      "short",
+      "short",
+    ]);
+  });
+
+  it("keeps shadow log failures observable without failing forgetting", async () => {
+    const now = Date.now();
+    const manager = new InMemoryManager();
+
+    manager.rawMessages = [
+      createRaw({
+        messageId: "log-shadow-1",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 10 * DAY_MS) / 1000),
+        text: "User prefers concise answers",
+        metadata: {
+          relationGroup: "answer-style",
+          relationValue: "concise",
+          relationScope: "stable",
+        },
+      }),
+      createRaw({
+        messageId: "log-shadow-2",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 9 * DAY_MS) / 1000),
+        text: "User repeats that answers should be concise",
+        metadata: {
+          relationGroup: "answer-style",
+          relationValue: "concise",
+          relationScope: "stable",
+        },
+      }),
+    ];
+
+    const result = await runMemoryForgettingCycle(
+      manager as unknown as IndexedDBManager,
+      "u1",
+      {
+        now,
+        dryRun: true,
+        shadowDiagnostics: {
+          enabled: true,
+          dryRun: true,
+          logReport: () => {
+            throw new Error("shadow sink unavailable");
+          },
+        },
+      },
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.shadowDiagnostics?.status).toBe("success");
+    expect(result.shadowDiagnostics?.log).toEqual({
+      status: "failed",
+      error: {
+        name: "Error",
+        message: "shadow sink unavailable",
+      },
+    });
+    expect(result.shadowDiagnostics?.reasonCodes).toEqual(
+      expect.arrayContaining(["shadow_log_failed"]),
+    );
+  });
+
+  it("does not load records when opt-in shadow diagnostics are not dry-run", async () => {
+    const now = Date.now();
+    const manager = new InMemoryManager();
+
+    manager.rawMessages = [
+      createRaw({
+        messageId: "unsupported-shadow",
+        userId: "u1",
+        stage: "short",
+        timestampSec: Math.floor((now - 10 * DAY_MS) / 1000),
+        text: "record should not be loaded by unsupported shadow diagnostics",
+      }),
+    ];
+
+    const result = await runMemoryForgettingCycle(
+      manager as unknown as IndexedDBManager,
+      "u1",
+      {
+        now,
+        dryRun: true,
+        shadowDiagnostics: {
+          enabled: true,
+          dryRun: false,
+        },
+      },
+    );
+
+    expect(result.shadowDiagnostics).toMatchObject({
+      status: "unsupported",
+      dryRun: false,
+      scannedRecordCount: 0,
+      reasonCodes: ["shadow_dry_run_required"],
+    });
   });
 
   it("queries summaries as fallback when raw is insufficient", async () => {

--- a/packages/indexeddb/src/forgetting.ts
+++ b/packages/indexeddb/src/forgetting.ts
@@ -5,6 +5,7 @@ import {
   type MemoryLockHandle,
   type MemoryPageResult,
   type MemoryRecord,
+  type MemoryTier,
   type MemorySemanticRecallHit,
   type MemorySemanticRecallQuery,
   type MemorySearchQuery,
@@ -13,6 +14,11 @@ import {
   type MemorySummary,
   type MemorySummarySearchQuery,
 } from "../../ai/src/memory";
+import type { MemoryConsolidationRuntimeRelationKeys } from "../../ai/memory-consolidation/src/runtime";
+import type {
+  MemoryConsolidationShadowDiagnosticsRunResult,
+  RunMemoryConsolidationShadowDiagnosticsInput,
+} from "../../ai/memory-consolidation/src/shadow";
 import { cosineSimilarity } from "./embedding";
 import type {
   IndexedDBManager,
@@ -495,11 +501,27 @@ export function createIndexedDBMemoryStorageAdapter(
   };
 }
 
+export interface RunMemoryForgettingCycleShadowDiagnosticsOptions {
+  enabled?: boolean;
+  dryRun?: boolean;
+  limit?: number;
+  candidateTier?: MemoryTier;
+  olderThan?: number;
+  relationKeys?: MemoryConsolidationRuntimeRelationKeys;
+  semanticDraftCandidates?: RunMemoryConsolidationShadowDiagnosticsInput<MemoryRecord>["semanticDraftCandidates"];
+  summarizerProvider?: RunMemoryConsolidationShadowDiagnosticsInput<MemoryRecord>["summarizerProvider"];
+  summarizerContext?: RunMemoryConsolidationShadowDiagnosticsInput<MemoryRecord>["summarizerContext"];
+  minConfidence?: number;
+  metadata?: Record<string, unknown>;
+  logReport?: RunMemoryConsolidationShadowDiagnosticsInput<MemoryRecord>["logReport"];
+}
+
 export interface RunMemoryForgettingCycleOptions {
   now?: number;
   dryRun?: boolean;
   policy?: MemoryForgettingPolicyOverrides;
   hardDeleteArchivedOlderThan?: number;
+  shadowDiagnostics?: RunMemoryForgettingCycleShadowDiagnosticsOptions;
 }
 
 export interface RunMemoryForgettingCycleResult {
@@ -514,6 +536,7 @@ export interface RunMemoryForgettingCycleResult {
   transitionedRecords: number;
   archivedDetailRecords: number;
   hardDeletedRecords: number;
+  shadowDiagnostics?: MemoryConsolidationShadowDiagnosticsRunResult;
 }
 
 export async function runMemoryForgettingCycle(
@@ -527,10 +550,52 @@ export async function runMemoryForgettingCycle(
     storage,
     policy: options?.policy,
   });
+  const now =
+    options?.shadowDiagnostics === undefined
+      ? options?.now
+      : (options.now ?? Date.now());
+  let shadowDiagnostics:
+    | MemoryConsolidationShadowDiagnosticsRunResult
+    | undefined;
+
+  if (options?.shadowDiagnostics) {
+    const { buildMemoryConsolidationRuntimeRecordSelectors } =
+      await import("../../ai/memory-consolidation/src/runtime");
+    const { runMemoryConsolidationShadowDiagnostics } =
+      await import("../../ai/memory-consolidation/src/shadow");
+    const shadowOptions = options.shadowDiagnostics;
+    shadowDiagnostics = await runMemoryConsolidationShadowDiagnostics({
+      enabled: shadowOptions.enabled,
+      dryRun: shadowOptions.dryRun ?? true,
+      now,
+      limit: shadowOptions.limit,
+      defaultUserId: userId,
+      defaultTier: shadowOptions.candidateTier ?? "short",
+      selectors: buildMemoryConsolidationRuntimeRecordSelectors({
+        relationKeys: shadowOptions.relationKeys,
+      }),
+      semanticDraftCandidates: shadowOptions.semanticDraftCandidates,
+      summarizerProvider: shadowOptions.summarizerProvider,
+      summarizerContext: shadowOptions.summarizerContext,
+      minConfidence: shadowOptions.minConfidence,
+      metadata: {
+        ...(shadowOptions.metadata ?? {}),
+        integration: "forgetting-cycle",
+      },
+      loadRecords: ({ now: shadowNow, limit }) =>
+        storage.listCandidates({
+          userId,
+          tier: shadowOptions.candidateTier ?? "short",
+          olderThan: shadowOptions.olderThan ?? shadowNow,
+          limit: limit ?? 500,
+        }),
+      logReport: shadowOptions.logReport,
+    });
+  }
 
   const result = await engine.runCycle({
     userId,
-    now: options?.now,
+    now,
     dryRun: options?.dryRun,
   });
 
@@ -549,6 +614,7 @@ export async function runMemoryForgettingCycle(
   return {
     ...result,
     hardDeletedRecords,
+    shadowDiagnostics,
   };
 }
 


### PR DESCRIPTION
## Summary

Add an opt-in runtime-facing shadow diagnostics hook to the IndexedDB forgetting cycle.

This lets callers attach the existing memory-consolidation shadow diagnostics flow to `runMemoryForgettingCycle` while keeping the default forgetting behavior unchanged.

## Scope

- Adds optional `shadowDiagnostics` options to `runMemoryForgettingCycle`
- Runs consolidation shadow diagnostics only when explicitly configured
- Returns the shadow diagnostics result alongside the existing forgetting result
- Keeps the hook dry-run/report-only and observable
- Adds focused tests for default-off behavior, dry-run diagnostics, log failure reporting, and non-dry-run rejection

## Non-goals

- Does not change default forgetting behavior
- Does not change storage schema or write semantic artifacts
- Does not change retrieval ranking
- Does not add a scheduler, API route, UI, DB migration, or real provider

## Testing

- `corepack pnpm exec prettier --check packages/indexeddb/src/forgetting.ts apps/web/tests/unit/indexeddb-forgetting.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/indexeddb-forgetting.test.ts tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web lint`
- `corepack pnpm tsc`
- `git diff --check`