### PR TITLE
fix(pet): resolve noDelete lint errors from #263

### DIFF
--- a/apps/pet/README.md
+++ b/apps/pet/README.md
@@ -6,12 +6,12 @@ A desktop pet for OpenLoomi: the official Loomi fox sits on your desktop, watche
 
 ## How it senses OpenLoomi (all local, all read-only)
 
-| Source | Path / port | Drives |
-|---|---|---|
-| Process / local API | `openloomi.app` process, `127.0.0.1:3414/3415` (auto-detected) | awake / asleep / greeting on launch |
-| Audit stream | `~/.openloomi/logs/audit.jsonl` | working expression + tool icon overhead |
-| Main log | `~/.openloomi/logs/openloomi.log` | `[ERROR]` → error face; `Permission request/decision` → waiting (approval) / needs-input, auto-released on decision |
-| Message store | `~/.openloomi/data/data.db` (sqlite, read-only) | new prompt → thinking; new reply → talking + speech bubble |
+| Source              | Path / port                                                    | Drives                                                                                                              |
+| ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Process / local API | `openloomi.app` process, `127.0.0.1:3414/3415` (auto-detected) | awake / asleep / greeting on launch                                                                                 |
+| Audit stream        | `~/.openloomi/logs/audit.jsonl`                                | working expression + tool icon overhead                                                                             |
+| Main log            | `~/.openloomi/logs/openloomi.log`                              | `[ERROR]` → error face; `Permission request/decision` → waiting (approval) / needs-input, auto-released on decision |
+| Message store       | `~/.openloomi/data/data.db` (sqlite, read-only)                | new prompt → thinking; new reply → talking + speech bubble                                                          |
 
 Nothing is written to OpenLoomi's data, and nothing leaves your machine except the optional bubble-generation call to your configured LLM provider.
 
@@ -19,11 +19,11 @@ Nothing is written to OpenLoomi's data, and nothing leaves your machine except t
 
 The pet ships **enabled by default** and starts automatically together with the OpenLoomi client.
 
-| Where | What it does |
-|---|---|
+| Where                                | What it does                                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | **Settings → General → Desktop Pet** | One switch. Turning it **on** launches the pet immediately; turning it **off** stops it immediately. No client restart needed. |
-| `~/.openloomi/pet-settings.json` | Where the preference persists (`{ "enabled": true }`). Missing file = enabled. |
-| `GET/PUT /api/preferences/pet` | The API behind the switch (auth required). `GET` returns `{enabled, running}`; `PUT {enabled}` saves and applies on the spot. |
+| `~/.openloomi/pet-settings.json`     | Where the preference persists (`{ "enabled": true }`). Missing file = enabled.                                                 |
+| `GET/PUT /api/preferences/pet`       | The API behind the switch (auth required). `GET` returns `{enabled, running}`; `PUT {enabled}` saves and applies on the spot.  |
 
 How the plumbing works: at client startup the server (Tauri mode) reads the preference and, when enabled, spawns the pet from `apps/pet` (or `OPENLOOMI_PET_PATH`). The pet writes `~/.openloomipet/pet.pid` and honors `SIGTERM`, which is how the switch detects and stops it. A single-instance lock guarantees auto-launch and manual runs never stack two foxes.
 
@@ -55,25 +55,25 @@ or set `DEEPSEEK_API_KEY`. Without a key the pet still works — bubbles fall ba
 
 17 expressions cut from the official Loomi sheet (`assets/loomi-src/loomi-sheet-green.png`, mapping in `assets/loomi/grid-map.json`). The state machine is **turn-aware**: your prompt opens a turn; the first tool activity switches to the laptop pose and holds it until the reply lands.
 
-| Expression | State | When |
-|---|---|---|
-| 💻 typing on a laptop | `working` | agent is on the job — from its first tool call until the reply; the chip shows the concrete action (read file / run command / skill / memory / search / connector) |
-| 🤔 chin scratch | `thinking` | after your prompt, before the agent touches any tool |
-| 👉 explaining | `talking` | the reply just landed (with the speech bubble) |
-| 👍 thumbs up | `done` | flashes right after talking — turn completed |
-| 🧍 standing by | `idle` | OpenLoomi online, nothing to do |
-| 🚶 strolling | `roam` | idle for 10+ minutes, occasional wander |
-| ✉️ envelope leap | `juggling` | subagents fanned out |
-| ✍️ taking notes | `sweeping` | memory consolidation / context tidying |
-| 🐕 sitting politely | `waiting` | a tool call awaits your approval (golden glow, auto-released on decision) |
-| ❓ question marks | `needsinput` | the agent asked you a question / needs a choice |
-| ❗ startled | `attention` | something wants a look |
-| 🎉 joyful jump | `happy` | celebration |
-| 👋 waving | `greet` | OpenLoomi just came online |
-| 😴 yawning + Zzz | `sleeping` | OpenLoomi is not running |
-| 😭 crying | `error` | an `[ERROR]` hit the log (8s, then recovers) |
-| 💢 fuming | `angry` | second error within five minutes — repeated failures look different from a hiccup |
-| 😍 heart eyes | `loved` | you petted it (hover 1.5s; 10s cooldown) |
+| Expression            | State        | When                                                                                                                                                               |
+| --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 💻 typing on a laptop | `working`    | agent is on the job — from its first tool call until the reply; the chip shows the concrete action (read file / run command / skill / memory / search / connector) |
+| 🤔 chin scratch       | `thinking`   | after your prompt, before the agent touches any tool                                                                                                               |
+| 👉 explaining         | `talking`    | the reply just landed (with the speech bubble)                                                                                                                     |
+| 👍 thumbs up          | `done`       | flashes right after talking — turn completed                                                                                                                       |
+| 🧍 standing by        | `idle`       | OpenLoomi online, nothing to do                                                                                                                                    |
+| 🚶 strolling          | `roam`       | idle for 10+ minutes, occasional wander                                                                                                                            |
+| ✉️ envelope leap      | `juggling`   | subagents fanned out                                                                                                                                               |
+| ✍️ taking notes       | `sweeping`   | memory consolidation / context tidying                                                                                                                             |
+| 🐕 sitting politely   | `waiting`    | a tool call awaits your approval (golden glow, auto-released on decision)                                                                                          |
+| ❓ question marks     | `needsinput` | the agent asked you a question / needs a choice                                                                                                                    |
+| ❗ startled           | `attention`  | something wants a look                                                                                                                                             |
+| 🎉 joyful jump        | `happy`      | celebration                                                                                                                                                        |
+| 👋 waving             | `greet`      | OpenLoomi just came online                                                                                                                                         |
+| 😴 yawning + Zzz      | `sleeping`   | OpenLoomi is not running                                                                                                                                           |
+| 😭 crying             | `error`      | an `[ERROR]` hit the log (8s, then recovers)                                                                                                                       |
+| 💢 fuming             | `angry`      | second error within five minutes — repeated failures look different from a hiccup                                                                                  |
+| 😍 heart eyes         | `loved`      | you petted it (hover 1.5s; 10s cooldown)                                                                                                                           |
 
 ## Layout
 

--- a/apps/pet/backend/brain.js
+++ b/apps/pet/backend/brain.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // 桌宠的嘴 —— 用 DeepSeek 把"OpenLoomi 正在发生的事"变成一句台词气泡。
 //
@@ -11,42 +11,44 @@
 // 约束：最短间隔 bubbleEveryMs（默认 90s，reply/error 例外可插队），
 // 失败/没配 key 时用内置兜底台词，绝不阻塞主流程。
 
-const https = require('https');
-const config = require('./config');
-const { log } = require('./log');
+const https = require("https");
+const config = require("./config");
+const { log } = require("./log");
 
-const MODEL = process.env.DEEPSEEK_MODEL || 'deepseek-chat';
-const API_HOST = 'api.deepseek.com';
+const MODEL = process.env.DEEPSEEK_MODEL || "deepseek-chat";
+const API_HOST = "api.deepseek.com";
 const TIMEOUT_MS = 30000;
 
 const PERSONA =
-  '你是 Loomi，一只白色小狐狸桌宠，是 AI 伙伴应用 OpenLoomi 的官方形象。' +
-  '你趴在用户桌面上，替正在后台干活的 OpenLoomi 向用户说话。' +
-  '规则：只输出一句话台词本身，不带引号不带前缀；中文；不超过 40 个字；' +
-  '语气活泼但有信息量，像小动物在汇报；不要编造具体数字或没给你的事实。';
+  "你是 Loomi，一只白色小狐狸桌宠，是 AI 伙伴应用 OpenLoomi 的官方形象。" +
+  "你趴在用户桌面上，替正在后台干活的 OpenLoomi 向用户说话。" +
+  "规则：只输出一句话台词本身，不带引号不带前缀；中文；不超过 40 个字；" +
+  "语气活泼但有信息量，像小动物在汇报；不要编造具体数字或没给你的事实。";
 
 const FALLBACK = {
-  online: ['我上线啦，有事随时叫我～', 'Loomi 就位，今天也一起加油！'],
-  reply: ['刚回了你一条消息，去看看嘛～', '你的消息我处理好啦！'],
-  error: ['呜，刚才出了点小差错…', '有个任务翻车了，我看看怎么回事。'],
-  working: ['我在后台忙着呢，别担心～', '正在整理你的信息流…'],
-  waiting: ['有个操作在等你点头，快去看看～', '我举着爪子等你批准呢！'],
+  online: ["我上线啦，有事随时叫我～", "Loomi 就位，今天也一起加油！"],
+  reply: ["刚回了你一条消息，去看看嘛～", "你的消息我处理好啦！"],
+  error: ["呜，刚才出了点小差错…", "有个任务翻车了，我看看怎么回事。"],
+  working: ["我在后台忙着呢，别担心～", "正在整理你的信息流…"],
+  waiting: ["有个操作在等你点头，快去看看～", "我举着爪子等你批准呢！"],
 };
 
