### PR TITLE
feat(agent): support env-selected OpenCode runtime

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,6 +10,19 @@ ANTHROPIC_API_KEY=****
 ANTHROPIC_AUTH_TOKEN=****
 ANTHROPIC_MODEL=****
 
+# Agent runtime provider (optional)
+# Defaults to Claude. Set to "opencode" to run native agent tasks through a
+# locally installed OpenCode CLI. OpenCode is an AgentPlugin/IAgent runtime
+# provider, not a sandbox provider, and it is not installed automatically.
+# OPENLOOMI_AGENT_PROVIDER=opencode
+# OPENLOOMI_AGENT_OPENCODE_COMMAND=opencode
+# OPENLOOMI_AGENT_OPENCODE_MODEL=anthropic/claude-sonnet-4.6
+# OPENLOOMI_AGENT_OPENCODE_AGENT=build
+# OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS=300000
+# --auto remains off by default. This only permits --auto when the request
+# permission mode is also bypassPermissions.
+# OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE=false
+
 # Cloud API Configuration for Tauri Desktop App
 # Tauri version uses cloud API for user authentication and data sync
 # Set to your cloud server address (e.g., https://app.alloomi.ai)

--- a/apps/web/app/api/native/providers/route.ts
+++ b/apps/web/app/api/native/providers/route.ts
@@ -14,7 +14,7 @@ import {
   getAllAgentMetadata,
 } from "@openloomi/ai/agent/registry";
 import { opencodePlugin } from "@/lib/ai/extensions/agent/opencode";
-import { DEFAULT_AGENT_PROVIDER } from "@/lib/env/config/constants";
+import { getConfiguredDefaultAgentProvider } from "@/lib/ai/native-agent/provider-env";
 
 // Register lightweight built-in Agent plugins used by this metadata route.
 const registry = getAgentRegistry();
@@ -41,7 +41,7 @@ export async function GET() {
 
     return NextResponse.json({
       agents: agentProviders,
-      defaultAgent: DEFAULT_AGENT_PROVIDER,
+      defaultAgent: getConfiguredDefaultAgentProvider(),
     });
   } catch (error) {
     console.error("[ProvidersAPI] Error:", error);

--- a/apps/web/lib/ai/extensions/agent/opencode/command.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/command.ts
@@ -8,6 +8,7 @@ export interface OpenCodeProviderConfig {
   agent?: string;
   files?: string[];
   allowAutoApprove?: boolean;
+  timeoutMs?: number;
   env?: Record<string, string>;
 }
 
@@ -32,6 +33,8 @@ export type OpenCodeCliEvent =
       stderr: string;
       exitCode: number;
       duration: number;
+      timedOut?: boolean;
+      timeoutMs?: number;
     };
 
 export class OpenCodeCommandNotFoundError extends Error {
@@ -72,6 +75,12 @@ export function normalizeOpenCodeProviderConfig(
         : undefined,
     files,
     allowAutoApprove: value?.allowAutoApprove === true,
+    timeoutMs:
+      typeof value?.timeoutMs === "number" &&
+      Number.isInteger(value.timeoutMs) &&
+      value.timeoutMs > 0
+        ? value.timeoutMs
+        : undefined,
     env,
   };
 }
