### PR TITLE
feat(ai): add Hermes ACP runtime provider

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,6 +22,17 @@ ANTHROPIC_MODEL=****
 # --auto remains off by default. This only permits --auto when the request
 # permission mode is also bypassPermissions.
 # OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE=false
+#
+# Set to "hermes" to run native agent tasks through a locally installed Hermes
+# ACP runtime. Hermes is an AgentPlugin/IAgent runtime provider, not a sandbox
+# provider, and OpenLoomi does not install Hermes automatically.
+# OPENLOOMI_AGENT_PROVIDER=hermes
+# OPENLOOMI_AGENT_HERMES_COMMAND=hermes
+# OPENLOOMI_AGENT_HERMES_PROFILE=coding
+# OPENLOOMI_AGENT_HERMES_TIMEOUT_MS=300000
+# Hermes --yolo is not enabled by OpenLoomi. Configure Hermes model/provider
+# selection in Hermes profile/config; OPENLOOMI_AGENT_HERMES_MODEL and
+# OPENLOOMI_AGENT_HERMES_PROVIDER are intentionally unsupported in this MVP.
 
 # Cloud API Configuration for Tauri Desktop App
 # Tauri version uses cloud API for user authentication and data sync

--- a/apps/web/app/api/native/providers/route.ts
+++ b/apps/web/app/api/native/providers/route.ts
@@ -13,17 +13,23 @@ import {
   getAgentRegistry,
   getAllAgentMetadata,
 } from "@openloomi/ai/agent/registry";
+import { hermesPlugin } from "@/lib/ai/extensions/agent/hermes";
 import { opencodePlugin } from "@/lib/ai/extensions/agent/opencode";
 import { getConfiguredDefaultAgentProvider } from "@/lib/ai/native-agent/provider-env";
 
 // Register lightweight built-in Agent plugins used by this metadata route.
 const registry = getAgentRegistry();
 registry.register(opencodePlugin);
+registry.register(hermesPlugin);
 
 function getProviderMetadata(): AgentProviderMetadata[] {
   const metadataByType = new Map<string, AgentProviderMetadata>();
 
-  for (const metadata of [CLAUDE_METADATA, opencodePlugin.metadata]) {
+  for (const metadata of [
+    CLAUDE_METADATA,
+    opencodePlugin.metadata,
+    hermesPlugin.metadata,
+  ]) {
     metadataByType.set(metadata.type, metadata);
   }
 

--- a/apps/web/lib/ai/extensions/agent/hermes/acp-client.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/acp-client.ts
@@ -226,7 +226,7 @@ export class HermesAcpClient {
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 250));
     this.kill();
   }
 

