### PR TITLE
feat(agent): add OpenCode CLI runtime provider

### DIFF
--- a/apps/web/app/api/native/providers/route.ts
+++ b/apps/web/app/api/native/providers/route.ts
@@ -5,21 +5,43 @@
  */
 
 import { NextResponse } from "next/server";
-import { getAgentRegistry } from "@openloomi/ai/agent/registry";
-import { getAllAgentMetadata } from "@openloomi/ai/agent/registry";
-import { claudePlugin } from "@/lib/ai/extensions";
+import {
+  CLAUDE_METADATA,
+  type AgentProviderMetadata,
+} from "@openloomi/ai/agent/plugin";
+import {
+  getAgentRegistry,
+  getAllAgentMetadata,
+} from "@openloomi/ai/agent/registry";
+import { opencodePlugin } from "@/lib/ai/extensions/agent/opencode";
+import { DEFAULT_AGENT_PROVIDER } from "@/lib/env/config/constants";
 
-// Register Claude Agent plugin
-getAgentRegistry().register(claudePlugin);
+// Register lightweight built-in Agent plugins used by this metadata route.
+const registry = getAgentRegistry();
+registry.register(opencodePlugin);
+
+function getProviderMetadata(): AgentProviderMetadata[] {
+  const metadataByType = new Map<string, AgentProviderMetadata>();
+
+  for (const metadata of [CLAUDE_METADATA, opencodePlugin.metadata]) {
+    metadataByType.set(metadata.type, metadata);
+  }
+
+  for (const metadata of getAllAgentMetadata()) {
+    metadataByType.set(metadata.type, metadata);
+  }
+
+  return Array.from(metadataByType.values());
+}
 
 // GET /api/native/providers - Get all available providers
 export async function GET() {
   try {
-    const agentProviders = getAllAgentMetadata();
+    const agentProviders = getProviderMetadata();
 
     return NextResponse.json({
       agents: agentProviders,
-      defaultAgent: "claude",
+      defaultAgent: DEFAULT_AGENT_PROVIDER,
     });
   } catch (error) {
     console.error("[ProvidersAPI] Error:", error);

--- a/apps/web/lib/ai/extensions/agent/opencode/command.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/command.ts
@@ -1,0 +1,254 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { platform } from "node:os";
+
+import type { AgentOptions } from "@openloomi/ai/agent/types";
+
+export interface OpenCodeProviderConfig {
+  opencodePath?: string;
+  agent?: string;
+  files?: string[];
+  allowAutoApprove?: boolean;
+  env?: Record<string, string>;
+}
+
+export interface OpenCodeRunCommandOptions {
+  prompt: string;
+  cwd: string;
+  model?: string;
+  permissionMode?: AgentOptions["permissionMode"];
+  providerConfig?: Record<string, unknown>;
+}
+
+export interface OpenCodeRunCommand {
+  command: string;
+  args: string[];
+}
+
+export type OpenCodeCliEvent =
+  | { type: "line"; line: string }
+  | {
+      type: "close";
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+      duration: number;
+    };
+
+export class OpenCodeCommandNotFoundError extends Error {
+  constructor(command: string) {
+    super(
+      `OpenCode CLI executable not found: ${command}. Install OpenCode or set providerConfig.opencodePath to the opencode executable.`,
+    );
+    this.name = "OpenCodeCommandNotFoundError";
+  }
+}
+
+export function normalizeOpenCodeProviderConfig(
+  value: Record<string, unknown> | undefined,
+): OpenCodeProviderConfig {
+  const files = Array.isArray(value?.files)
+    ? value.files
+        .filter((file): file is string => typeof file === "string")
+        .map((file) => file.trim())
+        .filter((file) => file.length > 0 && !file.startsWith("-"))
+    : undefined;
+  const env =
+    value?.env && typeof value.env === "object" && !Array.isArray(value.env)
+      ? Object.fromEntries(
+          Object.entries(value.env as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : undefined;
+
+  return {
+    opencodePath:
+      typeof value?.opencodePath === "string" && value.opencodePath.trim()
+        ? value.opencodePath
+        : undefined,
+    agent:
+      typeof value?.agent === "string" && value.agent.trim()
+        ? value.agent
+        : undefined,
+    files,
+    allowAutoApprove: value?.allowAutoApprove === true,
+    env,
+  };
+}
+
+export function buildOpenCodeRunCommand(
+  options: OpenCodeRunCommandOptions,
+): OpenCodeRunCommand {
+  const providerConfig = normalizeOpenCodeProviderConfig(
+    options.providerConfig,
+  );
+  const args = ["run", "--format", "json", "--dir", options.cwd];
+
+  if (options.model) {
+    args.push("--model", options.model);
+  }
+  if (providerConfig.agent) {
+    args.push("--agent", providerConfig.agent);
+  }
+  for (const file of providerConfig.files ?? []) {
+    args.push("--file", file);
+  }
+  if (
+    options.permissionMode === "bypassPermissions" &&
+    providerConfig.allowAutoApprove
+  ) {
+    args.push("--auto");
+  }
+
+  args.push(options.prompt);
+
+  return {
+    command: providerConfig.opencodePath || "opencode",
+    args,
+  };
+}
+
+export async function* runOpenCodeCli(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env?: Record<string, string>;
+    signal?: AbortSignal;
+  },
+): AsyncGenerator<OpenCodeCliEvent> {
+  const startTime = Date.now();
+  const events: OpenCodeCliEvent[] = [];
+  let notify: (() => void) | undefined;
+  let stdout = "";
+  let stderr = "";
+  let stdoutBuffer = "";
+  let done = false;
+  let spawnError: Error | undefined;
+  let proc: ChildProcessWithoutNullStreams;
+
+  const push = (event: OpenCodeCliEvent) => {
+    events.push(event);
+    notify?.();
+    notify = undefined;
+  };
+
+  const wake = () => {
+    notify?.();
+    notify = undefined;
+  };
+
+  try {
+    proc = spawn(command, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      windowsHide: true,
+    });
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    if (isCommandNotFoundError(err)) {
+      throw new OpenCodeCommandNotFoundError(command);
+    }
+    throw err;
+  }
+
+  const flushStdoutLines = () => {
+    const lines = stdoutBuffer.split(/\r?\n/);
+    stdoutBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) {
+        push({ type: "line", line });
+      }
+    }
+  };
+
+  const abortHandler = () => {
+    killProcessTree(proc);
+  };
+
+  options.signal?.addEventListener("abort", abortHandler, { once: true });
+  if (options.signal?.aborted) {
+    abortHandler();
+  }
+
+  proc.stdout.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stdout += text;
+    stdoutBuffer += text;
+    flushStdoutLines();
+  });
+
+  proc.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+
+  proc.on("error", (error: Error & { code?: string }) => {
+    spawnError = isCommandNotFoundError(error)
+      ? new OpenCodeCommandNotFoundError(command)
+      : error;
+    done = true;
+    wake();
+  });
+
+  proc.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+    if (stdoutBuffer.trim()) {
+      push({ type: "line", line: stdoutBuffer });
+      stdoutBuffer = "";
+    }
+    push({
+      type: "close",
+      stdout,
+      stderr,
+      exitCode: code ?? (signal ? 130 : 0),
+      duration: Date.now() - startTime,
+    });
+    done = true;
+    wake();
+  });
+
+  try {
+    while (!done || events.length > 0) {
+      const event = events.shift();
+      if (event) {
+        yield event;
+        continue;
+      }
+      if (spawnError) {
+        throw spawnError;
+      }
+      await new Promise<void>((resolve) => {
+        notify = resolve;
+      });
+      if (spawnError) {
+        throw spawnError;
+      }
+    }
+    if (spawnError) {
+      throw spawnError;
+    }
+  } finally {
+    options.signal?.removeEventListener("abort", abortHandler);
+  }
+}
+
+function killProcessTree(proc: ChildProcessWithoutNullStreams) {
+  if (proc.killed) {
+    return;
+  }
+
+  if (platform() === "win32" && proc.pid) {
+    spawn("taskkill", ["/F", "/T", "/PID", String(proc.pid)], {
+      windowsHide: true,
+      stdio: "ignore",
+    }).on("error", () => {
+      proc.kill();
+    });
+    return;
+  }
+
+  proc.kill("SIGTERM");
+}
+
+function isCommandNotFoundError(error: Error & { code?: string }) {
+  return error.code === "ENOENT";
+}