-function pick(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
 
 function momentPrompt(m) {
   switch (m.kind) {
-    case 'reply':
+    case "reply":
       return `OpenLoomi 刚刚回复了用户，内容是：「${m.text}」。请把它浓缩/转述成你的一句台词，提醒用户去看。`;
-    case 'online':
-      return '你（OpenLoomi）刚刚启动上线。跟用户打个招呼。';
-    case 'error':
-      return `OpenLoomi 后台刚出了个错：「${m.detail || '未知错误'}」。用一句话向用户报告，语气委屈一点。`;
-    case 'working':
-      return `你正在后台忙碌（大类：${m.tool || '杂务'}）。用一句话表达"我在后台干活呢"的状态。注意：你只知道大类，不知道具体内容，严禁编造具体任务名、文件名或细节。`;
-    case 'waiting':
-      return `你（OpenLoomi 的 agent）想执行「${m.tool || '一个操作'}」，正在等用户批准或回复。用一句话催用户去看一眼，语气乖巧。`;
+    case "online":
+      return "你（OpenLoomi）刚刚启动上线。跟用户打个招呼。";
+    case "error":
+      return `OpenLoomi 后台刚出了个错：「${m.detail || "未知错误"}」。用一句话向用户报告，语气委屈一点。`;
+    case "working":
+      return `你正在后台忙碌（大类：${m.tool || "杂务"}）。用一句话表达"我在后台干活呢"的状态。注意：你只知道大类，不知道具体内容，严禁编造具体任务名、文件名或细节。`;
+    case "waiting":
+      return `你（OpenLoomi 的 agent）想执行「${m.tool || "一个操作"}」，正在等用户批准或回复。用一句话催用户去看一眼，语气乖巧。`;
     default:
       return null;
   }
@@ -54,12 +56,12 @@ function momentPrompt(m) {
 
 function callDeepSeek(userPrompt, cb) {
   const key = config.apiKey();
-  if (!key) return cb(new Error('no api key'));
+  if (!key) return cb(new Error("no api key"));
   const payload = JSON.stringify({
     model: MODEL,
     messages: [
-      { role: 'system', content: PERSONA },
-      { role: 'user', content: userPrompt },
+      { role: "system", content: PERSONA },
+      { role: "user", content: userPrompt },
     ],
     max_tokens: 80,
     temperature: 1.1,
@@ -67,30 +69,45 @@ function callDeepSeek(userPrompt, cb) {
   const req = https.request(
     {
       hostname: API_HOST,
-      path: '/chat/completions',
-      method: 'POST',
+      path: "/chat/completions",
+      method: "POST",
       timeout: TIMEOUT_MS,
       headers: {
-        Authorization: 'Bearer ' + key,
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(payload),
+        Authorization: "Bearer " + key,
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(payload),
       },
     },
     (res) => {
-      let body = '';
-      res.on('data', (c) => { body += c; });
-      res.on('end', () => {
+      let body = "";
+      res.on("data", (c) => {
+        body += c;
+      });
+      res.on("end", () => {
         try {
           const j = JSON.parse(body);
-          const text = j.choices && j.choices[0] && j.choices[0].message && j.choices[0].message.content;
+          const text =
+            j.choices &&
+            j.choices[0] &&
+            j.choices[0].message &&
+            j.choices[0].message.content;
           if (res.statusCode === 200 && text) cb(null, String(text).trim());
-          else cb(new Error(`http ${res.statusCode}: ${String(body).slice(0, 120)}`));
-        } catch (e) { cb(e); }
+          else
+            cb(
+              new Error(
+                `http ${res.statusCode}: ${String(body).slice(0, 120)}`,
+              ),
+            );
+        } catch (e) {
+          cb(e);
+        }
       });
-    }
+    },
   );
-  req.on('error', cb);
-  req.on('timeout', () => { req.destroy(new Error('timeout')); });
+  req.on("error", cb);
+  req.on("timeout", () => {
+    req.destroy(new Error("timeout"));
+  });
   req.end(payload);
 }
 
@@ -101,7 +118,9 @@ function createBrain(onBubble) {
   function say(moment) {
     const now = Date.now();
     const minGap = config.get().bubbleEveryMs || 90000;
-    const urgent = ['reply', 'error', 'online', 'waiting'].includes(moment.kind);
+    const urgent = ["reply", "error", "online", "waiting"].includes(
+      moment.kind,
+    );
     if (!urgent && now - lastBubbleAt < minGap) return;
     if (urgent && now - lastBubbleAt < 8000) return; // 插队也别连珠炮
     if (inflight) return;
@@ -113,13 +132,13 @@ function createBrain(onBubble) {
     callDeepSeek(prompt, (err, text) => {
       inflight = false;
       if (err) {
-        log('brain', 'deepseek failed:', err.message);
+        log("brain", "deepseek failed:", err.message);
         const fb = FALLBACK[moment.kind];
         if (fb) onBubble(pick(fb));
         return;
       }
-      const line = text.replace(/^["'「『]+|["'」』]+$/g, '').slice(0, 80);
-      log('brain', `[${moment.kind}] ${line}`);
+      const line = text.replace(/^["'「『]+|["'」』]+$/g, "").slice(0, 80);
+      log("brain", `[${moment.kind}] ${line}`);
       onBubble(line);
     });
   }

--- a/apps/pet/backend/config.js
+++ b/apps/pet/backend/config.js
@@ -1,18 +1,18 @@
-'use strict';
+"use strict";
 
 // 配置持久化：~/.openloomipet/config.json（原子写）。
 // 字段：deepseekApiKey / petPosition {x,y} / muted / bubbleEveryMs
 // key 也可用环境变量 DEEPSEEK_API_KEY 覆盖（优先）。
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
-const CONFIG_DIR = path.join(os.homedir(), '.openloomipet');
-const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const CONFIG_DIR = path.join(os.homedir(), ".openloomipet");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 
 const DEFAULTS = {
-  deepseekApiKey: '',
+  deepseekApiKey: "",
   petPosition: null,
   muted: false,
   bubbleEveryMs: 90 * 1000, // DeepSeek 台词最短间隔
@@ -23,8 +23,10 @@ let cache = null;
 function get() {
   if (cache) return cache;
   let raw = {};
-  try { raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')); } catch {}
-  cache = { ...DEFAULTS, ...(raw && typeof raw === 'object' ? raw : {}) };
+  try {
+    raw = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+  } catch {}
+  cache = { ...DEFAULTS, ...(raw && typeof raw === "object" ? raw : {}) };
   return cache;
 }
 
@@ -34,14 +36,14 @@ function save(patch) {
   try {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
     const tmp = path.join(CONFIG_DIR, `.config.${process.pid}.tmp`);
-    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), 'utf8');
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), "utf8");
     fs.renameSync(tmp, CONFIG_PATH);
   } catch {}
   return next;
 }
 
 function apiKey() {
-  return process.env.DEEPSEEK_API_KEY || get().deepseekApiKey || '';
+  return process.env.DEEPSEEK_API_KEY || get().deepseekApiKey || "";
 }
 
 module.exports = { get, save, apiKey, CONFIG_PATH };

--- a/apps/pet/backend/log.js
+++ b/apps/pet/backend/log.js
@@ -1,13 +1,13 @@
-'use strict';
+"use strict";
 
 // 极简滚动日志：~/.openloomipet/openloomipet.log（超 2MB 滚一份 .1）。
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
-const LOG_DIR = path.join(os.homedir(), '.openloomipet');
-const LOG_PATH = path.join(LOG_DIR, 'openloomipet.log');
+const LOG_DIR = path.join(os.homedir(), ".openloomipet");
+const LOG_PATH = path.join(LOG_DIR, "openloomipet.log");
 const MAX_BYTES = 2 * 1024 * 1024;
 
 let stream = null;
@@ -16,9 +16,10 @@ function open() {
   try {
     fs.mkdirSync(LOG_DIR, { recursive: true });
     try {
-      if (fs.statSync(LOG_PATH).size > MAX_BYTES) fs.renameSync(LOG_PATH, LOG_PATH + '.1');
+      if (fs.statSync(LOG_PATH).size > MAX_BYTES)
+        fs.renameSync(LOG_PATH, LOG_PATH + ".1");
     } catch {}
-    stream = fs.createWriteStream(LOG_PATH, { flags: 'a' });
+    stream = fs.createWriteStream(LOG_PATH, { flags: "a" });
   } catch {
     stream = null;
   }
@@ -27,8 +28,10 @@ function open() {
 function log(tag, ...args) {
   if (!stream) open();
   if (!stream) return;
-  const line = `${new Date().toISOString()} [${tag}] ${args.map(String).join(' ')}\n`;
-  try { stream.write(line); } catch {}
+  const line = `${new Date().toISOString()} [${tag}] ${args.map(String).join(" ")}\n`;
+  try {
+    stream.write(line);
+  } catch {}
 }
 
 module.exports = { log, LOG_PATH };

--- a/apps/pet/backend/watcher.js
+++ b/apps/pet/backend/watcher.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // OpenLoomi 活动观察器 —— 桌宠唯一的事件来源，全部盯**本机真实数据**：
 //
@@ -16,81 +16,86 @@
 //
 // OPENLOOMI_PET_DEMO=1 时改跑内置演示脚本（轮播所有表情，验收皮肤用）。
 
-const { execFile } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const http = require('http');
-const { log } = require('./log');
+const { execFile } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const http = require("http");
+const { log } = require("./log");
 
-const LOOMI_HOME = process.env.OPENLOOMI_HOME || path.join(os.homedir(), '.openloomi');
-const AUDIT_LOG = path.join(LOOMI_HOME, 'logs', 'audit.jsonl');
-const MAIN_LOG = path.join(LOOMI_HOME, 'logs', 'openloomi.log');
-const DATA_DB = path.join(LOOMI_HOME, 'data', 'data.db');
+const LOOMI_HOME =
+  process.env.OPENLOOMI_HOME || path.join(os.homedir(), ".openloomi");
+const AUDIT_LOG = path.join(LOOMI_HOME, "logs", "audit.jsonl");
+const MAIN_LOG = path.join(LOOMI_HOME, "logs", "openloomi.log");
+const DATA_DB = path.join(LOOMI_HOME, "data", "data.db");
 // 本地服务端口随版本变过（0.5.x=3415，0.6.x=3414），全部探测，命中后记住。
 const API_URLS = process.env.OPENLOOMI_API_URL
   ? [process.env.OPENLOOMI_API_URL]
-  : ['http://127.0.0.1:3414', 'http://127.0.0.1:3415'];
+  : ["http://127.0.0.1:3414", "http://127.0.0.1:3415"];
 
 const PRESENCE_MS = 5000;
 const TAIL_MS = 1500;
-const DB_MS = 3000;                        // 消息要跟手，轮询给快
+const DB_MS = 3000; // 消息要跟手，轮询给快
 const TICK_MS = 1000;
-const QUIET_TO_IDLE_MS = 30 * 1000;       // 忙碌态静默回落（30s，别假忙）
-const IDLE_TO_ROAM_MS = 10 * 60 * 1000;   // 待命太久出去溜达
+const QUIET_TO_IDLE_MS = 30 * 1000; // 忙碌态静默回落（30s，别假忙）
+const IDLE_TO_ROAM_MS = 10 * 60 * 1000; // 待命太久出去溜达
 const ROAM_EVERY_MS = 4 * 60 * 1000;
 const ROAM_LEN_MS = 12 * 1000;
 
 const TOOLS = {
-  Read:      { icon: '📄', label: '读文件' },
-  Exec:      { icon: '🛠️', label: '执行命令' },
-  Connector: { icon: '🔌', label: '同步连接器' },
-  Memory:    { icon: '🧠', label: '整理记忆' },
-  Agent:     { icon: '🤖', label: 'agent 干活' },
-  Skill:     { icon: '✨', label: '读技能' },
-  Search:    { icon: '🔍', label: '检索上下文' },
+  Read: { icon: "📄", label: "读文件" },
+  Exec: { icon: "🛠️", label: "执行命令" },
+  Connector: { icon: "🔌", label: "同步连接器" },
+  Memory: { icon: "🧠", label: "整理记忆" },
+  Agent: { icon: "🤖", label: "agent 干活" },
+  Skill: { icon: "✨", label: "读技能" },
+  Search: { icon: "🔍", label: "检索上下文" },
 };
 
 // audit 行 → {tool, hint}。hint 是给状态条看的具体对象（文件名/命令），
 // 只取短尾巴，绝不外传（hint 只进本地 UI，不进 brain 的 prompt）。
 function classifyAudit(type, detail) {
-  const d = String(detail || '');
+  const d = String(detail || "");
   const dl = d.toLowerCase();
-  const base = (d.split('/').pop() || '').slice(0, 24);
-  if (type === 'command_exec') return { tool: 'Exec', hint: d.trim().slice(0, 24) };
-  if (dl.includes('/skills/') || dl.endsWith('skill.md')) return { tool: 'Skill', hint: base };
-  if (dl.includes('memory')) return { tool: 'Memory', hint: base };
-  if (dl.includes('/rag/') || dl.includes('document')) return { tool: 'Search', hint: base };
-  if (dl.includes('integration') || dl.includes('connector')) return { tool: 'Connector', hint: base };
-  return { tool: 'Read', hint: base };
+  const base = (d.split("/").pop() || "").slice(0, 24);
+  if (type === "command_exec")
+    return { tool: "Exec", hint: d.trim().slice(0, 24) };
+  if (dl.includes("/skills/") || dl.endsWith("skill.md"))
+    return { tool: "Skill", hint: base };
+  if (dl.includes("memory")) return { tool: "Memory", hint: base };
+  if (dl.includes("/rag/") || dl.includes("document"))
+    return { tool: "Search", hint: base };
+  if (dl.includes("integration") || dl.includes("connector"))
+    return { tool: "Connector", hint: base };
+  return { tool: "Read", hint: base };
 }
 
 function stripText(s, max = 400) {
-  const t = String(s || '')
-    .replace(/[\u0000-\u001F\u007F]/g, ' ')
-    .replace(/\s+/g, ' ')
+  const t = String(s || "")
+    .replace(/[\u0000-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
     .trim();
-  return t.length > max ? t.slice(0, max) + '…' : t;
+  return t.length > max ? t.slice(0, max) + "…" : t;
 }
 
 function createWatcher(handlers) {
-  const onState = handlers.onState || (() => {});     // ({state, tool, icon, label})
-  const onMoment = handlers.onMoment || (() => {});   // 给 brain 的"值得说话的时刻"
+  const onState = handlers.onState || (() => {}); // ({state, tool, icon, label})
+  const onMoment = handlers.onMoment || (() => {}); // 给 brain 的"值得说话的时刻"
 
   let stopped = false;
   const timers = [];
 
-  let base = 'sleeping';
+  let base = "sleeping";
   let baseTool = null;
   let baseHint = null;
-  let overlay = null;            // {state, until, tool}
+  let overlay = null; // {state, until, tool}
   let lastEffective = null;
 
   let online = null;
   let lastActivity = 0;
-  let lastChatTs = 0;            // 最近一次聊天消息（区分"聊天干活"和"后台家务"）
-  let turnUntil = 0;             // 回合窗口：用户提问后、回复到达前（上限 10 分钟）
-  let lastToolTs = 0;            // 最近一次工具活动；回合内工具间隙回落 thinking
+  let lastChatTs = 0; // 最近一次聊天消息（区分"聊天干活"和"后台家务"）
+  let turnUntil = 0; // 回合窗口：用户提问后、回复到达前（上限 10 分钟）
+  let lastToolTs = 0; // 最近一次工具活动；回合内工具间隙回落 thinking
   let idleSince = 0;
   let lastRoam = 0;
   let auditPos = -1;
@@ -101,30 +106,40 @@ function createWatcher(handlers) {
   const TURN_MAX_MS = 10 * 60 * 1000;
   const TOOL_GAP_TO_THINKING_MS = 8 * 1000;
 
-  function turnActive() { return Date.now() < turnUntil; }
+  function turnActive() {
+    return Date.now() < turnUntil;
+  }
 
   // ── 状态输出 ───────────────────────────────────────────────────────────────
   function effective() {
     const now = Date.now();
-    if (overlay && overlay.until > now) return { state: overlay.state, tool: overlay.tool || null, hint: null };
+    if (overlay && overlay.until > now)
+      return { state: overlay.state, tool: overlay.tool || null, hint: null };
     return { state: base, tool: baseTool, hint: baseHint };
   }
 
   function publish() {
     const e = effective();
-    const key = e.state + ':' + (e.tool || '') + ':' + (e.hint || '');
+    const key = e.state + ":" + (e.tool || "") + ":" + (e.hint || "");
     if (key === lastEffective) return;
     lastEffective = key;
     const t = e.tool && TOOLS[e.tool] ? TOOLS[e.tool] : null;
-    onState({ state: e.state, tool: e.tool, icon: t ? t.icon : null, label: t ? t.label : null, hint: e.hint });
+    onState({
+      state: e.state,
+      tool: e.tool,
+      icon: t ? t.icon : null,
+      label: t ? t.label : null,
+      hint: e.hint,
+    });
   }
 
   function setBase(state, tool = null, hint = null) {
     base = state;
     baseTool = tool;
     baseHint = hint;
-    if (state === 'idle') { if (!idleSince) idleSince = Date.now(); }
-    else idleSince = 0;
+    if (state === "idle") {
+      if (!idleSince) idleSince = Date.now();
+    } else idleSince = 0;
     publish();
   }
 
@@ -133,34 +148,51 @@ function createWatcher(handlers) {
     publish();
   }
 
-  function markActive() { lastActivity = Date.now(); }
+  function markActive() {
+    lastActivity = Date.now();
+  }
 
   // ── ① 进程/端口存活 ───────────────────────────────────────────────────────
   function probeProcess(cb) {
-    if (process.platform === 'win32') return cb(false);
-    execFile('pgrep', ['-f', 'openloomi.app/Contents/MacOS|openloomi-desktop'], (err, out) => {
-      cb(!err && String(out).trim().length > 0);
-    });
+    if (process.platform === "win32") return cb(false);
+    execFile(
+      "pgrep",
+      ["-f", "openloomi.app/Contents/MacOS|openloomi-desktop"],
+      (err, out) => {
+        cb(!err && String(out).trim().length > 0);
+      },
+    );
   }
 
   let apiHit = null; // 上次探通的 base URL，优先复用
   function probeOne(base, cb) {
     // 只要端口上有 HTTP 服务在应答（无论状态码）就算在线
-    const req = http.get(base + '/', { timeout: 1500 }, (res) => {
+    const req = http.get(base + "/", { timeout: 1500 }, (res) => {
       res.resume();
       cb(true);
     });
-    req.on('error', () => cb(false));
-    req.on('timeout', () => { req.destroy(); cb(false); });
+    req.on("error", () => cb(false));
+    req.on("timeout", () => {
+      req.destroy();
+      cb(false);
+    });
   }
   function probeApi(cb) {
-    const order = apiHit ? [apiHit, ...API_URLS.filter((u) => u !== apiHit)] : API_URLS;
+    const order = apiHit
+      ? [apiHit, ...API_URLS.filter((u) => u !== apiHit)]
+      : API_URLS;
     let i = 0;
     const next = () => {
-      if (i >= order.length) { apiHit = null; return cb(false); }
+      if (i >= order.length) {
+        apiHit = null;
+        return cb(false);
+      }
       const base = order[i++];
       probeOne(base, (ok) => {
-        if (ok) { apiHit = base; return cb(true); }
+        if (ok) {
+          apiHit = base;
+          return cb(true);
+        }
         next();
       });
     };
@@ -180,15 +212,15 @@ function createWatcher(handlers) {
     const was = online;
     online = up;
     if (up && was !== true) {
-      log('watcher', 'OpenLoomi online');
-      setBase('idle');
-      flash('greet', 3500);
+      log("watcher", "OpenLoomi online");
+      setBase("idle");
+      flash("greet", 3500);
       markActive();
-      if (was === false) onMoment({ kind: 'online' });
+      if (was === false) onMoment({ kind: "online" });
     } else if (!up && was !== false) {
-      log('watcher', 'OpenLoomi offline → sleeping');
+      log("watcher", "OpenLoomi offline → sleeping");
       overlay = null;
-      setBase('sleeping');
+      setBase("sleeping");
     }
   }
 
@@ -198,14 +230,23 @@ function createWatcher(handlers) {
       if (err) return cb(pos, []);
       if (pos < 0 || pos > st.size) return cb(st.size, []);
       if (st.size === pos) return cb(pos, []);
-      const stream = fs.createReadStream(file, { start: pos, end: st.size - 1, encoding: 'utf8' });
-      let buf = '';
-      stream.on('data', (c) => { buf += c; });
-      stream.on('error', () => cb(pos, []));
-      stream.on('end', () => {
-        const nl = buf.lastIndexOf('\n');
+      const stream = fs.createReadStream(file, {
+        start: pos,
+        end: st.size - 1,
+        encoding: "utf8",
+      });
+      let buf = "";
+      stream.on("data", (c) => {
+        buf += c;
+      });
+      stream.on("error", () => cb(pos, []));
+      stream.on("end", () => {
+        const nl = buf.lastIndexOf("\n");
         if (nl < 0) return cb(pos, []);
-        cb(pos + Buffer.byteLength(buf.slice(0, nl + 1), 'utf8'), buf.slice(0, nl).split('\n'));
+        cb(
+          pos + Buffer.byteLength(buf.slice(0, nl + 1), "utf8"),
+          buf.slice(0, nl).split("\n"),
+        );
       });
     });
   }
@@ -219,20 +260,25 @@ function createWatcher(handlers) {
       const tally = {};
       const hints = {};
       for (const line of lines.slice(0, 2000)) {
-        let ev; try { ev = JSON.parse(line); } catch { continue; }
+        let ev;
+        try {
+          ev = JSON.parse(line);
+        } catch {
+          continue;
+        }
         const { tool, hint } = classifyAudit(ev.type, ev.detail);
         tally[tool] = (tally[tool] || 0) + 1;
         if (hint) hints[tool] = hint; // 留每类最后一个对象名给状态条
       }
       const top = Object.keys(tally).sort((a, b) => tally[b] - tally[a])[0];
       if (top) {
-        setBase('working', top, hints[top] || null);
+        setBase("working", top, hints[top] || null);
         lastToolTs = Date.now();
         markActive();
         // 聊天进行中不为"干活"单独发台词——回复台词马上就来，别抢戏；
         // 只有纯后台家务（近 2 分钟没聊天）才值得汇报一句。
         if (Date.now() - lastChatTs > 2 * 60 * 1000) {
-          onMoment({ kind: 'working', tool: top, count: lines.length });
+          onMoment({ kind: "working", tool: top, count: lines.length });
         }
       }
     });
@@ -245,8 +291,8 @@ function createWatcher(handlers) {
   const MAIN_RE = /^\[[^\]]+\] \[([A-Z]+)\] \[([^\]]*)\]\s*(.*)$/;
   const PERM_REQ_RE = /Permission request[^:]*:\s*(\S+)/;
   const PERM_DEC_RE = /Permission decision[^:]*:\s*(allow|deny)/;
-  let permHold = null;    // {tool, since} 等待用户批准/回复中
-  let recentErrors = [];  // 近 5 分钟错误时间戳（连续出错 → angry）
+  let permHold = null; // {tool, since} 等待用户批准/回复中
+  let recentErrors = []; // 近 5 分钟错误时间戳（连续出错 → angry）
 
   function mainLogTick() {
     if (stopped) return;
@@ -257,28 +303,30 @@ function createWatcher(handlers) {
       for (const line of lines) {
         const m = MAIN_RE.exec(line);
         if (!m) continue;
-        const msg = m[3] || '';
+        const msg = m[3] || "";
         const req = PERM_REQ_RE.exec(msg);
         const dec = PERM_DEC_RE.exec(msg);
         if (req) {
           const tool = req[1];
           permHold = { tool, since: Date.now() };
           // 提问/选择类 → needsinput；其余工具授权 → waiting
-          const state = /AskUserQuestion|ExitPlanMode/i.test(tool) ? 'needsinput' : 'waiting';
+          const state = /AskUserQuestion|ExitPlanMode/i.test(tool)
+            ? "needsinput"
+            : "waiting";
           overlay = { state, until: Date.now() + 10 * 60 * 1000, tool: null };
           publish();
           markActive();
-          onMoment({ kind: 'waiting', tool });
+          onMoment({ kind: "waiting", tool });
         } else if (dec) {
           if (permHold) {
             permHold = null;
             overlay = null;
-            setBase('working', 'Agent');
+            setBase("working", "Agent");
             markActive();
           }
-        } else if (m[1] === 'ERROR') {
+        } else if (m[1] === "ERROR") {
           errLine = stripText(msg, 160);
-        } else if (m[2] === 'ClaudeAgent') {
+        } else if (m[2] === "ClaudeAgent") {
           sawAgent = true;
         }
       }
@@ -286,18 +334,22 @@ function createWatcher(handlers) {
         // 出错也解除等待和回合（会话已经翻车了，别一直举着手/装思考）
         permHold = null;
         turnUntil = 0;
-        if (overlay && (overlay.state === 'waiting' || overlay.state === 'needsinput')) overlay = null;
+        if (
+          overlay &&
+          (overlay.state === "waiting" || overlay.state === "needsinput")
+        )
+          overlay = null;
         // 5 分钟内第二次出错 → 从"大哭"升级成"生气冒烟"
         const now2 = Date.now();
         recentErrors = recentErrors.filter((t) => now2 - t < 5 * 60 * 1000);
         recentErrors.push(now2);
-        flash(recentErrors.length >= 2 ? 'angry' : 'error', 8000);
+        flash(recentErrors.length >= 2 ? "angry" : "error", 8000);
         markActive();
-        onMoment({ kind: 'error', detail: errLine });
+        onMoment({ kind: "error", detail: errLine });
       } else if (sawAgent && !permHold && !turnActive()) {
         // 回合内不让 runtime 杂音（同步技能等日志行）打断 thinking——
         // 回合内只有真实工具活动（audit）才切 working。
-        setBase('working', 'Agent');
+        setBase("working", "Agent");
         markActive();
       }
     });
@@ -307,69 +359,108 @@ function createWatcher(handlers) {
   function extractText(partsJson) {
     try {
       for (const p of JSON.parse(partsJson)) {
-        if (p && p.type === 'text' && p.text) return stripText(p.text);
+        if (p && p.type === "text" && p.text) return stripText(p.text);
       }
     } catch {}
-    return '';
+    return "";
   }
 
   function dbTick() {
     if (stopped || dbBroken || !fs.existsSync(DATA_DB)) return;
-    const sql = 'SELECT rowid, role, parts FROM Message_v2 ORDER BY rowid DESC LIMIT 8;';
-    execFile('sqlite3', ['-readonly', '-json', DATA_DB, sql], { timeout: 4000 }, (err, out) => {
-      if (stopped) return;
-      if (err) {
-        dbBroken = true;
-        log('watcher', 'db poll disabled:', String(err.message).slice(0, 120));
-        return;
-      }
-      let rows; try { rows = JSON.parse(out || '[]'); } catch { return; }
-      if (!rows.length) return;
-      const maxRowid = rows[0].rowid;
-      if (dbLastRowid < 0) { dbLastRowid = maxRowid; return; } // 首查不回放历史
-      if (maxRowid <= dbLastRowid) return;
-      const fresh = rows.filter((r) => r.rowid > dbLastRowid);   // 新→旧
-      dbLastRowid = maxRowid;
-      lastChatTs = Date.now();
-      // 只按"最新一条"定状态，别把已过时的中间态回放出来
-      // （轮询间隔内 user+assistant 一起到时，直接演最终幕）。
-      const latest = fresh[0];
-      if (latest.role === 'user') {
-        turnUntil = Date.now() + TURN_MAX_MS;   // 开回合：思考态可持续，工具间隙会回落回来
-        setBase('thinking');
-        markActive();
-      } else if (latest.role === 'assistant') {
-        turnUntil = 0;                           // 收回合
-        const text = extractText(latest.parts);
-        setBase('idle');
-        flash('talking', 6000);
-        // 说完话竖个大拇指：回合圆满收工
-        timers.push(setTimeout(() => { if (!stopped) flash('done', 3500); }, 6100));
-        markActive();
-        if (text) onMoment({ kind: 'reply', text });
-      }
-    });
+    const sql =
+      "SELECT rowid, role, parts FROM Message_v2 ORDER BY rowid DESC LIMIT 8;";
+    execFile(
+      "sqlite3",
+      ["-readonly", "-json", DATA_DB, sql],
+      { timeout: 4000 },
+      (err, out) => {
+        if (stopped) return;
+        if (err) {
+          dbBroken = true;
+          log(
+            "watcher",
+            "db poll disabled:",
+            String(err.message).slice(0, 120),
+          );
+          return;
+        }
+        let rows;
+        try {
+          rows = JSON.parse(out || "[]");
+        } catch {
+          return;
+        }
+        if (!rows.length) return;
+        const maxRowid = rows[0].rowid;
+        if (dbLastRowid < 0) {
+          dbLastRowid = maxRowid;
+          return;
+        } // 首查不回放历史
+        if (maxRowid <= dbLastRowid) return;
+        const fresh = rows.filter((r) => r.rowid > dbLastRowid); // 新→旧
+        dbLastRowid = maxRowid;
+        lastChatTs = Date.now();
+        // 只按"最新一条"定状态，别把已过时的中间态回放出来
+        // （轮询间隔内 user+assistant 一起到时，直接演最终幕）。
+        const latest = fresh[0];
+        if (latest.role === "user") {
+          turnUntil = Date.now() + TURN_MAX_MS; // 开回合：思考态可持续，工具间隙会回落回来
+          setBase("thinking");
+          markActive();
+        } else if (latest.role === "assistant") {
+          turnUntil = 0; // 收回合
+          const text = extractText(latest.parts);
+          setBase("idle");
+          flash("talking", 6000);
+          // 说完话竖个大拇指：回合圆满收工
+          timers.push(
+            setTimeout(() => {
+              if (!stopped) flash("done", 3500);
+            }, 6100),
+          );
+          markActive();
+          if (text) onMoment({ kind: "reply", text });
+        }
+      },
+    );
   }
 
   // ── 心跳：overlay 过期、静默回落、闲极溜达 ─────────────────────────────────
   function tick() {
     if (stopped) return;
     const now = Date.now();
-    if (overlay && overlay.until <= now) { overlay = null; publish(); }
+    if (overlay && overlay.until <= now) {
+      overlay = null;
+      publish();
+    }
     if (online) {
       if (turnActive()) {
         // 回合内：一旦动过工具就保持"拿电脑干活"直到回复（用户直觉：整个
         // 任务过程=工作中）。工具间隙只把具体动作（读文件 xx）过期掉，
         // 状态条退成"干活中…"。thinking 只属于提问后、第一次动工前。
-        if (base === 'working' && (baseTool || baseHint) && lastToolTs && now - lastToolTs > TOOL_GAP_TO_THINKING_MS) {
-          setBase('working', null, null);
+        if (
+          base === "working" &&
+          (baseTool || baseHint) &&
+          lastToolTs &&
+          now - lastToolTs > TOOL_GAP_TO_THINKING_MS
+        ) {
+          setBase("working", null, null);
         }
-      } else if ((base === 'working' || base === 'thinking') && lastActivity && now - lastActivity > QUIET_TO_IDLE_MS) {
-        setBase('idle');
+      } else if (
+        (base === "working" || base === "thinking") &&
+        lastActivity &&
+        now - lastActivity > QUIET_TO_IDLE_MS
+      ) {
+        setBase("idle");
       }
-      if (base === 'idle' && idleSince && now - idleSince > IDLE_TO_ROAM_MS && now - lastRoam > ROAM_EVERY_MS) {
+      if (
+        base === "idle" &&
+        idleSince &&
+        now - idleSince > IDLE_TO_ROAM_MS &&
+        now - lastRoam > ROAM_EVERY_MS
+      ) {
         lastRoam = now;
-        flash('roam', ROAM_LEN_MS);
+        flash("roam", ROAM_LEN_MS);
       }
     }
     publish();
@@ -377,11 +468,24 @@ function createWatcher(handlers) {
 
   // ── 演示模式：轮播所有表情（皮肤验收用） ───────────────────────────────────
   const DEMO = [
-    ['greet', 3000], ['idle', 3000], ['thinking', 3000], ['working', 3000, 'Connector'],
-    ['working', 3000, 'Memory'], ['juggling', 3000, 'Agent'], ['talking', 3000],
-    ['happy', 3000], ['sweeping', 3000, 'Memory'], ['waiting', 3000], ['needsinput', 3000],
-    ['attention', 3000], ['done', 3000], ['loved', 3000], ['roam', 3000],
-    ['error', 3000], ['angry', 3000], ['sleeping', 4000],
+    ["greet", 3000],
+    ["idle", 3000],
+    ["thinking", 3000],
+    ["working", 3000, "Connector"],
+    ["working", 3000, "Memory"],
+    ["juggling", 3000, "Agent"],
+    ["talking", 3000],
+    ["happy", 3000],
+    ["sweeping", 3000, "Memory"],
+    ["waiting", 3000],
+    ["needsinput", 3000],
+    ["attention", 3000],
+    ["done", 3000],
+    ["loved", 3000],
+    ["roam", 3000],
+    ["error", 3000],
+    ["angry", 3000],
+    ["sleeping", 4000],
   ];
   let demoIdx = 0;
   function demoTick() {
@@ -389,8 +493,17 @@ function createWatcher(handlers) {
     const [st, ms, tool] = DEMO[demoIdx % DEMO.length];
     demoIdx++;
     const t = tool && TOOLS[tool] ? TOOLS[tool] : null;
-    onState({ state: st, tool: tool || null, icon: t ? t.icon : null, label: t ? t.label : null });
-    if (st === 'talking') onMoment({ kind: 'reply', text: '（演示）我刚把 3 封邮件和 2 条 issue 织进了记忆图谱。' });
+    onState({
+      state: st,
+      tool: tool || null,
+      icon: t ? t.icon : null,
+      label: t ? t.label : null,
+    });
+    if (st === "talking")
+      onMoment({
+        kind: "reply",
+        text: "（演示）我刚把 3 封邮件和 2 条 issue 织进了记忆图谱。",
+      });
     timers.push(setTimeout(demoTick, ms));
   }
 
@@ -401,12 +514,15 @@ function createWatcher(handlers) {
   }
 
   function start() {
-    if (process.env.OPENLOOMI_PET_DEMO === '1') {
-      log('watcher', 'DEMO mode（表情轮播）');
+    if (process.env.OPENLOOMI_PET_DEMO === "1") {
+      log("watcher", "DEMO mode（表情轮播）");
       timers.push(setTimeout(demoTick, 1000));
       return;
     }
-    log('watcher', `watching OpenLoomi: api=${API_URLS.join(',')} home=${LOOMI_HOME}`);
+    log(
+      "watcher",
+      `watching OpenLoomi: api=${API_URLS.join(",")} home=${LOOMI_HOME}`,
+    );
     presenceTick();
     every(presenceTick, PRESENCE_MS);
     every(auditTick, TAIL_MS);
@@ -417,7 +533,10 @@ function createWatcher(handlers) {
 
   function stop() {
     stopped = true;
-    for (const t of timers) { clearTimeout(t); clearInterval(t); }
+    for (const t of timers) {
+      clearTimeout(t);
+      clearInterval(t);
+    }
     timers.length = 0;
   }
 

--- a/apps/pet/main.js
+++ b/apps/pet/main.js
@@ -1,20 +1,33 @@
-'use strict';
+"use strict";
 
 // OpenLoomiPet — Electron 主进程。
 // 透明置顶小窗（桌宠）+ 托盘 + 两个后台模块：
 //   watcher（盯 OpenLoomi 真实活动）→ pet:state
 //   brain（DeepSeek 生成台词）      → pet:bubble
 
-const path = require('path');
-const { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, screen, shell } = require('electron');
+const path = require("path");
+const {
+  app,
+  BrowserWindow,
+  ipcMain,
+  Tray,
+  Menu,
+  nativeImage,
+  screen,
+  shell,
+} = require("electron");
 
-try { app.setName('openloomipet'); } catch {}
-try { app.setAppUserModelId('com.openloomi.pet'); } catch {}
+try {
+  app.setName("openloomipet");
+} catch {}
+try {
+  app.setAppUserModelId("com.openloomi.pet");
+} catch {}
 
-const config = require('./backend/config');
-const { log, LOG_PATH } = require('./backend/log');
-const { createWatcher } = require('./backend/watcher');
-const { createBrain } = require('./backend/brain');
+const config = require("./backend/config");
+const { log, LOG_PATH } = require("./backend/log");
+const { createWatcher } = require("./backend/watcher");
+const { createBrain } = require("./backend/brain");
 
 const WIN_W = 240;
 const WIN_H = 280;
@@ -26,7 +39,8 @@ let brain = null;
 let lastState = null;
 
 function send(channel, payload) {
-  if (petWin && !petWin.isDestroyed()) petWin.webContents.send(channel, payload);
+  if (petWin && !petWin.isDestroyed())
+    petWin.webContents.send(channel, payload);
 }
 
 function frontendConfig() {
@@ -37,8 +51,10 @@ function frontendConfig() {
 function createPetWindow() {
   const saved = config.get().petPosition;
   let x, y;
-  if (saved && Number.isFinite(saved.x) && Number.isFinite(saved.y)) { x = saved.x; y = saved.y; }
-  else {
+  if (saved && Number.isFinite(saved.x) && Number.isFinite(saved.y)) {
+    x = saved.x;
+    y = saved.y;
+  } else {
     try {
       const wa = screen.getPrimaryDisplay().workArea;
       x = wa.x + wa.width - WIN_W - 24;
@@ -49,7 +65,8 @@ function createPetWindow() {
   petWin = new BrowserWindow({
     width: WIN_W,
     height: WIN_H,
-    x, y,
+    x,
+    y,
     frame: false,
     transparent: true,
     hasShadow: false,
@@ -58,81 +75,116 @@ function createPetWindow() {
     skipTaskbar: true,
     fullscreenable: false,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
     },
   });
-  petWin.setAlwaysOnTop(true, 'floating');
-  try { petWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true }); } catch {}
-  petWin.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-  petWin.webContents.on('will-navigate', (e, url) => { if (!url.startsWith('file://')) e.preventDefault(); });
-  petWin.loadFile(path.join(__dirname, 'renderer', 'pet.html'));
+  petWin.setAlwaysOnTop(true, "floating");
+  try {
+    petWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  } catch {}
+  petWin.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  petWin.webContents.on("will-navigate", (e, url) => {
+    if (!url.startsWith("file://")) e.preventDefault();
+  });
+  petWin.loadFile(path.join(__dirname, "renderer", "pet.html"));
 
-  petWin.on('moved', () => {
+  petWin.on("moved", () => {
     if (!petWin) return;
     const b = petWin.getBounds();
     config.save({ petPosition: { x: b.x, y: b.y } });
   });
-  petWin.webContents.on('did-finish-load', () => {
-    send('pet:config', frontendConfig());
-    if (lastState) send('pet:state', lastState);
+  petWin.webContents.on("did-finish-load", () => {
+    send("pet:config", frontendConfig());
+    if (lastState) send("pet:state", lastState);
   });
 }
 
 function launchOpenLoomi() {
-  const { spawn } = require('child_process');
-  const open = (bin, args) => new Promise((resolve) => {
-    try {
-      const c = spawn(bin, args, { detached: true, stdio: 'ignore' });
-      c.on('error', () => resolve(false));
-      c.on('spawn', () => { c.unref(); resolve(true); });
-    } catch { resolve(false); }
-  });
+  const { spawn } = require("child_process");
+  const open = (bin, args) =>
+    new Promise((resolve) => {
+      try {
+        const c = spawn(bin, args, { detached: true, stdio: "ignore" });
+        c.on("error", () => resolve(false));
+        c.on("spawn", () => {
+          c.unref();
+          resolve(true);
+        });
+      } catch {
+        resolve(false);
+      }
+    });
   (async () => {
-    if (process.platform === 'darwin' && (await open('open', ['-a', 'openloomi']))) return;
-    if (process.platform === 'win32' && (await open('cmd.exe', ['/c', 'start', '', 'openloomi://']))) return;
-    if (process.platform === 'linux' && (await open('openloomi', []))) return;
-    await open(process.platform === 'darwin' ? 'open' : 'xdg-open', ['https://openloomi.ai']);
+    if (
+      process.platform === "darwin" &&
+      (await open("open", ["-a", "openloomi"]))
+    )
+      return;
+    if (
+      process.platform === "win32" &&
+      (await open("cmd.exe", ["/c", "start", "", "openloomi://"]))
+    )
+      return;
+    if (process.platform === "linux" && (await open("openloomi", []))) return;
+    await open(process.platform === "darwin" ? "open" : "xdg-open", [
+      "https://openloomi.ai",
+    ]);
   })().catch(() => {});
 }
 
 function registerIpc() {
-  ipcMain.handle('get-config', () => frontendConfig());
-  ipcMain.handle('get-win-pos', () => {
+  ipcMain.handle("get-config", () => frontendConfig());
+  ipcMain.handle("get-win-pos", () => {
     if (!petWin || petWin.isDestroyed()) return [0, 0];
     const b = petWin.getBounds();
     return [b.x, b.y];
   });
-  ipcMain.on('set-win-pos', (_e, x, y) => {
-    if (petWin && !petWin.isDestroyed() && Number.isFinite(x) && Number.isFinite(y)) {
+  ipcMain.on("set-win-pos", (_e, x, y) => {
+    if (
+      petWin &&
+      !petWin.isDestroyed() &&
+      Number.isFinite(x) &&
+      Number.isFinite(y)
+    ) {
       const b = petWin.getBounds();
-      petWin.setBounds({ x: Math.round(x), y: Math.round(y), width: b.width, height: b.height });
+      petWin.setBounds({
+        x: Math.round(x),
+        y: Math.round(y),
+        width: b.width,
+        height: b.height,
+      });
     }
   });
-  ipcMain.on('set-ignore-mouse', (_e, ignore) => {
+  ipcMain.on("set-ignore-mouse", (_e, ignore) => {
     if (petWin && !petWin.isDestroyed()) {
-      try { petWin.setIgnoreMouseEvents(!!ignore, { forward: true }); } catch {}
+      try {
+        petWin.setIgnoreMouseEvents(!!ignore, { forward: true });
+      } catch {}
     }
   });
-  ipcMain.on('launch-openloomi', launchOpenLoomi);
-  ipcMain.on('toggle-mute', () => {
+  ipcMain.on("launch-openloomi", launchOpenLoomi);
+  ipcMain.on("toggle-mute", () => {
     config.save({ muted: !config.get().muted });
-    send('pet:config', frontendConfig());
+    send("pet:config", frontendConfig());
     refreshTrayMenu();
   });
-  ipcMain.on('open-log', () => shell.openPath(LOG_PATH));
-  ipcMain.on('quit-app', () => app.quit());
-  ipcMain.on('pet-log', (_e, tag, msg) => log('ui:' + tag, msg));
+  ipcMain.on("open-log", () => shell.openPath(LOG_PATH));
+  ipcMain.on("quit-app", () => app.quit());
+  ipcMain.on("pet-log", (_e, tag, msg) => log("ui:" + tag, msg));
 }
 
 function bootBackend() {
   brain = createBrain((text) => {
-    if (!config.get().muted) send('pet:bubble', { text, ts: Date.now() });
+    if (!config.get().muted) send("pet:bubble", { text, ts: Date.now() });
   });
   watcher = createWatcher({
-    onState: (s) => { lastState = s; send('pet:state', s); },
+    onState: (s) => {
+      lastState = s;
+      send("pet:state", s);
+    },
     onMoment: (m) => brain.say(m),
   });
   watcher.start();
@@ -142,44 +194,49 @@ function buildTray() {
   let img;
   try {
     img = nativeImage
-      .createFromPath(path.join(__dirname, 'assets', 'loomi', 'loomi-idle.png'))
+      .createFromPath(path.join(__dirname, "assets", "loomi", "loomi-idle.png"))
       .resize({ width: 18, height: 18 });
   } catch {}
   tray = new Tray(img || nativeImage.createEmpty());
-  tray.setToolTip('OpenLoomiPet — OpenLoomi 桌宠');
+  tray.setToolTip("OpenLoomiPet — OpenLoomi 桌宠");
   refreshTrayMenu();
 }
 
 function refreshTrayMenu() {
   if (!tray) return;
   const muted = config.get().muted;
-  tray.setContextMenu(Menu.buildFromTemplate([
-    { label: '🐾 显示桌宠', click: () => petWin && petWin.show() },
-    { label: '🚀 唤起 OpenLoomi', click: launchOpenLoomi },
-    { type: 'separator' },
-    { label: muted ? '🔔 打开台词气泡' : '🔇 关闭台词气泡', click: () => {
-      config.save({ muted: !muted });
-      send('pet:config', frontendConfig());
-      refreshTrayMenu();
-    } },
-    { label: '📄 打开日志', click: () => shell.openPath(LOG_PATH) },
-    { type: 'separator' },
-    { label: '⏻ 退出', click: () => app.quit() },
-  ]));
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: "🐾 显示桌宠", click: () => petWin && petWin.show() },
+      { label: "🚀 唤起 OpenLoomi", click: launchOpenLoomi },
+      { type: "separator" },
+      {
+        label: muted ? "🔔 打开台词气泡" : "🔇 关闭台词气泡",
+        click: () => {
+          config.save({ muted: !muted });
+          send("pet:config", frontendConfig());
+          refreshTrayMenu();
+        },
+      },
+      { label: "📄 打开日志", click: () => shell.openPath(LOG_PATH) },
+      { type: "separator" },
+      { label: "⏻ 退出", click: () => app.quit() },
+    ]),
+  );
 }
 
 // pid 文件：OpenLoomi 客户端（apps/web 的 pet launcher）靠它检测在跑/停止。
-const PID_PATH = path.join(require('os').homedir(), '.openloomipet', 'pet.pid');
+const PID_PATH = path.join(require("os").homedir(), ".openloomipet", "pet.pid");
 function writePidFile() {
   try {
-    require('fs').mkdirSync(path.dirname(PID_PATH), { recursive: true });
-    require('fs').writeFileSync(PID_PATH, String(process.pid), 'utf8');
+    require("fs").mkdirSync(path.dirname(PID_PATH), { recursive: true });
+    require("fs").writeFileSync(PID_PATH, String(process.pid), "utf8");
   } catch {}
 }
 function removePidFile() {
   try {
-    const cur = require('fs').readFileSync(PID_PATH, 'utf8').trim();
-    if (cur === String(process.pid)) require('fs').unlinkSync(PID_PATH);
+    const cur = require("fs").readFileSync(PID_PATH, "utf8").trim();
+    if (cur === String(process.pid)) require("fs").unlinkSync(PID_PATH);
   } catch {}
 }
 
@@ -188,23 +245,31 @@ if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
   app.whenReady().then(() => {
-    if (process.platform === 'darwin' && app.dock) app.dock.hide();
+    if (process.platform === "darwin" && app.dock) app.dock.hide();
     writePidFile();
     registerIpc();
     bootBackend();
     createPetWindow();
-    try { buildTray(); } catch (e) { log('main', 'tray unavailable:', e.message); }
-    log('main', 'OpenLoomiPet ready');
+    try {
+      buildTray();
+    } catch (e) {
+      log("main", "tray unavailable:", e.message);
+    }
+    log("main", "OpenLoomiPet ready");
   });
 }
 
-app.on('window-all-closed', () => { /* 托盘应用：保持存活 */ });
+app.on("window-all-closed", () => {
+  /* 托盘应用：保持存活 */
+});
 
 // launcher 用 SIGTERM 停桌宠 → 走正常退出流程
-process.on('SIGTERM', () => app.quit());
+process.on("SIGTERM", () => app.quit());
 
-app.on('before-quit', () => {
-  try { if (watcher) watcher.stop(); } catch {}
+app.on("before-quit", () => {
+  try {
+    if (watcher) watcher.stop();
+  } catch {}
   removePidFile();
-  log('main', 'OpenLoomiPet quit');
+  log("main", "OpenLoomiPet quit");
 });

--- a/apps/pet/preload.js
+++ b/apps/pet/preload.js
@@ -1,20 +1,21 @@
-'use strict';
+"use strict";
 
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer } = require("electron");
 
-contextBridge.exposeInMainWorld('pet', {
+contextBridge.exposeInMainWorld("pet", {
   // 主进程 → 渲染层
-  onState: (cb) => ipcRenderer.on('pet:state', (_e, data) => cb(data)),
-  onBubble: (cb) => ipcRenderer.on('pet:bubble', (_e, data) => cb(data)),
-  onConfig: (cb) => ipcRenderer.on('pet:config', (_e, data) => cb(data)),
+  onState: (cb) => ipcRenderer.on("pet:state", (_e, data) => cb(data)),
+  onBubble: (cb) => ipcRenderer.on("pet:bubble", (_e, data) => cb(data)),
+  onConfig: (cb) => ipcRenderer.on("pet:config", (_e, data) => cb(data)),
   // 渲染层 → 主进程
-  getConfig: () => ipcRenderer.invoke('get-config'),
-  getWinPos: () => ipcRenderer.invoke('get-win-pos'),
-  setWinPos: (x, y) => ipcRenderer.send('set-win-pos', x, y),
-  setIgnoreMouse: (ignore) => ipcRenderer.send('set-ignore-mouse', ignore),
-  launchOpenLoomi: () => ipcRenderer.send('launch-openloomi'),
-  toggleMute: () => ipcRenderer.send('toggle-mute'),
-  openLog: () => ipcRenderer.send('open-log'),
-  quit: () => ipcRenderer.send('quit-app'),
-  petLog: (tag, msg) => ipcRenderer.send('pet-log', String(tag || ''), String(msg || '')),
+  getConfig: () => ipcRenderer.invoke("get-config"),
+  getWinPos: () => ipcRenderer.invoke("get-win-pos"),
+  setWinPos: (x, y) => ipcRenderer.send("set-win-pos", x, y),
+  setIgnoreMouse: (ignore) => ipcRenderer.send("set-ignore-mouse", ignore),
+  launchOpenLoomi: () => ipcRenderer.send("launch-openloomi"),
+  toggleMute: () => ipcRenderer.send("toggle-mute"),
+  openLog: () => ipcRenderer.send("open-log"),
+  quit: () => ipcRenderer.send("quit-app"),
+  petLog: (tag, msg) =>
+    ipcRenderer.send("pet-log", String(tag || ""), String(msg || "")),
 });

--- a/apps/pet/renderer/pet.css
+++ b/apps/pet/renderer/pet.css
@@ -1,9 +1,16 @@
 /* OpenLoomiPet — 桌宠渲染层。窗口透明，只有 Loomi 与气泡可见。 */
 
-* { margin: 0; padding: 0; box-sizing: border-box; user-select: none; }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  user-select: none;
+}
 
-html, body {
-  width: 100%; height: 100%;
+html,
+body {
+  width: 100%;
+  height: 100%;
   background: transparent;
   overflow: hidden;
   font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
@@ -11,7 +18,8 @@ html, body {
 
 #stage {
   position: relative;
-  width: 100%; height: 100%;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -21,52 +29,148 @@ html, body {
 
 /* ---------- Loomi 本体 ---------- */
 #loomi {
-  width: 132px; height: 132px;
+  width: 132px;
+  height: 132px;
   cursor: grab;
   touch-action: none;
   filter: drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
 }
-#loomi img { width: 100%; height: 100%; object-fit: contain; -webkit-user-drag: none; pointer-events: none; }
-#loomi.dragging { cursor: grabbing; animation: grabbed 0.45s ease-in-out infinite; }
+#loomi img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+#loomi.dragging {
+  cursor: grabbing;
+  animation: grabbed 0.45s ease-in-out infinite;
+}
 
 /* 状态动效：图换表情，CSS 补运动 */
-#loomi.idle { animation: bob 3.6s ease-in-out infinite; }
-#loomi.roam { animation: stroll 2.4s ease-in-out infinite; }
+#loomi.idle {
+  animation: bob 3.6s ease-in-out infinite;
+}
+#loomi.roam {
+  animation: stroll 2.4s ease-in-out infinite;
+}
 #loomi.working,
 #loomi.juggling,
 #loomi.thinking,
 #loomi.talking,
-#loomi.sweeping { animation: bob 2.2s ease-in-out infinite; }
-#loomi.sleeping { animation: breathe 4.5s ease-in-out infinite; }
+#loomi.sweeping {
+  animation: bob 2.2s ease-in-out infinite;
+}
+#loomi.sleeping {
+  animation: breathe 4.5s ease-in-out infinite;
+}
 #loomi.happy,
-#loomi.greet { animation: happyJump 0.6s ease-in-out 3; }
+#loomi.greet {
+  animation: happyJump 0.6s ease-in-out 3;
+}
 #loomi.waiting,
 #loomi.needsinput {
   animation: attn 0.6s ease-in-out infinite;
-  filter: drop-shadow(0 0 10px rgba(255, 190, 80, 0.95)) drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
+  filter: drop-shadow(0 0 10px rgba(255, 190, 80, 0.95))
+    drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
 }
-#loomi.attention { animation: attn 0.5s ease-in-out 4; }
+#loomi.attention {
+  animation: attn 0.5s ease-in-out 4;
+}
 #loomi.error {
   animation: errShake 0.42s ease-in-out 3;
-  filter: drop-shadow(0 0 9px rgba(232, 80, 55, 0.85)) drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
+  filter: drop-shadow(0 0 9px rgba(232, 80, 55, 0.85))
+    drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
 }
 #loomi.angry {
   animation: errShake 0.36s ease-in-out 4;
-  filter: drop-shadow(0 0 10px rgba(255, 120, 40, 0.9)) drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
+  filter: drop-shadow(0 0 10px rgba(255, 120, 40, 0.9))
+    drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
 }
-#loomi.done { animation: happyJump 0.55s ease-in-out 2; }
+#loomi.done {
+  animation: happyJump 0.55s ease-in-out 2;
+}
 #loomi.loved {
   animation: bob 1.2s ease-in-out infinite;
-  filter: drop-shadow(0 0 12px rgba(255, 105, 150, 0.85)) drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
+  filter: drop-shadow(0 0 12px rgba(255, 105, 150, 0.85))
+    drop-shadow(0 6px 9px rgba(60, 80, 120, 0.28));
 }
 
-@keyframes bob        { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-5px); } }
-@keyframes breathe    { 0%,100% { transform: scale(1); } 50% { transform: scale(1.035); } }
-@keyframes happyJump  { 0%,100% { transform: translateY(0); } 45% { transform: translateY(-16px); } }
-@keyframes attn       { 0%,100% { transform: translateY(0) rotate(0); } 30% { transform: translateY(-4px) rotate(-3deg); } 70% { transform: translateY(-4px) rotate(3deg); } }
-@keyframes errShake   { 0%,100% { transform: translateX(0); } 25% { transform: translateX(-6px); } 75% { transform: translateX(6px); } }
-@keyframes grabbed    { 0%,100% { transform: rotate(-3deg); } 50% { transform: rotate(3deg); } }
-@keyframes stroll     { 0%,100% { transform: translateX(-12px) translateY(0); } 25% { transform: translateX(0) translateY(-4px); } 50% { transform: translateX(12px) translateY(0); } 75% { transform: translateX(0) translateY(-4px); } }
+@keyframes bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+}
+@keyframes breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.035);
+  }
+}
+@keyframes happyJump {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  45% {
+    transform: translateY(-16px);
+  }
+}
+@keyframes attn {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0);
+  }
+  30% {
+    transform: translateY(-4px) rotate(-3deg);
+  }
+  70% {
+    transform: translateY(-4px) rotate(3deg);
+  }
+}
+@keyframes errShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  75% {
+    transform: translateX(6px);
+  }
+}
+@keyframes grabbed {
+  0%,
+  100% {
+    transform: rotate(-3deg);
+  }
+  50% {
+    transform: rotate(3deg);
+  }
+}
+@keyframes stroll {
+  0%,
+  100% {
+    transform: translateX(-12px) translateY(0);
+  }
+  25% {
+    transform: translateX(0) translateY(-4px);
+  }
+  50% {
+    transform: translateX(12px) translateY(0);
+  }
+  75% {
+    transform: translateX(0) translateY(-4px);
+  }
+}
 
 /* ---------- 头顶道具 ---------- */
 .prop {
@@ -75,11 +179,25 @@ html, body {
   line-height: 26px;
   opacity: 0;
   transform: translateY(4px);
-  transition: opacity 0.25s, transform 0.25s;
+  transition:
+    opacity 0.25s,
+    transform 0.25s;
   pointer-events: none;
 }
-.prop.on { opacity: 1; transform: translateY(0); animation: propFloat 1.6s ease-in-out infinite; }
-@keyframes propFloat { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }
+.prop.on {
+  opacity: 1;
+  transform: translateY(0);
+  animation: propFloat 1.6s ease-in-out infinite;
+}
+@keyframes propFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
 
 /* ---------- 台词气泡 ---------- */
 .bubble {
@@ -97,10 +215,12 @@ html, body {
   line-height: 1.45;
   box-shadow: 0 4px 12px rgba(40, 60, 100, 0.25);
   z-index: 5;
-  transition: opacity 0.25s, transform 0.25s;
+  transition:
+    opacity 0.25s,
+    transform 0.25s;
 }
 .bubble::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: -8px;
   left: 50%;
@@ -109,7 +229,11 @@ html, body {
   border-top-color: #33508c;
   border-bottom: none;
 }
-.bubble.hidden { opacity: 0; transform: translateX(-50%) translateY(4px); pointer-events: none; }
+.bubble.hidden {
+  opacity: 0;
+  transform: translateX(-50%) translateY(4px);
+  pointer-events: none;
+}
 
 /* ---------- 脚下状态条 ---------- */
 .status-chip {
@@ -129,7 +253,9 @@ html, body {
   transition: opacity 0.25s;
   pointer-events: none;
 }
-.status-chip.hidden { opacity: 0; }
+.status-chip.hidden {
+  opacity: 0;
+}
 
 /* ---------- 右键菜单 ---------- */
 .menu {
@@ -145,7 +271,9 @@ html, body {
   z-index: 10;
   min-width: 150px;
 }
-.menu.hidden { display: none; }
+.menu.hidden {
+  display: none;
+}
 .menu button {
   display: block;
   width: 100%;
@@ -157,4 +285,6 @@ html, body {
   color: #2b3a55;
   cursor: pointer;
 }
-.menu button:hover { background: #eef3fc; }
+.menu button:hover {
+  background: #eef3fc;
+}

--- a/apps/pet/renderer/pet.html
+++ b/apps/pet/renderer/pet.html
@@ -1,35 +1,43 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; img-src 'self'; script-src 'self'" />
-  <link rel="stylesheet" href="pet.css" />
-  <title>OpenLoomiPet</title>
-</head>
-<body>
-  <div id="stage">
-    <!-- 台词气泡 -->
-    <div id="bubble" class="bubble hidden"></div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self'; img-src 'self'; script-src 'self'"
+    />
+    <link rel="stylesheet" href="pet.css" />
+    <title>OpenLoomiPet</title>
+  </head>
+  <body>
+    <div id="stage">
+      <!-- 台词气泡 -->
+      <div id="bubble" class="bubble hidden"></div>
 
-    <!-- 头顶工具道具（working 时显示当前在忙什么） -->
-    <div id="prop" class="prop"></div>
+      <!-- 头顶工具道具（working 时显示当前在忙什么） -->
+      <div id="prop" class="prop"></div>
 
-    <!-- Loomi 本体：每个状态一张官方表情 PNG -->
-    <div id="loomi" class="idle">
-      <img id="loomi-img" src="../assets/loomi/loomi-idle.png" alt="loomi" draggable="false" />
+      <!-- Loomi 本体：每个状态一张官方表情 PNG -->
+      <div id="loomi" class="idle">
+        <img
+          id="loomi-img"
+          src="../assets/loomi/loomi-idle.png"
+          alt="loomi"
+          draggable="false"
+        />
+      </div>
+
+      <!-- 脚下状态条：正在做什么（工具 + 对象名） -->
+      <div id="status-chip" class="status-chip hidden"></div>
+
+      <!-- 右键小菜单 -->
+      <div id="menu" class="menu hidden">
+        <button data-op="launch">🚀 唤起 OpenLoomi</button>
+        <button data-op="mute">🔇 关闭台词气泡</button>
+        <button data-op="log">📄 打开日志</button>
+        <button data-op="quit">⏻ 退出</button>
+      </div>
     </div>
-
-    <!-- 脚下状态条：正在做什么（工具 + 对象名） -->
-    <div id="status-chip" class="status-chip hidden"></div>
-
-    <!-- 右键小菜单 -->
-    <div id="menu" class="menu hidden">
-      <button data-op="launch">🚀 唤起 OpenLoomi</button>
-      <button data-op="mute">🔇 关闭台词气泡</button>
-      <button data-op="log">📄 打开日志</button>
-      <button data-op="quit">⏻ 退出</button>
-    </div>
-  </div>
-  <script src="pet.js"></script>
-</body>
+    <script src="pet.js"></script>
+  </body>
 </html>

--- a/apps/pet/renderer/pet.js
+++ b/apps/pet/renderer/pet.js
@@ -1,19 +1,33 @@
-'use strict';
+"use strict";
 
 // 桌宠渲染层：状态贴图 + 气泡 + 拖动 + 右键菜单。
 // 数据只来自 preload 暴露的 window.pet（pet:state / pet:bubble / pet:config）。
 
-const loomi = document.getElementById('loomi');
-const img = document.getElementById('loomi-img');
-const bubble = document.getElementById('bubble');
-const prop = document.getElementById('prop');
-const statusChip = document.getElementById('status-chip');
-const menu = document.getElementById('menu');
+const loomi = document.getElementById("loomi");
+const img = document.getElementById("loomi-img");
+const bubble = document.getElementById("bubble");
+const prop = document.getElementById("prop");
+const statusChip = document.getElementById("status-chip");
+const menu = document.getElementById("menu");
 
 const STATES = [
-  'idle', 'roam', 'working', 'thinking', 'talking', 'juggling', 'sweeping',
-  'waiting', 'needsinput', 'happy', 'greet', 'attention', 'sleeping', 'error',
-  'done', 'angry', 'loved',
+  "idle",
+  "roam",
+  "working",
+  "thinking",
+  "talking",
+  "juggling",
+  "sweeping",
+  "waiting",
+  "needsinput",
+  "happy",
+  "greet",
+  "attention",
+  "sleeping",
+  "error",
+  "done",
+  "angry",
+  "loved",
 ];
 
 let muted = false;
@@ -25,50 +39,59 @@ let lovedActive = false;
 function setState(s) {
   lastStateData = s;
   if (lovedActive) return; // 摸头动画期间先记下，结束时恢复
-  const state = STATES.includes(s.state) ? s.state : 'idle';
+  const state = STATES.includes(s.state) ? s.state : "idle";
   loomi.classList.remove(...STATES);
   loomi.classList.add(state);
   const file = `../assets/loomi/loomi-${state}.png`;
   if (!img.src.endsWith(`loomi-${state}.png`)) img.src = file;
 
-  if (s.icon && (state === 'working' || state === 'juggling' || state === 'sweeping')) {
+  if (
+    s.icon &&
+    (state === "working" || state === "juggling" || state === "sweeping")
+  ) {
     prop.textContent = s.icon;
-    prop.classList.add('on');
-    prop.title = s.label || '';
+    prop.classList.add("on");
+    prop.title = s.label || "";
   } else {
-    prop.classList.remove('on');
+    prop.classList.remove("on");
   }
   updateStatusChip(state, s);
-  if (state === 'sleeping') hideBubble();
-  window.pet.petLog('state', state + (s.tool ? ':' + s.tool : '') + (s.hint ? '·' + s.hint : ''));
+  if (state === "sleeping") hideBubble();
+  window.pet.petLog(
+    "state",
+    state + (s.tool ? ":" + s.tool : "") + (s.hint ? "·" + s.hint : ""),
+  );
 }
 
 // ---------- 脚下状态条 ----------
 // 干活时显示"图标 动作 · 对象名"；思考/等待也给一句，让状态肉眼可读。
 function updateStatusChip(state, s) {
-  let text = '';
-  if ((state === 'working' || state === 'juggling' || state === 'sweeping') && s.label) {
-    text = `${s.icon || ''} ${s.label}${s.hint ? ' · ' + s.hint : ''}`.trim();
-  } else if (state === 'working') {
-    text = '💻 干活中…'; // 工具间隙：保持工作姿势，动作条退成泛化文案
-  } else if (state === 'thinking') {
-    text = '💭 思考中…';
-  } else if (state === 'waiting') {
-    text = '✋ 等你批准';
-  } else if (state === 'needsinput') {
-    text = '❓ 等你回复';
-  } else if (state === 'done') {
-    text = '✅ 搞定！';
-  } else if (state === 'angry') {
-    text = '💢 老是出错，气！';
-  } else if (state === 'loved') {
-    text = '🥰 好开心～';
+  let text = "";
+  if (
+    (state === "working" || state === "juggling" || state === "sweeping") &&
+    s.label
+  ) {
+    text = `${s.icon || ""} ${s.label}${s.hint ? " · " + s.hint : ""}`.trim();
+  } else if (state === "working") {
+    text = "💻 干活中…"; // 工具间隙：保持工作姿势，动作条退成泛化文案
+  } else if (state === "thinking") {
+    text = "💭 思考中…";
+  } else if (state === "waiting") {
+    text = "✋ 等你批准";
+  } else if (state === "needsinput") {
+    text = "❓ 等你回复";
+  } else if (state === "done") {
+    text = "✅ 搞定！";
+  } else if (state === "angry") {
+    text = "💢 老是出错，气！";
+  } else if (state === "loved") {
+    text = "🥰 好开心～";
   }
   if (text) {
     statusChip.textContent = text;
-    statusChip.classList.remove('hidden');
+    statusChip.classList.remove("hidden");
   } else {
-    statusChip.classList.add('hidden');
+    statusChip.classList.add("hidden");
   }
 }
 
@@ -84,60 +107,74 @@ function bubbleDuration(text) {
 
 function showBubble(text) {
   if (muted || !text) return;
-  if (!bubble.classList.contains('hidden')) {
+  if (!bubble.classList.contains("hidden")) {
     bubbleQueue.push(text);
     if (bubbleQueue.length > 3) bubbleQueue.shift(); // 最多攒 3 条，太旧的丢掉
     return;
   }
   bubble.textContent = text;
-  bubble.classList.remove('hidden');
+  bubble.classList.remove("hidden");
   armBubbleTimer(bubbleDuration(text));
 }
 
 function armBubbleTimer(ms) {
   if (bubbleTimer) clearTimeout(bubbleTimer);
   bubbleTimer = setTimeout(() => {
-    if (bubbleHovered) { armBubbleTimer(3000); return; } // 正在看：续命再查
+    if (bubbleHovered) {
+      armBubbleTimer(3000);
+      return;
+    } // 正在看：续命再查
     hideBubble();
   }, ms);
 }
 
 function hideBubble() {
-  bubble.classList.add('hidden');
-  if (bubbleTimer) { clearTimeout(bubbleTimer); bubbleTimer = null; }
+  bubble.classList.add("hidden");
+  if (bubbleTimer) {
+    clearTimeout(bubbleTimer);
+    bubbleTimer = null;
+  }
   const next = bubbleQueue.shift();
   if (next) setTimeout(() => showBubble(next), 400);
 }
 
-bubble.addEventListener('click', hideBubble);
-bubble.addEventListener('mouseenter', () => { bubbleHovered = true; });
-bubble.addEventListener('mouseleave', () => { bubbleHovered = false; });
+bubble.addEventListener("click", hideBubble);
+bubble.addEventListener("mouseenter", () => {
+  bubbleHovered = true;
+});
+bubble.addEventListener("mouseleave", () => {
+  bubbleHovered = false;
+});
 
 // ---------- 拖动（移动窗口）/ 点击 ----------
 let drag = null;
-loomi.addEventListener('pointerdown', (e) => {
+loomi.addEventListener("pointerdown", (e) => {
   if (e.button !== 0) return;
-  try { loomi.setPointerCapture(e.pointerId); } catch {}
+  try {
+    loomi.setPointerCapture(e.pointerId);
+  } catch {}
   drag = { sx: e.screenX, sy: e.screenY, win: null, moved: false };
-  window.pet.getWinPos().then(([x, y]) => { if (drag) drag.win = [x, y]; });
+  window.pet.getWinPos().then(([x, y]) => {
+    if (drag) drag.win = [x, y];
+  });
 });
-loomi.addEventListener('pointermove', (e) => {
+loomi.addEventListener("pointermove", (e) => {
   if (!drag || !drag.win) return;
   const dx = e.screenX - drag.sx;
   const dy = e.screenY - drag.sy;
   if (Math.abs(dx) + Math.abs(dy) > 4) {
     drag.moved = true;
-    loomi.classList.add('dragging');
+    loomi.classList.add("dragging");
     window.pet.setWinPos(drag.win[0] + dx, drag.win[1] + dy);
   }
 });
-loomi.addEventListener('pointerup', (e) => {
+loomi.addEventListener("pointerup", (e) => {
   const wasDrag = drag && drag.moved;
-  loomi.classList.remove('dragging');
+  loomi.classList.remove("dragging");
   drag = null;
   if (!wasDrag && e.button === 0) {
     // 单击：有气泡先收起，否则唤起 OpenLoomi
-    if (!bubble.classList.contains('hidden')) hideBubble();
+    if (!bubble.classList.contains("hidden")) hideBubble();
     else window.pet.launchOpenLoomi();
   }
 });
@@ -152,50 +189,64 @@ function triggerLoved() {
   lovedActive = true;
   lovedCooldownUntil = Date.now() + 10000;
   loomi.classList.remove(...STATES);
-  loomi.classList.add('loved');
-  img.src = '../assets/loomi/loomi-loved.png';
-  statusChip.textContent = '🥰 好开心～';
-  statusChip.classList.remove('hidden');
-  window.pet.petLog('state', 'loved(petting)');
+  loomi.classList.add("loved");
+  img.src = "../assets/loomi/loomi-loved.png";
+  statusChip.textContent = "🥰 好开心～";
+  statusChip.classList.remove("hidden");
+  window.pet.petLog("state", "loved(petting)");
   setTimeout(() => {
     lovedActive = false;
     if (lastStateData) setState(lastStateData);
   }, 3000);
 }
 
-loomi.addEventListener('mouseenter', () => {
+loomi.addEventListener("mouseenter", () => {
   if (petHoverTimer) clearTimeout(petHoverTimer);
   petHoverTimer = setTimeout(triggerLoved, 1500);
 });
-loomi.addEventListener('mouseleave', () => {
-  if (petHoverTimer) { clearTimeout(petHoverTimer); petHoverTimer = null; }
+loomi.addEventListener("mouseleave", () => {
+  if (petHoverTimer) {
+    clearTimeout(petHoverTimer);
+    petHoverTimer = null;
+  }
 });
 
 // ---------- 右键菜单 ----------
-loomi.addEventListener('contextmenu', (e) => {
+loomi.addEventListener("contextmenu", (e) => {
   e.preventDefault();
-  menu.classList.toggle('hidden');
+  menu.classList.toggle("hidden");
 });
-menu.addEventListener('click', (e) => {
+menu.addEventListener("click", (e) => {
   const op = e.target && e.target.dataset && e.target.dataset.op;
   if (!op) return;
-  menu.classList.add('hidden');
-  if (op === 'launch') window.pet.launchOpenLoomi();
-  else if (op === 'mute') window.pet.toggleMute();
-  else if (op === 'log') window.pet.openLog();
-  else if (op === 'quit') window.pet.quit();
+  menu.classList.add("hidden");
+  if (op === "launch") window.pet.launchOpenLoomi();
+  else if (op === "mute") window.pet.toggleMute();
+  else if (op === "log") window.pet.openLog();
+  else if (op === "quit") window.pet.quit();
 });
-document.addEventListener('click', (e) => {
-  if (!menu.classList.contains('hidden') && !menu.contains(e.target) && e.target !== loomi) {
-    menu.classList.add('hidden');
+document.addEventListener("click", (e) => {
+  if (
+    !menu.classList.contains("hidden") &&
+    !menu.contains(e.target) &&
+    e.target !== loomi
+  ) {
+    menu.classList.add("hidden");
   }
 });
 
 // ---------- 空白处鼠标穿透 ----------
 // 窗口是透明矩形，只有落在 Loomi/气泡/菜单上的鼠标事件才归我们。
-document.addEventListener('mousemove', (e) => {
+document.addEventListener("mousemove", (e) => {
   const el = document.elementFromPoint(e.clientX, e.clientY);
-  const mine = el && (loomi.contains(el) || el === loomi || bubble.contains(el) || el === bubble || menu.contains(el) || el === menu);
+  const mine =
+    el &&
+    (loomi.contains(el) ||
+      el === loomi ||
+      bubble.contains(el) ||
+      el === bubble ||
+      menu.contains(el) ||
+      el === menu);
   window.pet.setIgnoreMouse(!mine);
 });
 
@@ -205,7 +256,10 @@ window.pet.onBubble((b) => showBubble(b && b.text));
 window.pet.onConfig((c) => {
   muted = !!(c && c.muted);
   const muteBtn = menu.querySelector('[data-op="mute"]');
-  if (muteBtn) muteBtn.textContent = muted ? '🔔 打开台词气泡' : '🔇 关闭台词气泡';
+  if (muteBtn)
+    muteBtn.textContent = muted ? "🔔 打开台词气泡" : "🔇 关闭台词气泡";
   if (muted) hideBubble();
 });
-window.pet.getConfig().then((c) => { muted = !!(c && c.muted); });
+window.pet.getConfig().then((c) => {
+  muted = !!(c && c.muted);
+});

--- a/apps/web/components/pet-settings.tsx
+++ b/apps/web/components/pet-settings.tsx
@@ -59,10 +59,11 @@ export function PetSettings() {
       if (data.enabled && data.launchError) {
         toast({
           type: "error",
-          description: t(
-            "settings.petLaunchError",
-            "Saved, but the pet could not be started: ",
-          ) + data.launchError,
+          description:
+            t(
+              "settings.petLaunchError",
+              "Saved, but the pet could not be started: ",
+            ) + data.launchError,
         });
       }
     } catch (error) {

--- a/apps/web/lib/pet/launcher.ts
+++ b/apps/web/lib/pet/launcher.ts
@@ -77,7 +77,10 @@ export function findPetDir(): string | null {
     resolve(process.cwd(), "apps/pet"),
   ].filter((p): p is string => Boolean(p));
   for (const dir of candidates) {
-    if (existsSync(join(dir, "main.js")) && existsSync(join(dir, "package.json"))) {
+    if (
+      existsSync(join(dir, "main.js")) &&
+      existsSync(join(dir, "package.json"))
+    ) {
       return dir;
     }
   }
@@ -88,7 +91,11 @@ export function launchPet(): { ok: boolean; reason?: string } {
   if (isPetRunning()) return { ok: true, reason: "already running" };
   const dir = findPetDir();
   if (!dir) {
-    return { ok: false, reason: "pet app not found (set OPENLOOMI_PET_PATH or run from the monorepo)" };
+    return {
+      ok: false,
+      reason:
+        "pet app not found (set OPENLOOMI_PET_PATH or run from the monorepo)",
+    };
   }
   // electron 可能装在 pet 自己的 node_modules（独立 npm install），也可能被
   // pnpm hoisted 到 monorepo 根 node_modules —— 两处都找。
@@ -98,7 +105,10 @@ export function launchPet(): { ok: boolean; reason?: string } {
     resolve(dir, "../../node_modules/.bin", binName),
   ].find((p) => existsSync(p));
   if (!electronBin) {
-    return { ok: false, reason: `electron not installed for ${dir} (run install in the pet dir or monorepo root)` };
+    return {
+      ok: false,
+      reason: `electron not installed for ${dir} (run install in the pet dir or monorepo root)`,
+    };
   }
   try {
     // 剥掉会毒害 Electron 的继承环境：dev 脚本的 NODE_OPTIONS 带着相对路径

--- a/apps/web/lib/pet/launcher.ts
+++ b/apps/web/lib/pet/launcher.ts
@@ -103,9 +103,12 @@ export function launchPet(): { ok: boolean; reason?: string } {
   try {
     // 剥掉会毒害 Electron 的继承环境：dev 脚本的 NODE_OPTIONS 带着相对路径
     // 的 --require，在 pet 的 cwd 下解析不到会让进程秒退。
-    const env = { ...process.env };
-    delete env.NODE_OPTIONS;
-    delete env.ELECTRON_RUN_AS_NODE;
+    // （解构剔除而非 delete —— biome lint/performance/noDelete）
+    const {
+      NODE_OPTIONS: _nodeOptions,
+      ELECTRON_RUN_AS_NODE: _electronRunAsNode,
+      ...env
+    } = process.env;
     const child = spawn(electronBin, ["."], {
       cwd: dir,
       detached: true,


### PR DESCRIPTION
Follow-up to #263: the CI lint job flagged two `lint/performance/noDelete` errors in `apps/web/lib/pet/launcher.ts` (they surfaced only after workflow authorization, post-merge). Replaces the `delete env.X` calls with a destructuring omit — same behavior (stripping `NODE_OPTIONS` / `ELECTRON_RUN_AS_NODE` from the spawned pet's env), no `delete`.

`apps/web` lint now passes clean locally with the repo's own command (`biome lint`): 1124 files, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)