### PR TITLE
fix(claude-agent): ship a CLI-valid default model id (#323)

### DIFF
--- a/apps/web/components/agent/model-selector.tsx
+++ b/apps/web/components/agent/model-selector.tsx
@@ -6,6 +6,7 @@ import { useLocalStorage } from "usehooks-ts";
  */
 export type ModelType =
   | "default"
+  | "anthropic/claude-sonnet-5"
   | "anthropic/claude-sonnet-4.6"
   | "anthropic/claude-sonnet-4.5"
   | "anthropic/claude-opus-4.6"

--- a/apps/web/lib/env/client-constants.ts
+++ b/apps/web/lib/env/client-constants.ts
@@ -34,7 +34,7 @@ export const isTestEnvironment = Boolean(
 
 // AI Model and proxy configuration (client-safe, no node: dependencies)
 export const DEFAULT_AI_MODEL =
-  process.env.NEXT_PUBLIC_ANTHROPIC_MODEL || "anthropic/claude-sonnet-4.6";
+  process.env.NEXT_PUBLIC_ANTHROPIC_MODEL || "claude-sonnet-5";
 // Use a relative path so it works across both local web and tauri runtimes.
 export const AI_PROXY_BASE_URL =
   process.env.NEXT_PUBLIC_AI_PROXY_URL || "/api/ai";


### PR DESCRIPTION
The built-in claude agent runtime previously defaulted to `anthropic/claude-sonnet-4.6` — an OpenRouter-style prefixed id with a dotted version. The Claude Code CLI rejects that form, so every Loop tick / connector probe / brief attempt failed with "There's an issue with the selected model (...)" out of the box.

- Switch DEFAULT_AI_MODEL to the CLI-accepted `claude-sonnet-5` alias so a fresh install starts a working agent without env overrides.
- Add `anthropic/claude-sonnet-5` to the ModelType union so the new default remains selectable in the model picker.

Verified locally that the model error stops firing once the constant switches and agents proceed to execution.

closes #323