### PR TITLE
Archive opened brief and wrap cards

### DIFF
--- a/apps/web/public/loomi-card.html
+++ b/apps/web/public/loomi-card.html
@@ -3742,6 +3742,30 @@
           return base.join("\n");
         }
 
+        async function archiveOpenedBriefOrWrap(id, layout) {
+          if (!id || (layout !== "brief" && layout !== "wrap")) return;
+          try {
+            const res = await fetch(
+              "/api/loop/decision/" + encodeURIComponent(id),
+              {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  action: "dismiss",
+                  reason: `opened ${layout} details`,
+                }),
+              },
+            );
+            if (!res.ok) return;
+            const t = window.__TAURI__;
+            if (t && t.event && t.event.emit) {
+              t.event.emit("loop:decision-cleared", { id });
+            }
+          } catch (_) {
+            /* non-fatal: watcher keeps the card pending if archive fails */
+          }
+        }
+
         async function postAction(action, body) {
           if (!decision || !decision.id) {
             setStatus("error", "No pending decision — try refreshing.");
@@ -3763,6 +3787,7 @@
             // `/brief` / `/wrap` (the dedicated pages that read
             // brief.json / wrap.json directly).
             const t = window.__TAURI__;
+            const decisionId = decision.id;
             const activeLayout = document.querySelector("[data-layout].active")
               ?.dataset.layout;
             if (t && t.event && t.event.emit) {
@@ -3783,6 +3808,9 @@
                 window.location.href =
                   "/loop/" + encodeURIComponent(decision.id);
               }
+            }
+            if (activeLayout === "brief" || activeLayout === "wrap") {
+              archiveOpenedBriefOrWrap(decisionId, activeLayout);
             }
             return;
           }


### PR DESCRIPTION
## Summary
- Archive brief and wrap cards after the user opens their detail view.
- Emit the existing `loop:decision-cleared` event after the archive succeeds so the card UI can immediately fall back to its natural state.

## Why
Opening a brief or wrap currently only navigates to `/brief` or `/wrap`; it does not remove the source card from the pending queue. The watcher can therefore keep treating the card as pending, leaving the Loomi Pet sprite in its active/presentation state after the wrap has already been reviewed.

## Testing
- `git diff --check`
- Parsed the inline script in `loomi-card.html`

Not run:
- Full desktop app build, because this local Codex environment does not expose Rust tooling for Tauri builds.
