### PR TITLE
feat(codex-plugin): improve OpenLoomi readiness, runtime routing, and workflow safety

### DIFF
--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -130,15 +130,18 @@ node plugins/codex/scripts/loomi-bridge.mjs version
 ```json
 {
   "name": "openloomi-codex-bridge",
-  "version": "0.8.0",
+  "version": "0.7.3",
   "pluginPhase": "runtime-provider-readiness",
   "commands": [
+    "codex-runtime-info",
     "configure-ai-provider",
     "help",
     "initialize-session",
     "install-instructions",
     "install-openloomi",
+    "pet",
     "run",
+    "set-codex-runtime-env",
     "setup",
     "setup-status",
     "version",
@@ -446,10 +449,10 @@ user confirmation.
 
 ### Launching the desktop app with the Codex runtime
 
-By default the packaged desktop app routes chat and agent requests through the
-Claude provider. To run the same desktop binary against the local Codex CLI
-instead, set `OPENLOOMI_AGENT_PROVIDER=codex` in the environment the desktop
-app actually inherits.
+By default the packaged desktop app may route native-agent requests through
+the default runtime provider. If you need to run the same desktop binary
+against the local Codex CLI, set `OPENLOOMI_AGENT_PROVIDER=codex` in the
+environment the desktop app actually inherits.
 
 > **macOS caveat:** the desktop app's web server runs inside the GUI launchd
 > session, not your terminal. `export FOO=bar` in a terminal does **not**

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -649,6 +649,7 @@ open_openloomi
 configure_ai_provider
 configure_connectors
 show_openloomi_skills
+return_without_bridge
 run
 ```
 
@@ -664,6 +665,7 @@ READY_SESSION_BOOTSTRAP_PENDING
 AI_PROVIDER_REQUIRED
 AI_PROVIDER_STATUS_UNAVAILABLE
 CONNECTOR_SETUP_REQUIRED
+RECURSION_GUARD
 READY
 ```
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -447,80 +447,14 @@ If a source checkout exists but the CLI is not built or staged, the plugin
 should return actionable instructions rather than building automatically without
 user confirmation.
 
-### Launching the desktop app with the Codex runtime
+### Advanced Runtime Executor Diagnostics
 
-By default the packaged desktop app may route native-agent requests through
-the default runtime provider. If you need to run the same desktop binary
-against the local Codex CLI, set `OPENLOOMI_AGENT_PROVIDER=codex` in the
-environment the desktop app actually inherits.
+The Codex plugin does not require the OpenLoomi desktop runtime to use Codex as
+its native-agent executor. Keep the standard plugin path focused on
+`setup-status`, `initialize-session`, workflow guidance, and `run`.
 
-> **macOS caveat:** the desktop app's web server runs inside the GUI launchd
-> session, not your terminal. `export FOO=bar` in a terminal does **not**
-> reach the running web server. After setting the variable you must Quit and
-> reopen `OpenLoomi.app` so the new env is inherited by the freshly forked
-> web process. On Linux a per-user env file works after the next login, and
-> on Windows you edit the user environment via System Settings.
-
-```bash
-node plugins/codex/scripts/loomi-bridge.mjs set-codex-runtime-env codex
-# macOS: writes via launchctl setenv.
-# Linux: writes ~/.config/environment.d/openloomi-codex.conf.
-# Windows: prints manual steps (System Settings → Environment Variables).
-
-# Then quit and reopen OpenLoomi so the new env reaches the web server.
-```
-
-Flags accepted by `set-codex-runtime-env`:
-
-- `<value>` — defaults to `codex` (other supported values: `claude`,
-  `opencode`, `hermes`, `openclaw`).
-- `--unset` — clear `OPENLOOMI_AGENT_PROVIDER` from the host environment.
-- `--dry-run` — describe what would happen without performing the write.
-
-For a permanent shell-side switch on macOS or Linux, you can additionally
-append the export to your shell rc so future shells remember it:
-
-```bash
-echo 'export OPENLOOMI_AGENT_PROVIDER=codex' >> ~/.zshrc
-```
-
-The shell export helps the bridge itself and `openloomi-ctl`; the
-`set-codex-runtime-env` step is what makes the GUI launchd domain and the
-desktop session pick the variable up.
-
-Optional companion variables (all read by `apps/web`'s native-agent env
-resolver at startup):
-
-```bash
-export OPENLOOMI_AGENT_CODEX_COMMAND=codex           # defaults to `codex` on PATH
-export OPENLOOMI_AGENT_CODEX_MODEL=gpt-5.4            # optional model override
-export OPENLOOMI_AGENT_CODEX_PROFILE=work             # optional `-p <name>`
-export OPENLOOMI_AGENT_CODEX_SANDBOX=workspace-write # read-only | workspace-write | danger-full-access
-export OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL=on-request # untrusted | on-failure | on-request | never
-export OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK=true # default true
-export OPENLOOMI_AGENT_CODEX_FULL_AUTO=false         # set true to allow --full-auto under bypassPermissions
-export OPENLOOMI_AGENT_CODEX_TIMEOUT_MS=120000       # CLI runtime budget in ms
-```
-
-Prerequisites that must hold before the desktop app will actually drive Codex:
-
-- `which codex` resolves to a working Codex CLI binary (install via
-  `brew install --cask codex` or `npm i -g @openai/codex`).
-- `~/.codex/config.toml` is configured and `OPENAI_API_KEY` (or the Codex
-  CLI's other auth) is available to the spawned process.
-
-Verification after launch: the desktop app's `GET /api/native/providers`
-should return `codex` inside `agents` and `defaultAgent: "codex"`. If you
-still see `defaultAgent: "claude"` after running `set-codex-runtime-env` and
-reopening the app, the env change did not stick — re-run
-`launchctl getenv OPENLOOMI_AGENT_PROVIDER` in a terminal to confirm the
-GUI session actually has it.
-
-### Surface the switch from inside Codex
-
-The Codex plugin bridge exposes the same switch plan as structured JSON so it
-can be referenced from skills and shown verbatim in chat without retyping the
-shell snippets. From any Codex session, run:
+When explicitly diagnosing the desktop runtime executor, the bridge can return
+the current Codex runtime switch plan as structured JSON:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
@@ -529,29 +463,23 @@ node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 The bridge returns:
 
 - `envProviderKey` (`OPENLOOMI_AGENT_PROVIDER`)
-- `switch.oneOff` and `switch.permanent` — ready-to-run shell snippets, with
-  the macOS caveat that the snippet is `launchctl setenv …` rather than
-  `export …`
-- `prerequisites` — Codex CLI binary, `~/.codex/config.toml`, `OPENAI_API_KEY`
-- `companionEnvVars[]` — `OPENLOOMI_AGENT_CODEX_*` variables with their defaults
-- `verify.endpoint` / `verify.expectDefaultAgent` — the `GET /api/native/providers` contract
-- `defaults.currentDefaultProvider` — echoes the active `OPENLOOMI_AGENT_PROVIDER` so the model can spot a missing export before suggesting commands
-- `defaults.codexCliOnPath` — best-effort PATH probe for the `codex` binary
+- `switch.oneOff` and `switch.permanent` platform guidance
+- `prerequisites` for the local Codex CLI
+- `companionEnvVars[]` for the desktop runtime executor
+- `verify.endpoint` / `verify.expectDefaultAgent` for `/api/native/providers`
+- `defaults.currentDefaultProvider`
+- `defaults.codexCliOnPath`
 
-The companion command that performs the GUI-session env write is
-`set-codex-runtime-env`:
+If a runtime-executor switch is actually required, use:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env codex
-# Clear it later:
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env --unset
-# Plan only, do not write:
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env --dry-run
 ```
 
-After running `set-codex-runtime-env`, Quit and reopen `OpenLoomi.app` so the
-new env actually reaches the freshly forked web process — the env only
-applies to GUI processes launched **after** `launchctl setenv` (on macOS).
+After changing the desktop runtime environment, restart OpenLoomi and verify
+the active provider through `/api/native/providers`.
 
 ### Missing Install
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -4,14 +4,14 @@
 
 The OpenLoomi Codex plugin makes Codex an agent shell for a local OpenLoomi
 runtime. Codex provides the interactive coding surface, while OpenLoomi owns the
-personal memory layer, connector graph, model provider setup, task loop, and
+personal memory layer, connector graph, runtime/provider setup, task loop, and
 local privacy boundary.
 
 The plugin is designed to:
 
 - discover or install OpenLoomi for the user;
 - verify that `openloomi-ctl` is available;
-- guide first-use AI provider setup;
+- set up the Codex runtime path and guide AI provider fallback when needed;
 - run one-shot tasks through the local OpenLoomi runtime;
 - help users access OpenLoomi-related workflows such as `openloomi-loop` and
   `openloomi-memory` from Codex;
@@ -41,7 +41,8 @@ User installs the Codex plugin
   -> plugin checks whether OpenLoomi is installed
   -> plugin installs or guides installation if OpenLoomi is missing
   -> plugin verifies openloomi-ctl
-  -> plugin guides first-use AI provider setup
+  -> plugin sets or verifies the Codex runtime path
+  -> plugin guides AI provider fallback only when needed
   -> plugin initializes or reuses a guest/session token
   -> plugin runs a one-shot OpenLoomi task
   -> plugin shows related OpenLoomi skills and workflows
@@ -98,7 +99,8 @@ codex plugin add openloomi@openloomi
 - For local install: the OpenLoomi repository checked out somewhere writable.
 - OpenLoomi Desktop installed, or a source build that stages `openloomi-ctl`,
   for any runtime task (`run`, handoff, loop, memory, connectors).
-- An AI provider configured in OpenLoomi Desktop for runtime tasks.
+- Codex CLI available and configured as the recommended OpenLoomi desktop
+  runtime, or an AI provider configured in OpenLoomi Desktop as a fallback.
 
 The plugin alone is enough for setup guidance and workflow discovery. If
 `openloomi-ctl` is missing, the plugin can still report readiness, install
