### PR TITLE
feat(memory): expose shadow diagnostics opt-in

### DIFF
--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -10,6 +10,7 @@ import {
   queryMemoryWithFallback,
   runMemoryForgettingCycle,
 } from "@openloomi/indexeddb/forgetting";
+import type { RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions } from "@openloomi/indexeddb/forgetting";
 import type {
   MemorySummaryRecord,
   RawMessage,
@@ -27,6 +28,96 @@ function normalizeTimestampToMs(value: number | undefined): number | undefined {
     return Math.floor((value as number) * 1000);
   }
   return Math.floor(value as number);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function optionalMemoryTier(
+  value: unknown,
+): "short" | "mid" | "long" | undefined {
+  return value === "short" || value === "mid" || value === "long"
+    ? value
+    : undefined;
+}
+
+function optionalRelationKeys(
+  value: unknown,
+): RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions["relationKeys"] {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const relationKeys = {
+    relationGroup:
+      typeof value.relationGroup === "string" ? value.relationGroup : undefined,
+    relationValue:
+      typeof value.relationValue === "string" ? value.relationValue : undefined,
+    relationScope:
+      typeof value.relationScope === "string" ? value.relationScope : undefined,
+  };
+
+  return Object.values(relationKeys).some(Boolean) ? relationKeys : undefined;
+}
+
+function parseShadowDiagnosticsOptions(
+  value: unknown,
+): RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const shadowDiagnostics: RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions =
+    {};
+  const enabled = optionalBoolean(value.enabled);
+  const dryRun = optionalBoolean(value.dryRun);
+  const limit = optionalFiniteNumber(value.limit);
+  const olderThan = optionalFiniteNumber(value.olderThan);
+  const candidateTier = optionalMemoryTier(value.candidateTier);
+  const relationKeys = optionalRelationKeys(value.relationKeys);
+  const minConfidence = optionalFiniteNumber(value.minConfidence);
+
+  if (enabled !== undefined) shadowDiagnostics.enabled = enabled;
+  if (dryRun !== undefined) shadowDiagnostics.dryRun = dryRun;
+  if (limit !== undefined) shadowDiagnostics.limit = limit;
+  if (olderThan !== undefined) shadowDiagnostics.olderThan = olderThan;
+  if (candidateTier !== undefined) {
+    shadowDiagnostics.candidateTier = candidateTier;
+  }
+  if (relationKeys !== undefined) shadowDiagnostics.relationKeys = relationKeys;
+  if (minConfidence !== undefined) {
+    shadowDiagnostics.minConfidence = minConfidence;
+  }
+  if (isRecord(value.metadata)) {
+    shadowDiagnostics.metadata = { ...value.metadata };
+  }
+
+  return Object.keys(shadowDiagnostics).length > 0
+    ? shadowDiagnostics
+    : undefined;
+}
+
+function parseForgettingCycleOptions(value: unknown) {
+  const options = isRecord(value) ? value : {};
+  return {
+    dryRun: options.dryRun === true,
+    hardDeleteArchivedOlderThan:
+      typeof options.hardDeleteArchivedOlderThan === "number"
+        ? options.hardDeleteArchivedOlderThan
+        : undefined,
+    shadowDiagnostics: parseShadowDiagnosticsOptions(options.shadowDiagnostics),
+  };
 }
 
 function toRawSourceItem(message: RawMessage): RawMessage & {
@@ -315,13 +406,11 @@ export async function POST(request: NextRequest) {
       }
 
       case "forgettingCycle": {
-        const result = await runMemoryForgettingCycle(manager as any, userId, {
-          dryRun: body.options?.dryRun === true,
-          hardDeleteArchivedOlderThan:
-            typeof body.options?.hardDeleteArchivedOlderThan === "number"
-              ? body.options.hardDeleteArchivedOlderThan
-              : undefined,
-        });
+        const result = await runMemoryForgettingCycle(
+          manager as any,
+          userId,
+          parseForgettingCycleOptions(body.options),
+        );
         return Response.json({ success: true, result });
       }
 

--- a/apps/web/tests/unit/indexeddb-forgetting.test.ts
+++ b/apps/web/tests/unit/indexeddb-forgetting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   IndexedDBManager,
   MemoryStage,
@@ -11,8 +11,10 @@ import {
   queryMemoryWithFallback,
   runMemoryForgettingCycle,
 } from "../../../../packages/indexeddb/src/forgetting";
+import { sqliteRunMemoryForgettingCycleForUser } from "../../../../packages/indexeddb/src/sqlite-client";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const originalFetch = globalThis.fetch;
 
 class InMemoryManager {
   rawMessages: RawMessage[] = [];
@@ -234,6 +236,11 @@ function createRaw(input: {
 }
 
 describe("indexeddb forgetting bridge", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
   it("runs forgetting cycle and applies transition/archive/delete", async () => {
     const now = Date.now();
     const manager = new InMemoryManager();
@@ -509,6 +516,96 @@ describe("indexeddb forgetting bridge", () => {
       scannedRecordCount: 0,
       reasonCodes: ["shadow_dry_run_required"],
     });
+  });
+
+  it("forwards JSON-safe shadow diagnostics through SQLite raw message API", async () => {
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            result: {
+              status: "success",
+              createdSummaries: 0,
+              transitionedRecords: 0,
+              archivedDetailRecords: 0,
+              hardDeletedRecords: 0,
+              shadowDiagnostics: {
+                status: "success",
+                dryRun: true,
+                scannedRecordCount: 0,
+                reasonCodes: ["shadow_report_only"],
+                mutatesRuntime: false,
+                mutatesStorage: false,
+                mutatesRetrieval: false,
+                log: { status: "disabled" },
+                startedAt: 1,
+                finishedAt: 2,
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        );
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await sqliteRunMemoryForgettingCycleForUser("u1", {
+      dryRun: true,
+      shadowDiagnostics: {
+        enabled: true,
+        dryRun: true,
+        limit: 10,
+        candidateTier: "short",
+        olderThan: 123,
+        relationKeys: {
+          relationGroup: "relationGroup",
+          relationValue: "relationValue",
+        },
+        minConfidence: 0.7,
+        metadata: {
+          source: "test",
+        },
+      },
+    });
+
+    const requestBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    );
+
+    expect(requestBody).toMatchObject({
+      action: "forgettingCycle",
+      options: {
+        dryRun: true,
+        shadowDiagnostics: {
+          enabled: true,
+          dryRun: true,
+          limit: 10,
+          candidateTier: "short",
+          olderThan: 123,
+          relationKeys: {
+            relationGroup: "relationGroup",
+            relationValue: "relationValue",
+          },
+          minConfidence: 0.7,
+          metadata: {
+            source: "test",
+          },
+        },
+      },
+    });
+    expect(result.shadowDiagnostics).toEqual(
+      expect.objectContaining({
+        status: "success",
+        dryRun: true,
+        mutatesStorage: false,
+      }),
+    );
   });
 
   it("queries summaries as fallback when raw is insufficient", async () => {

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -9,6 +9,10 @@ import type {
   GroupByType,
   MemorySummaryRecord,
 } from "./manager";
+import type {
+  RunMemoryForgettingCycleResult,
+  RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions,
+} from "./forgetting";
 import {
   ensureRawMessagesSQLiteMigration,
   migrateIndexedDBRawMessagesToSQLite,
@@ -38,6 +42,23 @@ export type RawMessageSourceType = "raw" | "summary";
 export type RawMessageQueryResultItem =
   | (RawMessage & { sourceType: "raw" })
   | (MemorySummaryRecord & { sourceType: "summary" });
+
+export interface RunMemoryForgettingCycleForUserOptions {
+  dryRun?: boolean;
+  hardDeleteArchivedOlderThan?: number;
+  shadowDiagnostics?: RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions;
+}
+
+export interface RunMemoryForgettingCycleForUserResult {
+  success: boolean;
+  status?: "success" | "skipped_locked";
+  createdSummaries?: number;
+  transitionedRecords?: number;
+  archivedDetailRecords?: number;
+  hardDeletedRecords?: number;
+  shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
+  error?: string;
+}
 
 let managerInstance: any = null;
 
@@ -413,19 +434,8 @@ export async function clearOldRawMessages(
 
 export async function runMemoryForgettingCycleForUser(
   userId: string,
-  options?: {
-    dryRun?: boolean;
-    hardDeleteArchivedOlderThan?: number;
-  },
-): Promise<{
-  success: boolean;
-  status?: "success" | "skipped_locked";
-  createdSummaries?: number;
-  transitionedRecords?: number;
-  archivedDetailRecords?: number;
-  hardDeletedRecords?: number;
-  error?: string;
-}> {
+  options?: RunMemoryForgettingCycleForUserOptions,
+): Promise<RunMemoryForgettingCycleForUserResult> {
   if (shouldUseRawMessageApiStorage()) {
     try {
       return await sqliteRunMemoryForgettingCycleForUser(userId, options);
@@ -448,6 +458,7 @@ export async function runMemoryForgettingCycleForUser(
       transitionedRecords: result.transitionedRecords,
       archivedDetailRecords: result.archivedDetailRecords,
       hardDeletedRecords: result.hardDeletedRecords,
+      shadowDiagnostics: result.shadowDiagnostics,
     };
   } catch (error) {
     console.error(

--- a/packages/indexeddb/src/forgetting.ts
+++ b/packages/indexeddb/src/forgetting.ts
@@ -516,6 +516,18 @@ export interface RunMemoryForgettingCycleShadowDiagnosticsOptions {
   logReport?: RunMemoryConsolidationShadowDiagnosticsInput<MemoryRecord>["logReport"];
 }
 
+export type RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions = Pick<
+  RunMemoryForgettingCycleShadowDiagnosticsOptions,
+  | "enabled"
+  | "dryRun"
+  | "limit"
+  | "candidateTier"
+  | "olderThan"
+  | "relationKeys"
+  | "minConfidence"
+  | "metadata"
+>;
+
 export interface RunMemoryForgettingCycleOptions {
   now?: number;
   dryRun?: boolean;

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -8,6 +8,10 @@ import type {
   RunRawMessageEmbeddingDreamInput,
   RawMessageSemanticSearchInput,
 } from "./embedding";
+import type {
+  RunMemoryForgettingCycleResult,
+  RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions,
+} from "./forgetting";
 
 export type SQLiteRawMessageQueryResultItem =
   | (RawMessage & { sourceType: "raw" })
@@ -32,6 +36,23 @@ export interface RawMessagesSQLiteMigrationState {
   startedAt?: number;
   completedAt?: number;
   updatedAt: number;
+  error?: string;
+}
+
+export interface SQLiteRunMemoryForgettingCycleForUserOptions {
+  dryRun?: boolean;
+  hardDeleteArchivedOlderThan?: number;
+  shadowDiagnostics?: RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions;
+}
+
+export interface SQLiteRunMemoryForgettingCycleForUserResult {
+  success: boolean;
+  status?: "success" | "skipped_locked";
+  createdSummaries?: number;
+  transitionedRecords?: number;
+  archivedDetailRecords?: number;
+  hardDeletedRecords?: number;
+  shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
   error?: string;
 }
 
@@ -302,19 +323,8 @@ export async function sqliteClearOldRawMessages(
 
 export async function sqliteRunMemoryForgettingCycleForUser(
   _userId: string,
-  options?: {
-    dryRun?: boolean;
-    hardDeleteArchivedOlderThan?: number;
-  },
-): Promise<{
-  success: boolean;
-  status?: "success" | "skipped_locked";
-  createdSummaries?: number;
-  transitionedRecords?: number;
-  archivedDetailRecords?: number;
-  hardDeletedRecords?: number;
-  error?: string;
-}> {
+  options?: SQLiteRunMemoryForgettingCycleForUserOptions,
+): Promise<SQLiteRunMemoryForgettingCycleForUserResult> {
   const response = await requestSQLiteRawMessages<{
     success: boolean;
     result: {
@@ -323,6 +333,7 @@ export async function sqliteRunMemoryForgettingCycleForUser(
       transitionedRecords: number;
       archivedDetailRecords: number;
       hardDeletedRecords: number;
+      shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
     };
   }>("forgettingCycle", { options });
   return {
@@ -332,6 +343,7 @@ export async function sqliteRunMemoryForgettingCycleForUser(
     transitionedRecords: response.result.transitionedRecords,
     archivedDetailRecords: response.result.archivedDetailRecords,
     hardDeletedRecords: response.result.hardDeletedRecords,
+    shadowDiagnostics: response.result.shadowDiagnostics,
   };
 }
 


### PR DESCRIPTION
## Summary

Expose the memory-consolidation shadow diagnostics hook through the existing forgetting-cycle call sites.

This keeps the runtime hook opt-in and JSON-safe while allowing browser callers and the raw-message API proxy to request report-only shadow diagnostics.

## Scope

- Adds a JSON-safe shadow diagnostics option shape for forgetting-cycle call sites
- Lets `runMemoryForgettingCycleForUser` pass and return shadow diagnostics
- Lets the SQLite raw-message proxy forward shadow diagnostics options and return the report
- Whitelists shadow diagnostics fields in the raw-messages API route before calling `runMemoryForgettingCycle`
- Adds a focused SQLite proxy test covering request forwarding and response propagation

## Non-goals

- Does not enable shadow diagnostics by default
- Does not add a scheduler, UI, DB migration, or real provider
- Does not write semantic artifacts to storage
- Does not change retrieval ranking or forgetting behavior unless explicitly requested by the caller

## Testing

- `corepack pnpm exec prettier --check packages/indexeddb/src/forgetting.ts packages/indexeddb/src/client.ts packages/indexeddb/src/sqlite-client.ts apps/web/app/api/memory/raw-messages/route.ts apps/web/tests/unit/indexeddb-forgetting.test.ts`
- `corepack pnpm -C apps/web exec vitest run tests/unit/indexeddb-forgetting.test.ts tests/unit/memory-consolidation-eval.test.ts`
- `corepack pnpm -C apps/web lint`
- `corepack pnpm tsc`
- `git diff --check`