--- a/apps/web/lib/ai/extensions/agent/hermes/acp-client.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/acp-client.ts
@@ -1,0 +1,513 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { platform } from "node:os";
+
+type JsonRpcId = string | number;
+
+interface JsonRpcRequest {
+  jsonrpc?: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc?: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
+
+export type HermesAcpClientEvent =
+  | { type: "notification"; method: string; params?: unknown }
+  | { type: "diagnostic"; message: string }
+  | {
+      type: "close";
+      exitCode: number;
+      stderr: string;
+      stdout: string;
+      timedOut?: boolean;
+      timeoutMs?: number;
+    };
+
+export type HermesAcpClientRequestHandler = (request: {
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}) => Promise<unknown>;
+
+interface PendingRequest {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+interface PendingAgentRequest {
+  method: string;
+}
+
+export class HermesAcpCommandNotFoundError extends Error {
+  constructor(command: string) {
+    super(
+      `Hermes ACP executable not found: ${command}. Install Hermes with ACP support or set OPENLOOMI_AGENT_HERMES_COMMAND to the Hermes executable.`,
+    );
+    this.name = "HermesAcpCommandNotFoundError";
+  }
+}
+
+export class HermesAcpExitError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode?: number,
+  ) {
+    super(message);
+    this.name = "HermesAcpExitError";
+  }
+}
+
+export class HermesAcpJsonRpcError extends Error {
+  constructor(
+    readonly method: string,
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(`Hermes ACP ${method} failed: ${message}`);
+    this.name = "HermesAcpJsonRpcError";
+  }
+}
+
+export class HermesAcpClient {
+  private proc?: ChildProcessWithoutNullStreams;
+  private requestCounter = 0;
+  private stdout = "";
+  private stderr = "";
+  private stdoutBuffer = "";
+  private timeout?: ReturnType<typeof setTimeout>;
+  private timedOut = false;
+  private closed = false;
+  private pendingRequests = new Map<JsonRpcId, PendingRequest>();
+  private pendingAgentRequests = new Map<JsonRpcId, PendingAgentRequest>();
+  private eventQueue = new AsyncQueue<HermesAcpClientEvent>();
+  private resolveClosed?: () => void;
+  private readonly closedPromise = new Promise<void>((resolve) => {
+    this.resolveClosed = resolve;
+  });
+
+  constructor(
+    private readonly command: string,
+    private readonly args: string[],
+    private readonly options: {
+      cwd: string;
+      signal?: AbortSignal;
+      timeoutMs?: number;
+      onRequest?: HermesAcpClientRequestHandler;
+    },
+  ) {}
+
+  start(): void {
+    if (this.proc) {
+      return;
+    }
+
+    try {
+      this.proc = spawn(this.command, this.args, {
+        cwd: this.options.cwd,
+        env: process.env,
+        windowsHide: true,
+      });
+    } catch (error) {
+      const err = this.normalizeSpawnError(error);
+      throw err;
+    }
+
+    const proc = this.proc;
+
+    this.options.signal?.addEventListener("abort", this.abortHandler, {
+      once: true,
+    });
+    if (this.options.signal?.aborted) {
+      this.abortHandler();
+    }
+
+    if (this.options.timeoutMs && this.options.timeoutMs > 0) {
+      this.timeout = setTimeout(() => {
+        this.timedOut = true;
+        this.kill();
+      }, this.options.timeoutMs);
+    }
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      this.stdout += text;
+      this.stdoutBuffer += text;
+      this.flushStdoutLines();
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      this.stderr += chunk.toString();
+    });
+
+    proc.on("error", (error: Error & { code?: string }) => {
+      const err = isCommandNotFoundError(error)
+        ? new HermesAcpCommandNotFoundError(this.command)
+        : error;
+      this.rejectAll(err);
+      this.eventQueue.push({ type: "diagnostic", message: err.message });
+      this.finish();
+    });
+
+    proc.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      const exitCode = this.timedOut ? 124 : (code ?? (signal ? 130 : 0));
+      const closeEvent: HermesAcpClientEvent = {
+        type: "close",
+        exitCode,
+        stderr: this.stderr,
+        stdout: this.stdout,
+        timedOut: this.timedOut,
+        timeoutMs: this.timedOut ? this.options.timeoutMs : undefined,
+      };
+
+      if (this.stdoutBuffer.trim()) {
+        this.handleLine(this.stdoutBuffer);
+        this.stdoutBuffer = "";
+      }
+
+      const exitError = this.formatExitError(closeEvent);
+      if (exitError) {
+        this.rejectAll(exitError);
+      }
+
+      this.eventQueue.push(closeEvent);
+      this.finish();
+    });
+  }
+
+  request(method: string, params?: unknown): Promise<unknown> {
+    const id = ++this.requestCounter;
+    const message = { jsonrpc: "2.0", id, method, params };
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { method, resolve, reject });
+      try {
+        this.write(message);
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.write({ jsonrpc: "2.0", method, params });
+  }
+
+  nextEvent(): Promise<HermesAcpClientEvent | undefined> {
+    return this.eventQueue.shift();
+  }
+
+  drainEvents(): HermesAcpClientEvent[] {
+    return this.eventQueue.drain();
+  }
+
+  async cancel(sessionId?: string): Promise<void> {
+    this.cancelPendingAgentRequests();
+
+    if (sessionId && !this.closed) {
+      try {
+        this.notify("session/cancel", { sessionId });
+      } catch {
+        // The process may already be gone; shutdown will still kill it.
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    this.kill();
+  }
+
+  async shutdown(): Promise<void> {
+    this.cancelPendingAgentRequests();
+    this.kill();
+    this.cleanup();
+    await Promise.race([
+      this.closedPromise,
+      new Promise((resolve) => setTimeout(resolve, 1000)),
+    ]);
+  }
+
+  kill(): void {
+    if (!this.proc || this.proc.killed) {
+      return;
+    }
+
+    killProcessTree(this.proc);
+  }
+
+  private readonly abortHandler = () => {
+    this.cancelPendingAgentRequests();
+    this.kill();
+  };
+
+  private write(message: Record<string, unknown>): void {
+    if (!this.proc || this.closed) {
+      throw new Error("Hermes ACP process is not running");
+    }
+
+    this.proc.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private flushStdoutLines(): void {
+    const lines = this.stdoutBuffer.split(/\r?\n/);
+    this.stdoutBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) {
+        this.handleLine(line);
+      }
+    }
+  }
+
+  private handleLine(line: string): void {
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      this.eventQueue.push({
+        type: "diagnostic",
+        message: `Hermes ACP emitted invalid JSON: ${line}`,
+      });
+      return;
+    }
+
+    if ("method" in message && message.method) {
+      this.handleIncomingRequestOrNotification(message);
+      return;
+    }
+
+    if (isJsonRpcResponse(message)) {
+      this.handleResponse(message);
+    }
+  }
+
+  private handleResponse(message: JsonRpcResponse): void {
+    const pending = this.pendingRequests.get(message.id);
+    if (pending) {
+      this.pendingRequests.delete(message.id);
+      if (message.error) {
+        pending.reject(
+          new HermesAcpJsonRpcError(
+            pending.method,
+            message.error.code,
+            message.error.message,
+            message.error.data,
+          ),
+        );
+        return;
+      }
+      pending.resolve(message.result);
+      return;
+    }
+
+    if (this.pendingAgentRequests.has(message.id)) {
+      this.pendingAgentRequests.delete(message.id);
+    }
+  }
+
+  private handleIncomingRequestOrNotification(message: JsonRpcRequest): void {
+    if (message.id === undefined) {
+      this.eventQueue.push({
+        type: "notification",
+        method: message.method,
+        params: message.params,
+      });
+      return;
+    }
+
+    if (message.method !== "session/request_permission") {
+      const diagnostic = `Unsupported Hermes ACP client method: ${message.method}`;
+      this.respondError(message.id, -32601, diagnostic);
+      this.eventQueue.push({ type: "diagnostic", message: diagnostic });
+      return;
+    }
+
+    this.pendingAgentRequests.set(message.id, { method: message.method });
+
+    Promise.resolve(
+      this.options.onRequest?.({
+        id: message.id,
+        method: message.method,
+        params: message.params,
+      }) ?? { outcome: { outcome: "cancelled" } },
+    )
+      .then((result) => {
+        if (!this.pendingAgentRequests.has(message.id as JsonRpcId)) {
+          return;
+        }
+        this.pendingAgentRequests.delete(message.id as JsonRpcId);
+        this.respondResult(message.id as JsonRpcId, result);
+      })
+      .catch((error) => {
+        if (!this.pendingAgentRequests.has(message.id as JsonRpcId)) {
+          return;
+        }
+        this.pendingAgentRequests.delete(message.id as JsonRpcId);
+        this.respondError(
+          message.id as JsonRpcId,
+          -32000,
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+  }
+
+  private respondResult(id: JsonRpcId, result: unknown): void {
+    try {
+      this.write({ jsonrpc: "2.0", id, result });
+    } catch {
+      // The process may have exited while the handler was resolving.
+    }
+  }
+
+  private respondError(id: JsonRpcId, code: number, message: string): void {
+    try {
+      this.write({
+        jsonrpc: "2.0",
+        id,
+        error: { code, message },
+      });
+    } catch {
+      // The process may have exited while the handler was resolving.
+    }
+  }
+
+  private cancelPendingAgentRequests(): void {
+    for (const id of this.pendingAgentRequests.keys()) {
+      this.respondResult(id, { outcome: { outcome: "cancelled" } });
+      this.pendingAgentRequests.delete(id);
+    }
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  private finish(): void {
+    this.closed = true;
+    this.cleanup();
+    this.eventQueue.close();
+    this.resolveClosed?.();
+  }
+
+  private cleanup(): void {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+    this.options.signal?.removeEventListener("abort", this.abortHandler);
+  }
+
+  private normalizeSpawnError(error: unknown): Error {
+    const err = error instanceof Error ? error : new Error(String(error));
+    return isCommandNotFoundError(err as Error & { code?: string })
+      ? new HermesAcpCommandNotFoundError(this.command)
+      : err;
+  }
+
+  private formatExitError(
+    closeEvent: Extract<HermesAcpClientEvent, { type: "close" }>,
+  ): HermesAcpExitError | undefined {
+    if (closeEvent.exitCode === 0) {
+      return undefined;
+    }
+
+    const output = closeEvent.stderr.trim() || closeEvent.stdout.trim();
+    if (closeEvent.timedOut) {
+      return new HermesAcpExitError(
+        output
+          ? `Hermes ACP timed out after ${closeEvent.timeoutMs}ms: ${output}`
+          : `Hermes ACP timed out after ${closeEvent.timeoutMs}ms`,
+        closeEvent.exitCode,
+      );
+    }
+
+    return new HermesAcpExitError(
+      output
+        ? `Hermes ACP exited with code ${closeEvent.exitCode}: ${output}`
+        : `Hermes ACP exited with code ${closeEvent.exitCode}`,
+      closeEvent.exitCode,
+    );
+  }
+}
+
+class AsyncQueue<T> {
+  private items: T[] = [];
+  private waiters: Array<(value: T | undefined) => void> = [];
+  private closed = false;
+
+  push(item: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(item);
+      return;
+    }
+    this.items.push(item);
+  }
+
+  shift(): Promise<T | undefined> {
+    const item = this.items.shift();
+    if (item !== undefined) {
+      return Promise.resolve(item);
+    }
+    if (this.closed) {
+      return Promise.resolve(undefined);
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter(undefined);
+    }
+  }
+
+  drain(): T[] {
+    return this.items.splice(0);
+  }
+}
+
+function killProcessTree(proc: ChildProcessWithoutNullStreams) {
+  if (proc.killed) {
+    return;
+  }
+
+  if (platform() === "win32" && proc.pid) {
+    spawn("taskkill", ["/F", "/T", "/PID", String(proc.pid)], {
+      windowsHide: true,
+      stdio: "ignore",
+    }).on("error", () => {
+      proc.kill();
+    });
+    return;
+  }
+
+  proc.kill("SIGTERM");
+}
+
+function isCommandNotFoundError(error: Error & { code?: string }) {
+  return error.code === "ENOENT";
+}
+
+function isJsonRpcResponse(
+  message: JsonRpcMessage,
+): message is JsonRpcResponse {
+  return "id" in message && message.id !== undefined;
+}

--- a/apps/web/lib/ai/extensions/agent/hermes/acp-mapper.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/acp-mapper.ts
@@ -1,0 +1,253 @@
+import type { AgentMessage, AgentOptions } from "@openloomi/ai/agent/types";
+
+export function convertHermesAcpNotification(params: unknown): AgentMessage[] {
+  const record = asRecord(params);
+  const update = asRecord(record?.update);
+  if (!update) {
+    return [];
+  }
+
+  const updateType = readString(update.sessionUpdate);
+  switch (updateType) {
+    case "agent_message_chunk": {
+      const text = extractText(update.content);
+      return text ? [{ type: "text", content: text }] : [];
+    }
+    case "agent_thought_chunk": {
+      const text = extractText(update.content);
+      return text ? [{ type: "reasoning", content: text }] : [];
+    }
+    case "tool_call":
+      return [convertToolCall(update)];
+    case "tool_call_update": {
+      const toolResult = convertToolCallUpdate(update);
+      return toolResult ? [toolResult] : [];
+    }
+    case "usage_update": {
+      const usage = extractUsage(update.usage ?? update);
+      return usage ? [{ type: "result", content: "usage_update", usage }] : [];
+    }
+    default:
+      return [];
+  }
+}
+
+export function convertHermesPromptResponse(result: unknown): AgentMessage[] {
+  const record = asRecord(result);
+  const stopReason = readString(record?.stopReason) ?? "end_turn";
+  const usage = extractUsage(record?.usage);
+
+  if (stopReason === "cancelled") {
+    return [
+      {
+        type: "error",
+        message: "Hermes ACP prompt was cancelled",
+      },
+    ];
+  }
+
+  return [
+    {
+      type: "result",
+      content: stopReason,
+      usage,
+    },
+  ];
+}
+
+export async function mapHermesPermissionRequest(
+  params: unknown,
+  options: AgentOptions | undefined,
+  mode: "run" | "plan" | "execute",
+) {
+  const request = asRecord(params);
+  const toolCall = asRecord(request?.toolCall);
+  const permissionOptions = Array.isArray(request?.options)
+    ? request.options.filter(isRecord)
+    : [];
+
+  if (mode === "plan") {
+    return selectDenyOutcome(permissionOptions);
+  }
+
+  let behavior: "allow" | "deny" = "deny";
+  if (options?.onPermissionRequest) {
+    const decision = await options.onPermissionRequest({
+      toolName: readString(toolCall?.title) ?? "Hermes tool",
+      toolInput: asRecord(toolCall?.rawInput) ?? {},
+      toolUseID: readString(toolCall?.toolCallId) ?? "hermes-tool",
+    });
+    behavior = decision.behavior;
+  }
+
+  if (behavior === "allow") {
+    return selectAllowOutcome(permissionOptions);
+  }
+
+  return selectDenyOutcome(permissionOptions);
+}
+
+function convertToolCall(update: Record<string, unknown>): AgentMessage {
+  return {
+    type: "tool_use",
+    id: readString(update.toolCallId),
+    name: readString(update.title) || readString(update.kind) || "Hermes tool",
+    input: asRecord(update.rawInput) ?? undefined,
+  };
+}
+
+function convertToolCallUpdate(
+  update: Record<string, unknown>,
+): AgentMessage | undefined {
+  const output =
+    readString(update.rawOutput) ??
+    extractText(update.rawOutput) ??
+    extractText(update.content) ??
+    stringifyUnknown(update.rawOutput);
+  const status = readString(update.status);
+
+  if (!output && !status) {
+    return undefined;
+  }
+
+  return {
+    type: "tool_result",
+    toolUseId: readString(update.toolCallId),
+    output: output ?? "",
+    isError: status === "failed",
+  };
+}
+
+function selectAllowOutcome(options: Record<string, unknown>[]) {
+  const option =
+    findPermissionOption(options, ["allow_once"]) ??
+    findPermissionOption(options, ["allow_session"]) ??
+    findPermissionOption(options, ["allow"], ["always"]);
+
+  if (!option) {
+    return selectDenyOutcome(options);
+  }
+
+  return {
+    outcome: {
+      outcome: "selected",
+      optionId: option,
+    },
+  };
+}
+
+function selectDenyOutcome(options: Record<string, unknown>[]) {
+  const option =
+    findPermissionOption(options, ["reject_once"]) ??
+    findPermissionOption(options, ["deny_once"]) ??
+    findPermissionOption(options, ["reject", "deny"]);
+
+  if (!option) {
+    return {
+      outcome: {
+        outcome: "cancelled",
+      },
+    };
+  }
+
+  return {
+    outcome: {
+      outcome: "selected",
+      optionId: option,
+    },
+  };
+}
+
+function findPermissionOption(
+  options: Record<string, unknown>[],
+  includes: string[],
+  excludes: string[] = [],
+) {
+  for (const option of options) {
+    const haystack = `${readString(option.kind) ?? ""} ${
+      readString(option.name) ?? ""
+    }`.toLowerCase();
+    if (
+      includes.some((value) => haystack.includes(value)) &&
+      excludes.every((value) => !haystack.includes(value))
+    ) {
+      return readString(option.optionId);
+    }
+  }
+
+  return undefined;
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const record = asRecord(value);
+  if (record) {
+    for (const key of ["text", "content", "message", "delta"]) {
+      const direct = record[key];
+      if (typeof direct === "string") {
+        return direct;
+      }
+    }
+
+    const nested = extractText(record.content);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const text = value
+      .map((item) => extractText(item))
+      .filter((item): item is string => Boolean(item))
+      .join("");
+    return text || undefined;
+  }
+
+  return undefined;
+}
+
+function extractUsage(value: unknown): AgentMessage["usage"] | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const inputTokens = readNumber(record.inputTokens);
+  const outputTokens = readNumber(record.outputTokens);
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return undefined;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+  };
+}
+
+function stringifyUnknown(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}

--- a/apps/web/lib/ai/extensions/agent/hermes/command.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/command.ts
@@ -1,0 +1,49 @@
+export interface HermesProviderConfig {
+  hermesPath?: string;
+  profile?: string;
+  timeoutMs?: number;
+}
+
+export interface HermesAcpCommand {
+  command: string;
+  args: string[];
+}
+
+export function normalizeHermesProviderConfig(
+  value: Record<string, unknown> | undefined,
+): HermesProviderConfig {
+  return {
+    hermesPath:
+      typeof value?.hermesPath === "string" && value.hermesPath.trim()
+        ? value.hermesPath.trim()
+        : undefined,
+    profile:
+      typeof value?.profile === "string" && value.profile.trim()
+        ? value.profile.trim()
+        : undefined,
+    timeoutMs:
+      typeof value?.timeoutMs === "number" &&
+      Number.isInteger(value.timeoutMs) &&
+      value.timeoutMs > 0
+        ? value.timeoutMs
+        : undefined,
+  };
+}
+
+export function buildHermesAcpCommand(
+  providerConfig?: Record<string, unknown>,
+): HermesAcpCommand {
+  const config = normalizeHermesProviderConfig(providerConfig);
+  const args: string[] = [];
+
+  if (config.profile) {
+    args.push("--profile", config.profile);
+  }
+
+  args.push("acp");
+
+  return {
+    command: config.hermesPath || "hermes",
+    args,
+  };
+}