@@ -115,6 +124,7 @@ export async function* runOpenCodeCli(
     cwd: string;
     env?: Record<string, string>;
     signal?: AbortSignal;
+    timeoutMs?: number;
   },
 ): AsyncGenerator<OpenCodeCliEvent> {
   const startTime = Date.now();
@@ -124,6 +134,8 @@ export async function* runOpenCodeCli(
   let stderr = "";
   let stdoutBuffer = "";
   let done = false;
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   let spawnError: Error | undefined;
   let proc: ChildProcessWithoutNullStreams;
 
@@ -170,6 +182,12 @@ export async function* runOpenCodeCli(
   if (options.signal?.aborted) {
     abortHandler();
   }
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      killProcessTree(proc);
+    }, options.timeoutMs);
+  }
 
   proc.stdout.on("data", (chunk: Buffer) => {
     const text = chunk.toString();
@@ -183,6 +201,10 @@ export async function* runOpenCodeCli(
   });
 
   proc.on("error", (error: Error & { code?: string }) => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
     spawnError = isCommandNotFoundError(error)
       ? new OpenCodeCommandNotFoundError(command)
       : error;
@@ -191,6 +213,10 @@ export async function* runOpenCodeCli(
   });
 
   proc.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
     if (stdoutBuffer.trim()) {
       push({ type: "line", line: stdoutBuffer });
       stdoutBuffer = "";
@@ -199,8 +225,10 @@ export async function* runOpenCodeCli(
       type: "close",
       stdout,
       stderr,
-      exitCode: code ?? (signal ? 130 : 0),
+      exitCode: timedOut ? 124 : (code ?? (signal ? 130 : 0)),
       duration: Date.now() - startTime,
+      timedOut,
+      timeoutMs: timedOut ? options.timeoutMs : undefined,
     });
     done = true;
     wake();
@@ -227,6 +255,10 @@ export async function* runOpenCodeCli(
       throw spawnError;
     }
   } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
     options.signal?.removeEventListener("abort", abortHandler);
   }
 }