--- a/apps/web/lib/ai/extensions/agent/opencode/index.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/index.ts
@@ -1,0 +1,309 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import {
+  BaseAgent,
+  defineAgentPlugin,
+  formatPlanForExecution,
+  parsePlanFromResponse,
+  parsePlanningResponse,
+  PLANNING_INSTRUCTION,
+} from "@openloomi/ai/agent";
+import type { AgentPlugin } from "@openloomi/ai/agent/plugin";
+import type {
+  AgentConfig,
+  AgentMessage,
+  AgentOptions,
+  AgentProvider,
+  ExecuteOptions,
+  PlanOptions,
+} from "@openloomi/ai/agent/types";
+
+import {
+  buildOpenCodeRunCommand,
+  normalizeOpenCodeProviderConfig,
+  OpenCodeCommandNotFoundError,
+  runOpenCodeCli,
+  type OpenCodeCliEvent,
+} from "./command";
+import { OPENCODE_METADATA } from "./metadata";
+import { parseOpenCodeJsonLine } from "./parser";
+
+export class OpenCodeAgent extends BaseAgent {
+  readonly provider: AgentProvider = "opencode";
+
+  private messageCounter = 0;
+
+  private generateMessageId(): string {
+    return `opencode_msg_${Date.now()}_${++this.messageCounter}`;
+  }
+
+  async *run(
+    prompt: string,
+    options?: AgentOptions,
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession("executing", {
+      abortController: options?.abortController,
+    });
+
+    yield {
+      type: "session",
+      sessionId: session.id,
+      messageId: this.generateMessageId(),
+    };
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      yield* this.runOpenCodePrompt(
+        prompt,
+        cwd,
+        options,
+        session.abortController.signal,
+      );
+    } catch (error) {
+      yield this.toErrorMessage(error);
+    } finally {
+      this.sessions.delete(session.id);
+      yield { type: "done", messageId: this.generateMessageId() };
+    }
+  }
+
+  async *plan(
+    prompt: string,
+    options?: PlanOptions,
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession("planning", {
+      abortController: options?.abortController,
+    });
+
+    yield {
+      type: "session",
+      sessionId: session.id,
+      messageId: this.generateMessageId(),
+    };
+
+    let fullResponse = "";
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      const planningPrompt = `${PLANNING_INSTRUCTION(options?.timezone ?? undefined)}\n\n${prompt}`;
+      // TODO: Bridge OpenCode permission events once the CLI exposes a stable
+      // approval protocol. Until then, planning must never opt into --auto.
+      const planningOptions: AgentOptions = {
+        ...options,
+        permissionMode: "plan",
+      };
+
+      for await (const message of this.runOpenCodePrompt(
+        planningPrompt,
+        cwd,
+        planningOptions,
+        session.abortController.signal,
+      )) {
+        if (message.type === "text" && message.content) {
+          fullResponse += message.content;
+          yield message;
+        } else if (message.type === "error") {
+          yield message;
+          return;
+        }
+      }
+
+      const planningResult = parsePlanningResponse(fullResponse);
+      if (planningResult?.type === "direct_answer") {
+        yield {
+          type: "direct_answer",
+          content: planningResult.answer,
+          messageId: this.generateMessageId(),
+        };
+        return;
+      }
+
+      const plan =
+        planningResult?.type === "plan"
+          ? planningResult.plan
+          : parsePlanFromResponse(fullResponse);
+      if (plan && plan.steps.length > 0) {
+        this.storePlan(plan);
+        yield {
+          type: "plan",
+          plan,
+          messageId: this.generateMessageId(),
+        };
+        return;
+      }
+
+      yield {
+        type: "direct_answer",
+        content: fullResponse.trim(),
+        messageId: this.generateMessageId(),
+      };
+    } catch (error) {
+      yield this.toErrorMessage(error);
+    } finally {
+      this.sessions.delete(session.id);
+      yield { type: "done", messageId: this.generateMessageId() };
+    }
+  }
+
+  async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
+    const plan = options.plan || this.getPlan(options.planId);
+
+    if (!plan) {
+      yield {
+        type: "session",
+        sessionId: options.sessionId,
+        messageId: this.generateMessageId(),
+      };
+      yield {
+        type: "error",
+        message: `Plan not found: ${options.planId}`,
+        messageId: this.generateMessageId(),
+      };
+      yield { type: "done", messageId: this.generateMessageId() };
+      return;
+    }
+
+    let completedSuccessfully = false;
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      const executionPrompt = `${formatPlanForExecution(
+        plan,
+        cwd,
+        undefined,
+        options.aiSoulPrompt ?? undefined,
+        options.language ?? undefined,
+        options.timezone ?? undefined,
+      )}\n\nOriginal request: ${options.originalPrompt}`;
+
+      let sawError = false;
+      for await (const message of this.run(executionPrompt, {
+        ...options,
+        cwd,
+      })) {
+        if (message.type === "error") {
+          sawError = true;
+        }
+        yield message;
+      }
+
+      completedSuccessfully =
+        !sawError && !options.abortController?.signal.aborted;
+    } finally {
+      if (completedSuccessfully) {
+        this.deletePlan(options.planId);
+      }
+    }
+  }
+
+  private async *runOpenCodePrompt(
+    prompt: string,
+    cwd: string,
+    options?: AgentOptions,
+    signal?: AbortSignal,
+  ): AsyncGenerator<AgentMessage> {
+    const providerConfig = normalizeOpenCodeProviderConfig(
+      this.config.providerConfig,
+    );
+    const command = buildOpenCodeRunCommand({
+      prompt,
+      cwd,
+      model: this.config.model,
+      permissionMode: options?.permissionMode,
+      providerConfig: this.config.providerConfig,
+    });
+
+    let closeEvent: Extract<OpenCodeCliEvent, { type: "close" }> | undefined;
+
+    for await (const event of runOpenCodeCli(command.command, command.args, {
+      cwd,
+      env: providerConfig.env,
+      signal: signal ?? options?.abortController?.signal,
+    })) {
+      if (event.type === "line") {
+        for (const message of parseOpenCodeJsonLine(event.line)) {
+          yield this.withMessageId(message);
+        }
+        continue;
+      }
+
+      closeEvent = event;
+    }
+
+    if (!closeEvent) {
+      return;
+    }
+
+    if (closeEvent.exitCode !== 0) {
+      yield {
+        type: "error",
+        message: formatOpenCodeExitError(closeEvent),
+        messageId: this.generateMessageId(),
+      };
+      return;
+    }
+
+    yield {
+      type: "result",
+      content: "success",
+      duration: closeEvent.duration,
+      messageId: this.generateMessageId(),
+    };
+  }
+
+  private withMessageId(message: AgentMessage): AgentMessage {
+    return message.messageId
+      ? message
+      : { ...message, messageId: this.generateMessageId() };
+  }
+
+  private toErrorMessage(error: unknown): AgentMessage {
+    return {
+      type: "error",
+      message:
+        error instanceof OpenCodeCommandNotFoundError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : String(error),
+      messageId: this.generateMessageId(),
+    };
+  }
+
+  private async resolveAndPrepareWorkDir(options?: AgentOptions) {
+    const rawWorkDir = options?.cwd || this.config.workDir || process.cwd();
+    const resolved = resolveHome(rawWorkDir);
+    await mkdir(resolved, { recursive: true });
+    return resolved;
+  }
+}
+
+function formatOpenCodeExitError(
+  closeEvent: Extract<OpenCodeCliEvent, { type: "close" }>,
+) {
+  const output = closeEvent.stderr.trim() || closeEvent.stdout.trim();
+  return output
+    ? `OpenCode CLI exited with code ${closeEvent.exitCode}: ${output}`
+    : `OpenCode CLI exited with code ${closeEvent.exitCode}`;
+}
+
+function resolveHome(filePath: string) {
+  if (filePath === "~") {
+    return homedir();
+  }
+  if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+    return join(homedir(), filePath.slice(2));
+  }
+  return isAbsolute(filePath) ? filePath : join(process.cwd(), filePath);
+}
+
+export function createOpenCodeAgent(config: AgentConfig): OpenCodeAgent {
+  return new OpenCodeAgent(config);
+}
+
+export const opencodePlugin: AgentPlugin = defineAgentPlugin({
+  metadata: OPENCODE_METADATA,
+  factory: (config) => createOpenCodeAgent(config),
+});

