### PR TITLE
docs(memory): define graph evolution architecture and execution plan

### DIFF
--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-architecture.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-architecture.md
@@ -1,0 +1,663 @@
+# Memory Graph Evolution: Dynamic Clusters, Reinforcement, and Forgetting
+
+Execution plan: [memory-graph-evolution-execution-plan.md](./memory-graph-evolution-execution-plan.md)
+
+## Problem
+
+OpenLoomi's long-term memory should not remain a bag of isolated records plus
+semantic similarity search. That model is useful as an initial retrieval layer,
+but it does not explain how memory becomes more stable, more concise, or more
+trustworthy over time.
+
+The main gaps are:
+
+- Duplicate memories cannot naturally merge. Similar traces may be retrieved
+  together, but the system has no durable structure that says they support the
+  same belief, preference, fact, or working pattern.
+- New evidence cannot strengthen or weaken older memories. A new trace may be
+  similar to an old trace, but similarity alone does not update confidence,
+  relation weight, cluster status, or competition between alternatives.
+- Forgetting based only on time and per-record value is too coarse. A single old
+  record can be noisy, but an old cluster with repeated activation may still be
+  important. Likewise, a recent record may be noise if it never connects to
+  anything else.
+- Retrieval can return fragment noise. Similarity search can surface several
+  near-duplicate raw records, weak one-off traces, or conflicting records without
+  enough graph context to choose stable memory over evidence fragments.
+- Summary and deprecation are currently sedimentation actions, not a complete
+  graph mechanism. A summary can supersede source records, and soft-deprecation
+  can hide raw evidence by default, but the system still needs an explicit model
+  for how clusters form, stabilize, decay, compete, and remain auditable.
+
+The desired evolution is a dynamic memory graph: new memories interact with old
+memories, update relations, reshape clusters, and feed forgetting,
+consolidation, retrieval, and audit flows.
+
+## Design Goals
+
+- Represent memory records as a dynamic graph rather than isolated fragments.
+- Let new memory influence old memory by reinforcing, weakening, contradicting,
+  elaborating, or superseding existing graph structures.
+- Give memory clusters an explicit lifecycle so the system can distinguish
+  forming, active, stable, decaying, superseded, and audit-only memory.
+- Treat forgetting as a graph operation, not simple deletion. Forgetting should
+  hide, decay, archive, or supersede evidence according to graph state and audit
+  constraints.
+- Use graph signals during retrieval, including cluster stability, edge weight,
+  conflict status, summary coverage, recency, and source evidence quality.
+- Preserve audit trails from summaries and artifacts back to source records,
+  relation evidence, and the graph operations that changed visibility.
+- Keep graph state scoped to the owning user, workspace, or tenant. Cross-scope
+  edges should be opt-in product behavior, not a default graph operation.
+
+## Non-goals
+
+- Do not rewrite storage as part of the first architecture step.
+- Do not build UI.
+- Do not require real-time LLM calls for every memory write.
+- Do not implement a complete scheduler in one step.
+- Do not delete the raw audit chain.
+- Do not bind all relation judgment to one embedding strategy. Embeddings,
+  rules, metadata, explicit user feedback, and optional model judgments should
+  all be possible sources of graph evidence.
+
+## Core Concepts
+
+### Memory Node
+
+A `Memory Node` is a graph-addressable memory unit. It may represent:
+
+- `raw`: source traces such as messages, observations, or interaction fragments.
+- `summary`: stable cluster sedimentation used for compact long-term recall.
+- `artifact`: a durable memory product, report, plan, preference profile, or
+  externalized knowledge object.
+
+Nodes should keep identity, timestamps, source type, visibility state, and
+provenance. A node does not need to know every cluster it belongs to; cluster
+membership can be derived or stored by the graph layer.
+
+Graph identity must include the owning scope, such as user, workspace, or
+tenant. A graph operation should not connect nodes across scopes unless a caller
+explicitly opts into a product feature that permits shared memory.
+
+### Memory Edge
+
+A `Memory Edge` records a relationship between nodes. The architecture should
+allow at least these relation kinds:
+
+- `supports`: two nodes reinforce the same memory pattern.
+- `contradicts`: two nodes conflict or compete.
+- `elaborates`: one node adds detail to another without replacing it.
+- `supersedes`: one node is the preferred canonical representation of another.
+- `co-occurs`: nodes were observed or activated together.
+- `same-topic`: nodes are semantically adjacent but not yet judged as support or
+  conflict.
+
+Edges should carry weight, confidence, evidence count, last activation time,
+reason codes, and source evidence. Some edges are strong enough to shape
+clusters; others remain weak observations.
+
+Current relation-graph helpers already use a smaller operational vocabulary:
+`support`, `compete`, and `related`. The richer relation kinds above should be
+treated as architecture-level semantics that can project down into those current
+edge classes:
+
+- `supports` maps to `support`.
+- `contradicts` maps to `compete`.
+- `same-topic`, weak `elaborates`, and uncertain co-activation map to `related`.
+- `supersedes` is primarily a consolidation/audit relation and should connect to
+  summary or artifact provenance rather than force raw clusters to merge.
+
+This keeps existing helpers useful while leaving room for later interfaces to
+represent more nuance.
+
+### Memory Cluster
+
+A `Memory Cluster` is a stable or forming group of memory nodes connected by
+supporting evidence. A cluster is not just a search result. It is an evolving
+memory structure with its own lifecycle, score, evidence set, relation history,
+and possible competition with other clusters.
+
+Clusters should be able to contain raw nodes, summaries, and artifacts. A
+summary can become the active representative of a stable cluster while raw
+source nodes remain linked for audit.
+
+### Reinforcement
+
+`Reinforcement` happens when new evidence increases confidence in an existing
+node, edge, or cluster. Examples:
+
+- a new raw trace supports an existing preference cluster
+- a retrieved memory is reused successfully in an answer
+- multiple source records co-activate in the same task context
+- explicit user feedback confirms a prior memory
+
+Reinforcement should update edge weights, cluster stability, activation counts,
+and retrieval priority. It should not automatically overwrite raw evidence.
+
+### Weakening / Decay
+
+`Weakening` happens when evidence becomes stale, unsupported, contradicted, or
+unused. `Decay` is time-based weakening, but weakening can also come from new
+contradictory evidence or failed retrieval outcomes.
+
+Decay should operate on graph structure:
+
+- isolated raw nodes decay faster than reinforced clusters
+- weak edges decay when they are not reactivated
+- contradicted clusters can lose active status
+- superseded clusters can move toward audit-only visibility
+
+### Consolidation
+
+`Consolidation` turns stable graph structures into compact durable memory:
+summaries, artifacts, or canonical cluster representatives. Consolidation should
+consume cluster state and source evidence rather than treating records as an
+unordered batch.
+
+The consolidation output should preserve provenance: source node ids, relation
+evidence, reason codes, quality/confidence signals, and the cluster lifecycle
+state that justified sedimentation.
+
+### Soft Forgetting
+
+`Soft Forgetting` hides source raw records from default retrieval after a stable
+summary or artifact supersedes them. It does not delete audit evidence.
+
+Soft-forgotten records should keep fields such as deprecation timestamp, reason,
+superseding summary or artifact id, and source linkage. Default retrieval should
+prefer the active summary/cluster representative; audit retrieval should be able
+to include deprecated raw records.
+
+### Audit Trail
+
+The `Audit Trail` is the reversible chain from a summary or artifact back to:
+
+- source raw records
+- relation evidence
+- graph update operations
+- cluster lifecycle decisions
+- deprecation or visibility changes
+
+Audit is a first-class requirement. It lets operators answer why a memory exists,
+what evidence supports it, what was hidden by default, and how to recover the raw
+source chain when needed.
+
+## Architecture Layers
+
+### Graph Layer
+
+Responsibility: express memory nodes, edges, clusters, lifecycle state, and
+graph snapshots.
+
+The Graph Layer stores or derives:
+
+- node identity and visibility
+- edge kind, weight, confidence, and provenance
+- cluster membership and cluster representatives
+- competition relationships between clusters
+- graph version or operation metadata
+- owner scope, so graph reads and writes stay isolated by user, workspace, or
+  tenant
+
+It should not decide which model/provider judges relation meaning. It should not
+perform final retrieval ranking by itself. It should expose enough graph state
+for interaction, lifecycle, consolidation, retrieval, and audit layers.
+
+### Interaction Layer
+
+Responsibility: let new memory interact with existing memory and produce a graph
+update plan.
+
+The Interaction Layer takes new memory nodes plus candidate existing nodes or
+clusters. It proposes:
+
+- new edges
+- edge reinforcement
+- edge weakening
+- cluster joins or splits
+- conflict/competition observations
+- reason codes and evidence links
+
+It should support multiple signal sources: metadata rules, explicit relation
+keys, embeddings, co-activation, user feedback, and optional model judgment. It
+should output a plan before persistence so callers can dry-run, audit, or gate
+graph changes.
+
+### Cluster Lifecycle Layer
+
+Responsibility: manage cluster state transitions.
+
+Suggested lifecycle states:
+
+- `forming`: early evidence exists but is not stable.
+- `active`: the cluster is useful in retrieval and still evolving.
+- `stable`: evidence is strong enough for consolidation.
+- `decaying`: evidence or activation is weakening.
+- `superseded`: another summary, artifact, or cluster is the preferred
+  representative.
+- `audit-only`: hidden from default retrieval but retained for traceability.
+
+The lifecycle layer consumes graph state and policy. It should not generate
+summary text, mutate storage directly, or decide UI presentation.
+
+### Forgetting / Consolidation Layer
+
+Responsibility: convert stable or decaying cluster state into memory operations.
+
+Operations can include:
+
+- generate summary candidates from stable clusters
+- persist summaries or artifacts
+- soft-deprecate source raw records
+- archive source details when policy allows
+- mark weak clusters as decaying or audit-only
+- preserve contested clusters without premature summarization
+
+This layer is where current summary plus soft-deprecation behavior belongs. It
+should consume cluster lifecycle decisions and produce auditable actions.
+
+### Retrieval Layer
+
+Responsibility: use graph signals during recall.
+
+Retrieval should start with semantic, keyword, recency, or metadata candidates,
+then use graph state to:
+
+- expand from a raw hit to its active cluster representative
+- suppress deprecated source records by default
+- prefer stable summaries when they cover noisy raw traces
+- include conflicting clusters when contradiction matters
+- rank by relation strength, activation, lifecycle state, and evidence quality
+- support audit mode via `includeDeprecated` and provenance expansion
+
+Graph-aware retrieval should not replace all semantic search. It should make
+semantic candidates more contextual and less fragmentary.
+
+### Observability Layer
+
+Responsibility: report how the graph changed and why.
+
+Reports should include:
+
+- graph diffs
+- created/updated edges
+- reinforcement and decay events
+- cluster lifecycle transitions
+- consolidation outputs
+- source soft-deprecation outcomes
+- retrieval changes compared with baseline search
+- audit chain completeness
+
+The observability layer makes the system operable before fully automatic graph
+behavior is enabled.
+
+## Data Flows
+
+### Ingest-time Flow
+
+```text
+new memory
+  -> normalize node
+  -> retrieve candidate existing nodes/clusters
+  -> infer relation candidates
+  -> build graph update plan
+  -> reinforce / weaken / create edges
+  -> update cluster membership and lifecycle signals
+  -> emit GraphEvolutionReport
+```
+
+The ingest path should be incremental. It does not need to summarize
+immediately. Its job is to make the new memory interact with existing memory so
+future consolidation and retrieval have graph context.
+
+### Batch Consolidation Flow
+
+```text
+stable cluster
+  -> consolidation planner
+  -> summary or artifact draft
+  -> persist summary/artifact
+  -> soft-deprecate source raw records
+  -> update cluster representative
+  -> emit consolidation and deprecation diagnostics
+```
+
+This is the sedimentation path. The summary is not a replacement for the graph;
+it is the active compact representation of a stable cluster. Source raw records
+remain audit-linked and can be retrieved with audit options.
+
+### Retrieval Flow
+
+```text
+query
+  -> semantic / keyword / metadata candidates
+  -> graph expansion
+  -> lifecycle and visibility filtering
+  -> graph-aware ranking
+  -> active summaries and selected raw records
+```
+
+Default retrieval should hide deprecated raw source records when an active
+summary covers them. When the query needs evidence or conflict, retrieval can
+expand to source records, related clusters, or competing clusters.
+
+### Audit Flow
+
+```text
+summary or artifact
+  -> source record ids
+  -> relation evidence
+  -> graph operations
+  -> lifecycle decisions
+  -> deprecation / visibility history
+```
+
+Audit mode should prove why a summary exists and why raw records are hidden by
+default. It should recover source evidence without turning audit records back
+into normal retrieval noise.
+
+## Interface Boundary
+
+These names are conceptual boundaries, not final helper names. Each boundary
+should stay small enough to test independently and broad enough to guide future
+implementation.
+
+### MemoryGraphStore
+
+Input:
+
+- node writes and reads
+- edge writes and reads
+- cluster snapshots or cluster update operations
+- graph operation metadata
+- owner scope for every graph read and write
+
+Output:
+
+- graph snapshot for candidate records or clusters
+- persisted graph update result
+- audit provenance for nodes, edges, and clusters
+
+Not responsible for:
+
+- judging relation meaning
+- deciding lifecycle policy
+- generating summaries
+- final retrieval ranking
+
+Consumed by:
+
+- GraphInteractionEngine
+- ClusterLifecyclePolicy
+- MemoryConsolidationPlanner
+- GraphAwareRetriever
+- Observability Layer
+
+### GraphInteractionEngine
+
+Input:
+
+- new memory nodes
+- candidate existing nodes/clusters
+- signal sources such as embeddings, metadata, relation keys, co-activation, or
+  optional model judgments
+
+Output:
+
+- graph update plan
+- relation candidates and judgments
+- reinforcement or weakening events
+- evidence and reason codes
+
+Not responsible for:
+
+- storage schema migration
+- final persistence without caller approval
+- summary generation
+- default retrieval behavior
+
+Consumed by:
+
+- ingest-time memory pipeline
+- batch graph maintenance
+- GraphEvolutionReport
+
+### ClusterLifecyclePolicy
+
+Input:
+
+- graph snapshot
+- cluster scores
+- edge weights
+- activation history
+- conflict and supersession signals
+- policy thresholds
+
+Output:
+
+- lifecycle transitions
+- cluster representative suggestions
+- consolidation eligibility
+- decay or audit-only recommendations
+
+Not responsible for:
+
+- creating raw relation evidence
+- writing summaries
+- deleting raw records
+- ranking query results directly
+
+Consumed by:
+
+- MemoryConsolidationPlanner
+- GraphAwareRetriever
+- Observability Layer
+
+### MemoryConsolidationPlanner
+
+Input:
+
+- stable or decaying cluster state
+- source node ids and evidence
+- lifecycle recommendations
+- summarization or artifact constraints
+
+Output:
+
+- summary/artifact candidates
+- source soft-deprecation plan
+- archive recommendations
+- diagnostics for preserve / observe / decay decisions
+
+Not responsible for:
+
+- judging every relation from scratch
+- direct UI presentation
+- mandatory online writes
+- removing audit evidence
+
+Consumed by:
+
+- forgetting/consolidation runtime
+- summary/artifact generation boundary
+- audit tooling
+
+### GraphAwareRetriever
+
+Input:
+
+- query
+- semantic/keyword candidate hits
+- graph snapshot
+- visibility mode such as default retrieval or audit retrieval
+
+Output:
+
+- ranked memory hits
+- graph expansion explanation
+- active summaries/raw records
+- optional audit source chains
+
+Not responsible for:
+
+- mutating graph state by default
+- deciding cluster lifecycle
+- generating summaries
+- replacing the underlying semantic index
+
+Consumed by:
+
+- agent context assembly
+- memory search APIs
+- evaluation and retrieval dry-runs
+
+### GraphEvolutionReport
+
+Input:
+
+- graph update plan
+- persisted graph update result
+- lifecycle transitions
+- consolidation/deprecation outcomes
+- retrieval diff data
+
+Output:
+
+- human-readable and machine-readable graph diff
+- reinforcement and weakening summary
+- cluster lifecycle summary
+- audit chain completeness
+- warnings and no-op diagnostics
+
+Not responsible for:
+
+- deciding policy
+- mutating storage
+- ranking memories
+- summarizing source content
+
+Consumed by:
+
+- tests and evals
+- operators
+- future UI surfaces
+- rollout gates
+
+## Phased Implementation Plan
+
+### Phase 1: Architecture + Conceptual Contracts
+
+Define the graph architecture, terms, lifecycle states, and interface boundaries.
+Keep this phase documentation-first. Any contracts should be conceptual or
+dry-run only. The success criterion is shared understanding of where graph,
+interaction, lifecycle, consolidation, retrieval, and observability concerns
+belong.
+
+### Phase 2: Ingest-time Graph Interaction
+
+Add an opt-in path where new memory retrieves candidate existing memory and
+produces a graph update plan. Start with explicit metadata/relation keys and
+simple similarity candidates. Persist only behind a controlled boundary, with
+reports showing proposed edges, reinforcement, weakening, and cluster impact.
+
+### Phase 3: Cluster Lifecycle State
+
+Introduce lifecycle state for clusters. Compute forming, active, stable,
+decaying, superseded, and audit-only transitions from graph signals. Keep the
+policy separate from storage and summarization. Add dry-run lifecycle reports
+before changing default runtime behavior.
+
+### Phase 4: Graph-aware Forgetting / Consolidation
+
+Make forgetting and consolidation consume cluster lifecycle state. Stable
+clusters produce summaries or artifacts; source raw records are soft-deprecated
+after successful persistence; weak or unsupported structures decay; contested
+clusters are preserved for observation rather than prematurely summarized.
+
+### Phase 5: Graph-aware Retrieval
+
+Use graph state to improve retrieval. Start with dry-run comparison reports:
+baseline semantic candidates versus graph-expanded and graph-ranked results.
+Then enable controlled retrieval paths where active summaries represent stable
+clusters and deprecated raw source records are hidden by default but available
+for audit.
+
+### Phase 6: Evaluation and Observability
+
+Build evaluation scenarios and reports for:
+
+- duplicate memory reduction
+- stable preference recall
+- conflict handling
+- source evidence traceability
+- noise suppression
+- graph-aware retrieval quality
+- audit chain completeness
+
+Observability should make every graph operation explainable before broad runtime
+enablement.
+
+## Relationship to Existing Work
+
+- Relation graph and relation discovery already form the foundation of the Graph
+  Layer and Interaction Layer. Existing relation candidates, relation judgment,
+  graph assignment, competition groups, and lifecycle signals can be treated as
+  early graph mechanics.
+- Current `support`, `compete`, and `related` relation edges are the operational
+  projection of the broader relation taxonomy proposed here. Future interfaces
+  can add richer relation kinds without invalidating the current graph pipeline.
+- The current forgetting engine is an early Forgetting / Consolidation Layer. It
+  scans eligible memory, groups records, generates summaries, transitions tiers,
+  and provides a place for graph-aware cluster decisions to be consumed later.
+- Summary plus soft-deprecation is the sedimentation action after cluster
+  stabilization. It should eventually be driven by stable cluster lifecycle
+  state rather than only by record age or batch grouping.
+- `includeDeprecated` and audit retrieval are the foundation of the Audit Trail.
+  Default retrieval can hide superseded raw records, while audit retrieval can
+  recover the source chain behind a summary or artifact.
+- Existing semantic retrieval dry-runs and retrieval comparison reports can
+  become the evaluation harness for graph-aware retrieval before changing
+  default ranking.
+
+## Acceptance Criteria
+
+This architecture is sufficient when it can answer the following questions:
+
+- How does new memory affect old memory?
+
+  New memory becomes a node, retrieves candidate neighbors, produces relation
+  updates, reinforces or weakens edges, and can update cluster membership and
+  lifecycle state.
+
+- How do memory clusters form, stabilize, and decay?
+
+  Clusters form from supporting edges, become active through evidence and
+  activation, stabilize when policy thresholds are met, decay when unsupported or
+  contradicted, and move to superseded or audit-only states when a summary or
+  artifact becomes the active representative.
+
+- Why is forgetting a graph operation?
+
+  Forgetting must consider whether a record is isolated noise, part of a stable
+  cluster, contradicted by a stronger cluster, superseded by a summary, or still
+  needed for audit. Those are graph states, not simple per-record age checks.
+
+- Where do summary and deprecation sit in the architecture?
+
+  They are consolidation outputs after cluster stabilization. A summary or
+  artifact becomes the compact active representative; source raw records are
+  soft-deprecated by default but remain linked for audit.
+
+- How does retrieval use graph signals instead of only similarity?
+
+  Retrieval starts from semantic or keyword candidates, then expands and ranks by
+  cluster membership, edge strength, lifecycle state, contradiction,
+  supersession, activation, and visibility mode.
+
+- Which boundaries should future interface design use?
+
+  Future interfaces should center on `MemoryGraphStore`,
+  `GraphInteractionEngine`, `ClusterLifecyclePolicy`,
+  `MemoryConsolidationPlanner`, `GraphAwareRetriever`, and
+  `GraphEvolutionReport`.