--- a/apps/web/lib/ai/extensions/agent/opencode/index.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/index.ts
@@ -221,6 +221,7 @@ export class OpenCodeAgent extends BaseAgent {
       cwd,
       env: providerConfig.env,
       signal: signal ?? options?.abortController?.signal,
+      timeoutMs: providerConfig.timeoutMs,
     })) {
       if (event.type === "line") {
         for (const message of parseOpenCodeJsonLine(event.line)) {
@@ -284,6 +285,12 @@ function formatOpenCodeExitError(
   closeEvent: Extract<OpenCodeCliEvent, { type: "close" }>,
 ) {
   const output = closeEvent.stderr.trim() || closeEvent.stdout.trim();
+  if (closeEvent.timedOut) {
+    return output
+      ? `OpenCode CLI timed out after ${closeEvent.timeoutMs}ms: ${output}`
+      : `OpenCode CLI timed out after ${closeEvent.timeoutMs}ms`;
+  }
+
   return output
     ? `OpenCode CLI exited with code ${closeEvent.exitCode}: ${output}`
     : `OpenCode CLI exited with code ${closeEvent.exitCode}`;

--- a/apps/web/lib/ai/extensions/agent/opencode/metadata.ts
+++ b/apps/web/lib/ai/extensions/agent/opencode/metadata.ts
@@ -33,6 +33,10 @@ export const OPENCODE_CONFIG_SCHEMA = {
           description:
             "Allow passing --auto when OpenLoomi permissionMode is bypassPermissions",
         },
+        timeoutMs: {
+          type: "number",
+          description: "Maximum OpenCode CLI runtime in milliseconds",
+        },
       },
     },
   },

--- a/apps/web/lib/ai/native-agent/host.ts
+++ b/apps/web/lib/ai/native-agent/host.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/db/queries";
 import { readFile } from "@/lib/storage";
 import { detectSudoPasswordPrompt } from "./sudo";
+import { resolveNativeAgentProviderRequest } from "./provider-env";
 
 let providersRegistered = false;
 
@@ -34,6 +35,7 @@ function registerNativeAgentProviders() {
 export const nativeAgentHost: NativeAgentHost = {
   registry: getAgentRegistry(),
   registerProviders: registerNativeAgentProviders,
+  prepareRequest: (body) => resolveNativeAgentProviderRequest(body),
   getUserInsightSettings,
   getUserLlmProviderConfig,
   getDocument,

--- a/apps/web/lib/ai/native-agent/provider-env.ts
+++ b/apps/web/lib/ai/native-agent/provider-env.ts
@@ -1,0 +1,180 @@
+import {
+  NativeAgentRequestError,
+  type NativeAgentRequest,
+} from "@openloomi/ai/agent/native-runner";
+import type { AgentProvider } from "@openloomi/ai/agent/types";
+
+type EnvSource = Record<string, string | undefined>;
+
+const DEFAULT_AGENT_PROVIDER: AgentProvider = "claude";
+const ENV_PROVIDER_KEY = "OPENLOOMI_AGENT_PROVIDER";
+const OPENCODE_PROVIDER = "opencode";
+const SUPPORTED_ENV_PROVIDERS = new Set(["claude", OPENCODE_PROVIDER]);
+
+export function getConfiguredDefaultAgentProvider(
+  env: EnvSource = process.env,
+): AgentProvider {
+  return resolveEnvAgentProvider(env) ?? DEFAULT_AGENT_PROVIDER;
+}
+
+export function resolveNativeAgentProviderRequest(
+  body: NativeAgentRequest,
+  env: EnvSource = process.env,
+): NativeAgentRequest {
+  const provider =
+    resolveRequestAgentProvider(body.provider) ??
+    getConfiguredDefaultAgentProvider(env);
+
+  if (provider !== OPENCODE_PROVIDER) {
+    return {
+      ...body,
+      provider,
+    };
+  }
+
+  const opencodeEnvConfig = resolveOpenCodeEnvConfig(env);
+  const requestProviderConfig = isRecord(body.providerConfig)
+    ? body.providerConfig
+    : {};
+  const envAllowAutoApprove =
+    opencodeEnvConfig.providerConfig.allowAutoApprove === true;
+  const requestDisablesAutoApprove =
+    requestProviderConfig.allowAutoApprove === false;
+
+  const providerConfig = {
+    ...opencodeEnvConfig.providerConfig,
+    ...requestProviderConfig,
+    allowAutoApprove: envAllowAutoApprove && !requestDisablesAutoApprove,
+  };
+
+  const requestModel = normalizeOptionalString(body.modelConfig?.model);
+  const modelConfig =
+    opencodeEnvConfig.model && !requestModel
+      ? { ...body.modelConfig, model: opencodeEnvConfig.model }
+      : body.modelConfig;
+
+  return {
+    ...body,
+    provider,
+    modelConfig,
+    providerConfig,
+  };
+}
+
+function resolveRequestAgentProvider(
+  provider: NativeAgentRequest["provider"],
+): AgentProvider | undefined {
+  if (typeof provider !== "string") {
+    return undefined;
+  }
+
+  const trimmed = provider.trim();
+  return trimmed ? (trimmed as AgentProvider) : undefined;
+}
+
+function resolveEnvAgentProvider(env: EnvSource): AgentProvider | undefined {
+  const rawProvider = normalizeOptionalString(env[ENV_PROVIDER_KEY]);
+  if (!rawProvider) {
+    return undefined;
+  }
+
+  const provider = rawProvider.toLowerCase();
+  if (!SUPPORTED_ENV_PROVIDERS.has(provider)) {
+    throwConfigError(
+      `Unsupported ${ENV_PROVIDER_KEY}: ${rawProvider}. Supported values: claude, opencode.`,
+    );
+  }
+
+  return provider as AgentProvider;
+}
+
+function resolveOpenCodeEnvConfig(env: EnvSource) {
+  const providerConfig: Record<string, unknown> = {};
+  const command = normalizeOptionalString(env.OPENLOOMI_AGENT_OPENCODE_COMMAND);
+  const agent = normalizeOptionalString(env.OPENLOOMI_AGENT_OPENCODE_AGENT);
+  const model = normalizeOptionalString(env.OPENLOOMI_AGENT_OPENCODE_MODEL);
+  const timeoutMs = parsePositiveIntegerEnv(
+    env,
+    "OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS",
+  );
+  const allowAutoApprove = parseBooleanEnv(
+    env,
+    "OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE",
+  );
+
+  if (command) {
+    providerConfig.opencodePath = command;
+  }
+  if (agent) {
+    providerConfig.agent = agent;
+  }
+  if (timeoutMs !== undefined) {
+    providerConfig.timeoutMs = timeoutMs;
+  }
+  if (allowAutoApprove !== undefined) {
+    providerConfig.allowAutoApprove = allowAutoApprove;
+  }
+
+  return {
+    model,
+    providerConfig,
+  };
+}
+
+function parseBooleanEnv(env: EnvSource, key: string): boolean | undefined {
+  const raw = normalizeOptionalString(env[key]);
+  if (!raw) {
+    return undefined;
+  }
+
+  switch (raw.toLowerCase()) {
+    case "true":
+    case "1":
+      return true;
+    case "false":
+    case "0":
+      return false;
+    default:
+      throwConfigError(
+        `${key} must be one of true, false, 1, or 0. Received: ${raw}.`,
+      );
+  }
+}
+
+function parsePositiveIntegerEnv(
+  env: EnvSource,
+  key: string,
+): number | undefined {
+  const raw = normalizeOptionalString(env[key]);
+  if (!raw) {
+    return undefined;
+  }
+
+  if (!/^\d+$/.test(raw)) {
+    throwConfigError(`${key} must be a positive integer. Received: ${raw}.`);
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throwConfigError(`${key} must be a positive integer. Received: ${raw}.`);
+  }
+
+  return parsed;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function throwConfigError(message: string): never {
+  throw new NativeAgentRequestError(message, 500);
+}

--- a/apps/web/tests/unit/native-agent-provider-env.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-env.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildOpenCodeRunCommand } from "@/lib/ai/extensions/agent/opencode/command";
+import {
+  getConfiguredDefaultAgentProvider,
+  resolveNativeAgentProviderRequest,
+} from "@/lib/ai/native-agent/provider-env";
+import type { NativeAgentRequest } from "@openloomi/ai/agent/native-runner";
+
+const AGENT_ENV_KEYS = [
+  "OPENLOOMI_AGENT_PROVIDER",
+  "OPENLOOMI_AGENT_OPENCODE_COMMAND",
+  "OPENLOOMI_AGENT_OPENCODE_MODEL",
+  "OPENLOOMI_AGENT_OPENCODE_AGENT",
+  "OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS",
+  "OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE",
+];
+
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = process.env;
+  process.env = { ...originalEnv };
+  clearAgentEnv(process.env);
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("native agent provider env resolver", () => {
+  it("defaults to Claude without env or request provider", () => {
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.provider).toBe("claude");
+    expect(getConfiguredDefaultAgentProvider()).toBe("claude");
+  });
+
+  it("uses OpenCode from env when the request does not specify a provider", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.provider).toBe("opencode");
+    expect(getConfiguredDefaultAgentProvider()).toBe("opencode");
+  });
+
+  it("lets request provider override env provider", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      provider: "claude",
+    });
+
+    expect(request.provider).toBe("claude");
+  });
+
+  it("treats an empty provider env value as unconfigured", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "  ";
+
+    expect(resolveNativeAgentProviderRequest(baseRequest()).provider).toBe(
+      "claude",
+    );
+  });
+
+  it("fails clearly for an unknown env provider", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "unknown-runtime";
+
+    expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+      /Unsupported OPENLOOMI_AGENT_PROVIDER/,
+    );
+  });
+
+  it.each([
+    ["true", true],
+    ["1", true],
+    ["false", false],
+    ["0", false],
+  ])("parses allowAutoApprove boolean value %s", (rawValue, expected) => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE = rawValue;
+
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.providerConfig).toMatchObject({
+      allowAutoApprove: expected,
+    });
+  });
+
+  it("fails clearly for an invalid allowAutoApprove value", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE = "yes-please";
+
+    expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+      /OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE/,
+    );
+  });
+
+  it("parses a positive OpenCode timeout", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS = "2500";
+
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.providerConfig).toMatchObject({ timeoutMs: 2500 });
+  });
+
+  it.each(["0", "-1", "1.5", "slow"])(
+    "fails clearly for invalid OpenCode timeout %s",
+    (rawValue) => {
+      process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+      process.env.OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS = rawValue;
+
+      expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+        /OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS/,
+      );
+    },
+  );
+
+  it("lets request model override env model", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_MODEL = "env/model";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      modelConfig: { model: "request/model" },
+    });
+
+    expect(request.modelConfig?.model).toBe("request/model");
+  });
+
+  it("lets request providerConfig fields override env providerConfig fields", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND = "env-opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_AGENT = "env-agent";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      providerConfig: {
+        opencodePath: "request-opencode",
+        agent: "request-agent",
+      },
+    });
+
+    expect(request.providerConfig).toMatchObject({
+      opencodePath: "request-opencode",
+      agent: "request-agent",
+    });
+  });
+
+  it("does not let request allowAutoApprove enable --auto without the env cap", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      providerConfig: {
+        allowAutoApprove: true,
+      },
+    });
+    const command = buildOpenCodeRunCommand({
+      prompt: "ship it",
+      cwd: "/workspace/project",
+      permissionMode: "bypassPermissions",
+      providerConfig: request.providerConfig,
+    });
+
+    expect(request.providerConfig).toMatchObject({
+      allowAutoApprove: false,
+    });
+    expect(command.args).not.toContain("--auto");
+  });
+
+  it("lets request lower env-capped allowAutoApprove", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE = "true";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      providerConfig: {
+        allowAutoApprove: false,
+      },
+    });
+
+    expect(request.providerConfig).toMatchObject({
+      allowAutoApprove: false,
+    });
+  });
+});
+
+function baseRequest(): NativeAgentRequest {
+  return {
+    prompt: "hello",
+  };
+}
+
+function clearAgentEnv(env: NodeJS.ProcessEnv) {
+  for (const key of AGENT_ENV_KEYS) {
+    delete env[key];
+  }
+}

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -17,6 +17,7 @@ import type {
   IAgent,
   TaskPlan,
 } from "@openloomi/ai/agent/types";
