### PR TITLE
Keep Loomi Pet visible in macOS full-screen Spaces

### DIFF
--- a/apps/web/src-tauri/src/pet/bubble.rs
+++ b/apps/web/src-tauri/src/pet/bubble.rs
@@ -70,6 +70,7 @@ pub fn build_bubble_window(app: &AppHandle) -> tauri::Result<tauri::WebviewWindo
     let builder = base;
 
     let w = builder.build()?;
+    super::macos_window::configure_for_all_spaces(&w);
     // CloseRequested → hide (so the OS × button on the bubble isn't a
     // destroy gesture). Tauri's webview window has decorations(false) so
     // this branch is only hit if the user wires a close shortcut in the
@@ -105,6 +106,7 @@ pub fn show_bubble_window(app: &AppHandle) {
         let _ = w.show();
         let _ = w.set_always_on_top(true);
         let _ = w.set_visible_on_all_workspaces(true);
+        super::macos_window::configure_for_all_spaces(&w);
         let _ = w.set_focus();
         // Tell the bubble's JS to (re)arm its auto-dismiss timer. The
         // bubble owns the dismiss lifecycle (see

--- a/apps/web/src-tauri/src/pet/card.rs
+++ b/apps/web/src-tauri/src/pet/card.rs
@@ -67,6 +67,7 @@ pub fn build_card_window(app: &AppHandle) -> tauri::Result<tauri::WebviewWindow>
     let builder = base;
 
     let w = builder.build()?;
+    super::macos_window::configure_for_all_spaces(&w);
     let app_handle = app.clone();
     let label = PET_CARD_LABEL.to_string();
     w.on_window_event(move |ev| {
@@ -92,6 +93,7 @@ pub fn show_card_window(app: &AppHandle) {
         let _ = w.set_focus();
         let _ = w.set_always_on_top(true);
         let _ = w.set_visible_on_all_workspaces(true);
+        super::macos_window::configure_for_all_spaces(&w);
         return;
     }
     if let Err(e) = build_card_window(app) {
@@ -103,6 +105,7 @@ pub fn show_card_window(app: &AppHandle) {
         let _ = w.set_focus();
         let _ = w.set_always_on_top(true);
         let _ = w.set_visible_on_all_workspaces(true);
+        super::macos_window::configure_for_all_spaces(&w);
     }
 }
 

--- a/apps/web/src-tauri/src/pet/macos_window.rs
+++ b/apps/web/src-tauri/src/pet/macos_window.rs
@@ -1,0 +1,68 @@
+// macOS Space behavior shared by the resident pet and its auxiliary windows.
+//
+// Tauri's `visible_on_all_workspaces(true)` sets `CanJoinAllSpaces`, but a
+// window still needs `FullScreenAuxiliary` to appear above another app's
+// native full-screen Space. Without it the pet can be dragged between regular
+// desktops but disappears or stops at a display occupied by a full-screen app.
+
+const CAN_JOIN_ALL_SPACES: usize = 1 << 0;
+const FULL_SCREEN_AUXILIARY: usize = 1 << 8;
+
+fn collection_behavior_for_pet(current: usize) -> usize {
+    current | CAN_JOIN_ALL_SPACES | FULL_SCREEN_AUXILIARY
+}
+
+#[cfg(target_os = "macos")]
+pub fn configure_for_all_spaces(window: &tauri::WebviewWindow) {
+    use objc2::{msg_send, runtime::AnyObject};
+
+    let label = window.label().to_string();
+    let label_on_main = label.clone();
+    let window_on_main = window.clone();
+    if let Err(error) = window.run_on_main_thread(move || {
+        let raw = match window_on_main.ns_window() {
+            Ok(raw) if !raw.is_null() => raw.cast::<AnyObject>(),
+            Ok(_) => {
+                log::warn!("[loop-pet] {label_on_main}: NSWindow pointer was null");
+                return;
+            }
+            Err(error) => {
+                log::warn!("[loop-pet] {label_on_main}: NSWindow lookup failed: {error}");
+                return;
+            }
+        };
+
+        unsafe {
+            let current: usize = msg_send![raw, collectionBehavior];
+            let desired = collection_behavior_for_pet(current);
+            let _: () = msg_send![raw, setCollectionBehavior: desired];
+        }
+    }) {
+        log::warn!("[loop-pet] {label}: macOS Space configuration failed: {error}");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn configure_for_all_spaces(_window: &tauri::WebviewWindow) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_join_all_spaces_and_fullscreen_auxiliary() {
+        assert_eq!(
+            collection_behavior_for_pet(0),
+            CAN_JOIN_ALL_SPACES | FULL_SCREEN_AUXILIARY
+        );
+    }
+
+    #[test]
+    fn preserves_existing_collection_behavior_flags() {
+        let existing = (1 << 1) | (1 << 7);
+        assert_eq!(
+            collection_behavior_for_pet(existing),
+            existing | CAN_JOIN_ALL_SPACES | FULL_SCREEN_AUXILIARY
+        );
+    }
+}

--- a/apps/web/src-tauri/src/pet/mod.rs
+++ b/apps/web/src-tauri/src/pet/mod.rs
@@ -16,6 +16,7 @@ mod config_watcher;
 mod dev_panel;
 #[cfg(target_os = "macos")]
 mod dock;
+mod macos_window;
 pub mod theme;
 mod watcher;
 mod window;

--- a/apps/web/src-tauri/src/pet/window.rs
+++ b/apps/web/src-tauri/src/pet/window.rs
@@ -81,7 +81,8 @@ pub fn build_pet_window(app: &AppHandle) -> tauri::Result<()> {
     .visible(true)
     .focused(false);
 
-    builder.build()?;
+    let window = builder.build()?;
+    super::macos_window::configure_for_all_spaces(&window);
     wire_pet_window_events(app);
     Ok(())
 }
@@ -97,6 +98,7 @@ pub fn show_pet_window(app: &AppHandle) {
         let _ = w.set_focus();
         let _ = w.set_always_on_top(true);
         let _ = w.set_visible_on_all_workspaces(true);
+        super::macos_window::configure_for_all_spaces(&w);
     }
 }
 


### PR DESCRIPTION
## Summary

- add a shared native macOS Space behavior helper
- preserve existing `NSWindow` collection behavior while adding `CanJoinAllSpaces` and `FullScreenAuxiliary`
- apply the behavior to the pet, bubble, and card windows when created or shown
- add tests for the native behavior flags

## Root cause

Tauri's `visible_on_all_workspaces(true)` enables `CanJoinAllSpaces`, but it does not enable `FullScreenAuxiliary`.

As a result, the floating pet windows could not reliably appear on or move to a display whose active Space was occupied by a full-screen application.

## User impact

The pet, notification bubble, and decision card can follow the user across displays and remain available over native macOS full-screen Spaces.

## Validation

- compiled on Apple Silicon macOS
- `cargo test --bin openloomi pet::`
- 27 pet tests passed
