### PR TITLE
Fix Loomi Pet floating window dragging

### DIFF
--- a/apps/web/public/loomi-card.html
+++ b/apps/web/public/loomi-card.html
@@ -146,6 +146,15 @@
         align-items: center;
         gap: 6px;
         flex: 0 0 auto;
+        cursor: grab;
+      }
+      .header:active {
+        cursor: grabbing;
+      }
+      .header button,
+      .header [data-action],
+      .header a {
+        cursor: pointer;
       }
       .header .icon {
         font-size: 14px;
@@ -1777,6 +1786,67 @@
         const card = document.getElementById("card");
         const toast = document.getElementById("toast");
         const layouts = document.querySelectorAll("[data-layout]");
+
+        function getCurrentWindow() {
+          const t = window.__TAURI__;
+          if (!t) return null;
+          if (
+            t.webviewWindow &&
+            typeof t.webviewWindow.getCurrentWebviewWindow === "function"
+          ) {
+            return t.webviewWindow.getCurrentWebviewWindow();
+          }
+          if (t.window && typeof t.window.getCurrentWebviewWindow === "function") {
+            return t.window.getCurrentWebviewWindow();
+          }
+          if (t.window && typeof t.window.getCurrentWindow === "function") {
+            return t.window.getCurrentWindow();
+          }
+          if (t.window && typeof t.window.getCurrent === "function") {
+            return t.window.getCurrent();
+          }
+          return null;
+        }
+
+        function restoreCursorEvents() {
+          const win = getCurrentWindow();
+          if (win && typeof win.setIgnoreCursorEvents === "function") {
+            try {
+              win.setIgnoreCursorEvents(false);
+            } catch (_) {
+              /* non-fatal */
+            }
+          }
+          return win;
+        }
+
+        function isInteractiveTarget(target) {
+          return Boolean(
+            target &&
+              target.closest &&
+              target.closest(
+                "button,a,input,textarea,select,[contenteditable='true'],[data-action],[data-editor-action]",
+              ),
+          );
+        }
+
+        card.addEventListener("pointerdown", (e) => {
+          if (e.button !== 0) return;
+          if (isInteractiveTarget(e.target)) return;
+          const header =
+            e.target && e.target.closest ? e.target.closest(".header") : null;
+          if (!header) return;
+          const win = restoreCursorEvents();
+          if (win && typeof win.startDragging === "function") {
+            try {
+              const t = window.__TAURI__;
+              if (t && t.event && t.event.emit) t.event.emit("pet:card-drag-start");
+              win.startDragging();
+            } catch (_) {
+              /* native drag is best-effort */
+            }
+          }
+        });
 
         // ---------- State store ----------
         let state = "idle";

--- a/apps/web/public/loomi-widget.html
+++ b/apps/web/public/loomi-widget.html
@@ -456,7 +456,7 @@
             }
           }
           try {
-            fox.setPointerCapture(e.pointerId);
+            document.body.setPointerCapture(e.pointerId);
           } catch (_) {}
         }
 
@@ -472,7 +472,7 @@
         function onPointerUp(e) {
           document.body.classList.remove("dragging");
           try {
-            fox.releasePointerCapture(e.pointerId);
+            document.body.releasePointerCapture(e.pointerId);
           } catch (_) {}
           // Click only fires if the pointer didn't travel far — anything
           // beyond DRAG_THRESHOLD counts as a drag, not a click.
@@ -495,10 +495,10 @@
           }
         }
 
-        fox.addEventListener("pointerdown", onPointerDown);
-        fox.addEventListener("pointermove", onPointerMove);
-        fox.addEventListener("pointerup", onPointerUp);
-        fox.addEventListener("pointercancel", onPointerUp);
+        document.body.addEventListener("pointerdown", onPointerDown);
+        document.body.addEventListener("pointermove", onPointerMove);
+        document.body.addEventListener("pointerup", onPointerUp);
+        document.body.addEventListener("pointercancel", onPointerUp);
 
         // ---- Tauri bridge ----------------------------------------------
         // Only attach the listener when running inside Tauri. When the

--- a/apps/web/src-tauri/capabilities/loomi-pet.json
+++ b/apps/web/src-tauri/capabilities/loomi-pet.json
@@ -14,6 +14,7 @@
     "core:window:allow-hide",
     "core:window:allow-set-focus",
     "core:window:allow-set-always-on-top",