--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
@@ -1,0 +1,458 @@
+# Memory Graph Evolution Execution Plan
+
+## Purpose
+
+This plan turns the
+[Memory Graph Evolution architecture RFC](./memory-graph-evolution-architecture.md)
+into an implementation route. It does not replace the RFC. The RFC defines the
+target architecture and vocabulary; this document defines the order of execution,
+phase gates, review boundaries, and acceptance criteria for future Codex or
+human implementation sessions.
+
+The plan is intentionally architecture-first. It should not be read as a helper
+queue or a list of small implementation PRs. Each phase must leave the system
+clearer, more observable, and more reversible before runtime behavior changes.
+
+## Current Baseline
+
+The current codebase already contains pieces that fit into the dynamic memory
+graph direction:
+
+- relation graph assignment
+- relation pipeline execution
+- operational relation kinds: `support`, `compete`, and `related`
+- competition groups
+- diagnostics reports
+- semantic draft candidates
+- forgetting engine
+- summary plus soft-deprecation
+- `includeDeprecated` audit path
+
+These pieces are useful foundation, but they do not yet form a complete runtime
+memory graph. Current graph work is mostly package-local and diagnostic. Current
+forgetting/consolidation work can summarize and soft-hide source records, but it
+is not yet driven by a durable graph lifecycle. Current retrieval can hide
+deprecated records and run semantic draft comparisons, but default ranking is
+not yet graph-aware.
+
+## Execution Principles
+
+- Architecture first, interfaces second, implementation third.
+- Dry-run before persistence.
+- Opt-in before default behavior.
+- Graph state must be scoped by user, workspace, or tenant.
+- Raw audit chain must be preserved.
+- Do not start with a broad storage rewrite.
+- Do not change runtime behavior without observability.
+- Every phase must be independently reviewable.
+- Every phase must describe rollback or no-op behavior before persistence.
+- Existing relation helpers should be assigned to boundaries before new helpers
+  are proposed.
+- Production code should not be written until the phase's contract, report
+  shape, and acceptance criteria are clear.
+
+## Required Execution Order
+
+The work must proceed in this order:
+
+1. Architecture stability
+2. Interface design
+3. Dry-run / report
+4. Opt-in persistence
+5. Runtime integration
+6. Retrieval behavior
+7. Evaluation / rollout
+
+If a future task needs to jump ahead, split it. For example, if a retrieval
+change requires graph persistence, define the persistence boundary first; do not
+silently merge retrieval behavior into an earlier dry-run phase.
+
+## Phase 0: Architecture Stability Gate
+
+Goal: stabilize the architecture RFC and make sure future phases refer to a
+shared vocabulary before any new production behavior is attempted.
+
+Inputs:
+
+- `memory-graph-evolution-architecture.md`
+- current `roadmap.md`
+- current `execution-plan.md`
+- current relation graph, relation pipeline, forgetting, soft-deprecation, and
+  retrieval diagnostics code
+
+Outputs:
+
+- confirmed architecture terms
+- confirmed phase sequence
+- explicit mapping from existing work to architecture layers
+- known open questions
+- decision log for scope boundaries
+
+Acceptance:
+
+- The dynamic memory graph remains the main line, not a collection of isolated
+  helper tasks.
+- The RFC can answer how new memory affects old memory.
+- The RFC can explain cluster formation, stabilization, decay, supersession, and
+  audit-only visibility.
+- The RFC clearly places summary and soft-deprecation after cluster
+  stabilization.
+- The RFC states that graph scope is isolated by user, workspace, or tenant.
+- No production code, tests, storage migrations, UI, scheduler, or helper
+  implementation is required in this phase.
+
+Open questions:
+
+- Which product scope is primary for graph state: user, workspace, tenant, or a
+  composite key?
+- Should cross-workspace memory sharing be impossible by default or represented
+  as an explicit edge type later?
+- Which existing diagnostics should become durable graph operation reports?
+
+## Phase 1: Interface Boundary Design
+
+Goal: turn the RFC boundaries into concrete interface drafts without requiring
+implementation.
+
+Boundaries:
+
+- `MemoryGraphStore`
+- `GraphInteractionEngine`
+- `ClusterLifecyclePolicy`
+- `MemoryConsolidationPlanner`
+- `GraphAwareRetriever`
+- `GraphEvolutionReport`
+
+Each interface draft must describe:
+
+- input
+- output
+- non-responsibilities
+- existing code it maps to
+- expected first consumer
+- open questions
+
+Existing-code mapping:
+
+- `relation-graph.ts` maps mainly to `MemoryGraphStore` read models and
+  `ClusterLifecyclePolicy` inputs.
+- `pipeline.ts` relation candidate and judgment helpers map to
+  `GraphInteractionEngine`.
+- `buildMemoryConsolidationPlan` and summary candidate generation map to
+  `MemoryConsolidationPlanner`.
+- current forgetting engine behavior maps to the early
+  Forgetting / Consolidation runtime consumer.
+- current retrieval comparison and semantic draft retrieval helpers map to
+  `GraphAwareRetriever` dry-run inputs.
+- current diagnostics reports map to `GraphEvolutionReport`.
+
+Acceptance:
+
+- Current helpers can be assigned to one primary boundary.
+- The document can explain how `support`, `compete`, and `related` map to
+  higher-level relation semantics.
+- The graph scope model prevents cross-user or cross-workspace pollution.
+- Each boundary has at least one expected first consumer.
+- Each boundary has explicit non-responsibilities, so future work does not
+  collapse into a broad provider/helper layer.
+
+Review focus:
+
+- Are storage, interaction, policy, consolidation, retrieval, and reporting still
+  separated?
+- Does any boundary accidentally require a real-time LLM?
+- Does any boundary imply deleting raw audit evidence?
+
+## Phase 2: Graph Update Plan Dry Run
+
+Goal: when new memory enters the system, produce a graph update plan without
+persistence.
+
+Inputs:
+
+- new memory node
+- candidate existing records or summaries
+- explicit relation keys, metadata, or similarity candidates
+- current graph snapshot if available
+- owner scope such as user, workspace, or tenant
+
+Outputs:
+
+- proposed edges
+- reinforcement events
+- weakening or decay observations
+- cluster assignment impact
+- `GraphEvolutionReport`
+
+Expected behavior:
+
+- Similar new memory can propose reinforcement for an existing cluster.
+- Unrelated new memory does not pollute an existing cluster.
+- Conflict and competition signals can be represented.
+- Weak `same-topic` or `related` observations do not force cluster merges.
+- All results can be inspected as dry-run report data.
+- Runtime default behavior does not change.
+
+Acceptance:
+
+- A dry-run report can show which existing nodes were considered.
+- A dry-run report can show why an edge was proposed, weakened, or rejected.
+- A dry-run report can show potential cluster impact without writing graph
+  state.
+- The plan remains scoped to the caller's user/workspace/tenant.
+- No storage write is required.
+
+Open questions:
+
+- Should candidate retrieval begin from existing semantic recall, raw candidate
+  listing, relation keys, or a combined strategy?
+- What minimum evidence should be required before a proposed edge becomes
+  persistable?
+- How should explicit user feedback override automatic relation candidates?
+
+## Phase 3: Cluster Lifecycle Policy Dry Run
+
+Goal: make `forming`, `active`, `stable`, `decaying`, `superseded`, and
+`audit-only` computable states before any default persistence or retrieval
+behavior changes.
+
+Inputs:
+
+- graph snapshot
+- edge weights
+- activation history
+- support count
+- `compete` / conflict signals
+- consolidation and deprecation status
+- lifecycle thresholds
+
+Outputs:
+
+- lifecycle transition candidates
+- representative suggestions
+- consolidation eligibility
+- decay recommendations
+- audit-only recommendations
+- lifecycle section in `GraphEvolutionReport`
+
+Acceptance:
+
+- Repeated support can move a cluster from `forming` to `active` to `stable`.
+- Stale isolated nodes can move toward `decaying`.
+- Superseded source records can move toward `audit-only`.
+- Contested clusters are not summarized too early.
+- Lifecycle policy is separated from storage and summarizer behavior.
+- Lifecycle reports can be reviewed without changing persisted state.
+
+Review focus:
+
+- Are thresholds conservative enough to avoid false merges?
+- Can a contested cluster remain useful without becoming a summary?
+- Can the policy explain why a cluster is not eligible for consolidation?
+
+## Phase 4: Opt-in Persistence and Graph-aware Consolidation Planning
+
+Goal: allow graph plans and consolidation plans to persist only through explicit
+opt-in boundaries. Forgetting/consolidation should start consuming cluster
+lifecycle, but default runtime behavior should remain controlled.
+
+Actions:
+
+- persist graph update plans after dry-run approval
+- summarize stable clusters
+- soft-deprecate source raw records after successful summary or artifact
+  persistence
+- preserve contested clusters
+- decay weak structures
+- keep audit provenance
+
+Inputs:
+
+- stable or decaying lifecycle output
+- source record ids
+- relation evidence
+- summary or artifact candidate metadata
+- opt-in persistence mode
+
+Outputs:
+
+- persisted graph operation result
+- summary candidate or artifact candidate
+- soft-deprecation plan and result
+- preservation or decay diagnostics
+- audit provenance links
+
+Acceptance:
+
+- Stable cluster can produce a summary candidate.
+- After summary persistence succeeds, source raw records can be soft-deprecated.
+- `includeDeprecated` can recover the source evidence chain.
+- Deprecation failure becomes diagnostics and does not break the main flow unless
+  policy explicitly requires hard failure.
+- Audit chain is not deleted.
+- Persistence can be disabled or run in no-op mode for old adapters.
+
+Review focus:
+
+- Does the phase preserve raw source records?
+- Are persistence writes opt-in and observable?
+- Are graph operations and memory storage writes distinguishable in reports?
+
+## Phase 5: Controlled Runtime Integration
+
+Goal: gradually connect dry-run and opt-in persistence capabilities to real
+runtime paths without changing default behavior too early.
+
+Suggested stages:
+
+```text
+off
+dry-run
+log-only
+developer opt-in
+limited rollout
+default-on
+```
+
+Runtime integration surfaces:
+
+- ingest-time graph interaction
+- batch graph maintenance
+- forgetting/consolidation runtime
+- audit retrieval path
+- graph evolution reporting
+
+Acceptance:
+
+- Every stage is reversible.
+- Every graph mutation has a report.
+- Default behavior changes only after evaluation data exists.
+- UI is not required.
+- Scheduler is not required all at once.
+- Old adapters without graph/deprecation support degrade to no-op diagnostics.
+
+Review focus:
+
+- Can operators compare runtime behavior with and without graph participation?
+- Is there an escape hatch for each mutation type?
+- Are graph reports sufficient to debug wrong merges or wrong decay?
+
+## Phase 6: Graph-aware Retrieval Behavior
+
+Goal: compare baseline retrieval with graph-aware retrieval before changing
+default ranking, then enable graph-aware behavior only through controlled modes.
+
+Inputs:
+
+- query
+- semantic candidates
+- graph snapshot
+- lifecycle state
+- visibility mode
+
+Outputs:
+
+- baseline result
+- graph-expanded result
+- ranking differences
+- hidden deprecated count
+- audit expansion trace
+- explanation of graph signals used in ranking
+
+Expected behavior:
+
+- Stable summaries can rank ahead of duplicate raw traces.
+- Deprecated raw records are hidden by default.
+- Audit mode can expand source evidence.
+- Contested clusters can be explicitly exposed when conflict matters.
+- Reports can explain why ranking changed.
+
+Acceptance:
+
+- Graph-aware retrieval can run as dry-run comparison before default ranking
+  changes.
+- `includeDeprecated` remains an audit capability, not the normal retrieval path.
+- Retrieval can explain when it selected an active summary instead of source raw
+  records.
+- Retrieval can expose competing clusters intentionally rather than mixing them
+  as noise.
+- Ranking behavior remains feature-gated until evaluated.
+
+Open questions:
+
+- Should graph expansion happen before or after semantic score thresholds?
+- How should recency interact with cluster stability?
+- What should the retriever do when the best semantic hit is deprecated but its
+  summary is missing?
+
+## Phase 7: Evaluation and Rollout Criteria
+
+Goal: define how to prove that the dynamic graph system improves on isolated
+records plus similarity search.
+
+Metrics:
+
+- duplicate memory reduction
+- stable preference recall
+- contradiction handling
+- retrieval noise suppression
+- audit chain completeness
+- graph mutation explainability
+- false merge rate
+- false decay rate
+- runtime cost
+
+Acceptance:
+
+- Every metric has at least one scenario.
+- Reports can compare graph-aware behavior with baseline behavior.
+- Failure modes can be identified and categorized.
+- Rollout gates are explicit.
+- Evaluation includes both quality and safety: better recall should not come at
+  the cost of lost auditability or cross-scope contamination.
+
+Suggested rollout gates:
+
+- No cross-user/workspace graph edges in default mode.
+- No raw audit chain deletion.
+- False merge rate below an agreed threshold.
+- False decay cases are inspectable and reversible.
+- Retrieval dry-run shows noise reduction without hiding necessary evidence.
+- Runtime cost is bounded for expected candidate sizes.
+
+## Deliverables
+
+This planning task delivers only documentation:
+
+1. `memory-graph-evolution-execution-plan.md`
+2. A link from `memory-graph-evolution-architecture.md` to this execution plan
+3. No production code
+4. No test changes
+5. No new helper
+
+## Review Checklist
+
+- Does the plan still serve the dynamic memory graph direction?
+- Does it avoid becoming a helper checklist?
+- Does it put interface design before implementation?
+- Does it make the dry-run / persistence / runtime order explicit?
+- Does it preserve the audit chain?
+- Does it clearly isolate graph state by user, workspace, or tenant?
+- Does it leave clear phase boundaries for future Codex execution sessions?
+- Does each phase have reviewable acceptance criteria?
+- Does any phase accidentally require UI, scheduler, storage rewrite, or
+  real-time LLM behavior?
+
+## Final Reporting Template
+
+Future execution sessions should report:
+
+- documents changed
+- phase being advanced
+- phase goal
+- new or changed interface boundary
+- dry-run/report status
+- persistence/runtime status
+- unresolved architecture questions
+- verification performed
+- whether checkpoint/commit is recommended

--- a/packages/ai/memory-consolidation/docs/roadmap.md
+++ b/packages/ai/memory-consolidation/docs/roadmap.md
@@ -302,3 +302,8 @@ Future changes should follow these principles:
 
 The core direction is not to remember more. It is to gradually build a long-term
 memory formation process that can explain, compete, consolidate, and forget.
+
+See [memory-graph-evolution-architecture.md](./memory-graph-evolution-architecture.md)
+for the higher-level architecture that frames relation graph work, cluster
+lifecycle, graph-aware forgetting, retrieval, and observability as one dynamic
+memory graph.


### PR DESCRIPTION
## Summary
- Add a Memory Graph Evolution architecture RFC covering dynamic clusters, reinforcement, weakening, forgetting, retrieval, and observability.
- Add an execution plan that sequences architecture stability, interface design, dry-runs, opt-in persistence, runtime integration, retrieval, and evaluation.
- Link the roadmap to the new architecture document.

## Verification
- Checked local Markdown links for the new docs.
- Checked new docs for trailing whitespace.
- `git diff --cached --check`

Refs #254