### PR TITLE
feat(memory): soft-deprecate raw records after summary consolidation

### DIFF
--- a/apps/web/tests/unit/memory-deprecation.test.ts
+++ b/apps/web/tests/unit/memory-deprecation.test.ts
@@ -376,8 +376,7 @@ describe("deprecateMemoryRecords", () => {
       sourceRecordIds: ["r1", "r2"],
       keyPoints: ["User prefers morning planning and Monday calendar review."],
       keywords: ["planning", "calendar"],
-      summaryText:
-        "User prefers morning planning and Monday calendar review.",
+      summaryText: "User prefers morning planning and Monday calendar review.",
       qualityScore: 0.91,
       createdAt: 1700000003000,
       updatedAt: 1700000003000,

--- a/apps/web/tests/unit/memory-deprecation.test.ts
+++ b/apps/web/tests/unit/memory-deprecation.test.ts
@@ -13,6 +13,7 @@ import {
 import type {
   MemoryDeprecateRecordsInput,
   MemoryRecord,
+  MemorySummary,
   MemoryStorageAdapter,
 } from "../../../../packages/ai/src/memory/contracts";
 
@@ -32,6 +33,7 @@ function makeRecord(
 
 class InMemoryMemoryStorageAdapter implements MemoryStorageAdapter {
   records: MemoryRecord[] = [];
+  summaries: MemorySummary[] = [];
   deprecateCalls: MemoryDeprecateRecordsInput[] = [];
 
   async acquireLock() {
@@ -41,13 +43,15 @@ class InMemoryMemoryStorageAdapter implements MemoryStorageAdapter {
   async listCandidates() {
     return [];
   }
-  async saveSummaries() {}
+  async saveSummaries(summaries: MemorySummary[]) {
+    this.summaries.push(...summaries);
+  }
   async transitionRecords() {}
   async queryRaw() {
     return { items: [...this.records], hasMore: false };
   }
   async querySummaries() {
-    return { items: [], hasMore: false };
+    return { items: [...this.summaries], hasMore: false };
   }
   async deprecateRecords(input: MemoryDeprecateRecordsInput): Promise<number> {
     this.deprecateCalls.push(input);
@@ -352,6 +356,112 @@ describe("deprecateMemoryRecords", () => {
     expect(adapter.records).toHaveLength(1);
     expect(adapter.records[0]?.text).toBe("important fact");
     expect(adapter.records[0]?.deprecatedAt).toBeDefined();
+  });
+
+  it("connects persisted summaries to soft-deprecated raw records and audit retrieval", async () => {
+    const adapter = new InMemoryMemoryStorageAdapter();
+    adapter.records = [
+      makeRecord("r1", { text: "prefers morning planning" }),
+      makeRecord("r2", { text: "prefers calendar review on Mondays" }),
+      makeRecord("r3", { text: "unrelated active raw record" }),
+    ];
+    const summary: MemorySummary = {
+      summaryId: "summary-morning-planning",
+      userId: "u1",
+      summaryTier: "L1",
+      sourceTier: "short",
+      startTimestamp: 1700000000000,
+      endTimestamp: 1700000002000,
+      messageCount: 2,
+      sourceRecordIds: ["r1", "r2"],
+      keyPoints: ["User prefers morning planning and Monday calendar review."],
+      keywords: ["planning", "calendar"],
+      summaryText:
+        "User prefers morning planning and Monday calendar review.",
+      qualityScore: 0.91,
+      createdAt: 1700000003000,
+      updatedAt: 1700000003000,
+    };
+    const summaryCandidates: MemorySummaryCandidate[] = [
+      {
+        clusterKey: "planning-preferences",
+        competitionKey: "planning-preferences",
+        recordIds: summary.sourceRecordIds,
+        evidenceCount: summary.sourceRecordIds.length,
+        score: 0.91,
+        priority: 0.91,
+        reasonCodes: ["strong_repeated_evidence"],
+        sourceAction: "preserve",
+      },
+    ];
+
+    await adapter.saveSummaries([summary]);
+    const deprecationPlan = buildMemoryDeprecationEntries({
+      persistedSummaryIds: [summary.summaryId],
+      summaryCandidates,
+    });
+    const result = await deprecateMemoryRecords({
+      userId: "u1",
+      entries: deprecationPlan.entries,
+      store: adapter,
+      now: 1700000004000,
+    });
+
+    expect(result.persistedCount).toBe(2);
+    expect(deprecationPlan.bySummary[summary.summaryId]).toEqual(["r1", "r2"]);
+
+    const defaultRawRetrieval = filterDeprecatedRecords(
+      (await adapter.queryRaw()).items,
+    );
+    expect(defaultRawRetrieval.records.map((record) => record.id)).toEqual([
+      "r3",
+    ]);
+    expect(defaultRawRetrieval.hiddenDeprecatedCount).toBe(2);
+
+    const auditRawRetrieval = filterDeprecatedRecords(
+      (await adapter.queryRaw()).items,
+      { includeDeprecated: true },
+    );
+    expect(auditRawRetrieval.records.map((record) => record.id)).toEqual([
+      "r1",
+      "r2",
+      "r3",
+    ]);
+    expect(
+      auditRawRetrieval.records
+        .filter((record) => record.supersededBySummaryId === summary.summaryId)
+        .map((record) => ({
+          id: record.id,
+          deprecatedAt: record.deprecatedAt,
+          deprecationReason: record.deprecationReason,
+        })),
+    ).toEqual([
+      {
+        id: "r1",
+        deprecatedAt: 1700000004000,
+        deprecationReason: `summarized_into:${summary.summaryId}`,
+      },
+      {
+        id: "r2",
+        deprecatedAt: 1700000004000,
+        deprecationReason: `summarized_into:${summary.summaryId}`,
+      },
+    ]);
+
+    const summaryRetrieval = await adapter.querySummaries();
+    expect(summaryRetrieval.items).toEqual([summary]);
+    expect(summaryRetrieval.items[0]?.sourceRecordIds).toEqual(["r1", "r2"]);
+
+    const repeatResult = await deprecateMemoryRecords({
+      userId: "u1",
+      entries: deprecationPlan.entries,
+      store: adapter,
+      now: 1700000005000,
+    });
+    expect(repeatResult.persistedCount).toBe(0);
+    expect(
+      adapter.records.filter((record) => record.deprecatedAt !== undefined),
+    ).toHaveLength(2);
   });
 });
 

--- a/apps/web/tests/unit/memory-forgetting.test.ts
+++ b/apps/web/tests/unit/memory-forgetting.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   createMemoryForgettingEngine,
   createMemoryQueryApi,
+  filterDeprecatedRecords,
   normalizeMemoryRecordForIngest,
   normalizeMemoryRecordsForIngest,
+  type MemoryDeprecateRecordsInput,
   type MemoryLockHandle,
   type MemoryPageResult,
   type MemoryRecord,
@@ -28,6 +30,7 @@ class InMemoryStorageAdapter implements MemoryStorageAdapter {
   saveSummaryCalls = 0;
   transitionCalls = 0;
   archiveCalls = 0;
+  deprecateCalls = 0;
   markAccessCalls = 0;
 
   async acquireLock(input: {
@@ -90,6 +93,21 @@ class InMemoryStorageAdapter implements MemoryStorageAdapter {
     }
   }
 
+  async deprecateRecords(input: MemoryDeprecateRecordsInput): Promise<number> {
+    this.deprecateCalls += 1;
+    let affected = 0;
+    for (const record of this.records) {
+      if (record.userId !== input.userId) continue;
+      if (!input.ids.includes(record.id)) continue;
+      if (record.deprecatedAt !== undefined) continue;
+      record.deprecatedAt = input.deprecatedAt;
+      record.deprecationReason = input.reason;
+      record.supersededBySummaryId = input.supersededBySummaryId;
+      affected += 1;
+    }
+    return affected;
+  }
+
   async archiveRecordDetails(input: {
     userId: string;
     ids: string[];
@@ -105,15 +123,26 @@ class InMemoryStorageAdapter implements MemoryStorageAdapter {
   }
 
   async queryRaw(
-    _query: MemorySearchQuery,
+    query: MemorySearchQuery,
   ): Promise<MemoryPageResult<MemoryRecord>> {
-    return { items: [], hasMore: false };
+    const records = this.records.filter((record) => {
+      if (record.userId !== query.userId) return false;
+      if (query.tiers && !query.tiers.includes(record.tier)) return false;
+      return true;
+    });
+    const filtered = filterDeprecatedRecords(records, {
+      includeDeprecated: query.includeDeprecated,
+    });
+    return { items: filtered.records, hasMore: false };
   }
 
   async querySummaries(
-    _query: MemorySummarySearchQuery,
+    query: MemorySummarySearchQuery,
   ): Promise<MemoryPageResult<MemorySummary>> {
-    return { items: [], hasMore: false };
+    return {
+      items: this.summaries.filter((summary) => summary.userId === query.userId),
+      hasMore: false,
+    };
   }
 
   async markRecordsAccessed(input: {
@@ -153,6 +182,9 @@ function createRecord(
     archivedAt: input.archivedAt,
     dimensions: input.dimensions,
     metadata: input.metadata,
+    deprecatedAt: input.deprecatedAt,
+    deprecationReason: input.deprecationReason,
+    supersededBySummaryId: input.supersededBySummaryId,
   };
 }
 
@@ -503,7 +535,12 @@ describe("memory forgetting engine", () => {
 
     expect(result.createdSummaries).toBe(2);
     expect(result.transitionedRecords).toBe(6);
+    expect(result.deprecationStatus).toBe("persisted");
+    expect(result.deprecationPlannedRecords).toBe(6);
+    expect(result.deprecatedRecords).toBe(6);
+    expect(result.deprecationReasonCodes).toContain("persisted");
     expect(storage.saveSummaryCalls).toBeGreaterThan(0);
+    expect(storage.deprecateCalls).toBe(2);
     expect(storage.transitionCalls).toBeGreaterThan(0);
     expect(storage.archiveCalls).toBeGreaterThan(0);
 
@@ -518,6 +555,182 @@ describe("memory forgetting engine", () => {
     expect(midNowLong.every((record) => record.archivedAt !== undefined)).toBe(
       true,
     );
+    expect(
+      storage.records.every(
+        (record) =>
+          record.deprecatedAt === now &&
+          record.deprecationReason ===
+            `summarized_into:${record.metadata?.summaryId}` &&
+          record.supersededBySummaryId === record.metadata?.summaryId,
+      ),
+    ).toBe(true);
+
+    const queryApi = createMemoryQueryApi({
+      storage,
+      markRawAccessOnRead: false,
+    });
+    const defaultRetrieval = await queryApi.queryWithFallback({
+      userId: "u1",
+      pageSize: 10,
+      minRawResultsWithoutFallback: 10,
+    });
+    expect(defaultRetrieval.rawCount).toBe(0);
+    expect(defaultRetrieval.summaryCount).toBe(2);
+    expect(defaultRetrieval.items.every((item) => item.sourceType === "summary"))
+      .toBe(true);
+
+    const auditRawRecords = await storage.queryRaw({
+      userId: "u1",
+      includeDeprecated: true,
+      pageSize: 10,
+    });
+    expect(auditRawRecords.items).toHaveLength(6);
+    expect(
+      auditRawRecords.items.map((record) => record.supersededBySummaryId),
+    ).toEqual(
+      auditRawRecords.items.map((record) => record.metadata?.summaryId),
+    );
+
+    const summaryRetrieval = await storage.querySummaries({ userId: "u1" });
+    expect(summaryRetrieval.items).toHaveLength(2);
+
+    const deprecatedSnapshot = storage.records.map((record) => ({
+      id: record.id,
+      deprecatedAt: record.deprecatedAt,
+      deprecationReason: record.deprecationReason,
+      supersededBySummaryId: record.supersededBySummaryId,
+    }));
+    const repeatResult = await engine.runCycle({
+      userId: "u1",
+      now,
+      dryRun: false,
+    });
+    expect(repeatResult.createdSummaries).toBe(0);
+    expect(storage.records.map((record) => ({
+      id: record.id,
+      deprecatedAt: record.deprecatedAt,
+      deprecationReason: record.deprecationReason,
+      supersededBySummaryId: record.supersededBySummaryId,
+    }))).toEqual(deprecatedSnapshot);
+  });
+
+  it("keeps consolidation successful with no-op diagnostics when deprecation adapter is missing", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const shortWindowStart =
+      Math.floor(
+        (now - DEFAULT_MEMORY_FORGETTING_POLICY.shortMaxAgeMs - 2 * dayMs) /
+          DEFAULT_MEMORY_FORGETTING_POLICY.groupWindowMs.short,
+      ) * DEFAULT_MEMORY_FORGETTING_POLICY.groupWindowMs.short;
+    storage.records = [
+      createRecord({
+        id: "s1",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 1_000,
+        text: "old short one",
+      }),
+      createRecord({
+        id: "s2",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 2_000,
+        text: "old short two",
+      }),
+      createRecord({
+        id: "s3",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 3_000,
+        text: "old short three",
+      }),
+    ];
+    const storageWithoutDeprecate: MemoryStorageAdapter = {
+      acquireLock: storage.acquireLock.bind(storage),
+      releaseLock: storage.releaseLock.bind(storage),
+      listCandidates: storage.listCandidates.bind(storage),
+      saveSummaries: storage.saveSummaries.bind(storage),
+      transitionRecords: storage.transitionRecords.bind(storage),
+      archiveRecordDetails: storage.archiveRecordDetails.bind(storage),
+      queryRaw: storage.queryRaw.bind(storage),
+      querySummaries: storage.querySummaries.bind(storage),
+      markRecordsAccessed: storage.markRecordsAccessed.bind(storage),
+    };
+
+    const engine = createMemoryForgettingEngine({
+      storage: storageWithoutDeprecate,
+    });
+    const result = await engine.runCycle({ userId: "u1", now });
+
+    expect(result.status).toBe("success");
+    expect(result.createdSummaries).toBe(1);
+    expect(result.deprecationStatus).toBe("no-op");
+    expect(result.deprecationPlannedRecords).toBe(3);
+    expect(result.deprecatedRecords).toBe(0);
+    expect(result.deprecationReasonCodes).toContain(
+      "adapter_missing_deprecate_records",
+    );
+    expect(storage.summaries).toHaveLength(1);
+    expect(storage.records.every((record) => record.deprecatedAt === undefined))
+      .toBe(true);
+  });
+
+  it("keeps consolidation successful with failed diagnostics when deprecation adapter throws", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const shortWindowStart =
+      Math.floor(
+        (now - DEFAULT_MEMORY_FORGETTING_POLICY.shortMaxAgeMs - 2 * dayMs) /
+          DEFAULT_MEMORY_FORGETTING_POLICY.groupWindowMs.short,
+      ) * DEFAULT_MEMORY_FORGETTING_POLICY.groupWindowMs.short;
+    storage.records = [
+      createRecord({
+        id: "s1",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 1_000,
+        text: "old short one",
+      }),
+      createRecord({
+        id: "s2",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 2_000,
+        text: "old short two",
+      }),
+      createRecord({
+        id: "s3",
+        userId: "u1",
+        tier: "short",
+        timestamp: shortWindowStart + 3_000,
+        text: "old short three",
+      }),
+    ];
+    storage.deprecateRecords = async () => {
+      storage.deprecateCalls += 1;
+      throw new Error("deprecation write failed");
+    };
+
+    const engine = createMemoryForgettingEngine({ storage });
+    const result = await engine.runCycle({ userId: "u1", now });
+
+    expect(result.status).toBe("success");
+    expect(result.createdSummaries).toBe(1);
+    expect(result.transitionedRecords).toBe(3);
+    expect(result.deprecationStatus).toBe("failed");
+    expect(result.deprecationPlannedRecords).toBe(3);
+    expect(result.deprecatedRecords).toBe(0);
+    expect(result.deprecationReasonCodes).toContain(
+      "adapter_deprecate_records_error",
+    );
+    expect(storage.summaries).toHaveLength(1);
+    expect(storage.deprecateCalls).toBe(1);
+    expect(storage.transitionCalls).toBe(1);
+    expect(storage.records.every((record) => record.tier === "mid")).toBe(true);
+    expect(storage.records.every((record) => record.deprecatedAt === undefined))
+      .toBe(true);
   });
 });
 

--- a/apps/web/tests/unit/memory-forgetting.test.ts
+++ b/apps/web/tests/unit/memory-forgetting.test.ts
@@ -140,7 +140,9 @@ class InMemoryStorageAdapter implements MemoryStorageAdapter {
     query: MemorySummarySearchQuery,
   ): Promise<MemoryPageResult<MemorySummary>> {
     return {
-      items: this.summaries.filter((summary) => summary.userId === query.userId),
+      items: this.summaries.filter(
+        (summary) => summary.userId === query.userId,
+      ),
       hasMore: false,
     };
   }
@@ -576,8 +578,9 @@ describe("memory forgetting engine", () => {
     });
     expect(defaultRetrieval.rawCount).toBe(0);
     expect(defaultRetrieval.summaryCount).toBe(2);
-    expect(defaultRetrieval.items.every((item) => item.sourceType === "summary"))
-      .toBe(true);
+    expect(
+      defaultRetrieval.items.every((item) => item.sourceType === "summary"),
+    ).toBe(true);
 
     const auditRawRecords = await storage.queryRaw({
       userId: "u1",
@@ -606,12 +609,14 @@ describe("memory forgetting engine", () => {
       dryRun: false,
     });
     expect(repeatResult.createdSummaries).toBe(0);
-    expect(storage.records.map((record) => ({
-      id: record.id,
-      deprecatedAt: record.deprecatedAt,
-      deprecationReason: record.deprecationReason,
-      supersededBySummaryId: record.supersededBySummaryId,
-    }))).toEqual(deprecatedSnapshot);
+    expect(
+      storage.records.map((record) => ({
+        id: record.id,
+        deprecatedAt: record.deprecatedAt,
+        deprecationReason: record.deprecationReason,
+        supersededBySummaryId: record.supersededBySummaryId,
+      })),
+    ).toEqual(deprecatedSnapshot);
   });
 
   it("keeps consolidation successful with no-op diagnostics when deprecation adapter is missing", async () => {
@@ -672,8 +677,9 @@ describe("memory forgetting engine", () => {
       "adapter_missing_deprecate_records",
     );
     expect(storage.summaries).toHaveLength(1);
-    expect(storage.records.every((record) => record.deprecatedAt === undefined))
-      .toBe(true);
+    expect(
+      storage.records.every((record) => record.deprecatedAt === undefined),
+    ).toBe(true);
   });
 
   it("keeps consolidation successful with failed diagnostics when deprecation adapter throws", async () => {
@@ -729,8 +735,9 @@ describe("memory forgetting engine", () => {
     expect(storage.deprecateCalls).toBe(1);
     expect(storage.transitionCalls).toBe(1);
     expect(storage.records.every((record) => record.tier === "mid")).toBe(true);
-    expect(storage.records.every((record) => record.deprecatedAt === undefined))
-      .toBe(true);
+    expect(
+      storage.records.every((record) => record.deprecatedAt === undefined),
+    ).toBe(true);
   });
 });
 

--- a/packages/ai/src/memory/contracts.ts
+++ b/packages/ai/src/memory/contracts.ts
@@ -275,12 +275,7 @@ export interface MemoryForgettingRunResult {
   createdSummaries: number;
   transitionedRecords: number;
   archivedDetailRecords: number;
-  deprecationStatus?:
-    | "disabled"
-    | "dry-run"
-    | "failed"
-    | "no-op"
-    | "persisted";
+  deprecationStatus?: "disabled" | "dry-run" | "failed" | "no-op" | "persisted";
   deprecationPlannedRecords?: number;
   deprecatedRecords?: number;
   deprecationReasonCodes?: string[];

--- a/packages/ai/src/memory/contracts.ts
+++ b/packages/ai/src/memory/contracts.ts
@@ -257,6 +257,11 @@ export interface MemoryForgettingRunInput {
   userId: string;
   now?: number;
   dryRun?: boolean;
+  /**
+   * Soft-deprecate raw source records after their summary is saved.
+   * Defaults to true. Dry runs still skip all writes.
+   */
+  deprecateSourceRecords?: boolean;
 }
 
 export interface MemoryForgettingRunResult {
@@ -270,6 +275,15 @@ export interface MemoryForgettingRunResult {
   createdSummaries: number;
   transitionedRecords: number;
   archivedDetailRecords: number;
+  deprecationStatus?:
+    | "disabled"
+    | "dry-run"
+    | "failed"
+    | "no-op"
+    | "persisted";
+  deprecationPlannedRecords?: number;
+  deprecatedRecords?: number;
+  deprecationReasonCodes?: string[];
 }
 
 export type MemorySearchHit =

--- a/packages/ai/src/memory/engine.ts
+++ b/packages/ai/src/memory/engine.ts
@@ -1,3 +1,7 @@
+import {
+  buildMemoryDeprecationEntries,
+  type MemorySummaryCandidate,
+} from "../../memory-consolidation/src/pipeline";
 import type {
   MemoryForgettingRunInput,
   MemoryForgettingRunResult,
@@ -9,6 +13,7 @@ import type {
   MemorySummarizer,
   ScoredMemoryRecord,
 } from "./contracts";
+import { deprecateMemoryRecords } from "./deprecation";
 import {
   bucketStart,
   type MemoryForgettingPolicy,
@@ -141,6 +146,7 @@ export function createMemoryForgettingEngine(
       const startedAt = Date.now();
       const now = runInput.now ?? startedAt;
       const dryRun = runInput.dryRun ?? false;
+      const deprecateSourceRecords = runInput.deprecateSourceRecords !== false;
       const lockKey = `${policy.lock.keyPrefix}:${runInput.userId}`;
 
       const lock = await input.storage.acquireLock({
@@ -169,6 +175,12 @@ export function createMemoryForgettingEngine(
       let createdSummaries = 0;
       let transitionedRecords = 0;
       let archivedDetailRecords = 0;
+      let deprecationStatus:
+        | MemoryForgettingRunResult["deprecationStatus"]
+        | undefined;
+      let deprecationPlannedRecords = 0;
+      let deprecatedRecords = 0;
+      const deprecationReasonCodes = new Set<string>();
 
       try {
         const phases: Array<{
@@ -257,6 +269,49 @@ export function createMemoryForgettingEngine(
 
             if (!dryRun) {
               await input.storage.saveSummaries([summary]);
+              const summaryCandidate: MemorySummaryCandidate = {
+                clusterKey: group.groupId,
+                competitionKey: group.groupId,
+                recordIds: summary.sourceRecordIds,
+                evidenceCount: summary.sourceRecordIds.length,
+                score: draft.qualityScore ?? 1,
+                priority: draft.qualityScore ?? 1,
+                reasonCodes: ["strong_repeated_evidence"],
+                sourceAction: "preserve",
+              };
+              const deprecationPlan = buildMemoryDeprecationEntries({
+                persistedSummaryIds: [summary.summaryId],
+                summaryCandidates: [summaryCandidate],
+              });
+              try {
+                const deprecationResult = await deprecateMemoryRecords({
+                  userId: runInput.userId,
+                  entries: deprecationPlan.entries,
+                  enabled: deprecateSourceRecords,
+                  store: input.storage,
+                  now,
+                });
+                deprecationPlannedRecords += deprecationResult.plannedCount;
+                deprecatedRecords += deprecationResult.persistedCount;
+                if (
+                  deprecationStatus !== "failed" &&
+                  (deprecationStatus !== "persisted" ||
+                    deprecationResult.status === "persisted")
+                ) {
+                  deprecationStatus = deprecationResult.status;
+                }
+                for (const reasonCode of deprecationResult.reasonCodes) {
+                  deprecationReasonCodes.add(reasonCode);
+                }
+              } catch {
+                const plannedIds = new Set(
+                  deprecationPlan.entries.flatMap((entry) => entry.recordIds),
+                );
+                deprecationStatus = "failed";
+                deprecationPlannedRecords += plannedIds.size;
+                deprecationReasonCodes.add("adapter_deprecate_records_error");
+              }
+
               await input.storage.transitionRecords({
                 userId: runInput.userId,
                 ids: summary.sourceRecordIds,
@@ -294,6 +349,10 @@ export function createMemoryForgettingEngine(
         createdSummaries,
         transitionedRecords,
         archivedDetailRecords,
+        deprecationStatus,
+        deprecationPlannedRecords,
+        deprecatedRecords,
+        deprecationReasonCodes: [...deprecationReasonCodes],
       };
     },
   };


### PR DESCRIPTION
## Summary
- Wire the forgetting engine to soft-deprecate source raw records after summaries are persisted.
- Keep source raw records available for audit via includeDeprecated while hiding them from default retrieval.
- Report deprecation status/counts and degrade missing or throwing adapters to diagnostics.

## Verification
- `vitest run --config vitest.config.ts tests/unit/memory-forgetting.test.ts` (17 passed)
- `vitest run --config vitest.config.ts tests/unit/memory-deprecation.test.ts` (17 passed)
- `biome.exe lint apps/web/tests/unit/memory-forgetting.test.ts apps/web/tests/unit/memory-deprecation.test.ts packages/ai/src/memory/contracts.ts packages/ai/src/memory/engine.ts`
- `git diff --cached --check`

Refs #254