+import { resolveNativeAgentProviderRequest } from "@/lib/ai/native-agent/provider-env";
 
 const silentLogger = {
   log: () => {},
@@ -36,6 +37,133 @@ afterEach(async () => {
 });
 
 describe("native agent runner", () => {
+  it("defaults to Claude when no env or request provider is configured", async () => {
+    const agent = new CapturingAgent();
+    const getUserLlmProviderConfig = vi.fn(async () => ({
+      apiKey: "saved-key",
+      baseUrl: "https://llm.example.test",
+      model: "saved-model",
+    }));
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      prepareRequest: (body) => resolveNativeAgentProviderRequest(body, {}),
+      getUserLlmProviderConfig,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "default provider",
+        modelConfig: {
+          apiKey: "request-key",
+          model: "request-model",
+          thinkingLevel: "low",
+        },
+      },
+      createContext(),
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    expect(getUserLlmProviderConfig).toHaveBeenCalledWith({
+      userId: "user-1",
+      providerType: "anthropic_compatible",
+    });
+    expect(agent.config).toMatchObject({
+      provider: "claude",
+      apiKey: "saved-key",
+      baseUrl: "https://llm.example.test",
+      model: "saved-model",
+      thinkingLevel: "low",
+    });
+  });
+
+  it("uses OpenCode env defaults when request provider is not set", async () => {
+    const agent = new CapturingAgent();
+    const getUserLlmProviderConfig = vi.fn();
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      prepareRequest: (body) =>
+        resolveNativeAgentProviderRequest(body, {
+          OPENLOOMI_AGENT_PROVIDER: "opencode",
+          OPENLOOMI_AGENT_OPENCODE_COMMAND: "env-opencode",
+          OPENLOOMI_AGENT_OPENCODE_MODEL: "env/model",
+          OPENLOOMI_AGENT_OPENCODE_AGENT: "env-agent",
+          OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS: "5000",
+          OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE: "true",
+        }),
+      getUserLlmProviderConfig,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "use env opencode",
+        modelConfig: {
+          apiKey: "anthropic-key-that-should-not-leak",
+          baseUrl: "https://anthropic-compatible.example.test",
+          thinkingLevel: "low",
+        },
+      },
+      createContext(),
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    expect(getUserLlmProviderConfig).not.toHaveBeenCalled();
+    expect(agent.config).toMatchObject({
+      provider: "opencode",
+      model: "env/model",
+      providerConfig: {
+        opencodePath: "env-opencode",
+        agent: "env-agent",
+        timeoutMs: 5000,
+        allowAutoApprove: true,
+      },
+    });
+    expect(agent.config?.apiKey).toBeUndefined();
+    expect(agent.config?.baseUrl).toBeUndefined();
+    expect(agent.config?.thinkingLevel).toBeUndefined();
+  });
+
+  it("lets request provider override OpenCode env default", async () => {
+    const agent = new CapturingAgent();
+    const getUserLlmProviderConfig = vi.fn(async () => ({
+      apiKey: "saved-key",
+      baseUrl: "https://llm.example.test",
+      model: "saved-model",
+    }));
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      prepareRequest: (body) =>
+        resolveNativeAgentProviderRequest(body, {
+          OPENLOOMI_AGENT_PROVIDER: "opencode",
+        }),
+      getUserLlmProviderConfig,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "force claude",
+        provider: "claude",
+      },
+      createContext(),
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    expect(agent.config).toMatchObject({
+      provider: "claude",
+      apiKey: "saved-key",
+      baseUrl: "https://llm.example.test",
+      model: "saved-model",
+    });
+  });
+
   it("runs through package core using host-provided adapters", async () => {
     const workDir = await mkdtemp(join(tmpdir(), "openloomi-native-runner-"));
     tempDirs.push(workDir);
@@ -298,4 +426,12 @@ async function collectMessages(
     messages.push(message);
   }
   return messages;
+}
+
+function createContext() {
+  return {
+    session: { user: { id: "user-1", type: "regular" } },
+    userId: "user-1",
+    abortController: new AbortController(),
+  };
 }

--- a/apps/web/tests/unit/native-providers-api.test.ts
+++ b/apps/web/tests/unit/native-providers-api.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = process.env;
+  process.env = { ...originalEnv };
+  process.env.OPENLOOMI_AGENT_PROVIDER = undefined;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("native providers API", () => {
+  it("returns Claude as the default when no provider env is configured", async () => {
+    const { GET } = await import("@/app/api/native/providers/route");
+
+    const response = await GET();
+    const body = (await response.json()) as ProvidersResponse;
+
+    expect(body.defaultAgent).toBe("claude");
+    expect(body.agents.filter((agent) => agent.type === "claude")).toHaveLength(
+      1,
+    );
+    expect(
+      body.agents.filter((agent) => agent.type === "opencode"),
+    ).toHaveLength(1);
+    expect(body.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "opencode",
+          supportsSandbox: false,
+        }),
+      ]),
+    );
+  });
+
+  it("returns OpenCode as the default when configured by env", async () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    const { GET } = await import("@/app/api/native/providers/route");
+
+    const response = await GET();
+    const body = (await response.json()) as ProvidersResponse;
+
+    expect(body.defaultAgent).toBe("opencode");
+    expect(body.agents.filter((agent) => agent.type === "claude")).toHaveLength(
+      1,
+    );
+    expect(
+      body.agents.filter((agent) => agent.type === "opencode"),
+    ).toHaveLength(1);
+    expect(
+      body.agents.find((agent) => agent.type === "opencode")?.supportsSandbox,
+    ).toBe(false);
+  });
+});
+
+interface ProvidersResponse {
+  agents: Array<{ type: string; supportsSandbox: boolean }>;
+  defaultAgent: string;
+}