--- a/apps/web/lib/ai/extensions/agent/hermes/index.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/index.ts
@@ -1,0 +1,419 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import {
+  BaseAgent,
+  defineAgentPlugin,
+  formatPlanForExecution,
+  parsePlanFromResponse,
+  parsePlanningResponse,
+  PLANNING_INSTRUCTION,
+} from "@openloomi/ai/agent";
+import type { AgentPlugin } from "@openloomi/ai/agent/plugin";
+import type {
+  AgentConfig,
+  AgentMessage,
+  AgentOptions,
+  AgentProvider,
+  ExecuteOptions,
+  PlanOptions,
+} from "@openloomi/ai/agent/types";
+
+import {
+  HermesAcpClient,
+  HermesAcpCommandNotFoundError,
+  type HermesAcpClientEvent,
+} from "./acp-client";
+import {
+  convertHermesAcpNotification,
+  convertHermesPromptResponse,
+  mapHermesPermissionRequest,
+} from "./acp-mapper";
+import {
+  buildHermesAcpCommand,
+  normalizeHermesProviderConfig,
+} from "./command";
+import { HERMES_METADATA } from "./metadata";
+
+interface ActiveHermesRun {
+  client: HermesAcpClient;
+  acpSessionId?: string;
+}
+
+export class HermesAgent extends BaseAgent {
+  readonly provider: AgentProvider = "hermes";
+
+  private messageCounter = 0;
+  private activeRuns = new Map<string, ActiveHermesRun>();
+
+  async *run(
+    prompt: string,
+    options?: AgentOptions,
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession("executing", {
+      abortController: options?.abortController,
+    });
+
+    yield {
+      type: "session",
+      sessionId: session.id,
+      messageId: this.generateMessageId(),
+    };
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      yield* this.runHermesPrompt(session.id, prompt, cwd, options, "run");
+    } catch (error) {
+      yield this.toErrorMessage(error);
+    } finally {
+      await this.cleanupRun(session.id);
+      yield { type: "done", messageId: this.generateMessageId() };
+    }
+  }
+
+  async *plan(
+    prompt: string,
+    options?: PlanOptions,
+  ): AsyncGenerator<AgentMessage> {
+    const session = this.createSession("planning", {
+      abortController: options?.abortController,
+    });
+
+    yield {
+      type: "session",
+      sessionId: session.id,
+      messageId: this.generateMessageId(),
+    };
+
+    let fullResponse = "";
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      const planningPrompt = `${PLANNING_INSTRUCTION(options?.timezone ?? undefined)}\n\n${prompt}`;
+      const planningOptions: AgentOptions = {
+        ...options,
+        permissionMode: "plan",
+      };
+
+      for await (const message of this.runHermesPrompt(
+        session.id,
+        planningPrompt,
+        cwd,
+        planningOptions,
+        "plan",
+      )) {
+        if (message.type === "text" && message.content) {
+          fullResponse += message.content;
+          yield message;
+        } else if (message.type === "error") {
+          yield message;
+          return;
+        }
+      }
+
+      const planningResult = parsePlanningResponse(fullResponse);
+      if (planningResult?.type === "direct_answer") {
+        yield {
+          type: "direct_answer",
+          content: planningResult.answer,
+          messageId: this.generateMessageId(),
+        };
+        return;
+      }
+
+      const plan =
+        planningResult?.type === "plan"
+          ? planningResult.plan
+          : parsePlanFromResponse(fullResponse);
+      if (plan && plan.steps.length > 0) {
+        this.storePlan(plan);
+        yield {
+          type: "plan",
+          plan,
+          messageId: this.generateMessageId(),
+        };
+        return;
+      }
+
+      if (fullResponse.trim()) {
+        yield {
+          type: "direct_answer",
+          content: fullResponse.trim(),
+          messageId: this.generateMessageId(),
+        };
+      }
+    } catch (error) {
+      yield this.toErrorMessage(error);
+    } finally {
+      await this.cleanupRun(session.id);
+      yield { type: "done", messageId: this.generateMessageId() };
+    }
+  }
+
+  async *execute(options: ExecuteOptions): AsyncGenerator<AgentMessage> {
+    const plan = options.plan || this.getPlan(options.planId);
+
+    if (!plan) {
+      yield {
+        type: "session",
+        sessionId: options.sessionId,
+        messageId: this.generateMessageId(),
+      };
+      yield {
+        type: "error",
+        message: `Plan not found: ${options.planId}`,
+        messageId: this.generateMessageId(),
+      };
+      yield { type: "done", messageId: this.generateMessageId() };
+      return;
+    }
+
+    let completedSuccessfully = false;
+
+    try {
+      const cwd = await this.resolveAndPrepareWorkDir(options);
+      const executionPrompt = `${formatPlanForExecution(
+        plan,
+        cwd,
+        undefined,
+        options.aiSoulPrompt ?? undefined,
+        options.language ?? undefined,
+        options.timezone ?? undefined,
+      )}\n\nOriginal request: ${options.originalPrompt}`;
+
+      let sawError = false;
+      for await (const message of this.run(executionPrompt, {
+        ...options,
+        cwd,
+      })) {
+        if (message.type === "error") {
+          sawError = true;
+        }
+        yield message;
+      }
+
+      completedSuccessfully =
+        !sawError && !options.abortController?.signal.aborted;
+    } finally {
+      if (completedSuccessfully) {
+        this.deletePlan(options.planId);
+      }
+    }
+  }
+
+  override async stop(sessionId: string): Promise<void> {
+    const activeRun = this.activeRuns.get(sessionId);
+    if (activeRun) {
+      await activeRun.client.cancel(activeRun.acpSessionId);
+    }
+    await super.stop(sessionId);
+  }
+
+  override async shutdown(): Promise<void> {
+    for (const sessionId of Array.from(this.activeRuns.keys())) {
+      await this.stop(sessionId);
+    }
+    await super.shutdown();
+  }
+
+  private async *runHermesPrompt(
+    sessionId: string,
+    prompt: string,
+    cwd: string,
+    options: AgentOptions | undefined,
+    mode: "run" | "plan" | "execute",
+  ): AsyncGenerator<AgentMessage> {
+    const providerConfig = normalizeHermesProviderConfig(
+      this.config.providerConfig,
+    );
+    const command = buildHermesAcpCommand(this.config.providerConfig);
+    const client = new HermesAcpClient(command.command, command.args, {
+      cwd,
+      signal: this.getSession(sessionId)?.abortController.signal,
+      timeoutMs: providerConfig.timeoutMs,
+      onRequest: async (request) => {
+        if (request.method !== "session/request_permission") {
+          return { outcome: { outcome: "cancelled" } };
+        }
+        return mapHermesPermissionRequest(request.params, options, mode);
+      },
+    });
+
+    this.activeRuns.set(sessionId, { client });
+    client.start();
+
+    await client.request("initialize", {
+      protocolVersion: 1,
+      clientInfo: {
+        name: "openloomi",
+        version: "1.0.0",
+      },
+      clientCapabilities: {},
+    });
+
+    const sessionResponse = asRecord(
+      await client.request("session/new", {
+        cwd,
+        mcpServers: [],
+      }),
+    );
+    const acpSessionId =
+      typeof sessionResponse?.sessionId === "string"
+        ? sessionResponse.sessionId
+        : undefined;
+    if (!acpSessionId) {
+      throw new Error("Hermes ACP session/new did not return a sessionId");
+    }
+
+    const activeRun = this.activeRuns.get(sessionId);
+    if (activeRun) {
+      activeRun.acpSessionId = acpSessionId;
+    }
+
+    let promptSettled = false;
+    let promptResult: unknown;
+    let promptError: unknown;
+    const promptPromise = client
+      .request("session/prompt", {
+        sessionId: acpSessionId,
+        prompt: [{ type: "text", text: prompt }],
+      })
+      .then((result) => {
+        promptSettled = true;
+        promptResult = result;
+      })
+      .catch((error) => {
+        promptSettled = true;
+        promptError = error;
+      });
+
+    while (!promptSettled) {
+      const event = await Promise.race([
+        client.nextEvent(),
+        promptPromise.then(() => undefined),
+      ]);
+
+      if (!event) {
+        continue;
+      }
+
+      for (const message of this.convertClientEvent(event)) {
+        yield this.withMessageId(message);
+      }
+    }
+
+    await promptPromise;
+    if (promptError) {
+      throw promptError;
+    }
+
+    for (const event of client.drainEvents()) {
+      for (const message of this.convertClientEvent(event)) {
+        yield this.withMessageId(message);
+      }
+    }
+
+    for (const message of convertHermesPromptResponse(promptResult)) {
+      yield this.withMessageId(message);
+    }
+  }
+
+  private convertClientEvent(event: HermesAcpClientEvent): AgentMessage[] {
+    if (event.type === "notification" && event.method === "session/update") {
+      return convertHermesAcpNotification(event.params);
+    }
+
+    if (event.type === "diagnostic") {
+      return [{ type: "error", message: event.message }];
+    }
+
+    if (event.type === "close" && event.exitCode !== 0) {
+      const output = event.stderr.trim() || event.stdout.trim();
+      if (event.timedOut) {
+        return [
+          {
+            type: "error",
+            message: output
+              ? `Hermes ACP timed out after ${event.timeoutMs}ms: ${output}`
+              : `Hermes ACP timed out after ${event.timeoutMs}ms`,
+          },
+        ];
+      }
+      return [
+        {
+          type: "error",
+          message: output
+            ? `Hermes ACP exited with code ${event.exitCode}: ${output}`
+            : `Hermes ACP exited with code ${event.exitCode}`,
+        },
+      ];
+    }
+
+    return [];
+  }
+
+  private async cleanupRun(sessionId: string) {
+    const activeRun = this.activeRuns.get(sessionId);
+    if (activeRun) {
+      await activeRun.client.shutdown();
+      this.activeRuns.delete(sessionId);
+    }
+    this.sessions.delete(sessionId);
+  }
+
+  private withMessageId(message: AgentMessage): AgentMessage {
+    return message.messageId
+      ? message
+      : { ...message, messageId: this.generateMessageId() };
+  }
+
+  private toErrorMessage(error: unknown): AgentMessage {
+    return {
+      type: "error",
+      message:
+        error instanceof HermesAcpCommandNotFoundError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : String(error),
+      messageId: this.generateMessageId(),
+    };
+  }
+
+  private generateMessageId(): string {
+    return `hermes_msg_${Date.now()}_${++this.messageCounter}`;
+  }
+
+  private async resolveAndPrepareWorkDir(options?: AgentOptions) {
+    const rawWorkDir = options?.cwd || this.config.workDir || process.cwd();
+    const resolved = resolveHome(rawWorkDir);
+    await mkdir(resolved, { recursive: true });
+    return resolved;
+  }
+}
+
+function resolveHome(filePath: string) {
+  if (filePath === "~") {
+    return homedir();
+  }
+  if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+    return join(homedir(), filePath.slice(2));
+  }
+  return isAbsolute(filePath) ? filePath : join(process.cwd(), filePath);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function createHermesAgent(config: AgentConfig): HermesAgent {
+  return new HermesAgent(config);
+}
+
+export const hermesPlugin: AgentPlugin = defineAgentPlugin({
+  metadata: HERMES_METADATA,
+  factory: (config) => createHermesAgent(config),
+});

--- a/apps/web/lib/ai/extensions/agent/hermes/metadata.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/metadata.ts
@@ -1,0 +1,42 @@
+import type { AgentProviderMetadata } from "@openloomi/ai/agent/plugin";
+
+export const HERMES_CONFIG_SCHEMA = {
+  type: "object",
+  properties: {
+    workDir: {
+      type: "string",
+      description: "Working directory for Hermes ACP sessions",
+    },
+    providerConfig: {
+      type: "object",
+      properties: {
+        hermesPath: {
+          type: "string",
+          description: "Path to the Hermes CLI executable",
+        },
+        profile: {
+          type: "string",
+          description: "Hermes profile passed as --profile before acp",
+        },
+        timeoutMs: {
+          type: "number",
+          description: "Maximum Hermes ACP prompt runtime in milliseconds",
+        },
+      },
+    },
+  },
+};
+
+export const HERMES_METADATA: AgentProviderMetadata = {
+  type: "hermes",
+  name: "Hermes",
+  version: "1.0.0",
+  description:
+    "Hermes ACP runtime provider using hermes acp over stdio JSON-RPC.",
+  configSchema: HERMES_CONFIG_SCHEMA,
+  builtin: true,
+  supportsPlan: true,
+  supportsStreaming: true,
+  supportsSandbox: false,
+  tags: ["hermes", "acp", "coding-agent"],
+};