--- a/apps/web/lib/ai/extensions/agent/opencode/metadata.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/metadata.ts
@@ -1,0 +1,53 @@
+import type { AgentProviderMetadata } from "@openloomi/ai/agent/plugin";
+
+export const OPENCODE_CONFIG_SCHEMA = {
+  type: "object",
+  properties: {
+    model: {
+      type: "string",
+      description: "OpenCode model in provider/model format",
+    },
+    workDir: {
+      type: "string",
+      description: "Working directory for OpenCode file operations",
+    },
+    providerConfig: {
+      type: "object",
+      properties: {
+        opencodePath: {
+          type: "string",
+          description: "Path to the opencode CLI executable",
+        },
+        agent: {
+          type: "string",
+          description: "OpenCode agent name to use",
+        },
+        files: {
+          type: "array",
+          items: { type: "string" },
+          description: "Files to attach to the OpenCode message",
+        },
+        allowAutoApprove: {
+          type: "boolean",
+          default: false,
+          description:
+            "Allow passing --auto when OpenLoomi permissionMode is bypassPermissions",
+        },
+      },
+    },
+  },
+};
+
+export const OPENCODE_METADATA: AgentProviderMetadata = {
+  type: "opencode",
+  name: "OpenCode CLI",
+  version: "1.0.0",
+  description:
+    "OpenCode CLI runtime integration using opencode run JSON events.",
+  configSchema: OPENCODE_CONFIG_SCHEMA,
+  builtin: true,
+  supportsPlan: true,
+  supportsStreaming: true,
+  supportsSandbox: false,
+  tags: ["opencode", "cli", "coding-agent"],
+};