--- a/apps/web/tests/unit/opencode-agent.test.ts
+++ b/apps/web/tests/unit/opencode-agent.test.ts
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { AgentMessage, TaskPlan } from "@openloomi/ai/agent/types";
 import { OpenCodeAgent } from "@/lib/ai/extensions/agent/opencode";
-import { buildOpenCodeRunCommand } from "@/lib/ai/extensions/agent/opencode/command";
+import {
+  buildOpenCodeRunCommand,
+  normalizeOpenCodeProviderConfig,
+} from "@/lib/ai/extensions/agent/opencode/command";
 import { parseOpenCodeJsonLine } from "@/lib/ai/extensions/agent/opencode/parser";
 
 const tempDirs: string[] = [];
@@ -85,11 +88,22 @@ describe("OpenCode command builder", () => {
       cwd: "/workspace/project",
       providerConfig: {
         files: ["safe.ts", "--auto"],
+        extraArgs: ["--auto"],
       },
+      permissionMode: "bypassPermissions",
     });
 
     expect(command.args).toContain("safe.ts");
     expect(command.args).not.toContain("--auto");
+  });
+
+  it("normalizes timeoutMs from provider config", () => {
+    expect(normalizeOpenCodeProviderConfig({ timeoutMs: 2500 }).timeoutMs).toBe(
+      2500,
+    );
+    expect(
+      normalizeOpenCodeProviderConfig({ timeoutMs: -1 }).timeoutMs,
+    ).toBeUndefined();
   });
 });
 