@@ -182,10 +184,12 @@ node plugins/codex/scripts/loomi-bridge.mjs setup
 ```
 
 The `setup` command walks the readiness state machine: install (with
-explicit `--yes`) -> initialize a local guest/session token -> re-check
-status. It returns a structured `steps` array and a final `status` block so
-Codex can render the path it took. The AI provider step is never automated;
-secret entry must happen in OpenLoomi-owned UI or interactive CLI surfaces.
+explicit `--yes`) -> set the Codex runtime environment -> launch OpenLoomi ->
+initialize a local guest/session token -> re-check status. It returns a
+structured `steps` array and a final `status` block so Codex can render the path
+it took. If the user chooses the AI provider fallback instead of the Codex
+runtime, secret entry must happen in OpenLoomi-owned UI or interactive CLI
+surfaces.
 
 ### Try the Plugin in Codex
 
@@ -239,7 +243,9 @@ session, then re-run `setup-status` or `setup`.
 
 `AI_PROVIDER_REQUIRED` / `AI_PROVIDER_STATUS_UNAVAILABLE`
 
-: Configure the AI provider in OpenLoomi Desktop. Secrets must stay in
+: Prefer setting the OpenLoomi desktop runtime to Codex so OpenLoomi can reuse
+the user's existing Codex CLI runtime. If the user chooses a separate AI
+provider fallback, configure it in OpenLoomi Desktop. Secrets must stay in
 OpenLoomi-owned UI or secure storage. If the local API is unreachable, the
 plugin reports status as unavailable rather than falsely reporting missing
 configuration.
@@ -257,8 +263,8 @@ automatically**. The plugin's primary skill (`openloomi`) and its companion
 sub-skills (`openloomi-install`, `openloomi-loop`, `openloomi-memory`,
 `openloomi-connectors`, `openloomi-handoff`, `openloomi-api`,
 `openloomi-feature-guide`) are picked up from
-`plugins/codex/.codex-plugin/plugin.json` → `skills` on the next Codex
-start. No additional registration step is required — opening any new Codex
+`plugins/codex/.codex-plugin/plugin.json` -> `skills` on the next Codex
+start. No additional registration step is required - opening any new Codex
 thread and mentioning `@OpenLoomi` (or any of the trigger phrases listed in
 the skill front-matter) is enough to route into the bridge.
 
@@ -283,7 +289,8 @@ machine in one invocation:
 2. install           -> download + install OpenLoomi from the official
                         GitHub release (only when --yes/--confirm is set)
 3. runtime_env       -> write OPENLOOMI_AGENT_PROVIDER=codex to the host
-                        GUI launchd / environment.d / registry
+                        GUI launchd / environment.d, or return Windows
+                        user-environment guidance
 4. launch_desktop    -> open OpenLoomi Desktop and wait for the local API
                         to come up (configurable via --max-wait)
 5. initialize-session -> mint a guest/session token via the local API
@@ -295,7 +302,7 @@ The wizard stops early at any step that requires explicit user action:
 
 - **Install** requires `--yes` (or `--confirm`). Without it, the wizard
   returns `setup: "awaiting_user_action"` with
-  `reason: "INSTALL_CONFIRMATION_REQUIRED"` and a clear message — it will
+  `reason: "INSTALL_CONFIRMATION_REQUIRED"` and a clear message - it will
   never download OpenLoomi silently. Per the non-goals, the wizard never
   installs from unofficial artifacts or non-default paths.
 - **AI provider configuration is never auto-run.** Secret entry must
@@ -336,11 +343,11 @@ render each step:
 
 Flags accepted by `setup`:
 
-- `--yes` / `--confirm` — authorize the install step when OpenLoomi is
+- `--yes` / `--confirm` - authorize the install step when OpenLoomi is
   missing. Without this flag the wizard is read-only.
-- `--max-wait <ms>` — how long to wait for the local API after launching
+- `--max-wait <ms>` - how long to wait for the local API after launching
   the desktop app (default `30000`).
-- `--non-interactive` — fail fast instead of waiting for the local API;
+- `--non-interactive` - fail fast instead of waiting for the local API;
   useful in CI.
 
 Typical first-use run from a Codex prompt:
@@ -447,14 +454,85 @@ If a source checkout exists but the CLI is not built or staged, the plugin
 should return actionable instructions rather than building automatically without
 user confirmation.
 
-### Advanced Runtime Executor Diagnostics
+### Launching the desktop app with the Codex runtime
 
-The Codex plugin does not require the OpenLoomi desktop runtime to use Codex as
-its native-agent executor. Keep the standard plugin path focused on
-`setup-status`, `initialize-session`, workflow guidance, and `run`.
+When OpenLoomi is used from Codex, this is the recommended first-use path: it
+lets OpenLoomi reuse the user's existing Codex runtime and avoids requiring a
+separate OpenLoomi AI provider key just to complete the first Codex plugin
+workflow.
 
-When explicitly diagnosing the desktop runtime executor, the bridge can return
-the current Codex runtime switch plan as structured JSON:
+By default the packaged desktop app routes chat and agent requests through the
+Claude provider. To run the same desktop binary against the local Codex CLI
+instead, set `OPENLOOMI_AGENT_PROVIDER=codex` in the environment the desktop app
+actually inherits.
+
+> **macOS caveat:** the desktop app's web server runs inside the GUI launchd
+> session, not your terminal. `export FOO=bar` in a terminal does **not** reach
+> the running web server. After setting the variable you must Quit and reopen
+> `OpenLoomi.app` so the new env is inherited by the freshly forked web process.
+> On Linux a per-user env file works after the next login, and on Windows you
+> edit the user environment via System Settings.
+
+```bash
+node plugins/codex/scripts/loomi-bridge.mjs set-codex-runtime-env codex
+# macOS: writes via launchctl setenv.
+# Linux: writes ~/.config/environment.d/openloomi-codex.conf.
+# Windows: prints manual steps (System Settings -> Environment Variables).
+
+# Then quit and reopen OpenLoomi so the new env reaches the web server.
+```
+
+Flags accepted by `set-codex-runtime-env`:
+
+- `<value>` - defaults to `codex` (other supported values: `claude`,
+  `opencode`, `hermes`, `openclaw`).
+- `--unset` - clear `OPENLOOMI_AGENT_PROVIDER` from the host environment.
+- `--dry-run` - describe what would happen without performing the write.
+
+For a permanent shell-side switch on macOS or Linux, you can additionally append
+the export to your shell rc so future shells remember it:
+
+```bash
+echo 'export OPENLOOMI_AGENT_PROVIDER=codex' >> ~/.zshrc
+```
+
+The shell export helps the bridge itself and `openloomi-ctl`; the
+`set-codex-runtime-env` step is what makes the GUI launchd domain and the
+desktop session pick the variable up.
+
+Optional companion variables (all read by `apps/web`'s native-agent env resolver
+at startup):
+
+```bash
+export OPENLOOMI_AGENT_CODEX_COMMAND=codex           # defaults to `codex` on PATH
+export OPENLOOMI_AGENT_CODEX_MODEL=gpt-5.4            # optional model override
+export OPENLOOMI_AGENT_CODEX_PROFILE=work             # optional `-p <name>`
+export OPENLOOMI_AGENT_CODEX_SANDBOX=workspace-write # read-only | workspace-write | danger-full-access
+export OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL=on-request # untrusted | on-failure | on-request | never
+export OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK=true # default true
+export OPENLOOMI_AGENT_CODEX_FULL_AUTO=false         # set true to allow --full-auto under bypassPermissions
+export OPENLOOMI_AGENT_CODEX_TIMEOUT_MS=120000       # CLI runtime budget in ms
+```
+
+Prerequisites that must hold before the desktop app will actually drive Codex:
+
+- `which codex` resolves to a working Codex CLI binary (install via
+  `brew install --cask codex` or `npm i -g @openai/codex`).
+- `~/.codex/config.toml` is configured and `OPENAI_API_KEY` (or the Codex CLI's
+  other auth) is available to the spawned process.
+
+Verification after launch: the desktop app's `GET /api/native/providers` should
+return `codex` inside `agents` and `defaultAgent: "codex"`. If you still see
+`defaultAgent: "claude"` after running `set-codex-runtime-env` and reopening the
+app, the env change did not stick - re-run
+`launchctl getenv OPENLOOMI_AGENT_PROVIDER` in a terminal to confirm the GUI
+session actually has it.
+
+### Surface the switch from inside Codex
+
+The Codex plugin bridge exposes the same switch plan as structured JSON so it
+can be referenced from skills and shown verbatim in chat without retyping the
+shell snippets. From any Codex session, run:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
@@ -464,22 +542,29 @@ The bridge returns:
 
 - `envProviderKey` (`OPENLOOMI_AGENT_PROVIDER`)
 - `switch.oneOff` and `switch.permanent` platform guidance
-- `prerequisites` for the local Codex CLI
-- `companionEnvVars[]` for the desktop runtime executor
-- `verify.endpoint` / `verify.expectDefaultAgent` for `/api/native/providers`
-- `defaults.currentDefaultProvider`
-- `defaults.codexCliOnPath`
+- `prerequisites` - Codex CLI binary, `~/.codex/config.toml`, `OPENAI_API_KEY`
+- `companionEnvVars[]` - `OPENLOOMI_AGENT_CODEX_*` variables with their
+  defaults
+- `verify.endpoint` / `verify.expectDefaultAgent` - the
+  `GET /api/native/providers` contract
+- `defaults.currentDefaultProvider` - echoes the active
+  `OPENLOOMI_AGENT_PROVIDER`
+- `defaults.codexCliOnPath` - best-effort PATH probe for the `codex` binary
 
-If a runtime-executor switch is actually required, use:
+The companion command that performs the GUI-session env write is
+`set-codex-runtime-env`:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env codex
+# Clear it later:
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env --unset
+# Plan only, do not write:
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" set-codex-runtime-env --dry-run
 ```
 
-After changing the desktop runtime environment, restart OpenLoomi and verify
-the active provider through `/api/native/providers`.
+After running `set-codex-runtime-env`, Quit and reopen `OpenLoomi.app` so the
+new env actually reaches the freshly forked web process. The env only applies
+to GUI processes launched after the env write.
 
 ### Missing Install
 
@@ -606,12 +691,12 @@ OpenLoomi initialize its guest session.
 
 The bridge attempts two guest endpoints, in order:
 
-1. `POST /api/remote-auth/guest` — the JSON bearer flow. This is the same
+1. `POST /api/remote-auth/guest` - the JSON bearer flow. This is the same
    endpoint the Claude plugin calls and the one that registers a fresh guest
    account in the OpenLoomi runtime's local database before returning a
    bearer. Prefer this when the running OpenLoomi build exposes it.
 2. `POST /api/auth/guest?redirectUrl=/` followed by `GET /api/auth/token`
-   using the `Set-Cookie` header — the legacy cookie-based flow kept for
+   using the `Set-Cookie` header - the legacy cookie-based flow kept for
    older OpenLoomi builds that don't ship the JSON endpoint. The bridge
    falls back to this path only when the JSON endpoint returns 404 or is
    unreachable before any response, so a transient 5xx or empty payload on
@@ -629,18 +714,22 @@ fields such as `hasApiKey`, `baseUrlPresent`, and `modelPresent`. If OpenLoomi
 is not running, the bridge should report `AI_PROVIDER_STATUS_UNAVAILABLE`
 instead of claiming the provider is missing.
 
-## First-Use AI Provider Setup
+## First-Use Runtime and Provider Setup
 
-The plugin should guide users through AI provider configuration when OpenLoomi
-is first used from Codex.
+The plugin should guide users toward the Codex runtime path when OpenLoomi is
+first used from Codex. This lets OpenLoomi reuse the user's existing Codex CLI
+runtime and avoids requiring a separate OpenLoomi AI provider key for the first
+plugin workflow.
 
 Preferred paths:
 
-1. Launch or guide an OpenLoomi-owned setup flow for:
+1. Set or verify `OPENLOOMI_AGENT_PROVIDER=codex` for the OpenLoomi desktop
+   runtime, then restart OpenLoomi and verify `/api/native/providers`.
+2. If the user chooses a separate AI provider fallback, launch or guide an
+   OpenLoomi-owned setup flow for:
    - base URL;
    - API key;
    - model name.
-2. Keep OpenLoomi Desktop settings as a fallback.
 
 Raw API keys must not be pasted into Codex chat. If a setup flow collects an API
 key, that input must happen in an OpenLoomi-owned UI or CLI surface that avoids
@@ -659,7 +748,7 @@ following skills under `plugins/codex/skills/`:
   and `SESSION_INITIALIZATION_REQUIRED` recovery flows.
 - `openloomi-loop`: run attention-loop and follow-up workflows.
 - `openloomi-memory`: search or write memory through OpenLoomi-owned runtime
-  surfaces. Thin wrapper — does not implement memory storage.
+  surfaces. Thin wrapper - does not implement memory storage.
 - `openloomi-connectors`: check whether Slack, GitHub, Gmail, Calendar, and
   other sources are configured before acting. Reports status only.
 - `openloomi-handoff`: send the current Codex task to Loomi for follow-up.
@@ -678,7 +767,7 @@ four workflow skills (`openloomi-loop`, `openloomi-memory`,
 `openloomi-connectors`, `openloomi-handoff`). All other skills are
 documentation or routing helpers. The plugin must not copy OpenLoomi
 connector, memory, loop, scheduling, or handoff persistence logic into
-Codex — runtime implementations stay inside the OpenLoomi desktop runtime.
+Codex - runtime implementations stay inside the OpenLoomi desktop runtime.
 
 ## Pet State Control
 
@@ -701,17 +790,17 @@ happy, idle, juggling, needsinput, presenting, sleeping, sweeping, thinking, wor
 
 Failure modes (all return structured JSON, never throw):
 
-- `MISSING_STATE` — no positional state argument.
-- `INVALID_STATE` — state not in the vocabulary; response includes
+- `MISSING_STATE` - no positional state argument.
+- `INVALID_STATE` - state not in the vocabulary; response includes
   `validStates` and `received`.
-- `TOKEN_MISSING` — `~/.openloomi/token` does not exist or is unreadable.
+- `TOKEN_MISSING` - `~/.openloomi/token` does not exist or is unreadable.
   Run `setup` or open OpenLoomi Desktop once before driving Pet state.
-- `ENDPOINT_MISSING` — runtime answered with HTTP 404. Treat as
+- `ENDPOINT_MISSING` - runtime answered with HTTP 404. Treat as
   non-blocking: the bridge returns the polite notice that the endpoint is
   pending. Pet control resumes automatically once OpenLoomi ships the route.
-- `API_UNREACHABLE` — no local API responded on 3414/3515. `attempts` lists
+- `API_UNREACHABLE` - no local API responded on 3414/3515. `attempts` lists
   every URL the bridge tried.
-- `PET_FAILED` — runtime answered but with a non-success status code.
+- `PET_FAILED` - runtime answered but with a non-success status code.
 
 The Codex plugin deliberately does **not** ship lifecycle-driven Pet
 transitions. The Claude Code plugin wires `SessionStart` / `Stop` /
@@ -733,14 +822,14 @@ side as of the current Codex plugin API.
 
 The intended Pet notification surface is:
 
-- a Codex task completes — Pet `happy`;
-- a Codex task needs user input — Pet `needsinput`;
-- a handoff has been queued for Loomi follow-up — Pet `working`;
-- OpenLoomi connector or model setup is blocking a task — Pet `thinking`.
+- a Codex task completes - Pet `happy`;
+- a Codex task needs user input - Pet `needsinput`;
+- a handoff has been queued for Loomi follow-up - Pet `working`;
+- OpenLoomi connector or model setup is blocking a task - Pet `thinking`.
 
 Until Codex adds an official lifecycle event surface, this section stays
 open. Do not ship a hand-rolled polling loop inside the Codex plugin to
-fake hooks — it would duplicate Claude-only state and conflict with the
+fake hooks - it would duplicate Claude-only state and conflict with the
 "thin wrapper, no business logic" rule.
 
 ## Secret Handling
@@ -793,7 +882,7 @@ to write the standard `~/.openloomi/token` file. It must keep the token out of
 argv, stdout, stderr, logs, and the Codex transcript.
 
 Which token-bearing endpoint the bridge ends up calling is implementation
-detail — both `POST /api/remote-auth/guest` and the cookie-based
+detail - both `POST /api/remote-auth/guest` and the cookie-based
 `POST /api/auth/guest` + `GET /api/auth/token` flow end up writing the same
 `~/.openloomi/token` file. From outside, the bridge exposes only that a
 guest/session token was obtained, not which path produced it.

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -31,6 +31,7 @@ const SESSION_BOOTSTRAP_POLL_MS = 2000;
 const SESSION_API_TIMEOUT_MS = 5000;
 const API_PROBE_TIMEOUT_MS = 1000;
 const MAX_COMMAND_OUTPUT = 4096;
