### PR TITLE
feat(web): add filesystem for browser and Tauri

### DIFF
--- a/apps/web/components/agent/insight-analytics-panel.tsx
+++ b/apps/web/components/agent/insight-analytics-panel.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { Button } from "@openloomi/ui";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import useSWR from "swr";
 import { RemixIcon } from "@/components/remix-icon";
 import { Spinner } from "@/components/spinner";
 import { cn, fetcher } from "@/lib/utils";
-import { isTauri } from "@tauri-apps/api/core";
-import { save } from "@tauri-apps/plugin-dialog";
-import { writeFile } from "@tauri-apps/plugin-fs";
+import { getFileSystem } from "@openloomi/shared";
 
 type AccessTrend = "rising" | "falling" | "stable";
 type OrganizationAction = "keep" | "archive" | "delete";
@@ -278,6 +276,7 @@ function InsightRecommendationRow({ item }: { item: AnalyticsInsight }) {
 
 export function InsightAnalyticsPanel() {
   const { t, i18n } = useTranslation();
+  const [isExporting, setIsExporting] = useState(false);
   const { data, error, isLoading, mutate } =
     useSWR<InsightUsageAnalyticsResponse>(
       "/api/insights/analytics?limit=10",
@@ -325,27 +324,26 @@ export function InsightAnalyticsPanel() {
   }).format(new Date(data.generatedAt));
 
   const exportAnalytics = async () => {
-    const isTauriApp = typeof window !== "undefined" && isTauri();
-    const exportUrl = "/api/insights/analytics/export";
-    if (!isTauriApp) {
-      window.location.href = exportUrl;
-      return;
+    if (isExporting) return;
+
+    setIsExporting(true);
+    try {
+      const exportUrl = "/api/insights/analytics/export";
+      const response = await fetch(exportUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch export analytics: ${response.status} ${response.statusText}`,
+        );
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      const disposition = response.headers.get("Content-Disposition");
+      const fileName =
+        disposition?.split("filename=")[1]?.replace(/^"|"$/g, "") ||
+        "export.csv";
+      await (await getFileSystem()).saveFile(bytes, { fileName });
+    } finally {
+      setIsExporting(false);
     }
-    const res = await fetch(exportUrl);
-    if (!res.ok) {
-      throw new Error(
-        `Failed to fetch export analytics: ${res.status} ${res.statusText}`,
-      );
-    }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const disposition = res.headers.get("Content-Disposition");
-    const filename =
-      disposition?.split("filename=")[1]?.replace(/"/g, "") || "export.csv";
-    const path = await save({
-      defaultPath: filename,
-    });
-    if (!path) return;
-    await writeFile(path, bytes);
   };
 
   return (
@@ -365,9 +363,14 @@ export function InsightAnalyticsPanel() {
           variant="outline"
           size="sm"
           className="h-8 shrink-0"
-          onClick={() => exportAnalytics()}
+          onClick={exportAnalytics}
+          disabled={isExporting}
         >
-          <RemixIcon name="download" size="size-4" />
+          <RemixIcon
+            name={isExporting ? "loader_2" : "download"}
+            size="size-4"
+            className={isExporting ? "animate-spin" : undefined}
+          />
           {t("common.export", "Export")}
         </Button>
       </div>

--- a/apps/web/src-tauri/capabilities/default.json
+++ b/apps/web/src-tauri/capabilities/default.json
@@ -87,6 +87,7 @@
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
     "global-shortcut:allow-is-registered",
+    "dialog:allow-save",
     {
       "identifier": "fs:allow-stat",
       "allow": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,10 @@
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.5.2",
     "zod": "^4.3.6",
-    "date-fns": "^4.1.0"
+    "date-fns": "^4.1.0",
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-fs": "^2.5.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from "./ref";
 export * from "./soul";
 export * from "./tokens";
 export * from "./locale/user-locale";
+export * from "./platform";

--- a/packages/shared/src/platform/adapters/browser/filesystem.ts
+++ b/packages/shared/src/platform/adapters/browser/filesystem.ts
@@ -1,0 +1,46 @@
+import type { PlatformFileSystem, SaveFileOptions } from "../../filesystem";
+
+type FilePickerWindow = Window & {
+  showSaveFilePicker?: (options?: {
+    suggestedName?: string;
+  }) => Promise<FileSystemFileHandle>;
+};
+
+export class BrowserFileSystem implements PlatformFileSystem {
+  async saveFile(data: Uint8Array, options?: SaveFileOptions): Promise<void> {
+    const bytes = new Uint8Array(data);
+    const browserWindow = window as FilePickerWindow;
+    if (browserWindow.showSaveFilePicker) {
+      try {
+        const handle = await browserWindow.showSaveFilePicker({
+          suggestedName: options?.fileName,
+        });
+        const writable = await handle.createWritable();
+        await writable.write(bytes);
+        await writable.close();
+        return;
+      } catch (error) {
+        // ignore user cancel error
+        // others error fallback to download with `a` tag
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error("[BrowserFileSystem] saving file failed:", error);
+      }
+    }
+
+    const blob = new Blob([bytes], {
+      type: "application/octet-stream",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = options?.fileName || "";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+}
+
+export const browserFileSystem = new BrowserFileSystem();

--- a/packages/shared/src/platform/adapters/tauri/filesystem.ts
+++ b/packages/shared/src/platform/adapters/tauri/filesystem.ts
@@ -1,0 +1,16 @@
+import type { PlatformFileSystem, SaveFileOptions } from "../../filesystem";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeFile } from "@tauri-apps/plugin-fs";
+
+export class TauriFileSystem implements PlatformFileSystem {
+  async saveFile(data: Uint8Array, options?: SaveFileOptions): Promise<void> {
+    const path = await save({
+      defaultPath: options?.fileName,
+    });
+    if (!path) return;
+
+    await writeFile(path, data);
+  }
+}
+
+export const tauriFileSystem = new TauriFileSystem();

--- a/packages/shared/src/platform/env.ts
+++ b/packages/shared/src/platform/env.ts
@@ -1,0 +1,25 @@
+import { isTauri as tauriIsTauri } from "@tauri-apps/api/core";
+
+export type PlatformKind = "tauri" | "browser";
+
+export function isClient(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function isTauri(): boolean {
+  if (!isClient()) return false;
+  try {
+    return tauriIsTauri();
+  } catch {
+    return false;
+  }
+}
+
+export function isBrowser(): boolean {
+  return isClient() && !isTauri();
+}
+
+export function getPlatformKind(): PlatformKind {
+  if (isTauri()) return "tauri";
+  return "browser";
+}

--- a/packages/shared/src/platform/filesystem.ts
+++ b/packages/shared/src/platform/filesystem.ts
@@ -1,0 +1,24 @@
+import { getPlatformKind } from "./env";
+
+export interface SaveFileOptions {
+  fileName?: string;
+}
+
+export interface PlatformFileSystem {
+  saveFile(data: Uint8Array, options?: SaveFileOptions): Promise<void>;
+}
+
+export async function getFileSystem(): Promise<PlatformFileSystem> {
+  const platform = getPlatformKind();
+
+  if (platform === "tauri") {
+    const mod = await import("./adapters/tauri/filesystem");
+    return mod.tauriFileSystem;
+  }
+  if (platform === "browser") {
+    const mod = await import("./adapters/browser/filesystem");
+    return mod.browserFileSystem;
+  }
+
+  throw new Error("unsupported platform");
+}

--- a/packages/shared/src/platform/index.ts
+++ b/packages/shared/src/platform/index.ts
@@ -1,0 +1,7 @@
+export {
+  getFileSystem,
+  type PlatformFileSystem,
+  type SaveFileOptions,
+} from "./filesystem";
+
+export { isClient, isTauri, isBrowser, getPlatformKind } from "./env";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1562,6 +1562,15 @@ importers:
 
   packages/shared:
     dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.11.0
+        version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
+      '@tauri-apps/plugin-fs':
+        specifier: ^2.5.1
+        version: 2.5.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
Related to #225

- add a shared filesystem abstraction for browser and Tauri
- support browser file saving with a download fallback
- migrate analytics export to the filesystem abstraction
- add a loading state to the export button