@@ -278,6 +292,38 @@ process.exit(7);
     expect(messages.at(-1)?.type).toBe("done");
   });
 
+  it("times out and terminates a long-running OpenCode process", async () => {
+    const workDir = await createFakeOpenCodeWorkDir(`
+console.log(JSON.stringify({ type: "text", text: "started" }));
+setInterval(() => {}, 1000);
+`);
+
+    const agent = new OpenCodeAgent({
+      provider: "opencode",
+      workDir,
+      providerConfig: {
+        opencodePath: process.execPath,
+        timeoutMs: 100,
+      },
+    });
+
+    const messages = await withTimeout(
+      collectMessages(agent.run("time out")),
+      5000,
+    );
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "started" }),
+      ]),
+    );
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("OpenCode CLI timed out after 100ms"),
+    });
+    expect(messages.at(-1)?.type).toBe("done");
+  });
+
   it("returns a clear error when the opencode executable is missing", async () => {
     const workDir = await mkdtemp(join(tmpdir(), "openloomi-opencode-test-"));
     tempDirs.push(workDir);
@@ -358,29 +404,36 @@ console.log(JSON.stringify({ type: "text", text: "done" }));
   });
 
   it("exposes OpenCode metadata from the providers API without changing the default", async () => {
+    const originalEnv = process.env;
+    process.env = { ...originalEnv };
+    process.env.OPENLOOMI_AGENT_PROVIDER = undefined;
     const { GET } = await import("@/app/api/native/providers/route");
 
-    const response = await GET();
-    const body = (await response.json()) as {
-      agents: Array<{ type: string; supportsSandbox: boolean }>;
-      defaultAgent: string;
-    };
+    try {
+      const response = await GET();
+      const body = (await response.json()) as {
+        agents: Array<{ type: string; supportsSandbox: boolean }>;
+        defaultAgent: string;
+      };
 
-    expect(body.defaultAgent).toBe("claude");
-    expect(body.agents.filter((agent) => agent.type === "claude")).toHaveLength(
-      1,
-    );
-    expect(
-      body.agents.filter((agent) => agent.type === "opencode"),
-    ).toHaveLength(1);
-    expect(body.agents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "opencode",
-          supportsSandbox: false,
-        }),
-      ]),
-    );
+      expect(body.defaultAgent).toBe("claude");
+      expect(
+        body.agents.filter((agent) => agent.type === "claude"),
+      ).toHaveLength(1);
+      expect(
+        body.agents.filter((agent) => agent.type === "opencode"),
+      ).toHaveLength(1);
+      expect(body.agents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "opencode",
+            supportsSandbox: false,
+          }),
+        ]),
+      );
+    } finally {
+      process.env = originalEnv;
+    }
   });
 });
 

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -136,6 +136,10 @@ export interface NativeAgentFocusedInsightData {
 export interface NativeAgentHost {
   registry?: AgentRegistry;
   registerProviders?: () => void | Promise<void>;
+  prepareRequest?: (
+    body: NativeAgentRequest,
+    context: NativeAgentRunnerContext,
+  ) => NativeAgentRequest | Promise<NativeAgentRequest>;
   getUserInsightSettings?: (
     userId: string,
   ) => Promise<NativeAgentInsightSettings | null>;
@@ -170,11 +174,16 @@ export async function runNativeAgentRequest(
   host: NativeAgentHost = {},
 ): Promise<NativeAgentRun> {
   await host.registerProviders?.();
+  const preparedBody = (await host.prepareRequest?.(body, context)) ?? body;
 
-  const finalPrompt = await buildNativeAgentPrompt(body, context.session, host);
+  const finalPrompt = await buildNativeAgentPrompt(
+    preparedBody,
+    context.session,
+    host,
+  );
   const userSettings = await host.getUserInsightSettings?.(context.userId);
-  const config = await buildAgentConfig(body, context.userId, host);
-  const agentOptions = buildAgentOptions(body, context, {
+  const config = await buildAgentConfig(preparedBody, context.userId, host);
+  const agentOptions = buildAgentOptions(preparedBody, context, {
     aiSoulPrompt: userSettings?.aiSoulPrompt ?? null,
     language: userSettings?.language ?? null,
   });
@@ -182,8 +191,8 @@ export async function runNativeAgentRequest(
   return runAgentRuntimeRequest(
     {
       prompt: finalPrompt,
-      phase: body.phase,
-      planId: body.planId,
+      phase: preparedBody.phase,
+      planId: preparedBody.planId,
       config,
       options: agentOptions,
     },


### PR DESCRIPTION
## Summary

Adds environment-based native agent runtime selection so OpenLoomi can run native agent tasks through the OpenCode CLI provider while keeping Claude as the default.

## Changes

- Add runtime provider env resolution:
  - request `provider` > `OPENLOOMI_AGENT_PROVIDER` > `claude`
  - supports `claude` and `opencode`
  - invalid provider values fail clearly
- Add `NativeAgentHost.prepareRequest` so web API and native CLI use the same provider selection flow.
- Wire OpenCode env config into agent config:
  - `OPENLOOMI_AGENT_OPENCODE_COMMAND`
  - `OPENLOOMI_AGENT_OPENCODE_MODEL`
  - `OPENLOOMI_AGENT_OPENCODE_AGENT`
  - `OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS`
  - `OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE`
- Update `/api/native/providers` so `defaultAgent` reflects the configured default.
- Add OpenCode CLI timeout support with process cleanup.
- Keep OpenCode permission behavior guarded:
  - request `providerConfig.allowAutoApprove` cannot enable `--auto` by itself
  - env allow-auto is the server-side cap
  - `--auto` still requires `permissionMode === "bypassPermissions"`
  - planning never passes `--auto`
- Document the OpenCode env options in `apps/web/.env.example`.

## Tests

Added and updated tests for:

- env resolver behavior
- provider precedence
- invalid env values
- native runner host integration
- OpenCode config merge behavior
- Anthropic-compatible config isolation
- providers API `defaultAgent`
- OpenCode timeout behavior
- `--auto` gating

Verification run:

```bash
pnpm --filter web test -- tests/unit/agent-runtime.test.ts tests/unit/native-agent-provider-env.test.ts tests/unit/native-agent-runner.test.ts tests/unit/native-providers-api.test.ts tests/unit/opencode-agent.test.ts
```

re #194 