### PR TITLE
Fix chat artifact previews for cross-session workspace files

### DIFF
--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -47,7 +47,10 @@ import {
   LibraryItemRow,
   type LibraryItem,
 } from "@/components/library/library-item-row";
-import { sessionRelativePathFromStoredPath } from "@/lib/files/open-workspace-file-locally";
+import {
+  workspaceFileReferenceFromStoredPath,
+  workspaceSessionFileReferenceFromStoredPath,
+} from "@/lib/files/open-workspace-file-locally";
 import { collectToolOutputFilesFromParts } from "./message-output-files";
 import { normalizeExtractedArtifactPath } from "@/lib/files/extract-artifact-paths";
 import { format } from "date-fns";
@@ -132,6 +135,30 @@ const PurePreviewMessage = ({
     setMessages: contextSetMessages,
   } = useChatContext();
   const [, copyToClipboard] = useCopyToClipboard();
+
+  const openMessageFilePreviewPanel = useCallback(
+    (file: { path: string; name: string; type: string; taskId?: string }) => {
+      const storedReference = workspaceSessionFileReferenceFromStoredPath(
+        file.path,
+      );
+      if (storedReference) {
+        openFilePreviewPanel({ ...file, ...storedReference });
+        return;
+      }
+
+      if (file.taskId) {
+        const reference = workspaceFileReferenceFromStoredPath(
+          file.path,
+          file.taskId,
+        );
+        openFilePreviewPanel({ ...file, ...reference });
+        return;
+      }
+
+      openFilePreviewPanel(file);
+    },
+    [openFilePreviewPanel],
+  );
 
   const { insightData, mutateInsightList } = useInsightPagination();
 
@@ -531,16 +558,19 @@ const PurePreviewMessage = ({
     );
 
     return files.map((f) => {
-      const rel = sessionRelativePathFromStoredPath(f.path, chatId);
+      const workspaceFile = workspaceFileReferenceFromStoredPath(
+        f.path,
+        chatId,
+      );
       return {
-        id: `${message.id}-${rel}`,
+        id: `${message.id}-${workspaceFile.taskId}-${workspaceFile.path}`,
         kind: "workspace_file",
         title: f.name,
         date: new Date(0), // epoch - date not shown for chat output files
         groupKey: "chat-output",
         workspaceFile: {
-          taskId: chatId,
-          path: rel,
+          taskId: workspaceFile.taskId,
+          path: workspaceFile.path,
           name: f.name,
           type: f.type,
         },
@@ -707,7 +737,7 @@ const PurePreviewMessage = ({
                                 }
                                 taskId={chatId}
                                 onPreviewFile={(file) => {
-                                  openFilePreviewPanel(file);
+                                  openMessageFilePreviewPanel(file);
                                 }}
                               />
                             )}
@@ -773,7 +803,9 @@ const PurePreviewMessage = ({
                                     <MarkdownWithCitations
                                       onCitationClick={handleCitationClick}
                                       insights={insightData.items}
-                                      onPreviewFile={openFilePreviewPanel}
+                                      onPreviewFile={
+                                        openMessageFilePreviewPanel
+                                      }
                                     >
                                       {textContent}
                                     </MarkdownWithCitations>
@@ -790,7 +822,9 @@ const PurePreviewMessage = ({
                                     <MarkdownWithCitations
                                       onCitationClick={handleCitationClick}
                                       insights={insightData.items}
-                                      onPreviewFile={openFilePreviewPanel}
+                                      onPreviewFile={
+                                        openMessageFilePreviewPanel
+                                      }
                                     >
                                       {textContent}
                                     </MarkdownWithCitations>
@@ -1239,7 +1273,7 @@ const PurePreviewMessage = ({
                       viewMode="list"
                       t={t as (key: string, fallback?: string) => string}
                       onOpenFile={(wf) =>
-                        openFilePreviewPanel({
+                        openMessageFilePreviewPanel({
                           path: wf.path,
                           name: wf.name,
                           type: wf.type ?? "",

--- a/apps/web/lib/files/open-workspace-file-locally.ts
+++ b/apps/web/lib/files/open-workspace-file-locally.ts
@@ -46,6 +46,35 @@ export function sessionRelativePathFromStoredPath(
   return base.replace(/^\/+/, "");
 }
 
+export type WorkspaceFileReference = {
+  taskId: string;
+  path: string;
+};
+
+export function workspaceSessionFileReferenceFromStoredPath(
+  filePath: string,
+): WorkspaceFileReference | null {
+  const norm = filePath.trim().replace(/\\/g, "/");
+  const match = norm.match(/(?:^|\/)\.openloomi\/sessions\/([^/]+)\/(.+)$/i);
+  const taskId = match?.[1]?.trim();
+  const path = match?.[2]?.replace(/^\/+/, "");
+  if (!taskId || !path) return null;
+  return { taskId, path };
+}
+
+export function workspaceFileReferenceFromStoredPath(
+  filePath: string,
+  fallbackTaskId: string,
+): WorkspaceFileReference {
+  const storedReference = workspaceSessionFileReferenceFromStoredPath(filePath);
+  if (storedReference) return storedReference;
+
+  return {
+    taskId: fallbackTaskId,
+    path: sessionRelativePathFromStoredPath(filePath, fallbackTaskId),
+  };
+}
+
 function looksLikeAbsolutePath(filePath: string): boolean {
   return (
     filePath.startsWith("/") ||

--- a/apps/web/tests/unit/open-workspace-file-locally.test.ts
+++ b/apps/web/tests/unit/open-workspace-file-locally.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sessionRelativePathFromStoredPath,
+  workspaceFileReferenceFromStoredPath,
+  workspaceSessionFileReferenceFromStoredPath,
+} from "@/lib/files/open-workspace-file-locally";
+
+describe("workspace file path references", () => {
+  it("extracts the owning session from a stored macOS session path", () => {
+    expect(
+      workspaceSessionFileReferenceFromStoredPath(
+        "/Users/alice/.openloomi/sessions/source-chat/reports/digest.md",
+      ),
+    ).toEqual({
+      taskId: "source-chat",
+      path: "reports/digest.md",
+    });
+  });
+
+  it("extracts the owning session from a stored Windows session path", () => {
+    expect(
+      workspaceSessionFileReferenceFromStoredPath(
+        String.raw`C:\Users\alice\.openloomi\sessions\source-chat\temp\digest.md`,
+      ),
+    ).toEqual({
+      taskId: "source-chat",
+      path: "temp/digest.md",
+    });
+  });
+
+  it("keeps a cross-session artifact attached to its source session", () => {
+    expect(
+      workspaceFileReferenceFromStoredPath(
+        "/Users/alice/.openloomi/sessions/source-chat/digest.md",
+        "visible-chat",
+      ),
+    ).toEqual({
+      taskId: "source-chat",
+      path: "digest.md",
+    });
+  });
+
+  it("falls back to the visible chat for ordinary relative paths", () => {
+    expect(
+      workspaceFileReferenceFromStoredPath("digest.md", "visible-chat"),
+    ).toEqual({
+      taskId: "visible-chat",
+      path: "digest.md",
+    });
+  });
+
+  it("still returns a session-relative path for same-session absolute paths", () => {
+    expect(
+      sessionRelativePathFromStoredPath(
+        "/Users/alice/.openloomi/sessions/visible-chat/temp/digest.md",
+        "visible-chat",
+      ),
+    ).toBe("temp/digest.md");
+  });
+
+  it("does not claim unrelated absolute paths belong to a workspace session", () => {
+    expect(
+      workspaceSessionFileReferenceFromStoredPath(
+        "/Users/alice/Desktop/digest.md",
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve stored workspace artifact paths to their owning session before opening chat previews.
- Use the same resolver for tool-card previews, markdown file links, and final artifact cards.
- Add unit coverage for macOS/Windows session paths and cross-session artifact references.

## Why
Generated files may be written by a background or scheduled execution session, then shown in another chat. Chat preview previously fell back to the visible chat id, which could make it request the right filename from the wrong session and show "File not found" even though Library could open the file.

## Validation
- Manual parser cases for macOS, Windows, and cross-session paths passed.
- `git diff --check` passed.
- Not run: targeted Vitest command, because dependency installation is blocked by the repo's current supply-chain policy on an existing git subdependency.