+const RUN_LOCK_TTL_MS = RUN_TIMEOUT_MS + 60_000;
 const DEBUG_DISCOVERY = process.env.OPENLOOMI_DEBUG_DISCOVERY === "1";
 const OFFICIAL_RELEASE_SOURCE = {
   owner: "melandlabs",
@@ -39,6 +40,11 @@ const OFFICIAL_RELEASE_SOURCE = {
     "https://api.github.com/repos/melandlabs/openloomi/releases/latest",
   releasePage: "https://github.com/melandlabs/openloomi/releases",
 };
+
+const RUNTIME_SAFE_PROMPT_GUARD = [
+  "You are already inside the OpenLoomi runtime.",
+  "Do not call tools, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge.",
+].join(" ");
 
 const COMMANDS = new Set([
   "codex-runtime-info",
@@ -85,7 +91,7 @@ const WORKFLOW_GUIDANCE = [
     readyRequired: true,
     bridgeCommand: "run",
     taskPromptPrefix:
-      "Use OpenLoomi loop workflow for this Codex task. Keep connector and memory operations inside OpenLoomi runtime.",
+      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a loop planning request. Return the final planning result only.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -107,7 +113,7 @@ const WORKFLOW_GUIDANCE = [
     readyRequired: true,
     bridgeCommand: "run",
     taskPromptPrefix:
-      "Use OpenLoomi memory workflow for this Codex task. Keep memory reads and writes inside OpenLoomi runtime.",
+      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a memory/context request. Return only the runtime result; do not read or write memory files directly.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -150,7 +156,7 @@ const WORKFLOW_GUIDANCE = [
     readyRequired: true,
     bridgeCommand: "run",
     taskPromptPrefix:
-      "Use OpenLoomi handoff workflow for this Codex task. Create a follow-up or delegated Loomi task when supported by the runtime.",
+      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a handoff or follow-up request. Return the final runtime result only.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -1713,6 +1719,125 @@ function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt, apiBaseUrl }) {
       env: getOpenLoomiCtlChildEnv({ apiBaseUrl }),
     },
   );
+}
+
+function acquireRunLock() {
+  const lockPath = getRunLockPath();
+  const now = Date.now();
+  const lock = {
+    id: `${process.pid}-${now}-${Math.random().toString(36).slice(2)}`,
+    pid: process.pid,
+    startedAt: now,
+    command: "run",
+  };
+
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const existing = readRunLock(lockPath);
+
+    if (existing && !isRunLockStale(existing, now)) {
+      return {
+        acquired: false,
+        lockPath,
+        existing,
+      };
+    }
+
+    if (existing) {
+      removeRunLock(lockPath);
+    }
+
+    try {
+      writeFileSync(lockPath, JSON.stringify(lock), {
+        flag: "wx",
+        mode: 0o600,
+      });
+
+      return {
+        acquired: true,
+        lockPath,
+        lock,
+      };
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    acquired: false,
+    lockPath,
+    existing: readRunLock(lockPath),
+  };
+}
+
+function releaseRunLock(acquiredLock) {
+  if (!acquiredLock?.acquired) {
+    return;
+  }
+
+  const current = readRunLock(acquiredLock.lockPath);
+  if (current?.id === acquiredLock.lock.id) {
+    removeRunLock(acquiredLock.lockPath);
+  }
+}
+
+function getRunLockPath() {
+  return path.join(os.homedir(), ".openloomi", "codex-plugin-run.lock");
+}
+
+function readRunLock(lockPath) {
+  if (!isFile(lockPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileText(lockPath));
+  } catch {
+    return {
+      id: "unreadable",
+      startedAt: 0,
+      command: "run",
+    };
+  }
+}
+
+function isRunLockStale(lock, now = Date.now()) {
+  const startedAt = Number(lock?.startedAt || 0);
+  return !startedAt || now - startedAt > getRunLockTtlMs();
+}
+
+function getRunLockTtlMs() {
+  const configured = Number(process.env.OPENLOOMI_CODEX_BRIDGE_RUN_LOCK_TTL_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : RUN_LOCK_TTL_MS;
+}
+
+function removeRunLock(lockPath) {
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function summarizeRunLock(lock) {
+  if (!lock) {
+    return null;
+  }
+
+  const startedAt = Number(lock.startedAt || 0);
+  return {
+    pid: Number(lock.pid || 0) || null,
+    command: lock.command || "run",
+    ageMs: startedAt ? Math.max(0, Date.now() - startedAt) : null,
+    stale: isRunLockStale(lock),
+  };
 }
 
 function getOpenLoomiCtlChildEnv({ apiBaseUrl } = {}) {
@@ -3511,12 +3636,37 @@ async function run() {
   }
 
   const permissionMode = getPermissionMode(flags.permissionMode);
-  const result = await runOpenLoomiOneShot({
-    ctlPath: setup.ctlPath,
-    permissionMode,
-    prompt,
-    apiBaseUrl: setup.apiBaseUrl,
-  });
+  const runLock = acquireRunLock();
+
+  if (!runLock.acquired) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command: "run",
+        nextAction: "return_without_bridge",
+        reason: "RECURSION_GUARD",
+        message:
+          "A loomi-bridge run is already active. Refusing nested OpenLoomi bridge invocation.",
+        lock: summarizeRunLock(runLock.existing),
+      },
+      1,
+    );
+    return;
+  }
+
+  let result;
+
+  try {
+    result = await runOpenLoomiOneShot({
+      ctlPath: setup.ctlPath,
+      permissionMode,
+      prompt,
+      apiBaseUrl: setup.apiBaseUrl,
+    });
+  } finally {
+    releaseRunLock(runLock);
+  }
 
   if (result.exitCode !== 0) {
     writeJson(

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -29,6 +29,7 @@ const DOWNLOAD_STALL_TIMEOUT_MS = 30000;
 const SESSION_BOOTSTRAP_TIMEOUT_MS = 30000;
 const SESSION_BOOTSTRAP_POLL_MS = 2000;
 const SESSION_API_TIMEOUT_MS = 5000;
+const API_PROBE_TIMEOUT_MS = 1000;
 const MAX_COMMAND_OUTPUT = 4096;
 const DEBUG_DISCOVERY = process.env.OPENLOOMI_DEBUG_DISCOVERY === "1";
 const OFFICIAL_RELEASE_SOURCE = {
@@ -194,13 +195,13 @@ async function getCodexRuntimeEnvStatus() {
     value,
     source: probe.source,
     key: RUNTIME_ENV_KEY,
-    requiresRestart: !set && value !== null, // changed away from codex → must restart GUI to clear
+    requiresRestart: !set && value !== null, // changed away from codex 鈫?must restart GUI to clear
   };
 }
 
 // Lightweight, unconditional reachability probe. Hits the runtime's
 // guest endpoint (the same one `initialize-session` will mint through)
-// and treats any HTTP response — including 4xx — as "the daemon is
+// and treats any HTTP response 鈥?including 4xx 鈥?as "the daemon is
 // listening". Used by `buildSetupStatus` to populate `apiProbe` and
 // `apiReachable` independently of whether a session token is present.
 //
@@ -255,6 +256,12 @@ async function buildSetupStatus() {
   const aiProvider = await getAiProviderStatus(token);
   const codexRuntimeEnv = await getCodexRuntimeEnvStatus();
   const apiProbe = await probeApiReachable();
+  const runtimeBaseUrl = normalizeLocalApiUrl(aiProvider.runtime?.baseUrl);
+
+  if (!apiProbe.reachableUrl && runtimeBaseUrl) {
+    apiProbe.reachableUrl = runtimeBaseUrl;
+    apiProbe.source = "aiProviderRuntime";
+  }
 
   const baseStatus = {
     mode: discovery.mode,
@@ -266,9 +273,11 @@ async function buildSetupStatus() {
     aiProviderStatus: aiProvider.status,
     connectorStatusAvailable: false,
     apiReachable: Boolean(apiProbe.reachableUrl),
+    apiBaseUrl: apiProbe.reachableUrl,
     apiProbe: {
       reachableUrl: apiProbe.reachableUrl,
       attempts: apiProbe.attempts,
+      source: apiProbe.source,
     },
     codexRuntimeEnvSet: codexRuntimeEnv.set,
     codexRuntimeEnv: {
@@ -294,6 +303,7 @@ async function buildSetupStatus() {
       auth: token.checked,
       aiProvider: aiProvider.checked,
       aiProviderRuntime: aiProvider.runtime,
+      apiProbe: apiProbe.attempts,
       discovery: discovery.checked,
       codexRuntimeEnv: {
         key: codexRuntimeEnv.key,
@@ -301,7 +311,6 @@ async function buildSetupStatus() {
         value: codexRuntimeEnv.value,
         source: codexRuntimeEnv.source,
       },
-      apiProbe: apiProbe.attempts,
     },
   };
 
@@ -1694,13 +1703,31 @@ function getPermissionMode(value) {
   return "deny";
 }
 
-function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt }) {
+function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt, apiBaseUrl }) {
   return runCommandWithInput(
     ctlPath,
     ["--one-shot", "--stdin", "--json", "--permission-mode", permissionMode],
     prompt,
     RUN_TIMEOUT_MS,
+    {
+      env: getOpenLoomiCtlChildEnv({ apiBaseUrl }),
+    },
   );
+}
+
+function getOpenLoomiCtlChildEnv({ apiBaseUrl } = {}) {
+  const env = {};
+  const inheritedApiUrl = normalizeLocalApiUrl(process.env.OPENLOOMI_API_URL);
+  const resolvedApiUrl =
+    inheritedApiUrl ||
+    normalizeLocalApiUrl(apiBaseUrl) ||
+    normalizeLocalApiUrl(process.env.OPENLOOMI_BASE_URL);
+
+  if (resolvedApiUrl && !inheritedApiUrl) {
+    env.OPENLOOMI_API_URL = resolvedApiUrl;
+  }
+
+  return env;
 }
 
 async function initializeSession() {
@@ -2080,8 +2107,8 @@ function summarizeSessionAttempt(result) {
 
 function getLocalApiBaseUrls() {
   // Resolve API URLs in priority order:
-  //   1. OPENLOOMI_API_URL — explicit override (canonical)
-  //   2. OPENLOOMI_BASE_URL — same explicit override, used by
+  //   1. OPENLOOMI_API_URL - explicit override (canonical)
+  //   2. OPENLOOMI_BASE_URL - same explicit override, used by
   //      `apiGET/apiPOST/apiPUT` and by the integration tests'
   //      `withFakeHome` helper.
   //   3. Loopback defaults (3414 / 3515) as a last-resort discovery aid
@@ -2103,6 +2130,63 @@ function getLocalApiBaseUrls() {
     "http://localhost:3515",
     "http://127.0.0.1:3515",
   ]);
+}
+
+async function probeLocalApi() {
+  const attempts = [];
+
+  if (typeof fetch !== "function") {
+    return {
+      reachableUrl: null,
+      attempts: getLocalApiBaseUrls().map((baseUrl) => ({
+        baseUrl,
+        reason: "FETCH_UNAVAILABLE",
+      })),
+    };
+  }
+
+  for (const baseUrl of getLocalApiBaseUrls()) {
+    const result = await probeLocalApiUrl(baseUrl);
+    attempts.push(result);
+
+    if (result.reachable) {
+      return {
+        reachableUrl: baseUrl,
+        attempts,
+      };
+    }
+  }
+
+  return {
+    reachableUrl: null,
+    attempts,
+  };
+}
+
+async function probeLocalApiUrl(baseUrl) {
+  try {
+    const response = await fetchWithTimeout(
+      `${baseUrl}/api/native/providers`,
+      {
+        method: "GET",
+        redirect: "manual",
+      },
+      API_PROBE_TIMEOUT_MS,
+    );
+
+    return {
+      baseUrl,
+      status: response.status,
+      reason: "HTTP_RESPONSE",
+      reachable: true,
+    };
+  } catch (error) {
+    return {
+      baseUrl,
+      reason: error?.name === "AbortError" ? "TIMEOUT" : "NETWORK_ERROR",
+      reachable: false,
+    };
+  }
 }
 
 function normalizeLocalApiUrl(value) {
@@ -2201,8 +2285,8 @@ async function launchDesktopApp({ ctlPath, desktopMarker } = {}) {
   // Resolve launch target. On macOS, ctlPath typically lives at
   //   <Foo.app>/Contents/Resources/cli/openloomi-ctl
   // so we walk up to the .app boundary. The default helper
-  // findOpenLoomiAppForCtl() only finds executables — it never returns
-  // the .app bundle itself — so without this fallback we'd be stuck on
+  // findOpenLoomiAppForCtl() only finds executables 鈥?it never returns
+  // the .app bundle itself 鈥?so without this fallback we'd be stuck on
   // every installed macOS user.
   let appPath = desktopMarker || null;
   if (!appPath && process.platform === "darwin" && ctlPath) {
@@ -2279,7 +2363,7 @@ async function launchDesktopApp({ ctlPath, desktopMarker } = {}) {
 }
 
 // Polls the local OpenLoomi HTTP API until it answers 2xx/3xx/4xx (any
-// real HTTP response — the route being 404 still means the daemon is up)
+// real HTTP response 鈥?the route being 404 still means the daemon is up)
 // or the deadline expires. Used by setup() after launching the desktop
 // app to confirm the helper process laid down its listener.
 async function waitForApi({ timeoutMs = 30_000, pollMs = 1000 } = {}) {
@@ -2295,7 +2379,7 @@ async function waitForApi({ timeoutMs = 30_000, pollMs = 1000 } = {}) {
           signal: AbortSignal.timeout(1500),
         });
         // Any HTTP response means the daemon is listening. We don't
-        // require a specific status — the runtime may not yet expose
+        // require a specific status 鈥?the runtime may not yet expose
         // /api/health on every build, so 404 here still counts.
         return {
           ok: true,
@@ -2366,11 +2450,15 @@ function sleep(ms) {
   });
 }
 
-function runCommandWithInput(command, args, input, timeoutMs) {
+function runCommandWithInput(command, args, input, timeoutMs, options = {}) {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       shell: process.platform === "win32" && /\.(cmd|bat)$/i.test(command),
       windowsHide: true,
+      env: {
+        ...process.env,
+        ...(options.env || {}),
+      },
     });
     let stdout = "";
     let stderr = "";
@@ -2481,6 +2569,154 @@ function version() {
 }
 
 // -----------------------------------------------------------------------------
+// pet
+// -----------------------------------------------------------------------------
+
+const PET_STATES = [
+  "happy",
+  "idle",
+  "juggling",
+  "needsinput",
+  "presenting",
+  "sleeping",
+  "sweeping",
+  "thinking",
+  "working",
+];
+
+const PET_STATE_SET = new Set(PET_STATES);
+
+async function pet(args) {
+  const state = args[0];
+
+  if (!hasValue(state)) {
+    writeJson({
+      ok: false,
+      code: "MISSING_STATE",
+      validStates: PET_STATES,
+    });
+    return;
+  }
+
+  if (!PET_STATE_SET.has(state)) {
+    writeJson({
+      ok: false,
+      code: "INVALID_STATE",
+      received: state,
+      validStates: PET_STATES,
+    });
+    return;
+  }
+
+  const tokenStatus = getTokenStatus();
+  const token = readOpenLoomiAuthToken(tokenStatus);
+
+  if (!hasValue(token)) {
+    writeJson({
+      ok: false,
+      code: "TOKEN_MISSING",
+      validStates: PET_STATES,
+      message:
+        "OpenLoomi needs a local guest/session token before the Codex plugin can update Pet state.",
+    });
+    return;
+  }
+
+  const attempts = [];
+
+  for (const baseUrl of getLocalApiBaseUrls()) {
+    const result = await postPetState(baseUrl, state, token);
+    attempts.push(result.attempt);
+
+    if (result.ok) {
+      writeJson({
+        ok: true,
+        code: "PET_STATE_SET",
+        state,
+        baseUrl,
+      });
+      return;
+    }
+
+    if (result.code === "ENDPOINT_MISSING") {
+      writeJson({
+        ok: false,
+        code: "ENDPOINT_MISSING",
+        state,
+        baseUrl,
+        attempts,
+        message:
+          "OpenLoomi runtime is reachable, but the Pet state endpoint is not available in this build.",
+      });
+      return;
+    }
+
+    if (result.code === "PET_FAILED") {
+      writeJson({
+        ok: false,
+        code: "PET_FAILED",
+        state,
+        baseUrl,
+        attempts,
+      });
+      return;
+    }
+  }
+
+  writeJson({
+    ok: false,
+    code: "API_UNREACHABLE",
+    state,
+    attempts,
+  });
+}
+
+async function postPetState(baseUrl, state, token) {
+  try {
+    const response = await fetchWithTimeout(
+      `${baseUrl}/api/pet/state`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          state,
+          source: "codex-plugin",
+        }),
+      },
+      SESSION_API_TIMEOUT_MS,
+    );
+
+    const attempt = {
+      baseUrl,
+      status: response.status,
+      reason: "HTTP_RESPONSE",
+    };
+
+    if (response.ok) {
+      return { ok: true, attempt };
+    }
+
+    return {
+      ok: false,
+      code: response.status === 404 ? "ENDPOINT_MISSING" : "PET_FAILED",
+      attempt,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      code: "API_UNREACHABLE",
+      attempt: {
+        baseUrl,
+        reason: error?.name === "AbortError" ? "TIMEOUT" : "NETWORK_ERROR",
+      },
+    };
+  }
+}
+
+// -----------------------------------------------------------------------------
 // codex-runtime-info
 //
 // Static guidance for switching the OpenLoomi desktop app's agent runtime
@@ -2492,7 +2728,7 @@ function version() {
 //
 // The runtime resolution logic here intentionally mirrors
 // `apps/web/lib/ai/native-agent/provider-env.ts`:
-//   * empty / whitespace / unsupported value → "claude"
+//   * empty / whitespace / unsupported value 鈫?"claude"
 //   * normalized lower-case otherwise
 // Anything else (e.g. unknown value) is surfaced verbatim so the caller
 // can spot a typo.
@@ -2599,7 +2835,7 @@ function codexRuntimeInfo() {
     envProviderKey: CODEX_RUNTIME_INFO_KEY,
     platform,
     switch: {
-      // Current-platform snippets — kept as strings so most callers
+      // Current-platform snippets 鈥?kept as strings so most callers
       // can copy-paste directly. Field name is unchanged; type just
       // narrows from `object` to `string`.
       oneOff: oneOffByPlatform[platform] || oneOffByPlatform.darwin,
@@ -2610,7 +2846,7 @@ function codexRuntimeInfo() {
         permanent: permanentByPlatform,
       },
       notes:
-        "macOS GUI apps inherit env from launchd — `export` in a terminal does NOT reach the OpenLoomi web server. Use `launchctl setenv OPENLOOMI_AGENT_PROVIDER codex` (handled by `set-codex-runtime-env`) and then Quit + reopen OpenLoomi.app so the new env is inherited by the freshly forked web process.",
+        "macOS GUI apps inherit env from launchd 鈥?`export` in a terminal does NOT reach the OpenLoomi web server. Use `launchctl setenv OPENLOOMI_AGENT_PROVIDER codex` (handled by `set-codex-runtime-env`) and then Quit + reopen OpenLoomi.app so the new env is inherited by the freshly forked web process.",
     },
     prerequisites: CODEX_RUNTIME_PREREQUISITES,
     companionEnvVars: CODEX_RUNTIME_COMPANION_ENV_VARS,
@@ -2654,13 +2890,13 @@ function codexRuntimeInfo() {
 //   in the GUI domain followed by a Quit + reopen of OpenLoomi.app.
 //
 // Behavior:
-//   • darwin: `launchctl setenv OPENLOOMI_AGENT_PROVIDER <value>` and
+//   鈥?darwin: `launchctl setenv OPENLOOMI_AGENT_PROVIDER <value>` and
 //     confirm with `launchctl getenv` after.
-//   • linux: write to `~/.config/environment.d/openloomi-codex.conf`. The
+//   鈥?linux: write to `~/.config/environment.d/openloomi-codex.conf`. The
 //     desktop session must pick this up on next login; a running session
 //     does not see the change unless the user re-logs in or runs
 //     `systemctl --user import-environment OPENLOOMI_AGENT_PROVIDER=codex`.
-//   • win32: emit the equivalent system-env instructions; the bridge
+//   鈥?win32: emit the equivalent system-env instructions; the bridge
 //     never modifies the Windows registry directly.
 //
 // Flags:
@@ -2864,7 +3100,7 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
 
   if (platform === "win32") {
     notes.push(
-      "Windows is not automated: edit the user environment via System Settings → Environment Variables, then restart OpenLoomi.",
+      "Windows is not automated: edit the user environment via System Settings 鈫?Environment Variables, then restart OpenLoomi.",
     );
     commands.push(`setx ${key} ${value || ""}`);
     return {
@@ -2873,7 +3109,7 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
       notes,
       requiresRestart,
       manualSteps: [
-        "Open System Settings → System → About → Advanced system settings → Environment Variables.",
+        "Open System Settings 鈫?System 鈫?About 鈫?Advanced system settings 鈫?Environment Variables.",
         `Under "User variables", add (or update) ${key} with value ${value || "<empty for unset>"}.`,
         "Click OK, then Quit + reopen OpenLoomi.",
       ],
@@ -3222,7 +3458,7 @@ async function run() {
     return;
   }
 
-  const setup = await buildSetupStatus();
+  let setup = await buildSetupStatus();
 
   if (!setup.ready) {
     writeJson(
@@ -3279,6 +3515,7 @@ async function run() {
     ctlPath: setup.ctlPath,
     permissionMode,
     prompt,
+    apiBaseUrl: setup.apiBaseUrl,
   });
 
   if (result.exitCode !== 0) {
@@ -3649,6 +3886,7 @@ function getReadinessDecision(discovery, token, aiProvider, codexRuntimeEnv, api
       ready: false,
       nextAction: "open_openloomi",
       reason: "OPENLOOMI_API_UNREACHABLE",
+      sessionInitializationRequired: true,
       message:
         "OpenLoomi is installed but the local API is not reachable. Open OpenLoomi Desktop, or run `setup --yes` to install + launch + mint a guest session automatically.",
     };
@@ -4275,7 +4513,7 @@ async function petCommand(args) {
           ok: false,
           code: "ENDPOINT_MISSING",
           message:
-            `OpenLoomi runtime does not yet expose POST /api/pet/state. Pending endpoint — would have set state to '${state}'.`,
+            `OpenLoomi runtime does not yet expose POST /api/pet/state. Pending endpoint 鈥?would have set state to '${state}'.`,
           state,
         },
         0,

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -90,8 +90,7 @@ const WORKFLOW_GUIDANCE = [
     wrapperSkill: "openloomi-loop",
     readyRequired: true,
     bridgeCommand: "run",
-    taskPromptPrefix:
-      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a loop planning request. Return the final planning result only.`,
+    taskPromptPrefix: `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a loop planning request. Return the final planning result only.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -112,8 +111,7 @@ const WORKFLOW_GUIDANCE = [
     wrapperSkill: "openloomi-memory",
     readyRequired: true,
     bridgeCommand: "run",
-    taskPromptPrefix:
-      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a memory/context request. Return only the runtime result; do not read or write memory files directly.`,
+    taskPromptPrefix: `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a memory/context request. Return only the runtime result; do not read or write memory files directly.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -155,8 +153,7 @@ const WORKFLOW_GUIDANCE = [
     wrapperSkill: "openloomi-handoff",
     readyRequired: true,
     bridgeCommand: "run",
-    taskPromptPrefix:
-      `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a handoff or follow-up request. Return the final runtime result only.`,
+    taskPromptPrefix: `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a handoff or follow-up request. Return the final runtime result only.`,
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -201,13 +198,13 @@ async function getCodexRuntimeEnvStatus() {
     value,
     source: probe.source,
     key: RUNTIME_ENV_KEY,
-    requiresRestart: !set && value !== null, // changed away from codex 鈫?must restart GUI to clear
+    requiresRestart: !set && value !== null, // changed away from codex - must restart GUI to clear
   };
 }
 
 // Lightweight, unconditional reachability probe. Hits the runtime's
 // guest endpoint (the same one `initialize-session` will mint through)
-// and treats any HTTP response 鈥?including 4xx 鈥?as "the daemon is
+// and treats any HTTP response - including 4xx - as "the daemon is
 // listening". Used by `buildSetupStatus` to populate `apiProbe` and
 // `apiReachable` independently of whether a session token is present.
 //
@@ -322,7 +319,13 @@ async function buildSetupStatus() {
 
   return {
     ...baseStatus,
-    ...getReadinessDecision(discovery, token, aiProvider, codexRuntimeEnv, apiProbe),
+    ...getReadinessDecision(
+      discovery,
+      token,
+      aiProvider,
+      codexRuntimeEnv,
+      apiProbe,
+    ),
   };
 }
 
@@ -2084,9 +2087,8 @@ async function requestRemoteAuthGuestToken(baseUrl) {
       };
     }
 
-    const token = payload && typeof payload.token === "string"
-      ? payload.token.trim()
-      : "";
+    const token =
+      payload && typeof payload.token === "string" ? payload.token.trim() : "";
     if (!token) {
       return {
         baseUrl,
@@ -2108,7 +2110,9 @@ async function requestRemoteAuthGuestToken(baseUrl) {
     return {
       baseUrl,
       reason:
-        error && error.name === "AbortError" ? "API_TIMEOUT" : "API_UNREACHABLE",
+        error && error.name === "AbortError"
+          ? "API_TIMEOUT"
+          : "API_UNREACHABLE",
       path: "remote-auth-guest",
     };
   }
@@ -2387,7 +2391,11 @@ function launchOpenLoomiForSession(ctlPath) {
 function findMacAppBundleForCtl(ctlPath) {
   if (!ctlPath) return null;
   let current = path.dirname(path.resolve(ctlPath));
-  for (let index = 0; index < 8 && current && current !== path.dirname(current); index += 1) {
+  for (
+    let index = 0;
+    index < 8 && current && current !== path.dirname(current);
+    index += 1
+  ) {
     if (current.endsWith(".app") && isDirectory(current)) {
       return current;
     }
@@ -2410,8 +2418,8 @@ async function launchDesktopApp({ ctlPath, desktopMarker } = {}) {
   // Resolve launch target. On macOS, ctlPath typically lives at
   //   <Foo.app>/Contents/Resources/cli/openloomi-ctl
   // so we walk up to the .app boundary. The default helper
-  // findOpenLoomiAppForCtl() only finds executables 鈥?it never returns
-  // the .app bundle itself 鈥?so without this fallback we'd be stuck on
+  // findOpenLoomiAppForCtl() only finds executables - it never returns
+  // the .app bundle itself - so without this fallback we'd be stuck on
   // every installed macOS user.
   let appPath = desktopMarker || null;
   if (!appPath && process.platform === "darwin" && ctlPath) {
@@ -2488,7 +2496,7 @@ async function launchDesktopApp({ ctlPath, desktopMarker } = {}) {
 }
 
 // Polls the local OpenLoomi HTTP API until it answers 2xx/3xx/4xx (any
-// real HTTP response 鈥?the route being 404 still means the daemon is up)
+// real HTTP response - the route being 404 still means the daemon is up)
 // or the deadline expires. Used by setup() after launching the desktop
 // app to confirm the helper process laid down its listener.
 async function waitForApi({ timeoutMs = 30_000, pollMs = 1000 } = {}) {
@@ -2504,7 +2512,7 @@ async function waitForApi({ timeoutMs = 30_000, pollMs = 1000 } = {}) {
           signal: AbortSignal.timeout(1500),
         });
         // Any HTTP response means the daemon is listening. We don't
-        // require a specific status 鈥?the runtime may not yet expose
+        // require a specific status - the runtime may not yet expose
         // /api/health on every build, so 404 here still counts.
         return {
           ok: true,
@@ -2853,7 +2861,7 @@ async function postPetState(baseUrl, state, token) {
 //
 // The runtime resolution logic here intentionally mirrors
 // `apps/web/lib/ai/native-agent/provider-env.ts`:
-//   * empty / whitespace / unsupported value 鈫?"claude"
+//   * empty / whitespace / unsupported value -> "claude"
 //   * normalized lower-case otherwise
 // Anything else (e.g. unknown value) is surfaced verbatim so the caller
 // can spot a typo.
@@ -2891,7 +2899,8 @@ const CODEX_RUNTIME_COMPANION_ENV_VARS = [
   },
   {
     name: "OPENLOOMI_AGENT_CODEX_FULL_AUTO",
-    description: "Set `true` to allow `--full-auto` only under `bypassPermissions`.",
+    description:
+      "Set `true` to allow `--full-auto` only under `bypassPermissions`.",
   },
   {
     name: "OPENLOOMI_AGENT_CODEX_TIMEOUT_MS",
@@ -2938,8 +2947,7 @@ function codexRuntimeInfo() {
       "systemctl --user import-environment OPENLOOMI_AGENT_PROVIDER=codex",
       "( next desktop session reads it; restart OpenLoomi now )",
     ].join("\n"),
-    win32:
-      "setx OPENLOOMI_AGENT_PROVIDER codex  (then restart OpenLoomi)",
+    win32: "setx OPENLOOMI_AGENT_PROVIDER codex  (then restart OpenLoomi)",
   };
   const permanentByPlatform = {
     darwin: [
@@ -2960,18 +2968,17 @@ function codexRuntimeInfo() {
     envProviderKey: CODEX_RUNTIME_INFO_KEY,
     platform,
     switch: {
-      // Current-platform snippets 鈥?kept as strings so most callers
+      // Current-platform snippets - kept as strings so most callers
       // can copy-paste directly. Field name is unchanged; type just
       // narrows from `object` to `string`.
       oneOff: oneOffByPlatform[platform] || oneOffByPlatform.darwin,
-      permanent:
-        permanentByPlatform[platform] || permanentByPlatform.darwin,
+      permanent: permanentByPlatform[platform] || permanentByPlatform.darwin,
       perPlatform: {
         oneOff: oneOffByPlatform,
         permanent: permanentByPlatform,
       },
       notes:
-        "macOS GUI apps inherit env from launchd 鈥?`export` in a terminal does NOT reach the OpenLoomi web server. Use `launchctl setenv OPENLOOMI_AGENT_PROVIDER codex` (handled by `set-codex-runtime-env`) and then Quit + reopen OpenLoomi.app so the new env is inherited by the freshly forked web process.",
+        "macOS GUI apps inherit env from launchd - `export` in a terminal does NOT reach the OpenLoomi web server. Use `launchctl setenv OPENLOOMI_AGENT_PROVIDER codex` (handled by `set-codex-runtime-env`) and then Quit + reopen OpenLoomi.app so the new env is inherited by the freshly forked web process.",
     },
     prerequisites: CODEX_RUNTIME_PREREQUISITES,
     companionEnvVars: CODEX_RUNTIME_COMPANION_ENV_VARS,
@@ -2989,7 +2996,7 @@ function codexRuntimeInfo() {
       expectDefaultAgent: CODEX_RUNTIME_PROVIDER,
       expectAgentType: CODEX_RUNTIME_PROVIDER,
       instructions:
-        "After launching the app, GET /api/native/providers should report `defaultAgent: \"codex\"` and include a `codex` entry in `agents`. If `defaultAgent` is still `\"claude\"`, the env var did not reach the web server.",
+        'After launching the app, GET /api/native/providers should report `defaultAgent: "codex"` and include a `codex` entry in `agents`. If `defaultAgent` is still `"claude"`, the env var did not reach the web server.',
     },
     bridge: {
       name: "openloomi-codex-bridge",
@@ -3015,13 +3022,13 @@ function codexRuntimeInfo() {
 //   in the GUI domain followed by a Quit + reopen of OpenLoomi.app.
 //
 // Behavior:
-//   鈥?darwin: `launchctl setenv OPENLOOMI_AGENT_PROVIDER <value>` and
+//   - darwin: `launchctl setenv OPENLOOMI_AGENT_PROVIDER <value>` and
 //     confirm with `launchctl getenv` after.
-//   鈥?linux: write to `~/.config/environment.d/openloomi-codex.conf`. The
+//   - linux: write to `~/.config/environment.d/openloomi-codex.conf`. The
 //     desktop session must pick this up on next login; a running session
 //     does not see the change unless the user re-logs in or runs
 //     `systemctl --user import-environment OPENLOOMI_AGENT_PROVIDER=codex`.
-//   鈥?win32: emit the equivalent system-env instructions; the bridge
+//   - win32: emit the equivalent system-env instructions; the bridge
 //     never modifies the Windows registry directly.
 //
 // Flags:
@@ -3052,13 +3059,25 @@ function runCapture(command, args, { timeoutMs = 5000 } = {}) {
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
-      try { child.kill("SIGKILL"); } catch {}
+      try {
+        child.kill("SIGKILL");
+      } catch {}
     }, timeoutMs);
-    child.stdout.on("data", (c) => { stdout += c.toString("utf8"); });
-    child.stderr.on("data", (c) => { stderr += c.toString("utf8"); });
+    child.stdout.on("data", (c) => {
+      stdout += c.toString("utf8");
+    });
+    child.stderr.on("data", (c) => {
+      stderr += c.toString("utf8");
+    });
     child.on("error", (error) => {
       clearTimeout(timer);
-      resolve({ exitCode: null, signal: null, stdout, stderr, error: error.message });
+      resolve({
+        exitCode: null,
+        signal: null,
+        stdout,
+        stderr,
+        error: error.message,
+      });
     });
     child.on("close", (exitCode, signal) => {
       clearTimeout(timer);
@@ -3078,7 +3097,12 @@ async function setCodexRuntimeEnv(args) {
   const beforeProbe = await probeRuntimeEnvValue(key);
   const beforeValue = beforeProbe.value;
 
-  const plan = planRuntimeEnvChange({ platform: process.platform, key, value, flags });
+  const plan = planRuntimeEnvChange({
+    platform: process.platform,
+    key,
+    value,
+    flags,
+  });
 
   if (flags.dryRun) {
     return writeJson({
@@ -3104,21 +3128,24 @@ async function setCodexRuntimeEnv(args) {
       stderr: (r.stderr || "").trim() || null,
     });
     if (r.exitCode !== 0) {
-      return writeJson({
-        ok: false,
-        platform: process.platform,
-        key,
-        value,
-        before: beforeValue,
-        error: {
-          stage: action.label,
-          exitCode: r.exitCode,
-          stderr: (r.stderr || "").trim() || null,
+      return writeJson(
+        {
+          ok: false,
+          platform: process.platform,
+          key,
+          value,
+          before: beforeValue,
+          error: {
+            stage: action.label,
+            exitCode: r.exitCode,
+            stderr: (r.stderr || "").trim() || null,
+          },
+          actions: executed,
+          notes: plan.notes,
+          commands: plan.commands,
         },
-        actions: executed,
-        notes: plan.notes,
-        commands: plan.commands,
-      }, 1);
+        1,
+      );
     }
   }
 
@@ -3180,15 +3207,15 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
   const requiresRestart = true;
 
   if (platform === "darwin") {
-    const args = flags.unset
-      ? ["unsetenv", key]
-      : ["setenv", key, value];
+    const args = flags.unset ? ["unsetenv", key] : ["setenv", key, value];
     actions.push({
       label: flags.unset ? "launchctl unsetenv" : "launchctl setenv",
       command: "launchctl",
       args,
     });
-    commands.push(`launchctl ${flags.unset ? "unsetenv" : "setenv"} ${key}${value ? " " + value : ""}`);
+    commands.push(
+      `launchctl ${flags.unset ? "unsetenv" : "setenv"} ${key}${value ? " " + value : ""}`,
+    );
     notes.push(
       flags.unset
         ? "Cleared OPENLOOMI_AGENT_PROVIDER from the GUI launchd domain."
@@ -3208,24 +3235,33 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
     if (flags.unset) {
       actions.push({ label: "rm env file", command: "rm", args: ["-f", file] });
       commands.push(`rm -f ${dir}/${LINUX_ENV_FILE}`);
-      notes.push("Removed the per-user env file. A re-login is required for the desktop session to drop the variable.");
+      notes.push(
+        "Removed the per-user env file. A re-login is required for the desktop session to drop the variable.",
+      );
       return { actions, commands, notes, requiresRestart };
     }
     actions.push({
       label: "write env file",
       command: "/bin/sh",
-      args: ["-c", `mkdir -p '${dir}' && printf '%s\n' '${key}=${value}' > '${dir}/${LINUX_ENV_FILE}'`],
+      args: [
+        "-c",
+        `mkdir -p '${dir}' && printf '%s\n' '${key}=${value}' > '${dir}/${LINUX_ENV_FILE}'`,
+      ],
     });
-    commands.push(`printf '%s\n' '${key}=${value}' >> ${dir}/${LINUX_ENV_FILE}`);
+    commands.push(
+      `printf '%s\n' '${key}=${value}' >> ${dir}/${LINUX_ENV_FILE}`,
+    );
     notes.push(
-      "Wrote the per-user env file. Run `systemctl --user import-environment " + key + "` (or re-login) so the current desktop session picks it up.",
+      "Wrote the per-user env file. Run `systemctl --user import-environment " +
+        key +
+        "` (or re-login) so the current desktop session picks it up.",
     );
     return { actions, commands, notes, requiresRestart };
   }
 
   if (platform === "win32") {
     notes.push(
-      "Windows is not automated: edit the user environment via System Settings 鈫?Environment Variables, then restart OpenLoomi.",
+      "Windows is not automated: edit the user environment via System Settings -> Environment Variables, then restart OpenLoomi.",
     );
     commands.push(`setx ${key} ${value || ""}`);
     return {
@@ -3234,7 +3270,7 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
       notes,
       requiresRestart,
       manualSteps: [
-        "Open System Settings 鈫?System 鈫?About 鈫?Advanced system settings 鈫?Environment Variables.",
+        "Open System Settings -> System -> About -> Advanced system settings -> Environment Variables.",
         `Under "User variables", add (or update) ${key} with value ${value || "<empty for unset>"}.`,
         "Click OK, then Quit + reopen OpenLoomi.",
       ],
@@ -3397,7 +3433,7 @@ async function setup(args) {
           status,
           install: r.parsed,
           message:
-            (r.parsed?.message) ||
+            r.parsed?.message ||
             "OpenLoomi installation did not complete. Follow the reported nextAction.",
         });
         return;
@@ -3406,7 +3442,7 @@ async function setup(args) {
     }
 
     // 2. Set OPENLOOMI_AGENT_PROVIDER=codex in the host GUI launchd /
-    //    environment.d / registry. On macOS the change only affects
+    //    environment.d, or return Windows user-env guidance. On macOS the change only affects
     //    processes started AFTER launchctl setenv, so we additionally
     //    return runtime_env_set_pending_restart when we know the GUI is
     //    already running.
@@ -3415,10 +3451,9 @@ async function setup(args) {
         reason: status.reason,
         codexRuntimeEnvSet: false,
       });
-      const r = await runBridgeSubcommand(
-        ["set-codex-runtime-env", "codex"],
-        { timeoutMs: 10_000 },
-      );
+      const r = await runBridgeSubcommand(["set-codex-runtime-env", "codex"], {
+        timeoutMs: 10_000,
+      });
       const ok = r.ok && r.parsed && r.parsed.ok === true;
       record("runtime_env", ok, {
         code: r.code,
@@ -3434,7 +3469,7 @@ async function setup(args) {
           status,
           runtimeEnv: r.parsed,
           message:
-            (r.parsed?.message) ||
+            r.parsed?.message ||
             "Failed to write OPENLOOMI_AGENT_PROVIDER=codex to the host environment. Follow the manual steps in codex-runtime-info.",
         });
         return;
@@ -3504,11 +3539,7 @@ async function setup(args) {
 
     // 4. Installed, API reachable, no token yet -> ask the local OpenLoomi
     //    API to mint a guest/session bearer.
-    if (
-      status.installed &&
-      status.apiReachable &&
-      !status.tokenPresent
-    ) {
+    if (status.installed && status.apiReachable && !status.tokenPresent) {
       record("status_check", false, { reason: status.reason });
       const r = await runBridgeSubcommand(["initialize-session"], {
         timeoutMs: maxWaitMs + 10_000,
@@ -3996,7 +4027,13 @@ async function validateCtlPath(candidate, options) {
   };
 }
 
-function getReadinessDecision(discovery, token, aiProvider, codexRuntimeEnv, apiProbe) {
+function getReadinessDecision(
+  discovery,
+  token,
+  aiProvider,
+  codexRuntimeEnv,
+  apiProbe,
+) {
   // codexRuntimeEnv is intentionally NOT a gate here: a missing
   // OPENLOOMI_AGENT_PROVIDER only blocks the OpenLoomi GUI desktop from
   // routing through Codex; the bridge itself can still drive openloomi-ctl.
@@ -4662,8 +4699,7 @@ async function petCommand(args) {
         {
           ok: false,
           code: "ENDPOINT_MISSING",
-          message:
-            `OpenLoomi runtime does not yet expose POST /api/pet/state. Pending endpoint 鈥?would have set state to '${state}'.`,
+          message: `OpenLoomi runtime does not yet expose POST /api/pet/state. Pending endpoint - would have set state to '${state}'.`,
           state,
         },
         0,

--- a/plugins/codex/skills/openloomi-feature-guide/SKILL.md
+++ b/plugins/codex/skills/openloomi-feature-guide/SKILL.md
@@ -663,16 +663,17 @@ A: Automatically extracted important information from your conversations, includ
 
 ### Q: How do I switch the desktop app to use the Codex CLI as its agent runtime?
 
-A: This is an advanced runtime-executor setting. It is not required for the
-Codex plugin to connect to OpenLoomi.
+A: When OpenLoomi is used from Codex, the Codex runtime is the recommended
+desktop runtime. It lets OpenLoomi reuse the user's existing Codex CLI runtime
+instead of requiring a separate OpenLoomi AI provider key for the first plugin
+workflow.
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 ```
 
-Follow the returned platform-specific guidance only when the user explicitly
-asks to switch the desktop runtime executor, then verify the active provider
-through `/api/native/providers`.
+Follow the returned platform-specific guidance, restart OpenLoomi, then verify
+the active provider through `/api/native/providers`.
 
 ### Q: How do I create automation tasks?
 

--- a/plugins/codex/skills/openloomi-feature-guide/SKILL.md
+++ b/plugins/codex/skills/openloomi-feature-guide/SKILL.md
@@ -663,33 +663,16 @@ A: Automatically extracted important information from your conversations, includ
 
 ### Q: How do I switch the desktop app to use the Codex CLI as its agent runtime?
 
-A: The packaged OpenLoomi Desktop defaults to the Claude agent runtime. To
-make it drive the local Codex CLI instead, export `OPENLOOMI_AGENT_PROVIDER=codex`
-in the shell that opens the app, then launch OpenLoomi from that same shell:
+A: This is an advanced runtime-executor setting. It is not required for the
+Codex plugin to connect to OpenLoomi.
 
 ```bash
-export OPENLOOMI_AGENT_PROVIDER=codex
-open /Applications/openloomi.app
+node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 ```
 
-For a permanent switch, add the export to your shell rc (`~/.zshrc`,
-`~/.bashrc`). Optional companion variables let you pick the Codex model,
-profile, sandbox mode, approval policy, CLI path, and timeout — all read
-from the shell environment at launch time:
-
-- `OPENLOOMI_AGENT_CODEX_COMMAND` — path to the Codex CLI (default `codex` on `PATH`)
-- `OPENLOOMI_AGENT_CODEX_MODEL` — e.g. `gpt-5.4`
-- `OPENLOOMI_AGENT_CODEX_PROFILE` — passed as `-p <name>`
-- `OPENLOOMI_AGENT_CODEX_SANDBOX` — `read-only` | `workspace-write` | `danger-full-access`
-- `OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL` — `untrusted` | `on-failure` | `on-request` | `never`
-- `OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK` — default `true`
-- `OPENLOOMI_AGENT_CODEX_FULL_AUTO` — default `false`
-- `OPENLOOMI_AGENT_CODEX_TIMEOUT_MS` — CLI runtime budget in ms
-
-Prerequisites: a working Codex CLI binary on `PATH`, a configured
-`~/.codex/config.toml`, and `OPENAI_API_KEY` (or Codex CLI's other auth)
-available to the spawned process. After launch, hit
-`GET /api/native/providers` and confirm `defaultAgent` is `codex`.
+Follow the returned platform-specific guidance only when the user explicitly
+asks to switch the desktop runtime executor, then verify the active provider
+through `/api/native/providers`.
 
 ### Q: How do I create automation tasks?
 

--- a/plugins/codex/skills/openloomi-handoff/SKILL.md
+++ b/plugins/codex/skills/openloomi-handoff/SKILL.md
@@ -23,12 +23,14 @@ node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" setup-status
 ```
 
 If `ready: false`, follow the reported `nextAction` before attempting handoff.
-When `ready: true`, pass the handoff request over stdin:
+When `ready: true`, wrap the handoff request with the `taskPromptPrefix`
+returned by `workflow-guidance`, then pass that runtime-safe prompt over stdin:
 
 ```bash
-printf "%s" "<handoff request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
+printf "%s" "<taskPromptPrefix>\n\nOriginal user request: <handoff request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
 ```
 
-Include enough task context for OpenLoomi to create a follow-up, but do not
-include secrets. OpenLoomi runtime owns handoff persistence and notification
-routing.
+Do not send wording that asks the inner runtime to invoke Codex plugins,
+OpenLoomi plugins, skills, shell commands, or `loomi-bridge`. Include enough
+task context for OpenLoomi to create a follow-up, but do not include secrets.
+OpenLoomi runtime owns handoff persistence and notification routing.

--- a/plugins/codex/skills/openloomi-install/SKILL.md
+++ b/plugins/codex/skills/openloomi-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openloomi-install
-description: "OpenLoomi install & first-use setup helper for Codex. Use when the user wants to install OpenLoomi, configure it, or troubleshoot `INSTALL_REQUIRED` / `SOURCE_FOUND_CLI_NOT_BUILT` / `AI_PROVIDER_REQUIRED` / `SESSION_INITIALIZATION_REQUIRED` after running setup-status. Triggers: install openloomi, 配置 openloomi, setup openloomi, openloomi not installed, openloomi not finalized, install_required, install missing, AI provider setup, guest session."
+description: "OpenLoomi install & first-use setup helper for Codex. Use when the user wants to install OpenLoomi, configure it, or troubleshoot `INSTALL_REQUIRED` / `SOURCE_FOUND_CLI_NOT_BUILT` / `AI_PROVIDER_REQUIRED` / `SESSION_INITIALIZATION_REQUIRED` after running setup-status. Triggers: install openloomi, configure openloomi, setup openloomi, openloomi not installed, openloomi not finalized, install_required, install missing, AI provider setup, guest session."
 allowed-tools: "Bash(node $SKILL_DIR/../../scripts/loomi-bridge.mjs *)"
 ---
 
@@ -19,56 +19,23 @@ or executes anything outside the plugin's own scripts.
 |---|---|
 | `install_openloomi` / `INSTALL_REQUIRED` | OpenLoomi Desktop is not on this machine. Call `install-instructions` to show the platform plan. Only call `install-openloomi --confirm` after the user explicitly approves installation. |
 | `SOURCE_FOUND_CLI_NOT_BUILT` | A source checkout is present but `openloomi-ctl` is not built. Recommend either building the source (`pnpm tauri:dev` / `pnpm build` per the OpenLoomi repo's `apps/web/src-tauri/README.md`) or installing the packaged Desktop release. |
-| `open_openloomi` / `SESSION_INITIALIZATION_REQUIRED` | OpenLoomi is installed but the local guest/session token could not be created. Ask the user to open OpenLoomi Desktop once so the local API can mint a guest session, then re-run `setup-status`. |
+| `open_openloomi` / `OPENLOOMI_API_UNREACHABLE` / `SESSION_INITIALIZATION_REQUIRED` | OpenLoomi is installed but the local API or guest/session token is not ready. Ask the user to open OpenLoomi Desktop once, or run `setup` so the bridge can launch/init through OpenLoomi-owned surfaces. |
 | `open_openloomi_ai_provider_setup` / `AI_PROVIDER_REQUIRED` | Walk the user through `configure-ai-provider`. Never pass an API key in argv. Secret entry must happen in OpenLoomi-owned UI / interactive CLI surfaces. |
 | `AI_PROVIDER_STATUS_UNAVAILABLE` | The local OpenLoomi API is not reachable, so the bridge cannot confirm whether provider settings are saved. Ask the user to open OpenLoomi Desktop and re-run `setup-status`. |
-| `run` / `READY_SESSION_BOOTSTRAP_PENDING` | Nothing to install. The bridge will bootstrap a guest session on the next `run`. |
+| `run` / `READY_SESSION_BOOTSTRAP_PENDING` | Nothing to install. The bridge will bootstrap a guest session on the next `run` when the local API is reachable. |
+
+## Runtime executor switch
+
+If the user explicitly asks to switch the desktop runtime executor to Codex,
+or diagnostics show a native-agent provider mismatch, call:
+
+```bash
+node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
+```
 
 ## Reminder: secrets contract
 
 - The bridge reads `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `OPENLOOMI_AUTH_TOKEN` etc. only as presence flags; values are never printed.
 - If the user pastes a key into chat, redact it: do NOT echo it back, and tell them to remove it from chat history.
-- Never pass `--api-key` as an argv flag — the bridge has no such flag, by design.
+- Never pass `--api-key` as an argv flag. The bridge has no such flag, by design.
 - The bridge does not auto-install. Always require an explicit user confirmation before calling `install-openloomi --confirm`.
-
----
-
-
-## Launching the desktop app with the Codex runtime
-
-The packaged desktop app defaults to the Claude provider. To switch its
-agent runtime to the Codex CLI, export `OPENLOOMI_AGENT_PROVIDER=codex` in
-the shell that opens the app so the variable reaches the Tauri-launched
-web server:
-
-```bash
-export OPENLOOMI_AGENT_PROVIDER=codex
-open /Applications/openloomi.app
-```
-
-For a permanent switch, add it to your shell rc (`~/.zshrc`):
-
-```bash
-echo 'export OPENLOOMI_AGENT_PROVIDER=codex' >> ~/.zshrc
-```
-
-Optional companion variables (read by the native-agent env resolver at
-startup):
-
-- `OPENLOOMI_AGENT_CODEX_COMMAND` — path to the Codex CLI binary (default: `codex` on `PATH`)
-- `OPENLOOMI_AGENT_CODEX_MODEL` — e.g. `gpt-5.4`
-- `OPENLOOMI_AGENT_CODEX_PROFILE` — passed as `-p <name>`
-- `OPENLOOMI_AGENT_CODEX_SANDBOX` — `read-only` | `workspace-write` | `danger-full-access` (default `workspace-write`; plan phase is always forced to `read-only`)
-- `OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL` — `untrusted` | `on-failure` | `on-request` | `never` (default `on-request`)
-- `OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK` — default `true`
-- `OPENLOOMI_AGENT_CODEX_FULL_AUTO` — set `true` to allow `--full-auto` only under `bypassPermissions`
-- `OPENLOOMI_AGENT_CODEX_TIMEOUT_MS` — CLI runtime budget in milliseconds
-
-### Prerequisites
-
-- `which codex` resolves to a working Codex CLI binary (`brew install --cask codex` or `npm i -g @openai/codex`).
-- `~/.codex/config.toml` is configured and `OPENAI_API_KEY` (or Codex CLI's other auth) is available to the spawned process.
-
-### Verify
-
-After launch, `GET /api/native/providers` should report `defaultAgent: "codex"` and include a `codex` entry in `agents`. If you still see `defaultAgent: "claude"`, the env var did not reach the web server — relaunch from a shell that has the export set, or check that the launcher script is not stripping the environment.

--- a/plugins/codex/skills/openloomi-install/SKILL.md
+++ b/plugins/codex/skills/openloomi-install/SKILL.md
@@ -20,14 +20,15 @@ or executes anything outside the plugin's own scripts.
 | `install_openloomi` / `INSTALL_REQUIRED` | OpenLoomi Desktop is not on this machine. Call `install-instructions` to show the platform plan. Only call `install-openloomi --confirm` after the user explicitly approves installation. |
 | `SOURCE_FOUND_CLI_NOT_BUILT` | A source checkout is present but `openloomi-ctl` is not built. Recommend either building the source (`pnpm tauri:dev` / `pnpm build` per the OpenLoomi repo's `apps/web/src-tauri/README.md`) or installing the packaged Desktop release. |
 | `open_openloomi` / `OPENLOOMI_API_UNREACHABLE` / `SESSION_INITIALIZATION_REQUIRED` | OpenLoomi is installed but the local API or guest/session token is not ready. Ask the user to open OpenLoomi Desktop once, or run `setup` so the bridge can launch/init through OpenLoomi-owned surfaces. |
-| `open_openloomi_ai_provider_setup` / `AI_PROVIDER_REQUIRED` | Walk the user through `configure-ai-provider`. Never pass an API key in argv. Secret entry must happen in OpenLoomi-owned UI / interactive CLI surfaces. |
+| `open_openloomi_ai_provider_setup` / `AI_PROVIDER_REQUIRED` | Prefer the Codex runtime path first: call `codex-runtime-info`, guide the user through the platform-specific runtime switch, then verify `/api/native/providers`. If the user chooses a separate AI provider fallback, walk them through `configure-ai-provider`. Never pass an API key in argv. Secret entry must happen in OpenLoomi-owned UI / interactive CLI surfaces. |
 | `AI_PROVIDER_STATUS_UNAVAILABLE` | The local OpenLoomi API is not reachable, so the bridge cannot confirm whether provider settings are saved. Ask the user to open OpenLoomi Desktop and re-run `setup-status`. |
 | `run` / `READY_SESSION_BOOTSTRAP_PENDING` | Nothing to install. The bridge will bootstrap a guest session on the next `run` when the local API is reachable. |
 
-## Advanced runtime executor diagnostics
+## Codex runtime setup
 
-If the user explicitly asks to switch the desktop runtime executor to Codex,
-or diagnostics show a native-agent provider mismatch, call:
+If the user is setting up OpenLoomi from Codex, explicitly asks to switch the
+desktop runtime executor to Codex, or diagnostics show a native-agent provider
+mismatch, call:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info

--- a/plugins/codex/skills/openloomi-install/SKILL.md
+++ b/plugins/codex/skills/openloomi-install/SKILL.md
@@ -24,7 +24,7 @@ or executes anything outside the plugin's own scripts.
 | `AI_PROVIDER_STATUS_UNAVAILABLE` | The local OpenLoomi API is not reachable, so the bridge cannot confirm whether provider settings are saved. Ask the user to open OpenLoomi Desktop and re-run `setup-status`. |
 | `run` / `READY_SESSION_BOOTSTRAP_PENDING` | Nothing to install. The bridge will bootstrap a guest session on the next `run` when the local API is reachable. |
 
-## Runtime executor switch
+## Advanced runtime executor diagnostics
 
 If the user explicitly asks to switch the desktop runtime executor to Codex,
 or diagnostics show a native-agent provider mismatch, call:

--- a/plugins/codex/skills/openloomi-loop/SKILL.md
+++ b/plugins/codex/skills/openloomi-loop/SKILL.md
@@ -27,11 +27,15 @@ loop task yet. Guest/session initialization must happen through OpenLoomi-owned
 surfaces. Never ask for API keys, OAuth tokens, connector secrets, or
 OpenLoomi auth tokens in Codex chat.
 
-When `ready: true`, pass the user request over stdin to the bridge:
+When `ready: true`, wrap the user request with the `taskPromptPrefix` returned
+by `workflow-guidance`, then pass that runtime-safe prompt over stdin to the
+bridge:
 
 ```bash
-printf "%s" "<user loop request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
+printf "%s" "<taskPromptPrefix>\n\nOriginal user request: <user loop request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
 ```
 
-Frame the request as an OpenLoomi loop task. Keep all persistence, connector
-state, memory access, and follow-up scheduling inside OpenLoomi runtime.
+Do not send wording that asks the inner runtime to invoke Codex plugins,
+OpenLoomi plugins, skills, shell commands, or `loomi-bridge`. Keep all
+persistence, connector state, memory access, and follow-up scheduling inside
+OpenLoomi runtime.

--- a/plugins/codex/skills/openloomi-memory/SKILL.md
+++ b/plugins/codex/skills/openloomi-memory/SKILL.md
@@ -26,12 +26,15 @@ If `ready: false`, follow the reported `nextAction`. Connector setup and
 guest/session initialization must happen through OpenLoomi-owned surfaces, not
 Codex chat.
 
-When `ready: true`, pass the user request over stdin to the bridge:
+When `ready: true`, wrap the user request with the `taskPromptPrefix` returned
+by `workflow-guidance`, then pass that runtime-safe prompt over stdin to the
+bridge:
 
 ```bash
-printf "%s" "<user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
+printf "%s" "<taskPromptPrefix>\n\nOriginal user request: <user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
 ```
 
-Only show memory content when OpenLoomi runtime returns it for the requested
-task. Keep secrets and connector credentials out of prompts, argv, stdout, and
-stderr.
+Do not send wording that asks the inner runtime to invoke Codex plugins,
+OpenLoomi plugins, skills, shell commands, or `loomi-bridge`. Only show memory
+content when OpenLoomi runtime returns it for the requested task. Keep secrets
+and connector credentials out of prompts, argv, stdout, and stderr.

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -114,41 +114,15 @@ login token in Codex chat.
 
 ---
 
-
 ## Launching the desktop app with the Codex runtime
 
-The packaged desktop app defaults to the Claude provider. To switch its
-agent runtime to the Codex CLI, export `OPENLOOMI_AGENT_PROVIDER=codex` in
-the shell that opens the app so the variable reaches the Tauri-launched
-web server:
+When the user asks to make OpenLoomi spawn Codex as the native-agent executor,
+or diagnostics show a runtime executor mismatch, call:
 
 ```bash
-export OPENLOOMI_AGENT_PROVIDER=codex
-open /Applications/openloomi.app
+node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 ```
 
-For a permanent switch, add it to your shell rc (`~/.zshrc`):
-
-```bash
-echo 'export OPENLOOMI_AGENT_PROVIDER=codex' >> ~/.zshrc
-```
-
-Optional companion variables (read by the native-agent env resolver at
-startup):
-
-- `OPENLOOMI_AGENT_CODEX_COMMAND` — path to the Codex CLI binary (default: `codex` on `PATH`)
-- `OPENLOOMI_AGENT_CODEX_MODEL` — e.g. `gpt-5.4`
-- `OPENLOOMI_AGENT_CODEX_PROFILE` — passed as `-p <name>`
-- `OPENLOOMI_AGENT_CODEX_SANDBOX` — `read-only` | `workspace-write` | `danger-full-access` (default `workspace-write`; plan phase is always forced to `read-only`)
-- `OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK` — default `true`
-- `OPENLOOMI_AGENT_CODEX_FULL_AUTO` — set `true` to allow `--full-auto` only under `bypassPermissions`
-- `OPENLOOMI_AGENT_CODEX_TIMEOUT_MS` — CLI runtime budget in milliseconds
-
-### Prerequisites
-
-- `which codex` resolves to a working Codex CLI binary (`brew install --cask codex` or `npm i -g @openai/codex`).
-- `~/.codex/config.toml` is configured and `OPENAI_API_KEY` (or Codex CLI's other auth) is available to the spawned process.
-
-### Verify
-
-After launch, `GET /api/native/providers` should report `defaultAgent: "codex"` and include a `codex` entry in `agents`. If you still see `defaultAgent: "claude"`, the env var did not reach the web server — relaunch from a shell that has the export set, or check that the launcher script is not stripping the environment.
+Show the returned platform-specific guidance and make clear that
+`set-codex-runtime-env` changes the desktop runtime environment outside the
+current Codex turn.

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -114,15 +114,18 @@ login token in Codex chat.
 
 ---
 
-## Advanced runtime executor diagnostics
+## Launching the desktop app with the Codex runtime
+
+When OpenLoomi is used from Codex, prefer the desktop Codex runtime so
+OpenLoomi can reuse the user's existing Codex CLI runtime instead of requiring
+a separate OpenLoomi AI provider setup for the first workflow.
 
 When the user asks to make OpenLoomi spawn Codex as the native-agent executor,
-or diagnostics show a runtime executor mismatch, call:
+or diagnostics show that the desktop runtime is not using Codex, call:
 
 ```bash
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 ```
 
-Show the returned platform-specific guidance only for that advanced runtime
-executor case. The standard Codex plugin flow does not require switching the
-desktop runtime provider.
+Show the returned platform-specific guidance, then ask the user to restart
+OpenLoomi and verify `/api/native/providers` reports `defaultAgent: "codex"`.

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -114,7 +114,7 @@ login token in Codex chat.
 
 ---
 
-## Launching the desktop app with the Codex runtime
+## Advanced runtime executor diagnostics
 
 When the user asks to make OpenLoomi spawn Codex as the native-agent executor,
 or diagnostics show a runtime executor mismatch, call:
@@ -123,6 +123,6 @@ or diagnostics show a runtime executor mismatch, call:
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" codex-runtime-info
 ```
 
-Show the returned platform-specific guidance and make clear that
-`set-codex-runtime-env` changes the desktop runtime environment outside the
-current Codex turn.
+Show the returned platform-specific guidance only for that advanced runtime
+executor case. The standard Codex plugin flow does not require switching the
+desktop runtime provider.

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -123,6 +123,25 @@ function writeFakeToken(home) {
   writeFileSync(join(dir, 'token'), Buffer.from('fake-openloomi-token', 'utf8').toString('base64'));
 }
 
+function getRunLockPath(home) {
+  return join(home, '.openloomi', 'codex-plugin-run.lock');
+}
+
+function writeRunLock(home, { startedAt = Date.now(), pid = 99999 } = {}) {
+  const lockPath = getRunLockPath(home);
+  mkdirSync(dirname(lockPath), { recursive: true });
+  writeFileSync(
+    lockPath,
+    JSON.stringify({
+      id: `test-lock-${startedAt}`,
+      pid,
+      startedAt,
+      command: 'run',
+    }),
+  );
+  return lockPath;
+}
+
 function writeFakeCtl(home) {
   const nodeScript = join(home, 'fake-openloomi-ctl.mjs');
   writeFileSync(
@@ -307,6 +326,64 @@ test('run injects OPENLOOMI_API_URL from OPENLOOMI_BASE_URL for openloomi-ctl', 
   });
 });
 
+test('run refuses nested bridge invocation when an active run lock exists', () => {
+  withFakeHome((env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+    writeRunLock(env.HOME);
+    const r = runOutcomeWithInput(
+      ['run'],
+      {
+        ...env,
+        OPENLOOMI_CTL: ctl,
+        ANTHROPIC_API_KEY: 'sk-test-never-print',
+      },
+      'Nested request should be refused.',
+    );
+    assert.equal(r.code, 1);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.reason, 'RECURSION_GUARD');
+    assert.equal(j.ran, false);
+    assert.equal(j.command, 'run');
+    assert.equal(j.nextAction, 'return_without_bridge');
+    assert.ok(!r.stdout.includes('sk-test-never-print'));
+  });
+});
+
+test('run cleans stale lock and proceeds', () => {
+  withFakeHome((env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+    const lockPath = writeRunLock(env.HOME, {
+      startedAt: Date.now() - 10_000,
+    });
+    const r = runOutcomeWithInput(
+      ['run'],
+      {
+        ...env,
+        OPENLOOMI_CTL: ctl,
+        OPENLOOMI_CODEX_BRIDGE_RUN_LOCK_TTL_MS: '1',
+        ANTHROPIC_API_KEY: 'sk-test-never-print',
+      },
+      'Stale lock should be ignored.',
+    );
+    assert.equal(r.code, 0, r.stderr || r.stdout);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.reason, 'RUN_COMPLETE');
+    assert.equal(j.result.prompt, 'Stale lock should be ignored.');
+    assert.equal(existsSync(lockPath), false, 'run lock should be released');
+  });
+});
+
+test('setup-status is not blocked by an active run lock', () => {
+  withFakeHome((env) => {
+    writeRunLock(env.HOME);
+    const j = runJson(['setup-status'], env);
+    assert.notEqual(j.reason, 'RECURSION_GUARD');
+    assert.ok('ready' in j);
+  });
+});
+
 // -----------------------------------------------------------------------------
 // install-instructions / workflow-guidance
 // -----------------------------------------------------------------------------
@@ -345,6 +422,17 @@ test('workflow-guidance lists the four openloomi workflows', () => {
 // -----------------------------------------------------------------------------
 // Secrets contract — the plugin must never echo API key / token values
 // -----------------------------------------------------------------------------
+
+test('workflow-guidance uses runtime-safe run prompts for agent workflows', () => {
+  for (const workflow of ['openloomi-loop', 'openloomi-memory', 'openloomi-handoff']) {
+    const j = runJson(['workflow-guidance', '--workflow', workflow]);
+    const prefix = j.workflow?.taskPromptPrefix || '';
+    assert.match(prefix, /already inside the OpenLoomi runtime/);
+    assert.match(prefix, /Do not call tools, shell, skills/);
+    assert.match(prefix, /loomi-bridge/);
+    assert.doesNotMatch(prefix, /^Use OpenLoomi .* workflow/);
+  }
+});
 
 test('secrets contract: fake key value never appears in any subcommand output', () => {
   withFakeHome((env) => {

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -632,15 +632,17 @@ test('codex-runtime-info returns the desktop-app Codex runtime switch plan', () 
   const j = runJson(['codex-runtime-info']);
   assert.equal(j.purpose.startsWith('Switch the OpenLoomi desktop app'), true);
   assert.equal(j.envProviderKey, 'OPENLOOMI_AGENT_PROVIDER');
-  assert.equal(typeof j.switch.oneOff, 'object');
-  assert.match(j.switch.oneOff.darwin, /OPENLOOMI_AGENT_PROVIDER codex/);
-  assert.match(j.switch.oneOff.darwin, /\/Applications\/openloomi\.app/);
-  assert.match(j.switch.oneOff.linux, /OPENLOOMI_AGENT_PROVIDER=codex/);
-  assert.match(j.switch.oneOff.win32, /OPENLOOMI_AGENT_PROVIDER codex/);
-  assert.equal(typeof j.switch.permanent, 'object');
-  assert.match(j.switch.permanent.darwin, /~\/\.zshrc/);
-  assert.match(j.switch.permanent.linux, /environment\.d/);
-  assert.match(j.switch.permanent.win32, /environment variables/i);
+  assert.equal(typeof j.switch.oneOff, 'string');
+  assert.equal(typeof j.switch.permanent, 'string');
+  assert.equal(typeof j.switch.perPlatform.oneOff, 'object');
+  assert.match(j.switch.perPlatform.oneOff.darwin, /OPENLOOMI_AGENT_PROVIDER codex/);
+  assert.match(j.switch.perPlatform.oneOff.darwin, /\/Applications\/openloomi\.app/);
+  assert.match(j.switch.perPlatform.oneOff.linux, /OPENLOOMI_AGENT_PROVIDER=codex/);
+  assert.match(j.switch.perPlatform.oneOff.win32, /OPENLOOMI_AGENT_PROVIDER codex/);
+  assert.equal(typeof j.switch.perPlatform.permanent, 'object');
+  assert.match(j.switch.perPlatform.permanent.darwin, /~\/\.zshrc/);
+  assert.match(j.switch.perPlatform.permanent.linux, /environment\.d/);
+  assert.match(j.switch.perPlatform.permanent.win32, /environment variables/i);
   assert.ok(Array.isArray(j.prerequisites) && j.prerequisites.length >= 3);
   const varNames = j.companionEnvVars.map((entry) => entry.name);
   for (const expected of [

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -15,7 +15,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { join, dirname, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -29,6 +29,7 @@ function run(args, env = {}) {
   return execFileSync('node', [BRIDGE, ...args], {
     encoding: 'utf8',
     env: { ...process.env, ...env },
+    cwd: env.BRIDGE_TEST_CWD || process.cwd(),
   });
 }
 
@@ -37,6 +38,25 @@ function runOutcome(args, env) {
     const stdout = execFileSync('node', [BRIDGE, ...args], {
       encoding: 'utf8',
       env: { ...process.env, ...env },
+      cwd: env.BRIDGE_TEST_CWD || process.cwd(),
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e) {
+    return {
+      code: e.status ?? 1,
+      stdout: String(e.stdout ?? ''),
+      stderr: String(e.stderr ?? ''),
+    };
+  }
+}
+
+function runOutcomeWithInput(args, env, input) {
+  try {
+    const stdout = execFileSync('node', [BRIDGE, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+      input,
+      cwd: env.BRIDGE_TEST_CWD || process.cwd(),
     });
     return { code: 0, stdout, stderr: '' };
   } catch (e) {
@@ -65,12 +85,29 @@ function withFakeHome(fn) {
   const env = {
     HOME: tmp,
     USERPROFILE: tmp,
+    LOCALAPPDATA: join(tmp, 'AppData', 'Local'),
+    APPDATA: join(tmp, 'AppData', 'Roaming'),
+    PROGRAMFILES: join(tmp, 'Program Files'),
+    'ProgramFiles(x86)': join(tmp, 'Program Files (x86)'),
+    BRIDGE_TEST_CWD: tmp,
     PATH: pathWithNode,
     OPENLOOMI_BIN: '',
+    OPENLOOMI_CTL: '',
     OPENLOOMI_HOME: '',
     OPENLOOMI_INSTALL_DIR: '',
     OPENLOOMI_REPO_DIR: '',
+    OPENLOOMI_API_URL: '',
     OPENLOOMI_BASE_URL: 'http://127.0.0.1:1',
+    OPENLOOMI_AUTH_TOKEN: '',
+    OPENAI_API_KEY: '',
+    ANTHROPIC_API_KEY: '',
+    OPENROUTER_API_KEY: '',
+    OPENLOOMI_AI_API_KEY: '',
+    OPENAI_BASE_URL: '',
+    ANTHROPIC_BASE_URL: '',
+    OPENROUTER_BASE_URL: '',
+    OPENLOOMI_AI_BASE_URL: '',
+    OPENLOOMI_AI_MODEL: '',
     OPENLOOMI_DEBUG_DISCOVERY: '1',
   };
   try {
@@ -78,6 +115,50 @@ function withFakeHome(fn) {
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+}
+
+function writeFakeToken(home) {
+  const dir = join(home, '.openloomi');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'token'), Buffer.from('fake-openloomi-token', 'utf8').toString('base64'));
+}
+
+function writeFakeCtl(home) {
+  const nodeScript = join(home, 'fake-openloomi-ctl.mjs');
+  writeFileSync(
+    nodeScript,
+    [
+      "if (process.argv.includes('--version')) {",
+      "  console.log('openloomi-ctl 9.9.9');",
+      "  process.exit(0);",
+      "}",
+      "let input = '';",
+      "process.stdin.setEncoding('utf8');",
+      "process.stdin.on('data', (chunk) => { input += chunk; });",
+      "process.stdin.on('end', () => {",
+      "  console.log(JSON.stringify({",
+      "    ok: true,",
+      "    env: { OPENLOOMI_API_URL: process.env.OPENLOOMI_API_URL || null },",
+      "    prompt: input,",
+      "  }));",
+      "});",
+    ].join('\n'),
+  );
+
+  if (process.platform === 'win32') {
+    const cmd = join(home, 'openloomi-ctl.cmd');
+    writeFileSync(cmd, `@"${process.execPath}" "%~dp0fake-openloomi-ctl.mjs" %*\r\n`);
+    return cmd;
+  }
+
+  const shim = join(home, 'openloomi-ctl');
+  const nodePath = process.execPath.replace(/'/g, "'\\''");
+  writeFileSync(
+    shim,
+    `#!/bin/sh\nexec '${nodePath}' "$(dirname "$0")/fake-openloomi-ctl.mjs" "$@"\n`,
+  );
+  chmodSync(shim, 0o755);
+  return shim;
 }
 
 // -----------------------------------------------------------------------------
@@ -135,10 +216,14 @@ test('setup-status apiProbe field is present and well-formed', () => {
 
 test('setup-status reports OPENLOOMI_API_UNREACHABLE when API down and no token', () => {
   withFakeHome((env) => {
+    const ctl = writeFakeCtl(env.HOME);
     // Make sure no token file is present and no local API is reachable
     // (fake HOME guarantees ~/.openloomi/token does not exist; the fake
     // env forces OPENLOOMI_BASE_URL to a closed port).
-    const j = JSON.parse(run(['setup-status'], env));
+    const j = runJson(['setup-status'], {
+      ...env,
+      OPENLOOMI_CTL: ctl,
+    });
     assert.equal(j.apiReachable, false);
     if (!j.tokenPresent) {
       assert.equal(j.ready, false);
@@ -180,7 +265,7 @@ test('setup-status exposes the protocol contract fields', () => {
 
 test('setup-status aiProvider checks only report presence, never values', () => {
   withFakeHome((env) => {
-    const j = JSON.parse(run(['setup-status'], env));
+    const j = runJson(['setup-status'], env);
     // Every check entry must have {key, present, source}; no value field.
     for (const entry of j.checks.aiProvider || []) {
       assert.equal(typeof entry.key, 'string');
@@ -194,6 +279,31 @@ test('setup-status aiProvider checks only report presence, never values', () => 
       assert.equal(typeof entry.source, 'string');
       assert.ok(!('value' in entry), `auth check leaked a value: ${entry.key}`);
     }
+  });
+});
+
+test('run injects OPENLOOMI_API_URL from OPENLOOMI_BASE_URL for openloomi-ctl', () => {
+  withFakeHome((env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+    const r = runOutcomeWithInput(
+      ['run'],
+      {
+        ...env,
+        OPENLOOMI_CTL: ctl,
+        OPENLOOMI_BASE_URL: 'http://localhost:3515',
+        OPENLOOMI_API_URL: '',
+        ANTHROPIC_API_KEY: 'sk-test-never-print',
+      },
+      'Reply with exactly: OpenLoomi ready.',
+    );
+    assert.equal(r.code, 0, r.stderr || r.stdout);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.ready, true);
+    assert.equal(j.reason, 'RUN_COMPLETE');
+    assert.equal(j.result.env.OPENLOOMI_API_URL, 'http://localhost:3515');
+    assert.equal(j.result.prompt, 'Reply with exactly: OpenLoomi ready.');
+    assert.ok(!r.stdout.includes('sk-test-never-print'));
   });
 });
 
@@ -388,7 +498,7 @@ test('pet with invalid state returns INVALID_STATE', () => {
 
 test('pet with token missing returns TOKEN_MISSING under fake HOME', () => {
   withFakeHome((env) => {
-    const j = JSON.parse(run(['pet', 'happy'], env));
+    const j = runJson(['pet', 'happy'], env);
     assert.equal(j.ok, false);
     // Either TOKEN_MISSING (no ~/.openloomi/token) or API_UNREACHABLE
     // (would-be call hits a closed port). Both are valid first-line
@@ -434,9 +544,15 @@ test('codex-runtime-info returns the desktop-app Codex runtime switch plan', () 
   const j = runJson(['codex-runtime-info']);
   assert.equal(j.purpose.startsWith('Switch the OpenLoomi desktop app'), true);
   assert.equal(j.envProviderKey, 'OPENLOOMI_AGENT_PROVIDER');
-  assert.match(j.switch.oneOff, /OPENLOOMI_AGENT_PROVIDER=codex/);
-  assert.match(j.switch.oneOff, /\/Applications\/openloomi\.app/);
-  assert.match(j.switch.permanent, /~\/\.zshrc/);
+  assert.equal(typeof j.switch.oneOff, 'object');
+  assert.match(j.switch.oneOff.darwin, /OPENLOOMI_AGENT_PROVIDER codex/);
+  assert.match(j.switch.oneOff.darwin, /\/Applications\/openloomi\.app/);
+  assert.match(j.switch.oneOff.linux, /OPENLOOMI_AGENT_PROVIDER=codex/);
+  assert.match(j.switch.oneOff.win32, /OPENLOOMI_AGENT_PROVIDER codex/);
+  assert.equal(typeof j.switch.permanent, 'object');
+  assert.match(j.switch.permanent.darwin, /~\/\.zshrc/);
+  assert.match(j.switch.permanent.linux, /environment\.d/);
+  assert.match(j.switch.permanent.win32, /environment variables/i);
   assert.ok(Array.isArray(j.prerequisites) && j.prerequisites.length >= 3);
   const varNames = j.companionEnvVars.map((entry) => entry.name);
   for (const expected of [

--- a/plugins/codex/tests/e2e/setup.md
+++ b/plugins/codex/tests/e2e/setup.md
@@ -66,7 +66,7 @@ Expected:
 
 - `initialize-session` reports `SESSION_READY`.
 - `setup-status` reports `apiReachable: true` and `apiBaseUrl:
-  "http://localhost:3515"` when the dev API is up.
+"http://localhost:3515"` when the dev API is up.
 - `run` passes the resolved local API URL to `openloomi-ctl` as
   `OPENLOOMI_API_URL` without requiring the user to set it manually.
 - A successful minimal prompt returns `RUN_COMPLETE` with `result.ok: true`.

--- a/plugins/codex/tests/e2e/setup.md
+++ b/plugins/codex/tests/e2e/setup.md
@@ -1,0 +1,98 @@
+# OpenLoomi Codex Plugin E2E Checklist
+
+This checklist is for human-run validation of the Codex plugin. It separates
+the normal user path from the source-development path so temporary environment
+variables do not leak into ordinary setup instructions.
+
+## A. Normal User Smoke Test
+
+Prerequisites:
+
+- OpenLoomi Desktop is installed or the user is willing to approve the plugin's
+  official installer flow.
+- An AI provider is configured in OpenLoomi-owned settings.
+- Codex can load the OpenLoomi plugin from a marketplace or local checkout.
+
+Steps:
+
+1. Start a new Codex thread after installing or refreshing the plugin cache.
+2. Ask: `@OpenLoomi Check whether OpenLoomi is ready.`
+3. Expected: the plugin calls `setup-status` and reports stable JSON fields:
+   `installed`, `ctlPath`, `tokenPresent`, `aiProviderConfigured`,
+   `apiReachable`, `ready`, `nextAction`, and `reason`.
+4. If `nextAction` is `open_openloomi`, open OpenLoomi Desktop and ask again.
+5. Ask: `@OpenLoomi Show the OpenLoomi workflows available from Codex.`
+6. Expected: Codex lists `openloomi-loop`, `openloomi-memory`,
+   `openloomi-connectors`, and `openloomi-handoff`.
+7. Ask a minimal run prompt: `@OpenLoomi Reply with exactly: OpenLoomi ready.`
+8. Expected: `loomi-bridge run` returns `RUN_COMPLETE` or a structured
+   runtime error. It must not ask the user to paste API keys or tokens into
+   Codex chat.
+
+## B. Source Development E2E
+
+Use this path when testing against a source checkout with `pnpm tauri:dev`.
+These variables are a dev harness, not the normal user flow.
+
+Terminal A:
+
+```powershell
+cd <openloomi-repo>
+
+$env:OPENLOOMI_AGENT_PROVIDER = "codex"
+$env:OPENLOOMI_AGENT_CODEX_COMMAND = "$HOME\.codex\plugins\.plugin-appserver\codex.exe"
+$env:OPENLOOMI_AGENT_CODEX_TIMEOUT_MS = "180000"
+$env:OPENLOOMI_AGENT_CODEX_SANDBOX = "workspace-write"
+$env:OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK = "1"
+
+pnpm tauri:dev *> plugins\codex\tests\logs\tauri-dev-local.log
+```
+
+Terminal B:
+
+```powershell
+cd <openloomi-repo>
+$repo = (Resolve-Path .).Path
+
+$env:OPENLOOMI_CTL = Join-Path $repo "apps\web\src-tauri\target\release\openloomi-ctl.exe"
+$env:OPENLOOMI_BASE_URL = "http://localhost:3515"
+
+node plugins\codex\scripts\loomi-bridge.mjs initialize-session
+node plugins\codex\scripts\loomi-bridge.mjs setup-status
+"Reply with exactly: OpenLoomi ready." | node plugins\codex\scripts\loomi-bridge.mjs run
+```
+
+Expected:
+
+- `initialize-session` reports `SESSION_READY`.
+- `setup-status` reports `apiReachable: true` and `apiBaseUrl:
+  "http://localhost:3515"` when the dev API is up.
+- `run` passes the resolved local API URL to `openloomi-ctl` as
+  `OPENLOOMI_API_URL` without requiring the user to set it manually.
+- A successful minimal prompt returns `RUN_COMPLETE` with `result.ok: true`.
+
+## C. Logs
+
+Temporary logs may be written under:
+
+```text
+plugins/codex/tests/logs/
+```
+
+Do not commit files from that directory. If needed, exclude them locally:
+
+```powershell
+Add-Content .git\info\exclude "plugins/codex/tests/logs/"
+```
+
+`.git/info/exclude` is local-only and is not pushed to the remote repository.
+
+## D. Focused Test Command
+
+```powershell
+node --test plugins\codex\tests\bridge.test.mjs
+```
+
+The unit test suite uses fake homes, fake `openloomi-ctl` shims, and local
+closed API URLs so it does not depend on the developer's real OpenLoomi token,
+default install path, or Desktop process.


### PR DESCRIPTION
## Summary

This PR improves the OpenLoomi Codex plugin readiness flow, runtime routing, workflow safety, and developer-facing diagnostics for using local OpenLoomi from Codex.

The goal is to make the Codex plugin a more reliable entry point into OpenLoomi: detect the local runtime accurately, confirm session and AI provider readiness, route `openloomi-ctl` to the correct local API, and avoid recursive Codex/OpenLoomi workflow calls.

## What Changed

### Runtime readiness and API discovery

- Extended `setup-status` with clearer local runtime readiness fields:
  - `apiReachable`
  - `apiBaseUrl`
  - `apiProbe`
- Made readiness output distinguish between:
  - OpenLoomi not installed
  - `openloomi-ctl` missing or invalid
  - local API unreachable
  - guest/session token not initialized
  - AI provider not configured or not confirmable
  - runtime ready for `run`
- Preserved upstream behavior where explicit `OPENLOOMI_API_URL` / `OPENLOOMI_BASE_URL` values are treated as pinned URLs and do not fall back to default loopback ports.

### Runtime/UI AI provider readiness

- Added support for detecting AI provider configuration from the OpenLoomi runtime/UI, not only from environment variables.
- This allows the plugin to recognize a valid provider setup when the user has configured provider settings inside OpenLoomi Desktop/runtime UI.
- The readiness check reports provider presence and status only; secret values are never printed.

### `openloomi-ctl` runtime routing

- Ensured `run` can pass the detected or configured local OpenLoomi API URL into the `openloomi-ctl` child process.
- This prevents the bridge from checking one runtime while `openloomi-ctl` accidentally talks to another runtime.

### Recursive run protection

- Added a run-level recursion guard for nested OpenLoomi bridge execution.
- This prevents problematic chains such as:

```text
Codex plugin -> OpenLoomi runtime -> Codex executor -> OpenLoomi plugin -> ...
```

- The guard only applies to `run`; setup/status/diagnostic commands remain available.
- When a nested run is detected, the bridge returns a structured `RECURSION_GUARD` response.

### Runtime-safe workflow guidance

- Updated OpenLoomi workflow guidance for loop, memory, and handoff workflows so the runtime is instructed not to call shell, skills, Codex plugins, OpenLoomi plugins, or `loomi-bridge` recursively.
- This reduces timeout risk and avoids accidental tool/plugin recursion during workflow execution.

### Runtime executor documentation cleanup

- Reframed Codex native runtime executor switching as an advanced diagnostic path, not the normal plugin usage path.
- The normal Codex plugin flow does not require users to set `OPENLOOMI_AGENT_PROVIDER=codex`.
- Documentation now better separates:
  - using the Codex plugin to connect to OpenLoomi
  - configuring OpenLoomi Desktop to use Codex as its native agent executor

### Upstream alignment

This branch has been rebased onto the latest `origin/main` and incorporates related work from other contributors, including:

- OpenLoomi `0.7.4` version updates
- the Codex bridge fix for pinned local API URLs
- updated Codex setup wizard documentation
- the latest `codex-runtime-info` response contract

The final branch keeps the latest upstream behavior while preserving this PR's readiness improvements, recursion guard, runtime-safe workflow guidance, and documentation cleanup.

## Tests Added / Updated

Updated `plugins/codex/tests/bridge.test.mjs` to cover:

- `setup-status` API probe and readiness contract
- `OPENLOOMI_API_UNREACHABLE` behavior when the pinned API is down
- AI provider checks reporting presence/status without leaking secret values
- `run` injecting the detected API URL into `openloomi-ctl`
- nested run protection via `RECURSION_GUARD`
- stale run lock cleanup
- `setup-status` remaining available while a run lock exists
- runtime-safe workflow guidance
- the latest `codex-runtime-info` contract

## Validation

Unit tests pass:

```powershell
node --test plugins\codex\tests\bridge.test.mjs
```

Result:

```text
24/24 pass
```

Source runtime E2E validation also passed.

Validated environment:

```text
OpenLoomi source runtime: 0.7.4
Codex plugin: 0.7.4
openloomi-ctl: 0.7.4
API endpoint: http://localhost:3515
```

Observed readiness result:

```text
apiReachable: true
aiProviderConfigured: true
aiProviderStatus: runtime_configured
ready: true
nextAction: run
```

The plugin successfully detected the AI provider configured in the OpenLoomi UI, including an enabled `anthropic_compatible` provider with API key, base URL, and model present.

Minimal run test passed:

```text
Reply with exactly: OpenLoomi ready.
```

Returned:

```text
OpenLoomi ready.
```

Guarded workflow run also passed:

- no shell/tool calls
- no recursive plugin invocation
- no timeout
- OpenLoomi returned a valid workflow response

## Notes

The source runtime `0.7.4` validation confirms that the AI provider readiness path works with the latest runtime.

A locally installed OpenLoomi Desktop `0.7.3` may still fail provider readiness with `SESSION_COOKIE_MISSING`. That appears to be a runtime version mismatch rather than a failure of the updated Codex plugin logic against the latest runtime.