### PR TITLE
feat(pet): add "Guide me to connect more" CTA to pet card

### DIFF
--- a/apps/web/app/(chat)/layout.tsx
+++ b/apps/web/app/(chat)/layout.tsx
@@ -16,6 +16,7 @@ import { SessionAuthChecker } from "@/components/session-auth-checker";
 import { ConversationApiOnboardingGuard } from "@/components/conversation-api-onboarding-guard";
 import { ScreenMemoryCaptureProvider } from "@/components/chronicle/screen-memory-provider";
 import { LoopNavBridge } from "@/components/loop/loop-nav-bridge";
+import { PetChatBridge } from "@/components/pet/pet-chat-bridge";
 
 export default async function Layout({
   children,
@@ -53,6 +54,16 @@ export default async function Layout({
                         components/loop/loop-nav-bridge.tsx for the why.
                       */}
                       <LoopNavBridge />
+                      {/*
+                        PetChatBridge forwards the
+                        openloomi:send-chat-message DOM event (fired by
+                        the Rust host when the pet card's
+                        "Guide me to connect more" CTA is clicked) into
+                        the chat composer via
+                        useChatContext().sendMessage(...). See
+                        components/pet/pet-chat-bridge.tsx for the why.
+                      */}
+                      <PetChatBridge />
                       <SidePanelShell>{children}</SidePanelShell>
                     </GlobalInsightDrawerProvider>
                   </ChatContextProvider>

--- a/apps/web/components/pet/pet-chat-bridge.tsx
+++ b/apps/web/components/pet/pet-chat-bridge.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Bridge between Tauri DOM events (dispatched by the Rust host on the
+ * main webview) and the chat composer. The Rust
+ * `pet:guide-connect-more` listener in main.rs emits an
+ * `openloomi:send-chat-message` CustomEvent with `{ text: <prompt> }`;
+ * we forward the text into the chat via
+ * useChatContext().sendMessage(...) so the user lands on a fresh user
+ * turn that the agent can act on.
+ *
+ * Why this lives in the (chat) layout (and not in Home):
+ *   LoopNavBridge is mounted at the layout level for the same reason —
+ *   the event can fire while the user is on /chat, /connectors, /brief,
+ *   etc. Mounting the bridge here keeps the wiring working from any
+ *   (chat) route, and ensures useChatContext is available above us
+ *   (the provider is mounted in layout.tsx).
+ */
+import { useEffect } from "react";
+import { useChatContext } from "@/components/chat-context";
+
+export function PetChatBridge() {
+  const { sendMessage, switchChatId } = useChatContext();
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ text?: string }>;
+      const text = ce.detail?.text?.trim();
+      if (!text) return;
+      // Start a fresh chat so the user prompt is not injected into an
+      // unrelated in-flight conversation. Mirrors the pattern used by
+      // AgentChatPanel's initialMessageToSend effect (see
+      // apps/web/components/agent/chat-panel.tsx).
+      switchChatId(null);
+      // Tiny delay so context state propagates before we send; matches
+      // the 350ms used by AgentChatPanel.
+      setTimeout(() => {
+        void sendMessage({ parts: [{ type: "text", text }] });
+      }, 350);
+    };
+    window.addEventListener("openloomi:send-chat-message", handler);
+    return () =>
+      window.removeEventListener("openloomi:send-chat-message", handler);
+  }, [sendMessage, switchChatId]);
+  return null;
+}

--- a/apps/web/public/loomi-card.html
+++ b/apps/web/public/loomi-card.html
@@ -256,6 +256,34 @@
         height: 30px;
       }
 