--- a/apps/web/lib/ai/extensions/agent/opencode/parser.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/parser.ts
@@ -1,0 +1,206 @@
+import type { AgentMessage } from "@openloomi/ai/agent/types";
+
+export function parseOpenCodeJsonLine(line: string): AgentMessage[] {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  let event: unknown;
+  try {
+    event = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  return convertOpenCodeEvent(event);
+}
+
+export function convertOpenCodeEvent(event: unknown): AgentMessage[] {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return [];
+  }
+
+  const record = event as Record<string, unknown>;
+  const type = readString(record.type) || readString(record.event);
+  const messages: AgentMessage[] = [];
+
+  const isErrorEvent = type?.toLowerCase().includes("error") ?? false;
+  const errorText = extractErrorText(record);
+  if (errorText || isErrorEvent) {
+    messages.push({
+      type: "error",
+      message: errorText || extractText(record) || "OpenCode event error",
+    });
+    return messages;
+  }
+
+  const toolMessage = extractToolMessage(record, type);
+  if (toolMessage) {
+    messages.push(toolMessage);
+    return messages;
+  }
+
+  const text = extractText(record);
+  if (text && shouldTreatAsText(type, record)) {
+    messages.push({
+      type: "text",
+      content: text,
+    });
+    return messages;
+  }
+
+  if (type === "result" || type === "done" || type === "complete") {
+    messages.push({
+      type: "result",
+      content: type,
+      cost: readNumber(record.cost) ?? readNumber(record.total_cost_usd),
+      duration: readNumber(record.duration) ?? readNumber(record.duration_ms),
+    });
+  }
+
+  return messages;
+}
+
+function extractToolMessage(
+  record: Record<string, unknown>,
+  type: string | undefined,
+): AgentMessage | undefined {
+  const lowerType = type?.toLowerCase() ?? "";
+  const tool =
+    asRecord(record.tool) ||
+    asRecord(record.toolCall) ||
+    asRecord(record.tool_call) ||
+    record;
+  const toolName =
+    readString(tool.name) ||
+    readString(tool.toolName) ||
+    readString(tool.tool_name);
+  const toolId =
+    readString(tool.id) ||
+    readString(tool.toolUseId) ||
+    readString(tool.tool_use_id);
+
+  if (!lowerType.includes("tool") && !toolName) {
+    return undefined;
+  }
+
+  const output =
+    readString(tool.output) ||
+    readString(tool.result) ||
+    readString(tool.content);
+
+  if (lowerType.includes("result") || output) {
+    return {
+      type: "tool_result",
+      toolUseId: toolId,
+      output: output ?? "",
+      isError: readBoolean(tool.isError) ?? readBoolean(tool.is_error) ?? false,
+    };
+  }
+
+  if (!toolName) {
+    return undefined;
+  }
+
+  return {
+    type: "tool_use",
+    id: toolId,
+    name: toolName,
+    input:
+      asRecord(tool.input) ||
+      asRecord(tool.args) ||
+      asRecord(tool.arguments) ||
+      undefined,
+  };
+}
+
+function shouldTreatAsText(
+  type: string | undefined,
+  record: Record<string, unknown>,
+) {
+  if (!type) {
+    return true;
+  }
+
+  const lowerType = type.toLowerCase();
+  if (
+    lowerType.includes("text") ||
+    lowerType.includes("message") ||
+    lowerType.includes("assistant") ||
+    lowerType.includes("content") ||
+    lowerType.includes("delta")
+  ) {
+    return true;
+  }
+
+  return (
+    typeof record.text === "string" ||
+    typeof record.delta === "string" ||
+    typeof record.message === "string"
+  );
+}
+
+function extractText(record: Record<string, unknown>): string | undefined {
+  for (const key of ["text", "content", "message", "delta"]) {
+    const value = record[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  const message = asRecord(record.message);
+  if (message) {
+    const text = extractText(message);
+    if (text) return text;
+  }
+
+  const part = asRecord(record.part) || asRecord(record.content_block);
+  if (part) {
+    const text = extractText(part);
+    if (text) return text;
+  }
+
+  if (Array.isArray(record.content)) {
+    const texts = record.content
+      .map((item) => {
+        const itemRecord = asRecord(item);
+        return itemRecord ? extractText(itemRecord) : undefined;
+      })
+      .filter((item): item is string => typeof item === "string");
+    if (texts.length > 0) {
+      return texts.join("");
+    }
+  }
+
+  return undefined;
+}
+
+function extractErrorText(record: Record<string, unknown>): string | undefined {
+  if (typeof record.error === "string") {
+    return record.error;
+  }
+  const error = asRecord(record.error);
+  if (error) {
+    return readString(error.message) || readString(error.name);
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/apps/web/lib/ai/extensions/index.ts
+++ b/apps/web/lib/ai/extensions/index.ts
@@ -5,3 +5,8 @@
  */
 
 export { claudePlugin, createClaudeAgent, ClaudeAgent } from "./agent/claude";
+export {
+  opencodePlugin,
+  createOpenCodeAgent,
+  OpenCodeAgent,
+} from "./agent/opencode";

--- a/apps/web/lib/ai/native-agent/host.ts
+++ b/apps/web/lib/ai/native-agent/host.ts
@@ -1,7 +1,7 @@
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
 import type { NativeAgentHost } from "@openloomi/ai/agent/native-runner";
 
-import { claudePlugin } from "@/lib/ai/extensions";
+import { claudePlugin, opencodePlugin } from "@/lib/ai/extensions";
 import { getDocument, getDocumentChunks } from "@/lib/ai/rag/langchain-service";
 import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
 import {
@@ -18,7 +18,9 @@ function registerNativeAgentProviders() {
     return;
   }
 
-  getAgentRegistry().register(claudePlugin);
+  const registry = getAgentRegistry();
+  registry.register(claudePlugin);
+  registry.register(opencodePlugin);
   providersRegistered = true;
 }
 

--- a/apps/web/lib/ai/runtime/register-plugins.ts
+++ b/apps/web/lib/ai/runtime/register-plugins.ts
@@ -6,10 +6,12 @@
  */
 
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
-import { claudePlugin } from "@/lib/ai/extensions";
+import { claudePlugin, opencodePlugin } from "@/lib/ai/extensions";
 
-// Register Claude Agent plugin
+// Register built-in Agent plugins
 // This must be called AFTER all modules are loaded to avoid circular deps
 export function registerPlugins() {
-  getAgentRegistry().register(claudePlugin);
+  const registry = getAgentRegistry();
+  registry.register(claudePlugin);
+  registry.register(opencodePlugin);
 }

--- a/apps/web/tests/unit/agent-runtime.test.ts
+++ b/apps/web/tests/unit/agent-runtime.test.ts
@@ -3,7 +3,7 @@ import {
   runAgentRuntimeRequest,
   type AgentRuntimePermissionRequest,
 } from "@openloomi/ai/agent/runtime";
-import type { AgentRegistry } from "@openloomi/ai/agent/registry";
+import { AgentRegistry } from "@openloomi/ai/agent/registry";
 import type {
   AgentConfig,
   AgentMessage,
@@ -21,6 +21,25 @@ const silentLogger = {
 };
 
 describe("agent runtime", () => {
+  it("registers and creates arbitrary string providers", () => {
+    const registry = new AgentRegistry();
+    const agent = new PermissionAgent("custom-cli");
+
+    registry.register({
+      metadata: {
+        type: "custom-cli",
+        name: "Custom CLI",
+        supportsPlan: true,
+        supportsStreaming: true,
+        supportsSandbox: false,
+      },
+      factory: () => agent,
+    });
+
+    expect(registry.create({ provider: "custom-cli" })).toBe(agent);
+    expect(registry.getRegistered()).toContain("custom-cli");
+  });
+
   it("runs through the shared runtime and surfaces permission request events", async () => {
     const permissionRequests: AgentRuntimePermissionRequest[] = [];
     const run = await runAgentRuntimeRequest(
@@ -125,7 +144,11 @@ describe("agent runtime", () => {
 });
 
 class PermissionAgent implements IAgent {
-  readonly provider: AgentProvider = "custom";
+  readonly provider: AgentProvider;
+
+  constructor(provider: AgentProvider = "custom") {
+    this.provider = provider;
+  }
 
   async *run(
     _prompt: string,

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -42,6 +42,11 @@ describe("native agent runner", () => {
 
     const agent = new CapturingAgent();
     const registerProviders = vi.fn();
+    const getUserLlmProviderConfig = vi.fn(async () => ({
+      apiKey: "saved-key",
+      baseUrl: "https://llm.example.test",
+      model: "saved-model",
+    }));
     const host: NativeAgentHost = {
       registry: createRegistry(agent),
       registerProviders,
@@ -49,11 +54,7 @@ describe("native agent runner", () => {
         aiSoulPrompt: "answer as the user's operator",
         language: "zh-CN",
       }),
-      getUserLlmProviderConfig: async () => ({
-        apiKey: "saved-key",
-        baseUrl: "https://llm.example.test",
-        model: "saved-model",
-      }),
+      getUserLlmProviderConfig,
       logger: silentLogger,
     };
 
@@ -89,6 +90,10 @@ describe("native agent runner", () => {
     const messages = await collectMessages(run.generator);
 
     expect(registerProviders).toHaveBeenCalledTimes(1);
+    expect(getUserLlmProviderConfig).toHaveBeenCalledWith({
+      userId: "user-1",
+      providerType: "anthropic_compatible",
+    });
     expect(agent.config).toMatchObject({
       provider: "claude",
       apiKey: "saved-key",
@@ -112,6 +117,126 @@ describe("native agent runner", () => {
       "hello from attachment",
     );
     expect(messages).toEqual([{ type: "text", content: "ok" }]);
+  });
+
+  it("passes custom provider config without reading Anthropic settings", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "openloomi-opencode-runner-"));
+    tempDirs.push(workDir);
+
+    const agent = new CapturingAgent();
+    const getUserLlmProviderConfig = vi.fn();
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      getUserLlmProviderConfig,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "use opencode",
+        provider: "opencode",
+        providerConfig: {
+          agent: "build",
+          allowAutoApprove: true,
+        },
+        modelConfig: {
+          apiKey: "anthropic-key-that-should-not-leak",
+          baseUrl: "https://anthropic-compatible.example.test",
+          model: "openai/gpt-5",
+          thinkingLevel: "low",
+        },
+        workDir,
+      },
+      {
+        session: { user: { id: "user-1", type: "regular" } },
+        userId: "user-1",
+        abortController: new AbortController(),
+      },
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    expect(getUserLlmProviderConfig).not.toHaveBeenCalled();
+    expect(agent.config).toMatchObject({
+      provider: "opencode",
+      model: "openai/gpt-5",
+      workDir,
+      providerConfig: {
+        agent: "build",
+        allowAutoApprove: true,
+      },
+    });
+    expect(agent.config?.apiKey).toBeUndefined();
+    expect(agent.config?.baseUrl).toBeUndefined();
+    expect(agent.config?.thinkingLevel).toBeUndefined();
+  });
+
+  it("sanitizes file attachment names before saving to the workspace", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "openloomi-native-files-"));
+    tempDirs.push(workDir);
+
+    const agent = new CapturingAgent();
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "sanitize attachments",
+        provider: "opencode",
+        workDir,
+        fileAttachments: [
+          {
+            name: "../escape.txt",
+            data: Buffer.from("escape").toString("base64"),
+            mimeType: "text/plain",
+          },
+          {
+            name: "/tmp/absolute.txt",
+            data: Buffer.from("absolute").toString("base64"),
+            mimeType: "text/plain",
+          },
+          {
+            name: "nested/name.txt",
+            data: Buffer.from("nested").toString("base64"),
+            mimeType: "text/plain",
+          },
+          {
+            name: "../escape.txt",
+            data: Buffer.from("second escape").toString("base64"),
+            mimeType: "text/plain",
+          },
+        ],
+      },
+      {
+        session: { user: { id: "user-1", type: "regular" } },
+        userId: "user-1",
+        abortController: new AbortController(),
+      },
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    await expect(readFile(join(workDir, "escape.txt"), "utf8")).resolves.toBe(
+      "escape",
+    );
+    await expect(readFile(join(workDir, "absolute.txt"), "utf8")).resolves.toBe(
+      "absolute",
+    );
+    await expect(readFile(join(workDir, "name.txt"), "utf8")).resolves.toBe(
+      "nested",
+    );
+    await expect(readFile(join(workDir, "escape-2.txt"), "utf8")).resolves.toBe(
+      "second escape",
+    );
+
+    await expect(readdir(join(workDir, "nested"))).rejects.toThrow();
+    expect(agent.prompt).toContain("escape.txt");
+    expect(agent.prompt).toContain("escape-2.txt");
+    expect(agent.prompt).not.toContain("../escape.txt");
   });
 });
 

--- a/apps/web/tests/unit/opencode-agent.test.ts
+++ b/apps/web/tests/unit/opencode-agent.test.ts
@@ -1,0 +1,425 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentMessage, TaskPlan } from "@openloomi/ai/agent/types";
+import { OpenCodeAgent } from "@/lib/ai/extensions/agent/opencode";
+import { buildOpenCodeRunCommand } from "@/lib/ai/extensions/agent/opencode/command";
+import { parseOpenCodeJsonLine } from "@/lib/ai/extensions/agent/opencode/parser";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("OpenCode command builder", () => {
+  it("builds the MVP run command without --auto by default", () => {
+    const command = buildOpenCodeRunCommand({
+      prompt: "fix the tests",
+      cwd: "/workspace/project",
+      model: "anthropic/claude-sonnet-4.6",
+      providerConfig: {
+        agent: "build",
+        files: ["src/a.ts", "src/b.ts"],
+        allowAutoApprove: true,
+      },
+    });
+
+    expect(command.command).toBe("opencode");
+    expect(command.args).toEqual([
+      "run",
+      "--format",
+      "json",
+      "--dir",
+      "/workspace/project",
+      "--model",
+      "anthropic/claude-sonnet-4.6",
+      "--agent",
+      "build",
+      "--file",
+      "src/a.ts",
+      "--file",
+      "src/b.ts",
+      "fix the tests",
+    ]);
+    expect(command.args).not.toContain("--auto");
+  });
+
+  it("passes --auto only for bypassPermissions with explicit provider opt-in", () => {
+    const command = buildOpenCodeRunCommand({
+      prompt: "ship it",
+      cwd: "/workspace/project",
+      permissionMode: "bypassPermissions",
+      providerConfig: {
+        allowAutoApprove: true,
+      },
+    });
+
+    expect(command.args).toContain("--auto");
+    expect(command.args.at(-1)).toBe("ship it");
+  });
+
+  it("does not pass --auto for bypassPermissions without explicit opt-in", () => {
+    const command = buildOpenCodeRunCommand({
+      prompt: "ship it",
+      cwd: "/workspace/project",
+      permissionMode: "bypassPermissions",
+      providerConfig: {
+        allowAutoApprove: false,
+      },
+    });
+
+    expect(command.args).not.toContain("--auto");
+  });
+
+  it("does not allow file values to smuggle --auto", () => {
+    const command = buildOpenCodeRunCommand({
+      prompt: "inspect files",
+      cwd: "/workspace/project",
+      providerConfig: {
+        files: ["safe.ts", "--auto"],
+      },
+    });
+
+    expect(command.args).toContain("safe.ts");
+    expect(command.args).not.toContain("--auto");
+  });
+});
+
+describe("OpenCode parser", () => {
+  it("parses a JSON text event", () => {
+    expect(
+      parseOpenCodeJsonLine(JSON.stringify({ type: "text", text: "hello" })),
+    ).toEqual([
+      {
+        type: "text",
+        content: "hello",
+      },
+    ]);
+  });
+
+  it("parses nested text events", () => {
+    expect(
+      parseOpenCodeJsonLine(
+        JSON.stringify({
+          type: "message",
+          message: { content: "nested hello" },
+        }),
+      ),
+    ).toEqual([
+      {
+        type: "text",
+        content: "nested hello",
+      },
+    ]);
+  });
+
+  it("parses partial tool result events", () => {
+    expect(
+      parseOpenCodeJsonLine(
+        JSON.stringify({ type: "tool_result", tool_use_id: "tool-1" }),
+      ),
+    ).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-1",
+        output: "",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("parses error events", () => {
+    expect(
+      parseOpenCodeJsonLine(
+        JSON.stringify({ type: "error", error: { message: "bad run" } }),
+      ),
+    ).toEqual([
+      {
+        type: "error",
+        message: "bad run",
+      },
+    ]);
+  });
+
+  it("parses done events as result messages", () => {
+    expect(
+      parseOpenCodeJsonLine(
+        JSON.stringify({ type: "done", cost: 0.25, duration_ms: 123 }),
+      ),
+    ).toEqual([
+      {
+        type: "result",
+        content: "done",
+        cost: 0.25,
+        duration: 123,
+      },
+    ]);
+  });
+
+  it("ignores invalid JSON lines", () => {
+    expect(parseOpenCodeJsonLine("not-json")).toEqual([]);
+  });
+
+  it("ignores unknown JSON events without crashing", () => {
+    expect(
+      parseOpenCodeJsonLine(JSON.stringify({ type: "unknown", raw: true })),
+    ).toEqual([]);
+  });
+});
+
+describe("OpenCodeAgent", () => {
+  it("does not pass --auto during planning", async () => {
+    const workDir = await createFakeOpenCodeWorkDir(`
+const fs = require("node:fs");
+fs.writeFileSync("args.json", JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({
+  type: "text",
+  text: JSON.stringify({ type: "direct_answer", answer: "ok" })
+}));
+`);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: process.execPath,
+        allowAutoApprove: true,
+      },
+    });
+
+    await collectMessages(
+      agent.plan("make a plan", { permissionMode: "bypassPermissions" }),
+    );
+
+    const args = JSON.parse(
+      await readFile(join(workDir, "args.json"), "utf8"),
+    ) as string[];
+    expect(args).not.toContain("--auto");
+  });
+
+  it("stops a running OpenCode process through the session controller", async () => {
+    const workDir = await createFakeOpenCodeWorkDir(`
+console.log(JSON.stringify({ type: "text", text: "started" }));
+setInterval(() => {}, 1000);
+`);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: process.execPath,
+      },
+    });
+    const generator = agent.run("run for a while");
+
+    const sessionResult = await generator.next();
+    const sessionMessage = sessionResult.value as AgentMessage;
+    expect(sessionMessage.type).toBe("session");
+    expect(sessionMessage.sessionId).toBeTruthy();
+    const sessionId = sessionMessage.sessionId;
+    if (!sessionId) {
+      throw new Error("Expected OpenCode run to yield a session id");
+    }
+
+    await expect(generator.next()).resolves.toMatchObject({
+      value: { type: "text", content: "started" },
+      done: false,
+    });
+
+    await agent.stop(sessionId);
+    const remainingMessages = await withTimeout(
+      collectMessages(generator),
+      5000,
+    );
+
+    expect(remainingMessages.some((message) => message.type === "error")).toBe(
+      true,
+    );
+    expect(remainingMessages.at(-1)?.type).toBe("done");
+  });
+
+  it("converts a nonzero CLI exit into an error message", async () => {
+    const workDir = await createFakeOpenCodeWorkDir(`
+console.log(JSON.stringify({ type: "text", text: "partial output" }));
+console.error("simulated failure");
+process.exit(7);
+`);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: process.execPath,
+      },
+    });
+
+    const messages = await collectMessages(agent.run("do work"));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "partial output" }),
+      ]),
+    );
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("OpenCode CLI exited with code 7"),
+    });
+    expect(
+      messages.find((message) => message.type === "error")?.message,
+    ).toContain("simulated failure");
+    expect(messages.at(-1)?.type).toBe("done");
+  });
+
+  it("returns a clear error when the opencode executable is missing", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "openloomi-opencode-test-"));
+    tempDirs.push(workDir);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: "definitely-not-openloomi-opencode",
+      },
+    });
+
+    const messages = await collectMessages(agent.run("do work"));
+
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("OpenCode CLI executable not found"),
+    });
+    expect(messages.at(-1)?.type).toBe("done");
+  });
+
+  it("retains a plan after failed execution and deletes it after success", async () => {
+    const workDir = await createFakeOpenCodeWorkDir(`
+const response = {
+  type: "plan",
+  goal: "Do work",
+  steps: [{ id: "1", description: "Complete implementation" }]
+};
+console.log(JSON.stringify({ type: "text", text: JSON.stringify(response) }));
+`);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: process.execPath,
+      },
+    });
+
+    const planMessages = await collectMessages(agent.plan("plan the work"));
+    const plan = planMessages.find((message) => message.type === "plan")
+      ?.plan as TaskPlan | undefined;
+    expect(plan).toBeDefined();
+    if (!plan) {
+      throw new Error("Expected OpenCode planning to produce a plan");
+    }
+    const planId = plan.id;
+
+    await writeFakeOpenCodeScript(
+      workDir,
+      `
+console.error("execution failed");
+process.exit(9);
+`,
+    );
+
+    const failedMessages = await collectMessages(
+      agent.execute({ planId, originalPrompt: "do work" }),
+    );
+
+    expect(
+      failedMessages.find((message) => message.type === "error"),
+    ).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("execution failed"),
+    });
+    expect(agent.getPlan(planId)).toBe(plan);
+
+    await writeFakeOpenCodeScript(
+      workDir,
+      `
+console.log(JSON.stringify({ type: "text", text: "done" }));
+`,
+    );
+
+    await collectMessages(agent.execute({ planId, originalPrompt: "do work" }));
+    expect(agent.getPlan(planId)).toBeUndefined();
+  });
+
+  it("exposes OpenCode metadata from the providers API without changing the default", async () => {
+    const { GET } = await import("@/app/api/native/providers/route");
+
+    const response = await GET();
+    const body = (await response.json()) as {
+      agents: Array<{ type: string; supportsSandbox: boolean }>;
+      defaultAgent: string;
+    };
+
+    expect(body.defaultAgent).toBe("claude");
+    expect(body.agents.filter((agent) => agent.type === "claude")).toHaveLength(
+      1,
+    );
+    expect(
+      body.agents.filter((agent) => agent.type === "opencode"),
+    ).toHaveLength(1);
+    expect(body.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "opencode",
+          supportsSandbox: false,
+        }),
+      ]),
+    );
+  });
+});
+
+async function createFakeOpenCodeWorkDir(script: string) {
+  const workDir = await mkdtemp(join(tmpdir(), "openloomi-opencode-test-"));
+  tempDirs.push(workDir);
+  await writeFakeOpenCodeScript(workDir, script);
+  return workDir;
+}
+
+async function writeFakeOpenCodeScript(workDir: string, script: string) {
+  await writeFile(join(workDir, "run"), script, "utf8");
+}
+
+async function collectMessages(
+  generator: AsyncGenerator<AgentMessage>,
+): Promise<AgentMessage[]> {
+  const messages: AgentMessage[] = [];
+  for await (const message of generator) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -10,6 +10,7 @@ export type {
   AgentMessage,
   AgentMessageType,
   AgentOptions,
+  BuiltinAgentProvider,
   AgentProvider,
   AgentQuestion,
   AgentRequest,

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_ALLOWED_TOOLS,
   type AgentConfig,
   type AgentOptions,
+  type AgentProvider,
   type FileAttachment,
   type ImageAttachment,
 } from "../types";
@@ -29,7 +30,8 @@ export interface NativeAgentRequest {
   workDir?: string;
   useProvidedWorkDir?: boolean;
   taskId?: string;
-  provider?: "claude" | "deepagents";
+  provider?: AgentProvider;
+  providerConfig?: Record<string, unknown>;
   modelConfig?: {
     apiKey?: string;
     baseUrl?: string;
@@ -200,10 +202,15 @@ async function buildAgentConfig(
   userId: string,
   host: NativeAgentHost,
 ): Promise<AgentConfig> {
-  const userAnthropicConfig = await host.getUserLlmProviderConfig?.({
-    userId,
-    providerType: "anthropic_compatible",
-  });
+  const provider = body.provider || "claude";
+  const useAnthropicCompatibleConfig = provider === "claude";
+
+  const userAnthropicConfig = useAnthropicCompatibleConfig
+    ? await host.getUserLlmProviderConfig?.({
+        userId,
+        providerType: "anthropic_compatible",
+      })
+    : undefined;
 
   const effectiveModelConfig = {
     ...body.modelConfig,
@@ -213,12 +220,19 @@ async function buildAgentConfig(
   // User-saved Anthropic settings win over request defaults such as the
   // frontend's selectedModel fallback to claude-sonnet-4.6.
   return {
-    provider: body.provider || "claude",
-    apiKey: effectiveModelConfig.apiKey,
-    baseUrl: effectiveModelConfig.baseUrl,
+    provider,
+    apiKey: useAnthropicCompatibleConfig
+      ? effectiveModelConfig.apiKey
+      : undefined,
+    baseUrl: useAnthropicCompatibleConfig
+      ? effectiveModelConfig.baseUrl
+      : undefined,
     model: effectiveModelConfig.model,
-    thinkingLevel: body.modelConfig?.thinkingLevel,
+    thinkingLevel: useAnthropicCompatibleConfig
+      ? body.modelConfig?.thinkingLevel
+      : undefined,
     workDir: body.workDir,
+    providerConfig: body.providerConfig,
   };
 }
 
@@ -593,6 +607,7 @@ async function saveFileAttachmentsToWorkspace(
 ): Promise<string[]> {
   const savedFilePaths: string[] = [];
   const resolvedWorkDir = resolveHomeDir(workDir);
+  const usedFileNames = new Set<string>();
 
   if (!existsSync(resolvedWorkDir)) {
     await fs.mkdir(resolvedWorkDir, { recursive: true });
@@ -602,14 +617,18 @@ async function saveFileAttachmentsToWorkspace(
     );
   }
 
-  for (const attachment of fileAttachments) {
+  for (const [index, attachment] of fileAttachments.entries()) {
     try {
       const base64Data = attachment.data.includes(",")
         ? attachment.data.split(",")[1]
         : attachment.data;
 
       const buffer = Buffer.from(base64Data, "base64");
-      const filePath = path.join(resolvedWorkDir, attachment.name);
+      const safeFileName = makeUniqueFileName(
+        sanitizeAttachmentFileName(attachment.name, index),
+        usedFileNames,
+      );
+      const filePath = path.join(resolvedWorkDir, safeFileName);
 
       await fs.writeFile(filePath, buffer);
       savedFilePaths.push(filePath);
@@ -626,6 +645,36 @@ async function saveFileAttachmentsToWorkspace(
   }
 
   return savedFilePaths;
+}
+
+function sanitizeAttachmentFileName(fileName: string, index: number): string {
+  const fallback = `attachment-${index + 1}`;
+  const baseName = path
+    .basename(fileName.replace(/\\/g, "/"))
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
+    .trim();
+  const normalized = baseName.replace(/^\.+$/, "").trim();
+  return normalized || fallback;
+}
+
+function makeUniqueFileName(fileName: string, usedFileNames: Set<string>) {
+  if (!usedFileNames.has(fileName)) {
+    usedFileNames.add(fileName);
+    return fileName;
+  }
+
+  const extension = path.extname(fileName);
+  const stem = extension ? fileName.slice(0, -extension.length) : fileName;
+  let counter = 2;
+
+  while (true) {
+    const candidate = `${stem}-${counter}${extension}`;
+    if (!usedFileNames.has(candidate)) {
+      usedFileNames.add(candidate);
+      return candidate;
+    }
+    counter += 1;
+  }
 }
 
 async function saveRAGDocumentsToWorkspace(

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -333,7 +333,8 @@ export interface PlanStep {
 // Agent Configuration
 // ============================================================================
 
-export type AgentProvider = "claude" | "codex" | "deepagents" | "custom";
+export type BuiltinAgentProvider = "claude" | "codex" | "deepagents" | "custom";
+export type AgentProvider = BuiltinAgentProvider | (string & {});
 
 export interface AgentConfig {
   /** Agent provider to use */
@@ -656,7 +657,9 @@ export interface AgentRequest {
   workDir?: string; // Working directory for session outputs
   taskId?: string; // Task ID for session folder
   /** Provider selection (optional, defaults to env config) */
-  provider?: "claude" | "deepagents";
+  provider?: AgentProvider;
+  /** Provider-specific configuration */
+  providerConfig?: Record<string, unknown>;
   /** Custom model configuration */
   modelConfig?: ModelConfig;
   /** Sandbox configuration for isolated execution */


### PR DESCRIPTION
## Summary

Implements Issue #194 Phase 1 by making agent runtime providers extensible and adding an OpenCode CLI runtime provider.

This PR only adds OpenCode as an `AgentPlugin` / `IAgent` runtime provider. It does not add or modify any sandbox provider, and Claude remains the default agent provider.

## Changes

- Loosened `AgentProvider` to support custom string providers while keeping built-in provider names.
- Added `providerConfig` passthrough for native agent requests and agent config.
- Updated native runner config handling so Anthropic-compatible user settings are only read for `provider === "claude"`.
- Added OpenCode CLI provider:
  - `opencode run --format json --dir <cwd> [--model <model>] [--agent <agent>] [--file <file>...] <prompt>`
  - NDJSON stdout parsing.
  - stderr/stdout collection.
  - AbortSignal support.
  - Windows process-tree cleanup via `taskkill /F /T /PID`.
  - Friendly command-not-found errors.
- Ensured OpenCode does not pass `--auto` by default.
- Allowed `--auto` only when `permissionMode === "bypassPermissions"` and `providerConfig.allowAutoApprove === true`.
- Forced OpenCode planning runs to avoid `--auto`.
- Made OpenCode execution retain plans on failure and delete plans only after successful execution.
- Sanitized native-runner file attachment names before saving to the workspace.
- Registered OpenCode in extension exports, native agent host, runtime plugin registration, and native providers API.
- Kept `defaultAgent` as Claude.
- Kept OpenCode metadata `supportsSandbox: false`.

## Tests

Added or expanded coverage for:

- `AgentRegistry` accepting arbitrary string providers.
- OpenCode command builder argument shape.
- `--auto` gating behavior.
- Prevention of `--file --auto` flag smuggling.
- OpenCode parser handling text, nested text, partial tool result, error, done, invalid JSON, and unknown events.
- OpenCode command-not-found error handling.
- Nonzero OpenCode exit producing an `AgentMessage` error with stderr.
- OpenCode `stop(sessionId)` terminating a running CLI process.
- OpenCode planning not passing `--auto`.
- Failed execution retaining plan for retry.
- Successful execution deleting plan.
- Providers API returning Claude and OpenCode metadata without duplicates.
- OpenCode `supportsSandbox: false`.
- Native runner not reading or injecting Anthropic-compatible config for OpenCode.
- Native runner preserving Claude Anthropic-compatible behavior.
- File attachment filename sanitization.

## Verification

Passed:

```bash
pnpm exec prettier --check -- <changed files>
pnpm --filter web lint
pnpm --filter web test -- tests/unit/agent-runtime.test.ts tests/unit/native-agent-runner.test.ts tests/unit/opencode-agent.test.ts
pnpm --filter web tsc

re #194 