### PR TITLE
chore(marketing): revert capabilities section to three pillars

### DIFF
--- a/apps/marketing/i18n/en.ts
+++ b/apps/marketing/i18n/en.ts
@@ -81,27 +81,27 @@ export const en = {
       {
         title: "Holistic Context",
         description:
-          "Short → mid → long-term memory that grows on its own — visible, auditable, and always remembering your people, projects, and decisions across months.",
+          "OpenLoomi understands your work across people, projects, and decisions — not just keywords, but relationships and history.",
       },
       {
-        title: "Platform Connectors",
+        title: "Strategic Memory",
         description:
-          "Auto-fetch background sync loop pulls commits, issues, emails, and docs proactively into your context graph — across Slack, Gmail, GitHub, Lark/Feishu, and the tools you already use.",
+          "Yesterday's discussion, last week's decision, the project's evolution — OpenLoomi remembers it all, across sessions and across days.",
       },
       {
-        title: "Proactive Tasks",
+        title: "Builtin Professional Skills",
         description:
-          "Intelligent task execution that anticipates your needs — not just scheduled automation, but context-aware actions that happen at the right moment, with your approval.",
+          "From drafting contracts to writing code — the right expertise at every critical moment.",
       },
       {
-        title: "Security & Ease of Use",
+        title: "You Approve, It Executes",
         description:
-          "Native apps for Windows, macOS, and Linux — works out of the box, minutes to set up. Local-first storage with IndexedDB + SQLite, AES-256 encryption, no data leaves your machine, auditable access logs.",
+          "Full control. No surprises. OpenLoomi acts on your behalf, with your approval, every step of the way.",
       },
       {
-        title: "Open Sourced Skills",
+        title: "Relentless Follow-Through",
         description:
-          "OpenLoomi Skills are open-source and can be integrated into any Agent — Claude Code, Codex, OpenClaw, Hermes, and more.",
+          "It doesn't stop at the first step. It tracks commitments, follows up, and sees things through.",
       },
     ],
   },

--- a/apps/marketing/i18n/zh-Hans.ts
+++ b/apps/marketing/i18n/zh-Hans.ts
@@ -75,32 +75,35 @@ export const zhHans = {
     eyebrow: "功能",
     heading: "五大支柱。一个工作空间。",
     description:
-      "Holistic Context、Proactive Tasks 与 Open Sourced Skills——协同工作,让你的 AI 带着感知与你的批准行事。",
+      "上下文、记忆、多渠道连接——协同工作，赋予你的 AI 所需的感知能力。",
     items: [
       {
-        title: "Holistic Context",
+        title: "上下文",
         description:
-          "短→中→长期记忆,自主生长——可见、可审计,数月之间始终记得你的人、项目与决策。",
+          "OpenLoomi 理解你跨人、项目和决策的工作——不只是关键词，而是关系和历史。",
       },
       {
-        title: "Platform Connectors",
+        title: "记忆",
         description:
-          "后台自动同步循环主动拉取提交、议题、邮件、文档进入你的上下文图谱——覆盖 Slack、Gmail、GitHub、Lark/Feishu 等你已使用的工具。",
+          "昨天的讨论、上周的决策、项目的演变——OpenLoomi 记住一切，跨会话、跨天。",
       },
       {
-        title: "Proactive Tasks",
+        title: "多渠道连接",
         description:
-          "智能任务执行,会预判你的需求——不只是定时自动化,而是在恰当时机发生、有上下文感知、经过你批准的行动。",
+          "Slack、邮件、日历、文档、Telegram、Discord——OpenLoomi 将你的整个工具栈连接成统一的上下文。",
       },
       {
-        title: "Security & Ease of Use",
-        description:
-          "Windows、macOS、Linux 原生应用——开箱即用,数分钟完成。本地优先存储 (IndexedDB + SQLite),AES-256 加密,数据不出本机,可审计的访问日志。",
+        title: "内置专业技能",
+        description: "从起草合同到编写代码——每个关键时刻都有正确的专业能力。",
       },
       {
-        title: "Open Sourced Skills",
+        title: "你批准，它执行",
         description:
-          "OpenLoomi Skills 完全开源,可被任意 Agent 集成——Claude Code、Codex、OpenClaw、Hermes 等。",
+          "完全掌控。没有意外。OpenLoomi 代表你行动，在你的批准下，每一步都如此。",
+      },
+      {
+        title: "持续跟进",
+        description: "不会在第一步就停下。它追踪承诺、持续跟进、把事情做到底。",
       },
     ],
   },

--- a/apps/marketing/i18n/zh-Hans.ts
+++ b/apps/marketing/i18n/zh-Hans.ts
@@ -226,7 +226,7 @@ export const zhHans = {
       "OpenLoomi 基于 Apache 2.0 开源,是一款 AI 同事与工作空间——本地优先的工作记忆,围绕你的 AI agent。在你的机器上自托管,并按你的方式使用它。",
     button: "立即开始 →",
     openSourceCta: "GitHub",
-    subtext: "开源 · 本地优先 · Holistic Context",
+    subtext: "开源 · 本地优先 · 全域上下文",
     mobileDesc:
       "OpenLoomi 支持 macOS、Linux 和 Windows。请在桌面设备上访问下载。",
   },


### PR DESCRIPTION
The capabilities block was switched to the new five-pillar framing (Holistic Context / Platform Connectors / Proactive Tasks / Security & Ease of Use / Open Sourced Skills), but it no longer fits the section's existing rhythm — the heading "Five pillars. One workspace." still understates the actual list count in the zh locale (six items) and the framing competes with howItWorks / thenItActs.

Roll capabilities back to the prior "Three pillars" copy in both en.ts and zh-Hans.ts. The 5-pillars repositioning in hero, problem, howItWorks, thenItActs, openSource, and cta is kept intact.