+      /* Single-column footer variant for layouts that surface one
+         full-width CTA (e.g. the connection layout's
+         "Guide me to connect more" button). The default `.footer` is
+         a 3-col grid tuned for decision layouts (Run / Cancel / Open
+         dashboard) — this variant resets to one column and lets the
+         single button stretch edge-to-edge. Picked up by the existing
+         `button.primary` styles for the blue fill / hover / shadow so
+         it visually matches the no-api-key footer CTA. */
+      .footer.single-col {
+        grid-template-columns: 1fr;
+      }
+      .footer.single-col button {
+        padding: 9px 12px;
+        font-size: 11px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+      }
+      .footer-cta-icon {
+        font-size: 13px;
+        line-height: 1;
+        font-weight: 700;
+      }
+      .footer-cta-label {
+        white-space: nowrap;
+      }
+
       /* ---------- Inline status banner (between decision body + footer) ----------
          Sits one line above the footer so the user sees an unmistakable
          "Running… → Sent ✓ → closing…" trail without losing the action
@@ -1241,6 +1269,12 @@
         <div class="queue-section">
           <div class="queue-label" id="queue-label">PENDING QUEUE · 0</div>
           <div class="queue-rows" id="connection-queue"></div>
+        </div>
+        <div class="footer single-col">
+          <button class="primary" data-action="guide-connect-more" type="button">
+            <span class="footer-cta-icon">＋</span>
+            <span class="footer-cta-label">Guide me to connect more</span>
+          </button>
         </div>
       </section>
 
@@ -2725,6 +2759,27 @@
             // Even without Tauri, hide the card locally so the click
             // produces a visible effect (e.g. when previewing the page
             // standalone in a browser).
+            card.style.opacity = "0";
+            setTimeout(() => {
+              card.style.display = "none";
+            }, 160);
+            return;
+          }
+          // Connection layout "Guide me to connect more" CTA → ask
+          // the Rust host to surface the main window and dispatch an
+          // `openloomi:send-chat-message` DOM event with the chat
+          // prompt. The PetChatBridge mounted in the (chat) layout
+          // forwards that text into the chat composer via
+          // useChatContext().sendMessage(...). Mirrors the
+          // `pet:open-ai-settings` flow above; without Tauri (designer
+          // / standalone preview) we fall back to the connectors page
+          // so the click still produces a visible effect.
+          if (action === "guide-connect-more") {
+            const t = window.__TAURI__;
+            if (t && t.event && t.event.emit)
+              t.event.emit("pet:guide-connect-more");
+            else
+              window.location.href = "/connectors?addPlatform=true";
             card.style.opacity = "0";
             setTimeout(() => {
               card.style.display = "none";

--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -672,6 +672,38 @@ fn main() {
                 }
             });
 
+            // Pet card "Guide me to connect more" CTA → show the main
+            // window and dispatch a new openloomi:send-chat-message
+            // DOM event with the chat prompt. The new PetChatBridge
+            // mounted in the (chat) layout listens for this event and
+            // forwards it to the chat composer via
+            // useChatContext().sendMessage(). Mirrors the
+            // `pet:open-decision` event-payload pattern (same escape
+            // helper for the JS literal so backslashes / quotes /
+            // newlines can't break the eval). English prompt by
+            // design — loomi-card.html is a static asset with no
+            // runtime i18n, and the agent can translate the response
+            // server-side.
+            let guide_app = app_handle.clone();
+            app_handle.listen("pet:guide-connect-more", move |_event| {
+                tray::show_main_window(&guide_app);
+                if let Some(window) = guide_app.get_webview_window("main") {
+                    let prompt = "Please help me connect more available connectors via Composio \
+(Gmail, Slack, Google Calendar, GitHub, Linear, Obsidian, etc.). \
+List the platforms I haven't connected yet, then walk me through \
+authorizing each one. Begin with Gmail if it's not connected.";
+                    let escaped = prompt
+                        .replace('\\', "\\\\")
+                        .replace('"', "\\\"")
+                        .replace('\n', "\\n");
+                    let js = format!(
+                        "window.dispatchEvent(new CustomEvent('openloomi:send-chat-message', {{ detail: {{ text: \"{}\" }} }}))",
+                        escaped
+                    );
+                    let _ = window.eval(&js);
+                }
+            });
+
             // B2b: "Open brief" / "Open wrap" inside the card. Brief and
             // wrap are not decisions — they're aggregate views
             // (morning brief, evening wrap) persisted to


### PR DESCRIPTION
## Summary
- Adds a full-width **"Guide me to connect more"** CTA to the connection layout of the pet card (`loomi-card.html`), styled via a new single-column `.footer` variant.
- Wires the click through the Rust host: it emits `pet:guide-connect-more`, which surfaces the main window and dispatches an `openloomi:send-chat-message` DOM event carrying the chat prompt.
- Introduces `PetChatBridge` (mounted in the `(chat)` layout) that listens for `openloomi:send-chat-message`, starts a fresh chat, and forwards the prompt into the composer via `useChatContext().sendMessage()`.
- Falls back to `/connectors?addPlatform=true` when running outside Tauri (designer / standalone preview) so the click still produces a visible effect.

## Why
Gives users a one-click path from the pet card into a guided, agent-driven flow for connecting more Composio connectors (Gmail, Slack, Google Calendar, GitHub, Linear, Obsidian, etc.), mirroring the existing `pet:open-ai-settings` / `pet:open-decision` event patterns.

## Test plan
- [ ] In Tauri, click **"Guide me to connect more"** on the pet card → main window surfaces and a fresh chat opens pre-filled with the connect prompt.
- [ ] Prompt text is escaped correctly (no broken `eval` on quotes/newlines/backslashes).
- [ ] Outside Tauri, the CTA navigates to `/connectors?addPlatform=true`.
- [ ] CTA renders full-width and matches the no-api-key footer styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)