+    "core:window:allow-set-ignore-cursor-events",
     "core:window:allow-close",
     "core:window:allow-start-dragging",
     "allow-emit-dev-state"

--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -627,6 +627,13 @@ fn main() {
                 pet::show_card_window(&open_card_app);
             });
 
+            // Card header drag → let the user manually park the card.
+            // The aux-position poller respects this until the pet moves
+            // again, at which point card following resumes.
+            app_handle.listen("pet:card-drag-start", move |_event| {
+                pet::set_card_manual_position(true);
+            });
+
             // B2: card × button → close card, restore bubble only if there's still
             // a pending decision surfacing. Without this gate the bubble
             // pops up empty ("All clear") when the user dismissed the

--- a/apps/web/src-tauri/src/pet/aux_position.rs
+++ b/apps/web/src-tauri/src/pet/aux_position.rs
@@ -1,7 +1,7 @@
 // Shared positioning helpers for the pet's auxiliary windows (bubble + card).
 //
-// Both `loomi-bubble` and `loomi-card` are anchored ABOVE the pet,
-// horizontally centered on it. The pet's `Moved` event invokes
+// `loomi-bubble` is anchored above the pet, while `loomi-card` is
+// anchored to the pet's left side. The pet's `Moved` event invokes
 // `reposition_bubble_to_pet` / `reposition_card_to_pet` so the auxiliary
 // windows track the pet as the user drags it across the desktop.
 //
@@ -14,20 +14,34 @@
 // at 20Hz — `set_position` is essentially a property write, so the
 // per-tick cost is negligible.
 //
-// All positions are in *logical* pixels when read via `set_position` —
-// Tauri accepts either physical or logical coordinates via the
-// `Position` enum, and using logical keeps the math aligned with the
-// `inner_size` values we declare on the windows. The pet's
-// `outer_position()` returns physical pixels, so we convert via the
-// pet's scale factor before adding offsets.
+// All desktop coordinates are computed in *physical* pixels. The aux
+// windows still declare logical CSS sizes, so helpers convert those
+// dimensions with the pet window's scale factor before calling
+// `set_position`. Keeping the final position physical avoids logical
+// coordinate drift across displays with different scale factors.
 
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::time::Duration;
 
-use tauri::{AppHandle, LogicalPosition, Manager, PhysicalPosition, WebviewWindow};
+use tauri::{AppHandle, Manager, PhysicalPosition, WebviewWindow};
 
 use super::{PET_AUX_GAP, PET_BUBBLE_LABEL, PET_CARD_LABEL, PET_LABEL, bubble, card};
 
 const POLL_INTERVAL_MS: u64 = 50;
+const SCREEN_MARGIN_LOGICAL: f64 = 4.0;
+const NO_PET_ANCHOR: i32 = i32::MIN;
+
+static CARD_MANUAL_POSITION: AtomicBool = AtomicBool::new(false);
+static CARD_ANCHOR_PET_X: AtomicI32 = AtomicI32::new(NO_PET_ANCHOR);
+static CARD_ANCHOR_PET_Y: AtomicI32 = AtomicI32::new(NO_PET_ANCHOR);
+
+#[derive(Clone, Copy, Debug)]
+struct PhysicalBounds {
+    left: f64,
+    top: f64,
+    right: f64,
+    bottom: f64,
+}
 
 /// Read the pet's current outer position in physical pixels. Returns
 /// `None` if the pet hasn't been built yet or the OS hasn't committed a
@@ -45,7 +59,73 @@ fn pet_outer_size_physical(app: &AppHandle) -> Option<(f64, f64)> {
     Some((s.width as f64, s.height as f64))
 }
 
