### PR TITLE
fix: gate macOS dock policy on Windows

### DIFF
--- a/apps/web/src-tauri/src/pet/mod.rs
+++ b/apps/web/src-tauri/src/pet/mod.rs
@@ -4,6 +4,7 @@
 // each concern (window lifecycle, decision-data watcher, macOS dock
 // policy) can be reasoned about and unit-tested on its own.
 
+#[cfg(target_os = "macos")]
 mod dock;
 mod watcher;
 mod window;


### PR DESCRIPTION
## Summary

Fixes the Windows Tauri build failure caused by compiling the macOS-only pet dock policy module.

`apps/web/src-tauri/src/pet/dock.rs` imports macOS-only Tauri APIs such as `ActivationPolicy` and `set_activation_policy`. The module was declared unconditionally, so Windows still attempted to compile it.

This change gates the dock module behind macOS:

```rust
#[cfg(target_os = "macos")]
mod dock;