### PR TITLE
docs: move openloomi-ctl page to sidebar end

### DIFF
--- a/apps/marketing/content/meta.json
+++ b/apps/marketing/content/meta.json
@@ -4,7 +4,6 @@
     "index",
     "what-is-openloomi",
     "getting-started",
-    "openloomi-ctl",
     "chat",
     "connectors",
     "messaging-apps",
@@ -16,6 +15,7 @@
     "benchmark",
     "glossary",
     "use-cases",
-    "changelog"
+    "changelog",
+    "openloomi-ctl"
   ]
 }


### PR DESCRIPTION
## Summary

- Move the `openloomi-ctl` docs page from the onboarding section to the end of the docs sidebar
- Keep the CLI page content, URL, title, and `FaTerminal` icon mapping unchanged
- Treat the CLI page as reference material instead of an early user-facing guide

Closes #274