-/// Compute the logical (left, top) for an aux window of the given
+/// Bounds for the monitor that currently contains the pet. Aux windows
+/// should stay on the same display as the pet so multi-monitor setups do
+/// not strand a card on a different screen.
+fn pet_monitor_bounds_physical(app: &AppHandle) -> Option<PhysicalBounds> {
+    let pet_window = app.get_webview_window(PET_LABEL)?;
+    let monitor = pet_window.current_monitor().ok().flatten()?;
+    let pos = monitor.position();
+    let size = monitor.size();
+    Some(PhysicalBounds {
+        left: pos.x as f64,
+        top: pos.y as f64,
+        right: pos.x as f64 + size.width as f64,
+        bottom: pos.y as f64 + size.height as f64,
+    })
+}
+
+fn clamp_start(start: f64, len: f64, min: f64, max: f64, margin: f64) -> f64 {
+    let min_start = min + margin;
+    let max_start = max - margin - len;
+    if max_start <= min_start {
+        min_start
+    } else {
+        start.clamp(min_start, max_start)
+    }
+}
+
+fn clamp_to_pet_monitor(
+    app: &AppHandle,
+    left: f64,
+    top: f64,
+    width: f64,
+    height: f64,
+    margin: f64,
+) -> (f64, f64) {
+    let Some(bounds) = pet_monitor_bounds_physical(app) else {
+        return (left, top);
+    };
+    (
+        clamp_start(left, width, bounds.left, bounds.right, margin),
+        clamp_start(top, height, bounds.top, bounds.bottom, margin),
+    )
+}
+
+fn physical_position(left: f64, top: f64) -> PhysicalPosition<i32> {
+    PhysicalPosition::new(left.round() as i32, top.round() as i32)
+}
+
+/// Keep a manually dragged card in place until the pet itself moves.
+pub fn set_card_manual_position(manual: bool) {
+    CARD_MANUAL_POSITION.store(manual, Ordering::Release);
+}
+
+pub fn clear_card_manual_position() {
+    set_card_manual_position(false);
+}
+
+fn remember_card_anchor_pet_position(pet: PhysicalPosition<i32>) {
+    CARD_ANCHOR_PET_X.store(pet.x, Ordering::Release);
+    CARD_ANCHOR_PET_Y.store(pet.y, Ordering::Release);
+}
+
+fn card_anchor_pet_position_matches(pet: PhysicalPosition<i32>) -> bool {
+    CARD_ANCHOR_PET_X.load(Ordering::Acquire) == pet.x
+        && CARD_ANCHOR_PET_Y.load(Ordering::Acquire) == pet.y
+}
+
+/// Compute the physical (left, top) for an aux window of the given
 /// logical size anchored ABOVE the pet, horizontally centered on it.
 ///
 /// `left = pet_center_x - aux_w / 2`  (the aux window's left edge)
