### PR TITLE
fix(codex-plugin): preserve the direct one-shot runner

### DIFF
--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -1712,14 +1712,14 @@ function getPermissionMode(value) {
   return "deny";
 }
 
-function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt, apiBaseUrl }) {
+function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt }) {
   return runCommandWithInput(
     ctlPath,
     ["--one-shot", "--stdin", "--json", "--permission-mode", permissionMode],
     prompt,
     RUN_TIMEOUT_MS,
     {
-      env: getOpenLoomiCtlChildEnv({ apiBaseUrl }),
+      env: getOpenLoomiCtlChildEnv(),
     },
   );
 }
@@ -1843,19 +1843,14 @@ function summarizeRunLock(lock) {
   };
 }
 
-function getOpenLoomiCtlChildEnv({ apiBaseUrl } = {}) {
-  const env = {};
-  const inheritedApiUrl = normalizeLocalApiUrl(process.env.OPENLOOMI_API_URL);
-  const resolvedApiUrl =
-    inheritedApiUrl ||
-    normalizeLocalApiUrl(apiBaseUrl) ||
-    normalizeLocalApiUrl(process.env.OPENLOOMI_BASE_URL);
-
-  if (resolvedApiUrl && !inheritedApiUrl) {
-    env.OPENLOOMI_API_URL = resolvedApiUrl;
-  }
-
-  return env;
+function getOpenLoomiCtlChildEnv() {
+  // Do not synthesize OPENLOOMI_API_URL from the readiness probe. In v0.7.5,
+  // setting it selects the legacy HTTP compatibility path and bypasses the
+  // packaged CLI's direct native-agent runner.
+  //
+  // An explicit caller-provided OPENLOOMI_API_URL is already inherited by the
+  // child through process.env in runCommandWithInput.
+  return {};
 }
 
 async function initializeSession() {
@@ -3693,7 +3688,6 @@ async function run() {
       ctlPath: setup.ctlPath,
       permissionMode,
       prompt,
-      apiBaseUrl: setup.apiBaseUrl,
     });
   } finally {
     releaseRunLock(runLock);

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -301,7 +301,7 @@ test('setup-status aiProvider checks only report presence, never values', () => 
   });
 });
 
-test('run injects OPENLOOMI_API_URL from OPENLOOMI_BASE_URL for openloomi-ctl', () => {
+test('run preserves the direct runner by not synthesizing OPENLOOMI_API_URL', () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
@@ -320,8 +320,32 @@ test('run injects OPENLOOMI_API_URL from OPENLOOMI_BASE_URL for openloomi-ctl', 
     const j = JSON.parse(r.stdout);
     assert.equal(j.ready, true);
     assert.equal(j.reason, 'RUN_COMPLETE');
-    assert.equal(j.result.env.OPENLOOMI_API_URL, 'http://localhost:3515');
+    assert.equal(j.result.env.OPENLOOMI_API_URL, null);
     assert.equal(j.result.prompt, 'Reply with exactly: OpenLoomi ready.');
+    assert.ok(!r.stdout.includes('sk-test-never-print'));
+  });
+});
+
+test('run preserves an explicitly configured OPENLOOMI_API_URL', () => {
+  withFakeHome((env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+    const r = runOutcomeWithInput(
+      ['run'],
+      {
+        ...env,
+        OPENLOOMI_CTL: ctl,
+        OPENLOOMI_BASE_URL: 'http://localhost:3414',
+        OPENLOOMI_API_URL: 'http://localhost:3515',
+        ANTHROPIC_API_KEY: 'sk-test-never-print',
+      },
+      'Reply with exactly: OpenLoomi ready.',
+    );
+    assert.equal(r.code, 0, r.stderr || r.stdout);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.ready, true);
+    assert.equal(j.reason, 'RUN_COMPLETE');
+    assert.equal(j.result.env.OPENLOOMI_API_URL, 'http://localhost:3515');
     assert.ok(!r.stdout.includes('sk-test-never-print'));
   });
 });


### PR DESCRIPTION
## Summary

- stop synthesizing `OPENLOOMI_API_URL` from the Codex plugin's readiness probe
- keep `openloomi-ctl` on its packaged direct native-agent runner by default
- preserve an explicitly configured `OPENLOOMI_API_URL` for callers that intentionally select the HTTP compatibility path
- add regression coverage for both behaviors

## Root cause

The bridge passed `setup.apiBaseUrl` into the `openloomi-ctl` child as `OPENLOOMI_API_URL`.

In the packaged v0.7.5 CLI, `OPENLOOMI_API_URL` is an explicit opt-in to the legacy HTTP compatibility path. Synthesizing it from a reachability probe therefore bypassed the direct runner, so `setup-status` could report `ready: true` while `run` failed with `service_unavailable`.

The child process already inherits `process.env`, so caller-provided `OPENLOOMI_API_URL` values continue to work without an injected override.

## Scope

This only changes the Codex plugin bridge and its tests. The Claude plugin and shared OpenLoomi runtime state are unchanged.

## Validation

- `node --test plugins/codex/tests/bridge.test.mjs` — 25/25 passed
- packaged OpenLoomi Desktop v0.7.5 end-to-end run returned `OPENLOOMI_PLUGIN_OK`
- `git diff --check`
