### PR TITLE
Show final artifacts under assistant replies

### DIFF
--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -521,12 +521,13 @@ const PurePreviewMessage = ({
 
   /**
    * Convert tool output paths to LibraryItem same as "My Files / Dialog Space" for LibraryItemRow rendering.
-   * Files already displayed via NativeToolCall are excluded to prevent duplicate display.
+   * Temporary helper files already shown in NativeToolCall are hidden, while final artifacts stay visible
+   * at the bottom of the assistant message so users can open them without scrolling back to the tool card.
    */
   const assistantOutputLibraryItems = useMemo((): LibraryItem[] => {
     if (message.role !== "assistant") return [];
     const files = collectToolOutputFilesFromParts(filteredParts).filter(
-      (f) => !nativeToolDisplayedFilePaths.has(f.path),
+      (f) => !nativeToolDisplayedFilePaths.has(f.path) || !f.isTemporary,
     );
 
     return files.map((f) => {


### PR DESCRIPTION
## Summary

- Keep final generated artifacts visible under assistant replies, even when the same file was already surfaced in the native tool call card.
- Continue hiding temporary helper files that are already shown in tool cards, such as files under `temp/`.
- This makes final deliverables, such as generated Markdown reports, directly clickable near the assistant's summary instead of requiring users to scroll back to a previous tool card.

## Why

When an agent writes a report, the tool card may include a preview button, but the final answer can still say only that a file was saved. Users then do not know where the file lives or how to open it from the final response.

This preserves the existing tool card behavior while adding a more discoverable final artifact entry.

## Validation

- `git diff --check HEAD~1 HEAD`
- Attempted `pnpm --filter web lint`, but this worktree had no installed dependencies and `pnpm` spent several minutes downloading packages from the registry. I interrupted it before lint started because the network install was stalling.