--- a/apps/web/lib/ai/extensions/index.ts
+++ b/apps/web/lib/ai/extensions/index.ts
@@ -10,3 +10,4 @@ export {
   createOpenCodeAgent,
   OpenCodeAgent,
 } from "./agent/opencode";
+export { hermesPlugin, createHermesAgent, HermesAgent } from "./agent/hermes";

--- a/apps/web/lib/ai/native-agent/host.ts
+++ b/apps/web/lib/ai/native-agent/host.ts
@@ -1,7 +1,11 @@
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
 import type { NativeAgentHost } from "@openloomi/ai/agent/native-runner";
 
-import { claudePlugin, opencodePlugin } from "@/lib/ai/extensions";
+import {
+  claudePlugin,
+  hermesPlugin,
+  opencodePlugin,
+} from "@/lib/ai/extensions";
 import { getDocument, getDocumentChunks } from "@/lib/ai/rag/langchain-service";
 import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
 import {
@@ -22,6 +26,7 @@ function registerNativeAgentProviders() {
   const registry = getAgentRegistry();
   registry.register(claudePlugin);
   registry.register(opencodePlugin);
+  registry.register(hermesPlugin);
   providersRegistered = true;
 }
 

--- a/apps/web/lib/ai/native-agent/provider-env.ts
+++ b/apps/web/lib/ai/native-agent/provider-env.ts
@@ -9,12 +9,21 @@ type EnvSource = Record<string, string | undefined>;
 const DEFAULT_AGENT_PROVIDER: AgentProvider = "claude";
 const ENV_PROVIDER_KEY = "OPENLOOMI_AGENT_PROVIDER";
 const OPENCODE_PROVIDER = "opencode";
-const SUPPORTED_ENV_PROVIDERS = new Set(["claude", OPENCODE_PROVIDER]);
+const HERMES_PROVIDER = "hermes";
+const SUPPORTED_ENV_PROVIDERS = new Set([
+  "claude",
+  OPENCODE_PROVIDER,
+  HERMES_PROVIDER,
+]);
 
 export function getConfiguredDefaultAgentProvider(
   env: EnvSource = process.env,
 ): AgentProvider {
-  return resolveEnvAgentProvider(env) ?? DEFAULT_AGENT_PROVIDER;
+  const provider = resolveEnvAgentProvider(env) ?? DEFAULT_AGENT_PROVIDER;
+  if (provider === HERMES_PROVIDER) {
+    validateHermesUnsupportedEnvConfig(env);
+  }
+  return provider;
 }
 
 export function resolveNativeAgentProviderRequest(
@@ -24,6 +33,15 @@ export function resolveNativeAgentProviderRequest(
   const provider =
     resolveRequestAgentProvider(body.provider) ??
     getConfiguredDefaultAgentProvider(env);
+
+  if (provider === HERMES_PROVIDER) {
+    return {
+      ...body,
+      provider,
+      modelConfig: resolveHermesModelConfig(body),
+      providerConfig: resolveHermesEnvConfig(env).providerConfig,
+    };
+  }
 
   if (provider !== OPENCODE_PROVIDER) {
     return {
@@ -81,11 +99,62 @@ function resolveEnvAgentProvider(env: EnvSource): AgentProvider | undefined {
   const provider = rawProvider.toLowerCase();
   if (!SUPPORTED_ENV_PROVIDERS.has(provider)) {
     throwConfigError(
-      `Unsupported ${ENV_PROVIDER_KEY}: ${rawProvider}. Supported values: claude, opencode.`,
+      `Unsupported ${ENV_PROVIDER_KEY}: ${rawProvider}. Supported values: claude, opencode, hermes.`,
     );
   }
 
   return provider as AgentProvider;
+}
+
+function resolveHermesModelConfig(body: NativeAgentRequest) {
+  const requestModel = normalizeOptionalString(body.modelConfig?.model);
+  if (requestModel) {
+    throwConfigError(
+      "Hermes model selection is not supported by this ACP MVP. Configure Hermes model selection through Hermes profile/config instead.",
+    );
+  }
+
+  return body.modelConfig;
+}
+
+function resolveHermesEnvConfig(env: EnvSource) {
+  validateHermesUnsupportedEnvConfig(env);
+
+  const providerConfig: Record<string, unknown> = {};
+  const command = normalizeOptionalString(env.OPENLOOMI_AGENT_HERMES_COMMAND);
+  const profile = normalizeOptionalString(env.OPENLOOMI_AGENT_HERMES_PROFILE);
+  const timeoutMs = parsePositiveIntegerEnv(
+    env,
+    "OPENLOOMI_AGENT_HERMES_TIMEOUT_MS",
+  );
+
+  if (command) {
+    providerConfig.hermesPath = command;
+  }
+  if (profile) {
+    providerConfig.profile = profile;
+  }
+  if (timeoutMs !== undefined) {
+    providerConfig.timeoutMs = timeoutMs;
+  }
+
+  return {
+    providerConfig,
+  };
+}
+
+function validateHermesUnsupportedEnvConfig(env: EnvSource) {
+  if (normalizeOptionalString(env.OPENLOOMI_AGENT_HERMES_MODEL)) {
+    throwConfigError(
+      "OPENLOOMI_AGENT_HERMES_MODEL is not supported by this ACP MVP. Configure Hermes model selection through Hermes profile/config instead.",
+    );
+  }
+
+  if (normalizeOptionalString(env.OPENLOOMI_AGENT_HERMES_PROVIDER)) {
+    throwConfigError(
+      "OPENLOOMI_AGENT_HERMES_PROVIDER is not supported by this ACP MVP. Configure Hermes provider selection through Hermes profile/config instead.",
+    );
+  }
 }
 
 function resolveOpenCodeEnvConfig(env: EnvSource) {

--- a/apps/web/lib/ai/runtime/register-plugins.ts
+++ b/apps/web/lib/ai/runtime/register-plugins.ts
@@ -6,7 +6,11 @@
  */
 
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
-import { claudePlugin, opencodePlugin } from "@/lib/ai/extensions";
+import {
+  claudePlugin,
+  hermesPlugin,
+  opencodePlugin,
+} from "@/lib/ai/extensions";
 
 // Register built-in Agent plugins
 // This must be called AFTER all modules are loaded to avoid circular deps
@@ -14,4 +18,5 @@ export function registerPlugins() {
   const registry = getAgentRegistry();
   registry.register(claudePlugin);
   registry.register(opencodePlugin);
+  registry.register(hermesPlugin);
 }

--- a/apps/web/tests/unit/agent-runtime.test.ts
+++ b/apps/web/tests/unit/agent-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   type AgentRuntimePermissionRequest,
 } from "@openloomi/ai/agent/runtime";
 import { AgentRegistry } from "@openloomi/ai/agent/registry";
+import { hermesPlugin } from "@/lib/ai/extensions/agent/hermes";
 import type {
   AgentConfig,
   AgentMessage,
@@ -38,6 +39,20 @@ describe("agent runtime", () => {
 
     expect(registry.create({ provider: "custom-cli" })).toBe(agent);
     expect(registry.getRegistered()).toContain("custom-cli");
+  });
+
+  it("registers and creates the Hermes provider plugin", () => {
+    const registry = new AgentRegistry();
+
+    registry.register(hermesPlugin);
+
+    const agent = registry.create({ provider: "hermes" });
+    expect(agent.provider).toBe("hermes");
+    expect(registry.getMetadata("hermes")).toMatchObject({
+      type: "hermes",
+      supportsStreaming: true,
+      supportsSandbox: false,
+    });
   });
 
   it("runs through the shared runtime and surfaces permission request events", async () => {

--- a/apps/web/tests/unit/hermes-agent.test.ts
+++ b/apps/web/tests/unit/hermes-agent.test.ts
@@ -1,0 +1,644 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentMessage, TaskPlan } from "@openloomi/ai/agent/types";
+import { HermesAgent } from "@/lib/ai/extensions/agent/hermes";
+import { buildHermesAcpCommand } from "@/lib/ai/extensions/agent/hermes/command";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("Hermes ACP command builder", () => {
+  it("builds hermes acp without yolo flags", () => {
+    const command = buildHermesAcpCommand({
+      hermesPath: "hermes-bin",
+      profile: "coding",
+      extraArgs: ["--yolo"],
+      yolo: true,
+      env: { HERMES_YOLO_MODE: "1" },
+    });
+
+    expect(command.command).toBe("hermes-bin");
+    expect(command.args).toEqual(["--profile", "coding", "acp"]);
+    expect(command.args).not.toContain("--yolo");
+  });
+});
+
+describe("HermesAgent", () => {
+  it("runs initialize/session/new/session/prompt and maps ACP updates", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(agent.run("normal run"));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({ type: "text", content: "hello" }),
+        expect.objectContaining({ type: "reasoning", content: "thinking" }),
+        expect.objectContaining({
+          type: "tool_use",
+          id: "tool-1",
+          name: "Run command",
+          input: { command: "pwd" },
+        }),
+        expect.objectContaining({
+          type: "tool_result",
+          toolUseId: "tool-1",
+          output: "tool output",
+          isError: false,
+        }),
+        expect.objectContaining({
+          type: "result",
+          content: "end_turn",
+          usage: { inputTokens: 3, outputTokens: 4 },
+        }),
+      ]),
+    );
+    expect(countDone(messages)).toBe(1);
+
+    const calls = await readJsonLines(join(workDir, "calls.jsonl"));
+    expect(calls.map((call) => call.method)).toEqual([
+      "initialize",
+      "session/new",
+      "session/prompt",
+    ]);
+    const initializeParams = calls[0].params as Record<string, unknown>;
+    const newSessionParams = calls[1].params as Record<string, unknown>;
+    expect(initializeParams).toMatchObject({
+      protocolVersion: expect.any(Number),
+      clientInfo: { name: "openloomi", version: expect.any(String) },
+    });
+    expect(initializeParams.clientCapabilities).not.toHaveProperty("terminal");
+    expect(newSessionParams).toMatchObject({
+      cwd: workDir,
+      mcpServers: [],
+    });
+  });
+
+  it("turns JSON-RPC prompt errors into one error and exactly one done", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(agent.run("jsonrpc-error"));
+
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("fake prompt failure"),
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("times out, kills the ACP process, and yields exactly one done", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir, { timeoutMs: 100 });
+
+    const messages = await withTimeout(
+      collectMessages(agent.run("hang forever")),
+      5000,
+    );
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "started" }),
+        expect.objectContaining({
+          type: "error",
+          message: expect.stringContaining("Hermes ACP timed out after 100ms"),
+        }),
+      ]),
+    );
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("returns a clear error when the Hermes executable is missing", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "openloomi-hermes-test-"));
+    tempDirs.push(workDir);
+    const agent = new HermesAgent({
+      provider: "hermes",
+      workDir,
+      providerConfig: {
+        hermesPath: "definitely-not-openloomi-hermes",
+      },
+    });
+
+    const messages = await collectMessages(agent.run("do work"));
+
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("Hermes ACP executable not found"),
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("maps permission allow decisions to an existing allow_once option id", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+    const onPermissionRequest = vi.fn(
+      async (): Promise<{ behavior: "allow" }> => ({ behavior: "allow" }),
+    );
+
+    const messages = await collectMessages(
+      agent.run("permission allow", { onPermissionRequest }),
+    );
+
+    expect(onPermissionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "Run command",
+        toolInput: { command: "rm -rf /tmp/example" },
+        toolUseID: "tool-2",
+      }),
+    );
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          content: "permission:allow-once",
+        }),
+      ]),
+    );
+    const permissions = await readJsonLines(
+      join(workDir, "permission-responses.jsonl"),
+    );
+    expect(permissions.at(-1)?.result).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("maps permission deny decisions to an existing reject option id", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(
+      agent.run("permission deny", {
+        onPermissionRequest: async () => ({ behavior: "deny" }),
+      }),
+    );
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          content: "permission:reject-once",
+        }),
+      ]),
+    );
+    const permissions = await readJsonLines(
+      join(workDir, "permission-responses.jsonl"),
+    );
+    expect(permissions.at(-1)?.result).toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("denies permission requests when no handler is configured", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(agent.run("permission no handler"));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          content: "permission:reject-once",
+        }),
+      ]),
+    );
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("cancels pending permissions and sends session/cancel on stop", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+    const generator = agent.run("permission wait", {
+      onPermissionRequest: async () => new Promise(() => {}),
+    });
+
+    const sessionMessage = (await generator.next()).value as AgentMessage;
+    expect(sessionMessage.type).toBe("session");
+    if (!sessionMessage.sessionId) {
+      throw new Error("Expected Hermes run to yield a session id");
+    }
+
+    const remainingMessagesPromise = collectMessages(generator);
+    await waitForFile(join(workDir, "permission-requests.jsonl"));
+    await agent.stop(sessionMessage.sessionId);
+    const messages = await withTimeout(remainingMessagesPromise, 5000);
+
+    const cancels = await readJsonLines(join(workDir, "cancels.jsonl"));
+    const permissions = await readJsonLines(
+      join(workDir, "permission-responses.jsonl"),
+    );
+    expect(cancels.at(-1)?.params).toEqual({ sessionId: "hermes-session-1" });
+    expect(permissions.at(-1)?.result).toEqual({
+      outcome: { outcome: "cancelled" },
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("denies permission requests during planning", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(agent.plan("permission plan"));
+
+    const permissions = await readJsonLines(
+      join(workDir, "permission-responses.jsonl"),
+    );
+    expect(permissions.at(-1)?.result).toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+    expect(messages.find((message) => message.type === "plan")).toBeUndefined();
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("returns method-not-found for unsupported agent-to-client requests", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const messages = await collectMessages(agent.run("unsupported request"));
+
+    const unsupported = await readJsonLines(join(workDir, "unsupported.jsonl"));
+    expect(unsupported.at(-1)?.error).toMatchObject({
+      code: -32601,
+      message: expect.stringContaining("Unsupported Hermes ACP client method"),
+    });
+    expect(messages.find((message) => message.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("Unsupported Hermes ACP client method"),
+    });
+    expect(countDone(messages)).toBe(1);
+  });
+
+  it("stores plans and deletes them only after successful execution", async () => {
+    const workDir = await createFakeHermesWorkDir(planFakeAcpScript());
+    const agent = createAgent(workDir);
+
+    const planMessages = await collectMessages(agent.plan("plan the work"));
+    const plan = planMessages.find((message) => message.type === "plan")
+      ?.plan as TaskPlan | undefined;
+    expect(plan).toBeDefined();
+    if (!plan) {
+      throw new Error("Expected Hermes planning to produce a plan");
+    }
+    expect(agent.getPlan(plan.id)).toBe(plan);
+
+    await writeFakeHermesScript(workDir, errorFakeAcpScript());
+    const failedMessages = await collectMessages(
+      agent.execute({ planId: plan.id, originalPrompt: "do work" }),
+    );
+
+    expect(
+      failedMessages.find((message) => message.type === "error"),
+    ).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("execution failed"),
+    });
+    expect(agent.getPlan(plan.id)).toBe(plan);
+    expect(countDone(failedMessages)).toBe(1);
+
+    await writeFakeHermesScript(workDir, successFakeAcpScript());
+    const successMessages = await collectMessages(
+      agent.execute({ planId: plan.id, originalPrompt: "do work" }),
+    );
+
+    expect(agent.getPlan(plan.id)).toBeUndefined();
+    expect(countDone(successMessages)).toBe(1);
+  });
+});
+
+function createAgent(
+  workDir: string,
+  providerConfig: Record<string, unknown> = {},
+) {
+  return new HermesAgent({
+    provider: "hermes",
+    workDir,
+    providerConfig: {
+      hermesPath: process.execPath,
+      ...providerConfig,
+    },
+  });
+}
+
+async function createFakeHermesWorkDir(script: string) {
+  const workDir = await mkdtemp(join(tmpdir(), "openloomi-hermes-test-"));
+  tempDirs.push(workDir);
+  await writeFakeHermesScript(workDir, script);
+  return workDir;
+}
+
+async function writeFakeHermesScript(workDir: string, script: string) {
+  await writeFile(join(workDir, "acp"), script, "utf8");
+}
+
+function defaultFakeAcpScript() {
+  return `
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+function append(file, value) {
+  fs.appendFileSync(file, JSON.stringify(value) + "\\n");
+}
+function send(value) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
+}
+function respond(id, result) {
+  send({ id, result });
+}
+function fail(id, message) {
+  send({ id, error: { code: -32000, message } });
+}
+function update(sessionId, update) {
+  send({ method: "session/update", params: { sessionId, update } });
+}
+function textContent(text) {
+  return { type: "text", text };
+}
+
+let promptId;
+let sessionId = "hermes-session-1";
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+
+  if (message.method) {
+    append("calls.jsonl", { method: message.method, params: message.params });
+  }
+
+  if (!message.method && message.id === "permission-1") {
+    append("permission-responses.jsonl", message);
+    const optionId = message.result?.outcome?.optionId || message.result?.outcome?.outcome;
+    update(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: textContent("permission:" + optionId)
+    });
+    respond(promptId, { stopReason: "end_turn" });
+    return;
+  }
+
+  if (!message.method && message.id === "unsupported-1") {
+    append("unsupported.jsonl", message);
+    respond(promptId, { stopReason: "end_turn" });
+    return;
+  }
+
+  switch (message.method) {
+    case "initialize":
+      respond(message.id, {
+        protocolVersion: message.params.protocolVersion,
+        agentInfo: { name: "fake-hermes", version: "0.0.0" },
+        agentCapabilities: { sessionCapabilities: {} },
+      });
+      break;
+    case "session/new":
+      respond(message.id, { sessionId });
+      break;
+    case "session/cancel":
+      append("cancels.jsonl", message);
+      if (promptId) {
+        respond(promptId, { stopReason: "cancelled" });
+      }
+      break;
+    case "session/prompt": {
+      promptId = message.id;
+      const prompt = message.params.prompt.map((block) => block.text || "").join("");
+      if (prompt.includes("jsonrpc-error")) {
+        fail(message.id, "fake prompt failure");
+        return;
+      }
+      if (prompt.includes("hang forever")) {
+        update(sessionId, {
+          sessionUpdate: "agent_message_chunk",
+          content: textContent("started")
+        });
+        setInterval(() => {}, 1000);
+        return;
+      }
+      if (prompt.includes("permission")) {
+        append("permission-requests.jsonl", { prompt });
+        send({
+          id: "permission-1",
+          method: "session/request_permission",
+          params: {
+            sessionId,
+            toolCall: {
+              toolCallId: "tool-2",
+              title: "Run command",
+              rawInput: { command: "rm -rf /tmp/example" }
+            },
+            options: [
+              { optionId: "allow-always", name: "Allow always", kind: "allow_always" },
+              { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+              { optionId: "reject-once", name: "Deny", kind: "reject_once" }
+            ]
+          }
+        });
+        return;
+      }
+      if (prompt.includes("unsupported request")) {
+        send({
+          id: "unsupported-1",
+          method: "terminal/create",
+          params: { command: "pwd" }
+        });
+        return;
+      }
+      update(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: textContent("hello")
+      });
+      update(sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: textContent("thinking")
+      });
+      update(sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "Run command",
+        rawInput: { command: "pwd" },
+        status: "pending"
+      });
+      update(sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        rawOutput: "tool output"
+      });
+      update(sessionId, {
+        sessionUpdate: "usage_update",
+        usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 }
+      });
+      update(sessionId, { sessionUpdate: "unknown_event", raw: true });
+      respond(message.id, {
+        stopReason: "end_turn",
+        usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 }
+      });
+      break;
+    }
+    default:
+      append("unsupported.jsonl", {
+        id: message.id,
+        method: message.method,
+        error: { code: -32601, message: "unsupported by fake server" }
+      });
+      send({ id: message.id, error: { code: -32601, message: "unsupported by fake server" } });
+  }
+});
+
+rl.on("close", () => process.exit(0));
+`;
+}
+
+function planFakeAcpScript() {
+  return `
+const readline = require("node:readline");
+function send(value) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
+}
+function respond(id, result) {
+  send({ id, result });
+}
+function update(sessionId, update) {
+  send({ method: "session/update", params: { sessionId, update } });
+}
+const sessionId = "hermes-session-1";
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    respond(message.id, { protocolVersion: message.params.protocolVersion, agentCapabilities: {} });
+  } else if (message.method === "session/new") {
+    respond(message.id, { sessionId });
+  } else if (message.method === "session/prompt") {
+    const response = {
+      type: "plan",
+      goal: "Do work",
+      steps: [{ id: "1", description: "Complete implementation" }]
+    };
+    update(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: JSON.stringify(response) }
+    });
+    respond(message.id, { stopReason: "end_turn" });
+  }
+});
+`;
+}
+
+function errorFakeAcpScript() {
+  return `
+const readline = require("node:readline");
+function send(value) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
+}
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ id: message.id, result: { protocolVersion: message.params.protocolVersion, agentCapabilities: {} } });
+  } else if (message.method === "session/new") {
+    send({ id: message.id, result: { sessionId: "hermes-session-1" } });
+  } else if (message.method === "session/prompt") {
+    send({ id: message.id, error: { code: -32000, message: "execution failed" } });
+  }
+});
+`;
+}
+
+function successFakeAcpScript() {
+  return `
+const readline = require("node:readline");
+function send(value) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
+}
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ id: message.id, result: { protocolVersion: message.params.protocolVersion, agentCapabilities: {} } });
+  } else if (message.method === "session/new") {
+    send({ id: message.id, result: { sessionId: "hermes-session-1" } });
+  } else if (message.method === "session/prompt") {
+    send({
+      method: "session/update",
+      params: {
+        sessionId: "hermes-session-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "executed" }
+        }
+      }
+    });
+    send({ id: message.id, result: { stopReason: "end_turn" } });
+  }
+});
+`;
+}
+
+async function collectMessages(
+  generator: AsyncGenerator<AgentMessage>,
+): Promise<AgentMessage[]> {
+  const messages: AgentMessage[] = [];
+  for await (const message of generator) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+function countDone(messages: AgentMessage[]) {
+  return messages.filter((message) => message.type === "done").length;
+}
+
+async function readJsonLines(filePath: string) {
+  const text = await readFile(filePath, "utf8");
+  return text
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function waitForFile(filePath: string, timeoutMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await readFile(filePath, "utf8");
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/web/tests/unit/hermes-agent.test.ts
+++ b/apps/web/tests/unit/hermes-agent.test.ts
@@ -370,6 +370,7 @@ function textContent(text) {
 
 let promptId;
 let sessionId = "hermes-session-1";
+let waitForCancel = false;
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
@@ -381,6 +382,9 @@ rl.on("line", (line) => {
 
   if (!message.method && message.id === "permission-1") {
     append("permission-responses.jsonl", message);
+    if (waitForCancel) {
+      return;
+    }
     const optionId = message.result?.outcome?.optionId || message.result?.outcome?.outcome;
     update(sessionId, {
       sessionUpdate: "agent_message_chunk",
@@ -429,6 +433,7 @@ rl.on("line", (line) => {
         return;
       }
       if (prompt.includes("permission")) {
+        waitForCancel = prompt.includes("permission wait");
         append("permission-requests.jsonl", { prompt });
         send({
           id: "permission-1",

--- a/apps/web/tests/unit/hermes-real.integration.test.ts
+++ b/apps/web/tests/unit/hermes-real.integration.test.ts
@@ -1,0 +1,725 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAgentRegistry } from "@openloomi/ai/agent/registry";
+import {
+  runNativeAgentRequest,
+  type NativeAgentHost,
+  type NativeAgentRunnerContext,
+} from "@openloomi/ai/agent/native-runner";
+import type { AgentMessage } from "@openloomi/ai/agent/types";
+
+import { HermesAgent, hermesPlugin } from "@/lib/ai/extensions/agent/hermes";
+import { resolveNativeAgentProviderRequest } from "@/lib/ai/native-agent/provider-env";
+
+const execFileAsync = promisify(execFile);
+const shouldRunRealHermes = process.env.RUN_HERMES_REAL === "1";
+const shouldRunRealHermesPermission =
+  shouldRunRealHermes && process.env.RUN_HERMES_REAL_PERMISSION === "1";
+const describeRealHermes = shouldRunRealHermes ? describe : describe.skip;
+const repoTempDir = join(process.cwd(), "..", "..", ".tmp");
+
+const tempDirs: string[] = [];
+const envSnapshot = { ...process.env };
+let providersRegistered = false;
+
+interface HermesRealCredentials {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+afterEach(async () => {
+  process.env = { ...envSnapshot };
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe.skipIf(!shouldRunRealHermes)(
+  "Hermes real ACP integration gate",
+  () => {
+    it("is skipped unless RUN_HERMES_REAL=1", () => {
+      expect(shouldRunRealHermes).toBe(true);
+    });
+  },
+);
+
+describeRealHermes("Hermes real ACP integration", () => {
+  it("can call the saved OpenLoomi Anthropic-compatible setting directly", async () => {
+    redirectHermesTestTempEnv();
+    const userId = process.env.OPENLOOMI_HERMES_REAL_USER_ID?.trim();
+    if (!userId) {
+      console.info(
+        "[Hermes real preflight] Skipped direct provider check because OPENLOOMI_HERMES_REAL_USER_ID is not set.",
+      );
+      return;
+    }
+
+    const { getUserLlmProviderConfig } =
+      await import("@/lib/ai/user-llm-api-settings");
+    const config = await getUserLlmProviderConfig({
+      userId,
+      providerType: "anthropic_compatible",
+    });
+    if (!config) {
+      throw new Error(
+        `No enabled anthropic_compatible OpenLoomi LLM setting was found for OPENLOOMI_HERMES_REAL_USER_ID=${userId}.`,
+      );
+    }
+
+    const result = await fetchAnthropicCompatibleSmoke(config);
+    console.info(
+      "[Hermes real preflight direct provider smoke]",
+      JSON.stringify(result, null, 2),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain("HERMES_OPENLOOMI_DIRECT_OK");
+  }, 70_000);
+
+  it("runs a read-only prompt through native host, provider env, registry, and real Hermes ACP", async () => {
+    withHermesProviderEnv();
+    await applyHermesRealCredentials();
+    const workDir = await createTempWorkDir();
+    const beforePids = await listHermesProcessIds();
+    const abortController = new AbortController();
+    const host = createHermesRealHost();
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt:
+          "Reply with exactly: HERMES_OPENLOOMI_SMOKE_OK. Do not modify files. Do not run shell commands.",
+        workDir,
+        useProvidedWorkDir: true,
+        permissionMode: "dontAsk",
+        providerConfig: {
+          hermesPath: "request-must-not-override-command",
+          profile: "request-must-not-override-profile",
+          timeoutMs: 1,
+          extraArgs: ["--yolo"],
+          yolo: true,
+        },
+      },
+      createContext(120_000, abortController),
+      host,
+    );
+
+    const messages = await collectMessagesWithTimeout(
+      run.generator,
+      120_000,
+      abortController,
+    );
+    console.info(
+      "[Hermes real read-only smoke messages]",
+      JSON.stringify(messages, null, 2),
+    );
+    const text = collectText(messages);
+    const errors = messages.filter((message) => message.type === "error");
+
+    expect(messages.some((message) => message.type === "session")).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "text" || message.type === "reasoning",
+      ),
+    ).toBe(true);
+    expect(messages.some((message) => message.type === "result")).toBe(true);
+    expect(text).toContain("HERMES_OPENLOOMI_SMOKE_OK");
+    expect(errors).toEqual([]);
+    expect(countDone(messages)).toBe(1);
+
+    await expectNoNewHermesProcesses(beforePids);
+  }, 130_000);
+
+  it("cleans up the real Hermes ACP process when the run is aborted", async () => {
+    withHermesProviderEnv({ timeoutMs: "120000" });
+    await applyHermesRealCredentials();
+    const workDir = await createTempWorkDir();
+    const beforePids = await listHermesProcessIds();
+    const abortController = new AbortController();
+    const host = createHermesRealHost();
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt:
+          "Think for a while before answering. Do not modify files. Do not run tools.",
+        workDir,
+        useProvidedWorkDir: true,
+        permissionMode: "dontAsk",
+      },
+      createContext(120_000, abortController),
+      host,
+    );
+
+    const messages: AgentMessage[] = [];
+    const reader = (async () => {
+      for await (const message of run.generator) {
+        messages.push(message);
+        if (
+          message.type === "session" ||
+          message.type === "text" ||
+          message.type === "reasoning"
+        ) {
+          abortController.abort();
+        }
+      }
+    })();
+
+    await withTimeout(reader, 120_000);
+    console.info(
+      "[Hermes real abort smoke messages]",
+      JSON.stringify(messages, null, 2),
+    );
+
+    expect(messages.some((message) => message.type === "session")).toBe(true);
+    expect(countDone(messages)).toBe(1);
+    await expectNoNewHermesProcesses(beforePids);
+  }, 130_000);
+
+  it("stops a direct real HermesAgent run through stop(sessionId)", async () => {
+    withHermesProviderEnv({ timeoutMs: "120000" });
+    await applyHermesRealCredentials();
+    const workDir = await createTempWorkDir();
+    const beforePids = await listHermesProcessIds();
+    const abortController = new AbortController();
+    const agent = new HermesAgent({
+      provider: "hermes",
+      providerConfig: {
+        hermesPath: findLocalHermesCommand(),
+        timeoutMs: 120_000,
+      },
+      workDir,
+    });
+    const messages: AgentMessage[] = [];
+    let sessionId: string | undefined;
+
+    const reader = (async () => {
+      for await (const message of agent.run(
+        "Think for a while before answering. Do not modify files. Do not run tools.",
+        {
+          abortController,
+          cwd: workDir,
+          permissionMode: "dontAsk",
+        },
+      )) {
+        messages.push(message);
+        if (message.type === "session") {
+          sessionId = message.sessionId;
+        }
+      }
+    })();
+
+    await waitFor(() => Boolean(sessionId), 10_000);
+    await sleep(12_000);
+    if (!sessionId) {
+      throw new Error(
+        "Hermes real direct stop smoke did not receive a session",
+      );
+    }
+    await agent.stop(sessionId);
+    await withTimeout(reader, 120_000);
+
+    console.info(
+      "[Hermes real direct stop smoke messages]",
+      JSON.stringify(messages, null, 2),
+    );
+
+    expect(messages.some((message) => message.type === "session")).toBe(true);
+    expect(countDone(messages)).toBe(1);
+    await expectNoNewHermesProcesses(beforePids);
+  }, 140_000);
+
+  it.skipIf(!shouldRunRealHermesPermission)(
+    "attempts a real Hermes permission request and denies it safely",
+    async () => {
+      withHermesProviderEnv({ timeoutMs: "120000" });
+      await applyHermesRealCredentials();
+      const workDir = await createTempWorkDir();
+      const targetFile = join(workDir, "permission-smoke.txt");
+      const beforePids = await listHermesProcessIds();
+      const abortController = new AbortController();
+      const host = createHermesRealHost();
+      const permissionRequests: unknown[] = [];
+
+      const run = await runNativeAgentRequest(
+        {
+          prompt:
+            "Create a file named permission-smoke.txt in the current directory with exactly this content: HERMES_PERMISSION_SMOKE.",
+          workDir,
+          useProvidedWorkDir: true,
+          permissionMode: "default",
+        },
+        createContext(120_000, abortController, async (request) => {
+          permissionRequests.push(request);
+          return { behavior: "deny" as const };
+        }),
+        host,
+      );
+
+      const messages = await collectMessagesWithTimeout(
+        run.generator,
+        120_000,
+        abortController,
+      );
+      console.info(
+        "[Hermes real permission smoke messages]",
+        JSON.stringify(messages, null, 2),
+      );
+
+      const permissionMessages = messages.filter(
+        (message) => message.type === "permission_request",
+      );
+      if (permissionRequests.length === 0 && permissionMessages.length === 0) {
+        console.info(
+          "[Hermes real permission smoke] Inconclusive: Hermes completed without emitting session/request_permission.",
+        );
+      } else {
+        expect(permissionRequests.length).toBeGreaterThan(0);
+        expect(permissionMessages.length).toBeGreaterThan(0);
+      }
+
+      expect(existsSync(targetFile)).toBe(false);
+      expect(countDone(messages)).toBe(1);
+      await expectNoNewHermesProcesses(beforePids);
+    },
+    130_000,
+  );
+
+  it("rejects unsupported Hermes model/provider env overrides before spawning", async () => {
+    withHermesProviderEnv();
+    process.env.OPENLOOMI_AGENT_HERMES_MODEL = "not-supported";
+    process.env.OPENLOOMI_AGENT_HERMES_PROVIDER = "not-supported";
+    const host = createHermesRealHost();
+
+    await expect(
+      runNativeAgentRequest(
+        {
+          prompt: "This should fail before Hermes ACP starts.",
+          workDir: await createTempWorkDir(),
+          useProvidedWorkDir: true,
+        },
+        createContext(10_000),
+        host,
+      ),
+    ).rejects.toThrow(/OPENLOOMI_AGENT_HERMES_MODEL is not supported/);
+  }, 20_000);
+});
+
+function withHermesProviderEnv(options: { timeoutMs?: string } = {}) {
+  redirectHermesTestTempEnv();
+  process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+  process.env.OPENLOOMI_AGENT_HERMES_COMMAND =
+    process.env.OPENLOOMI_AGENT_HERMES_COMMAND || findLocalHermesCommand();
+  process.env.OPENLOOMI_AGENT_HERMES_TIMEOUT_MS =
+    options.timeoutMs ||
+    process.env.OPENLOOMI_AGENT_HERMES_TIMEOUT_MS ||
+    "120000";
+  process.env.OPENLOOMI_AGENT_HERMES_MODEL = "";
+  process.env.OPENLOOMI_AGENT_HERMES_PROVIDER = "";
+}
+
+async function applyHermesRealCredentials() {
+  const userId = process.env.OPENLOOMI_HERMES_REAL_USER_ID?.trim();
+  if (userId) {
+    const { getUserLlmProviderConfig } =
+      await import("@/lib/ai/user-llm-api-settings");
+    const config = await getUserLlmProviderConfig({
+      userId,
+      providerType: "anthropic_compatible",
+    });
+
+    if (!config) {
+      throw new Error(
+        `RUN_HERMES_REAL=1 was set, but no enabled anthropic_compatible OpenLoomi LLM setting was found for OPENLOOMI_HERMES_REAL_USER_ID=${userId}.`,
+      );
+    }
+
+    await configureHermesRealCredentials(config);
+    console.info(
+      `[Hermes real smoke] Loaded OpenLoomi LLM setting for user ${userId}.`,
+    );
+    return;
+  }
+
+  if (
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.OPENROUTER_API_KEY ||
+    process.env.OPENAI_API_KEY
+  ) {
+    return;
+  }
+
+  const directApiKey = process.env.OPENLOOMI_HERMES_REAL_API_KEY?.trim();
+  if (directApiKey) {
+    await configureHermesRealCredentials({
+      apiKey: directApiKey,
+      baseUrl: process.env.OPENLOOMI_HERMES_REAL_BASE_URL,
+      model: process.env.OPENLOOMI_HERMES_REAL_MODEL,
+    });
+    return;
+  }
+
+  throw new Error(
+    "RUN_HERMES_REAL=1 requires Hermes credentials. Set OPENLOOMI_HERMES_REAL_USER_ID to a user with an enabled OpenLoomi anthropic_compatible LLM setting, or provide Hermes-supported env credentials such as ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or OPENAI_API_KEY.",
+  );
+}
+
+async function configureHermesRealCredentials(
+  credentials: HermesRealCredentials,
+) {
+  setHermesCredentialEnv(credentials.apiKey, credentials.baseUrl);
+
+  if (credentials.baseUrl && credentials.model) {
+    await createHermesRealHome(credentials);
+  }
+}
+
+function setHermesCredentialEnv(apiKey: string, baseUrl?: string) {
+  const normalizedBaseUrl = baseUrl?.trim();
+  if (normalizedBaseUrl) {
+    process.env.OPENAI_BASE_URL = normalizedBaseUrl;
+  }
+
+  process.env.OPENAI_API_KEY = apiKey;
+  process.env.ANTHROPIC_API_KEY = apiKey;
+  process.env.OPENLOOMI_HERMES_REAL_PROVIDER_API_KEY = apiKey;
+
+  if (normalizedBaseUrl && /openrouter\.ai/i.test(normalizedBaseUrl)) {
+    process.env.OPENROUTER_API_KEY = apiKey;
+  }
+}
+
+async function createHermesRealHome(credentials: HermesRealCredentials) {
+  const hermesHome = await mkdtemp(join(repoTempDir, "openloomi-hermes-home-"));
+  tempDirs.push(hermesHome);
+  process.env.HERMES_HOME = hermesHome;
+
+  const model = credentials.model?.trim();
+  const baseUrl = credentials.baseUrl?.trim();
+  if (!model || !baseUrl) {
+    return;
+  }
+
+  await writeFile(
+    join(hermesHome, "config.yaml"),
+    [
+      "model:",
+      "  provider: openloomi-real",
+      `  default: ${yamlString(model)}`,
+      "",
+      "agent:",
+      "  coding_context: off",
+      "  environment_probe: false",
+      "  intent_ack_continuation: false",
+      "  parallel_tool_call_guidance: false",
+      "  task_completion_guidance: false",
+      "  tool_use_enforcement: false",
+      "  verify_on_stop: false",
+      "  disabled_toolsets:",
+      "    - hermes-acp",
+      "",
+      "auxiliary:",
+      "  vision:",
+      "    provider: none",
+      "",
+      "custom_providers:",
+      "  - name: openloomi-real",
+      `    base_url: ${yamlString(baseUrl)}`,
+      "    key_env: OPENLOOMI_HERMES_REAL_PROVIDER_API_KEY",
+      "    api_mode: anthropic_messages",
+      `    model: ${yamlString(model)}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function yamlString(value: string) {
+  return JSON.stringify(value);
+}
+
+function redirectHermesTestTempEnv() {
+  const tempDir = join(repoTempDir, "temp");
+  process.env.TEMP = tempDir;
+  process.env.TMP = tempDir;
+  process.env.UV_CACHE_DIR = join(repoTempDir, "uv-cache");
+  process.env.UV_PYTHON_INSTALL_DIR = join(repoTempDir, "uv-python");
+  process.env.PIP_CACHE_DIR = join(repoTempDir, "pip-cache");
+  process.env.npm_config_cache = join(repoTempDir, "npm-cache");
+  process.env.PLAYWRIGHT_BROWSERS_PATH = join(
+    repoTempDir,
+    "playwright-browsers",
+  );
+
+  const localHermesHome = join(repoTempDir, "hermes-home");
+  if (!process.env.HERMES_HOME && existsSync(localHermesHome)) {
+    process.env.HERMES_HOME = localHermesHome;
+  }
+}
+
+async function fetchAnthropicCompatibleSmoke(
+  credentials: HermesRealCredentials,
+) {
+  const baseUrl = credentials.baseUrl?.trim();
+  const model = credentials.model?.trim();
+  if (!baseUrl || !model) {
+    throw new Error(
+      "The OpenLoomi anthropic_compatible setting must include baseUrl and model for the direct real smoke.",
+    );
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/messages`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60_000);
+  timeout.unref?.();
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "anthropic-version": "2023-06-01",
+        authorization: `Bearer ${credentials.apiKey}`,
+        "content-type": "application/json",
+        "x-api-key": credentials.apiKey,
+      },
+      body: JSON.stringify({
+        max_tokens: 32,
+        messages: [
+          {
+            role: "user",
+            content: "Reply with exactly: HERMES_OPENLOOMI_DIRECT_OK",
+          },
+        ],
+        model,
+      }),
+      signal: controller.signal,
+    });
+    const body = await response.text();
+    return {
+      host: new URL(baseUrl).host,
+      model,
+      ok: response.ok,
+      status: response.status,
+      text: extractAnthropicText(body),
+      bodyStart: body.slice(0, 500),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function extractAnthropicText(body: string) {
+  try {
+    const parsed = JSON.parse(body) as {
+      content?: Array<{ text?: unknown; type?: unknown }>;
+    };
+    return (parsed.content || [])
+      .map((part) => (typeof part.text === "string" ? part.text : ""))
+      .join("");
+  } catch {
+    return body;
+  }
+}
+
+function findLocalHermesCommand() {
+  const localHermes = join(
+    repoTempDir,
+    "hermes-home",
+    "hermes-agent",
+    "venv",
+    "Scripts",
+    "hermes.exe",
+  );
+  return existsSync(localHermes) ? localHermes : "hermes";
+}
+
+function createHermesRealHost(): NativeAgentHost {
+  const getUserLlmProviderConfig = vi.fn(async () => {
+    throw new Error(
+      "Hermes real smoke must not read Anthropic-compatible settings",
+    );
+  });
+
+  return {
+    registry: getAgentRegistry(),
+    registerProviders: registerRealSmokeProviders,
+    prepareRequest: (body) => resolveNativeAgentProviderRequest(body),
+    getUserLlmProviderConfig,
+    logger: console,
+  };
+}
+
+function registerRealSmokeProviders() {
+  if (providersRegistered) {
+    return;
+  }
+
+  const registry = getAgentRegistry();
+  registry.register(hermesPlugin);
+  providersRegistered = true;
+}
+
+async function createTempWorkDir() {
+  const baseDir = repoTempDir;
+  await mkdir(baseDir, { recursive: true });
+  const workDir = await mkdtemp(join(baseDir, "openloomi-hermes-real-"));
+  tempDirs.push(workDir);
+  await writeFile(
+    join(workDir, "README.txt"),
+    "Temporary OpenLoomi Hermes real smoke workspace.\n",
+    "utf8",
+  );
+  return workDir;
+}
+
+function createContext(
+  timeoutMs: number,
+  abortController = new AbortController(),
+  permissionHandler: NativeAgentRunnerContext["permissionHandler"] = async () => ({
+    behavior: "deny" as const,
+  }),
+) {
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  timeout.unref?.();
+  const userId =
+    process.env.OPENLOOMI_HERMES_REAL_USER_ID?.trim() || "hermes-real-user";
+
+  return {
+    session: { user: { id: userId, type: "test" } },
+    userId,
+    abortController,
+    permissionHandler,
+    emitPermissionRequestEvents: true,
+  };
+}
+
+async function collectMessagesWithTimeout(
+  generator: AsyncGenerator<AgentMessage>,
+  timeoutMs: number,
+  abortController?: AbortController,
+) {
+  const messages: AgentMessage[] = [];
+  const reader = (async () => {
+    for await (const message of generator) {
+      messages.push(message);
+    }
+  })();
+
+  try {
+    await withTimeout(reader, timeoutMs);
+  } catch (error) {
+    abortController?.abort();
+    await withTimeout(
+      reader.catch(() => undefined),
+      5000,
+    ).catch(() => undefined);
+    console.info(
+      "[Hermes real smoke partial messages before timeout]",
+      JSON.stringify(messages, null, 2),
+    );
+    throw error;
+  }
+
+  return messages;
+}
+
+async function collectMessages(generator: AsyncGenerator<AgentMessage>) {
+  const messages: AgentMessage[] = [];
+  for await (const message of generator) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+function collectText(messages: AgentMessage[]) {
+  return messages
+    .map((message) => {
+      if (message.type === "text" || message.type === "reasoning") {
+        return message.content;
+      }
+      return "";
+    })
+    .join("");
+}
+
+function countDone(messages: AgentMessage[]) {
+  return messages.filter((message) => message.type === "done").length;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+    }
+    await sleep(50);
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function listHermesProcessIds() {
+  if (process.platform === "win32") {
+    try {
+      const { stdout } = await execFileAsync("powershell", [
+        "-NoProfile",
+        "-Command",
+        "Get-Process | Where-Object { $_.ProcessName -like '*hermes*' } | ForEach-Object { $_.Id }",
+      ]);
+      return parseProcessIds(stdout);
+    } catch {
+      return new Set<number>();
+    }
+  }
+
+  try {
+    const { stdout } = await execFileAsync("pgrep", ["-f", "hermes"]);
+    return parseProcessIds(stdout);
+  } catch {
+    return new Set<number>();
+  }
+}
+
+async function expectNoNewHermesProcesses(beforePids: Set<number>) {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const afterPids = await listHermesProcessIds();
+  const newPids = [...afterPids].filter((pid) => !beforePids.has(pid));
+  expect(newPids).toEqual([]);
+}
+
+function parseProcessIds(stdout: string) {
+  return new Set(
+    stdout
+      .split(/\r?\n/)
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter(Number.isFinite),
+  );
+}

--- a/apps/web/tests/unit/native-agent-provider-env.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-env.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildHermesAcpCommand } from "@/lib/ai/extensions/agent/hermes/command";
 import { buildOpenCodeRunCommand } from "@/lib/ai/extensions/agent/opencode/command";
 import {
   getConfiguredDefaultAgentProvider,
@@ -13,6 +14,11 @@ const AGENT_ENV_KEYS = [
   "OPENLOOMI_AGENT_OPENCODE_AGENT",
   "OPENLOOMI_AGENT_OPENCODE_TIMEOUT_MS",
   "OPENLOOMI_AGENT_OPENCODE_ALLOW_AUTO_APPROVE",
+  "OPENLOOMI_AGENT_HERMES_COMMAND",
+  "OPENLOOMI_AGENT_HERMES_PROFILE",
+  "OPENLOOMI_AGENT_HERMES_TIMEOUT_MS",
+  "OPENLOOMI_AGENT_HERMES_MODEL",
+  "OPENLOOMI_AGENT_HERMES_PROVIDER",
 ];
 
 let originalEnv: NodeJS.ProcessEnv;
@@ -44,8 +50,17 @@ describe("native agent provider env resolver", () => {
     expect(getConfiguredDefaultAgentProvider()).toBe("opencode");
   });
 
+  it("uses Hermes from env when the request does not specify a provider", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.provider).toBe("hermes");
+    expect(getConfiguredDefaultAgentProvider()).toBe("hermes");
+  });
+
   it("lets request provider override env provider", () => {
-    process.env.OPENLOOMI_AGENT_PROVIDER = "opencode";
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
 
     const request = resolveNativeAgentProviderRequest({
       ...baseRequest(),
@@ -184,6 +199,91 @@ describe("native agent provider env resolver", () => {
     expect(request.providerConfig).toMatchObject({
       allowAutoApprove: false,
     });
+  });
+
+  it("parses Hermes command, profile, and timeout from env", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_COMMAND = "env-hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_PROFILE = "coding";
+    process.env.OPENLOOMI_AGENT_HERMES_TIMEOUT_MS = "3000";
+
+    const request = resolveNativeAgentProviderRequest(baseRequest());
+
+    expect(request.providerConfig).toEqual({
+      hermesPath: "env-hermes",
+      profile: "coding",
+      timeoutMs: 3000,
+    });
+  });
+
+  it.each(["0", "-1", "1.5", "slow"])(
+    "fails clearly for invalid Hermes timeout %s",
+    (rawValue) => {
+      process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+      process.env.OPENLOOMI_AGENT_HERMES_TIMEOUT_MS = rawValue;
+
+      expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+        /OPENLOOMI_AGENT_HERMES_TIMEOUT_MS/,
+      );
+    },
+  );
+
+  it("rejects Hermes model env because ACP model switching is not supported in this MVP", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_MODEL = "nous/hermes";
+
+    expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+      /OPENLOOMI_AGENT_HERMES_MODEL is not supported/,
+    );
+  });
+
+  it("rejects Hermes provider env because ACP provider switching is not supported in this MVP", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_PROVIDER = "openrouter";
+
+    expect(() => resolveNativeAgentProviderRequest(baseRequest())).toThrow(
+      /OPENLOOMI_AGENT_HERMES_PROVIDER is not supported/,
+    );
+  });
+
+  it("rejects request model for Hermes because ACP model switching is not supported in this MVP", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+
+    expect(() =>
+      resolveNativeAgentProviderRequest({
+        ...baseRequest(),
+        modelConfig: { model: "request/model" },
+      }),
+    ).toThrow(/Hermes model selection is not supported/);
+  });
+
+  it("does not let request providerConfig override Hermes server-side config or inject flags", () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_COMMAND = "env-hermes";
+    process.env.OPENLOOMI_AGENT_HERMES_PROFILE = "env-profile";
+    process.env.OPENLOOMI_AGENT_HERMES_TIMEOUT_MS = "3000";
+
+    const request = resolveNativeAgentProviderRequest({
+      ...baseRequest(),
+      providerConfig: {
+        hermesPath: "request-hermes",
+        profile: "request-profile",
+        timeoutMs: 1,
+        extraArgs: ["--yolo"],
+        yolo: true,
+        env: { HERMES_YOLO_MODE: "1" },
+      },
+    });
+    const command = buildHermesAcpCommand(request.providerConfig);
+
+    expect(request.providerConfig).toEqual({
+      hermesPath: "env-hermes",
+      profile: "env-profile",
+      timeoutMs: 3000,
+    });
+    expect(command.command).toBe("env-hermes");
+    expect(command.args).toEqual(["--profile", "env-profile", "acp"]);
+    expect(command.args).not.toContain("--yolo");
   });
 });
 

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -128,6 +128,52 @@ describe("native agent runner", () => {
     expect(agent.config?.thinkingLevel).toBeUndefined();
   });
 
+  it("uses Hermes env defaults without reading Anthropic-compatible settings", async () => {
+    const agent = new CapturingAgent();
+    const getUserLlmProviderConfig = vi.fn();
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      prepareRequest: (body) =>
+        resolveNativeAgentProviderRequest(body, {
+          OPENLOOMI_AGENT_PROVIDER: "hermes",
+          OPENLOOMI_AGENT_HERMES_COMMAND: "env-hermes",
+          OPENLOOMI_AGENT_HERMES_PROFILE: "env-profile",
+          OPENLOOMI_AGENT_HERMES_TIMEOUT_MS: "5000",
+        }),
+      getUserLlmProviderConfig,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      {
+        prompt: "use env hermes",
+        modelConfig: {
+          apiKey: "anthropic-key-that-should-not-leak",
+          baseUrl: "https://anthropic-compatible.example.test",
+          thinkingLevel: "low",
+        },
+      },
+      createContext(),
+      host,
+    );
+
+    await collectMessages(run.generator);
+
+    expect(getUserLlmProviderConfig).not.toHaveBeenCalled();
+    expect(agent.config).toMatchObject({
+      provider: "hermes",
+      providerConfig: {
+        hermesPath: "env-hermes",
+        profile: "env-profile",
+        timeoutMs: 5000,
+      },
+    });
+    expect(agent.config?.apiKey).toBeUndefined();
+    expect(agent.config?.baseUrl).toBeUndefined();
+    expect(agent.config?.model).toBeUndefined();
+    expect(agent.config?.thinkingLevel).toBeUndefined();
+  });
+
   it("lets request provider override OpenCode env default", async () => {
     const agent = new CapturingAgent();
     const getUserLlmProviderConfig = vi.fn(async () => ({

--- a/apps/web/tests/unit/native-providers-api.test.ts
+++ b/apps/web/tests/unit/native-providers-api.test.ts
@@ -6,6 +6,8 @@ beforeEach(() => {
   originalEnv = process.env;
   process.env = { ...originalEnv };
   process.env.OPENLOOMI_AGENT_PROVIDER = undefined;
+  process.env.OPENLOOMI_AGENT_HERMES_MODEL = undefined;
+  process.env.OPENLOOMI_AGENT_HERMES_PROVIDER = undefined;
 });
 
 afterEach(() => {
@@ -26,10 +28,17 @@ describe("native providers API", () => {
     expect(
       body.agents.filter((agent) => agent.type === "opencode"),
     ).toHaveLength(1);
+    expect(body.agents.filter((agent) => agent.type === "hermes")).toHaveLength(
+      1,
+    );
     expect(body.agents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: "opencode",
+          supportsSandbox: false,
+        }),
+        expect.objectContaining({
+          type: "hermes",
           supportsSandbox: false,
         }),
       ]),
@@ -50,8 +59,33 @@ describe("native providers API", () => {
     expect(
       body.agents.filter((agent) => agent.type === "opencode"),
     ).toHaveLength(1);
+    expect(body.agents.filter((agent) => agent.type === "hermes")).toHaveLength(
+      1,
+    );
     expect(
       body.agents.find((agent) => agent.type === "opencode")?.supportsSandbox,
+    ).toBe(false);
+  });
+
+  it("returns Hermes as the default when configured by env", async () => {
+    process.env.OPENLOOMI_AGENT_PROVIDER = "hermes";
+    const { GET } = await import("@/app/api/native/providers/route");
+
+    const response = await GET();
+    const body = (await response.json()) as ProvidersResponse;
+
+    expect(body.defaultAgent).toBe("hermes");
+    expect(body.agents.filter((agent) => agent.type === "claude")).toHaveLength(
+      1,
+    );
+    expect(
+      body.agents.filter((agent) => agent.type === "opencode"),
+    ).toHaveLength(1);
+    expect(body.agents.filter((agent) => agent.type === "hermes")).toHaveLength(
+      1,
+    );
+    expect(
+      body.agents.find((agent) => agent.type === "hermes")?.supportsSandbox,
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds Hermes as an ACP-first native agent runtime provider. Hermes runs through `hermes acp` over stdio JSON-RPC, supports streaming ACP updates, and is registered as an `AgentPlugin` / `IAgent` provider while keeping Claude as the default when no provider is configured.

## Changes

- Add Hermes provider registration and metadata.
- Add a thin Hermes ACP client for:
  - `initialize`
  - `session/new`
  - `session/prompt`
  - `session/update`
  - `session/request_permission`
  - `session/cancel`
- Map Hermes ACP updates into OpenLoomi `AgentMessage` events.
- Implement Hermes `run`, `plan`, `execute`, `stop`, and `shutdown`.
- Add Hermes env provider selection:
  - `OPENLOOMI_AGENT_PROVIDER=hermes`
  - `OPENLOOMI_AGENT_HERMES_COMMAND`
  - `OPENLOOMI_AGENT_HERMES_PROFILE`
  - `OPENLOOMI_AGENT_HERMES_TIMEOUT_MS`
- Reject unsupported Hermes model/provider overrides with clear errors.
- Keep Hermes command/profile/timeout server-side controlled.
- Ensure Hermes does not inherit Anthropic-compatible `apiKey`, `baseUrl`, or `thinkingLevel`.
- Add gated real Hermes ACP smoke tests using `RUN_HERMES_REAL=1`.
- Document Hermes env options in `apps/web/.env.example`.

## Permission And Safety

- Hermes does not pass `--yolo`.
- Request `providerConfig` cannot inject command flags, `extraArgs`, env, profile, timeout, or yolo-like behavior.
- Plan mode never enables protected work.
- Permission requests are mapped through OpenLoomi permission handling when Hermes emits `session/request_permission`.
- Hermes is an agent runtime provider, not a sandbox provider.

## Tests

Added and updated tests for:

- Hermes provider registry creation
- Hermes env selection and provider precedence
- unsupported Hermes model/provider env errors
- native runner isolation from Anthropic-compatible config
- providers API metadata and default agent behavior
- ACP streaming text, tool events, errors, timeout, cancel, and exactly-one-done behavior
- gated real Hermes ACP smoke coverage

Verification run:

- `pnpm --filter web test -- tests/unit/hermes-agent.test.ts tests/unit/native-agent-provider-env.test.ts tests/unit/native-agent-runner.test.ts tests/unit/native-providers-api.test.ts`
- `RUN_HERMES_REAL=1 pnpm --filter web test -- tests/unit/hermes-real.integration.test.ts`
- `pnpm --filter web tsc`
- `pnpm --filter web lint -- tests/unit/hermes-real.integration.test.ts`
- `pnpm exec prettier --check -- apps/web/tests/unit/hermes-real.integration.test.ts`

re #194 