@@ -55,7 +135,7 @@ fn position_above_pet(
     pet: PhysicalPosition<i32>,
     aux_w_logical: f64,
     aux_h_logical: f64,
-) -> LogicalPosition<f64> {
+) -> PhysicalPosition<i32> {
     let scale = pet_scale_factor(app).unwrap_or(1.0);
     let (pet_w_phys, _pet_h_phys) =
         pet_outer_size_physical(app).unwrap_or((168.0 * scale, 168.0 * scale));
@@ -65,14 +145,21 @@ fn position_above_pet(
     // is `aux_w_logical * scale` physical wide.
     let pet_center_x_phys = pet.x as f64 + pet_w_phys / 2.0;
     let aux_w_phys = aux_w_logical * scale;
-    let left_logical = (pet_center_x_phys - aux_w_phys / 2.0) / scale;
+    let left_phys = pet_center_x_phys - aux_w_phys / 2.0;
 
     // Sit just above the pet. The aux window's bottom edge will be
     // PET_AUX_GAP above the pet's top.
-    let top_logical = (pet.y as f64 - aux_h_logical * scale - PET_AUX_GAP * scale)
-        / scale;
+    let top_phys = pet.y as f64 - aux_h_logical * scale - PET_AUX_GAP * scale;
+    let (left_phys, top_phys) = clamp_to_pet_monitor(
+        app,
+        left_phys,
+        top_phys,
+        aux_w_phys,
+        aux_h_logical * scale,
+        SCREEN_MARGIN_LOGICAL * scale,
+    );
 
-    LogicalPosition::new(left_logical, top_logical)
+    physical_position(left_phys, top_phys)
 }
 
 fn pet_scale_factor(app: &AppHandle) -> Option<f64> {
@@ -81,7 +168,7 @@ fn pet_scale_factor(app: &AppHandle) -> Option<f64> {
         .map(|s| s)
 }
 
-/// Compute the logical (left, top) for the card anchored to the LEFT of
+/// Compute the physical (left, top) for the card anchored to the LEFT of
 /// the pet, vertically centered on it. The bubble sits above the pet
 /// (separately, via `position_above_pet`); the card lives beside the
 /// pet so the two never compete for the same vertical slot. The card's
@@ -95,7 +182,7 @@ fn position_left_of_pet(
     pet: PhysicalPosition<i32>,
     card_w_logical: f64,
     card_h_logical: f64,
-) -> LogicalPosition<f64> {
+) -> PhysicalPosition<i32> {
     let scale = pet_scale_factor(app).unwrap_or(1.0);
     let (_pet_w_phys, pet_h_phys) =
         pet_outer_size_physical(app).unwrap_or((168.0 * scale, 168.0 * scale));
@@ -103,18 +190,22 @@ fn position_left_of_pet(
     let card_w_phys = card_w_logical * scale;
     let card_h_phys = card_h_logical * scale;
 
-    // Card's right edge sits PET_AUX_GAP to the left of the pet's left
-    // edge. Clamp to a 4px screen margin so the card stays on-screen
-    // when the user drags the pet to the far left of the desktop.
-    let raw_left_phys = pet.x as f64 - PET_AUX_GAP * scale - card_w_phys;
-    let clamped_left_phys = raw_left_phys.max(4.0 * scale);
-    let left_logical = clamped_left_phys / scale;
+    // Card's right edge sits PET_AUX_GAP to the left of the pet's left edge.
+    let left_phys = pet.x as f64 - PET_AUX_GAP * scale - card_w_phys;
 
     // Vertically center the card on the pet.
     let pet_center_y_phys = pet.y as f64 + pet_h_phys / 2.0;
-    let top_logical = (pet_center_y_phys - card_h_phys / 2.0) / scale;
+    let top_phys = pet_center_y_phys - card_h_phys / 2.0;
+    let (left_phys, top_phys) = clamp_to_pet_monitor(
+        app,
+        left_phys,
+        top_phys,
+        card_w_phys,
+        card_h_phys,
+        SCREEN_MARGIN_LOGICAL * scale,
+    );
 
-    LogicalPosition::new(left_logical, top_logical)
+    physical_position(left_phys, top_phys)
 }
 
 fn reposition(
@@ -176,6 +267,16 @@ pub fn reposition_card_to_pet(app: &AppHandle) {
         log::debug!("[loop-pet] reposition {PET_CARD_LABEL}: pet position not ready");
         return;
     };
+    if CARD_MANUAL_POSITION.load(Ordering::Acquire) {
+        if card_anchor_pet_position_matches(pet) {
+            log::debug!(
+                "[loop-pet] reposition {PET_CARD_LABEL}: preserving manual card position"
+            );
+            return;
+        }
+        clear_card_manual_position();
+    }
+    remember_card_anchor_pet_position(pet);
     let target = position_left_of_pet(app, pet, card::CARD_W, card::CARD_H);
     log::debug!(
         "[loop-pet] reposition {PET_CARD_LABEL}: pet=({:.0},{:.0}) card=({:.0}x{:.0}) → ({:.0},{:.0})",

--- a/apps/web/src-tauri/src/pet/bubble.rs
+++ b/apps/web/src-tauri/src/pet/bubble.rs
@@ -54,6 +54,7 @@ pub fn build_bubble_window(app: &AppHandle) -> tauri::Result<tauri::WebviewWindo
     .decorations(false)
     .transparent(true)
     .always_on_top(true)
+    .visible_on_all_workspaces(true)
     .skip_taskbar(true)
     .shadow(false)
     .visible(false)
@@ -103,6 +104,7 @@ pub fn show_bubble_window(app: &AppHandle) {
     if let Some(w) = app.get_webview_window(PET_BUBBLE_LABEL) {
         let _ = w.show();
         let _ = w.set_always_on_top(true);
+        let _ = w.set_visible_on_all_workspaces(true);
         let _ = w.set_focus();
         // Tell the bubble's JS to (re)arm its auto-dismiss timer. The
         // bubble owns the dismiss lifecycle (see

--- a/apps/web/src-tauri/src/pet/card.rs
+++ b/apps/web/src-tauri/src/pet/card.rs
@@ -51,6 +51,7 @@ pub fn build_card_window(app: &AppHandle) -> tauri::Result<tauri::WebviewWindow>
     .decorations(false)
     .transparent(true)
     .always_on_top(true)
+    .visible_on_all_workspaces(true)
     .skip_taskbar(true)
     .shadow(false)
     .visible(false)
@@ -83,18 +84,25 @@ pub fn build_card_window(app: &AppHandle) -> tauri::Result<tauri::WebviewWindow>
 /// when there is a pending decision. If the window doesn't exist yet
 /// the first call builds it.
 pub fn show_card_window(app: &AppHandle) {
+    super::aux_position::clear_card_manual_position();
+    super::aux_position::reposition_card_to_pet(app);
     if let Some(w) = app.get_webview_window(PET_CARD_LABEL) {
+        let _ = w.set_ignore_cursor_events(false);
         let _ = w.show();
         let _ = w.set_focus();
         let _ = w.set_always_on_top(true);
+        let _ = w.set_visible_on_all_workspaces(true);
         return;
     }
     if let Err(e) = build_card_window(app) {
         log::warn!("[loop-pet] show_card_window: build failed: {e}");
     }
     if let Some(w) = app.get_webview_window(PET_CARD_LABEL) {
+        let _ = w.set_ignore_cursor_events(false);
         let _ = w.show();
         let _ = w.set_focus();
+        let _ = w.set_always_on_top(true);
+        let _ = w.set_visible_on_all_workspaces(true);
     }
 }
 

--- a/apps/web/src-tauri/src/pet/mod.rs
+++ b/apps/web/src-tauri/src/pet/mod.rs
@@ -18,7 +18,8 @@ mod watcher;
 mod window;
 
 pub use aux_position::{
-    reposition_bubble_to_pet, reposition_card_to_pet, spawn_position_poller,
+    clear_card_manual_position, reposition_bubble_to_pet, reposition_card_to_pet,
+    set_card_manual_position, spawn_position_poller,
 };
 pub use bubble::{
     build_bubble_window, hide_bubble_window, show_bubble_window, BUBBLE_H, BUBBLE_W,
@@ -131,4 +132,3 @@ pub async fn emit_dev_state(
     let _ = app.emit_to(PET_BUBBLE_LABEL, "loop:state", payload);
     Ok(())
 }
-

--- a/apps/web/src-tauri/src/pet/window.rs
+++ b/apps/web/src-tauri/src/pet/window.rs
@@ -56,6 +56,7 @@ pub fn build_pet_window(app: &AppHandle) -> tauri::Result<()> {
     .decorations(false)
     .transparent(true)
     .always_on_top(true)
+    .visible_on_all_workspaces(true)
     .skip_taskbar(true)
     .shadow(false)
     .visible(true)
@@ -74,6 +75,7 @@ pub fn build_pet_window(app: &AppHandle) -> tauri::Result<()> {
     .decorations(false)
     .transparent(true)
     .always_on_top(true)
+    .visible_on_all_workspaces(true)
     .skip_taskbar(true)
     .shadow(false)
     .visible(true)
@@ -94,6 +96,7 @@ pub fn show_pet_window(app: &AppHandle) {
         let _ = w.show();
         let _ = w.set_focus();
         let _ = w.set_always_on_top(true);
+        let _ = w.set_visible_on_all_workspaces(true);
     }
 }
 

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
         "decorations": false,
         "transparent": true,
         "alwaysOnTop": true,
+        "visibleOnAllWorkspaces": true,
         "skipTaskbar": true,
         "shadow": false,
         "visible": true,


### PR DESCRIPTION
## Summary
- Keep Loomi Pet auxiliary windows positioned in physical coordinates and clamp them to the pet's current monitor.
- Allow the decision card header to be dragged without the position poller immediately snapping it back.
- Restore card cursor events whenever the card is shown.
- Make the full pet window surface draggable instead of only binding drag handlers to the image element.
- Keep the pet, bubble, and card visible across workspaces so the pet remains reachable when switching displays or macOS Spaces.

## Notes
- The workspace/fullscreen change uses Tauri's supported `visibleOnAllWorkspaces` / `set_visible_on_all_workspaces` APIs. macOS native fullscreen Spaces should still be verified on a built app because standard window behavior can differ from ordinary desktop Spaces.

## Testing
- `git diff --check origin/main..HEAD`
- Parsed inline scripts in `loomi-card.html` and `loomi-widget.html`
- Parsed `loomi-pet.json` and `tauri.conf.json`

Not run:
- Rust `cargo fmt` / compile check, because the local Codex environment does not currently expose `cargo` or `rustfmt`.
