### PR TITLE
feat(plugins): add Codex pet lifecycle hooks and strengthen plugin test coverage

### DIFF
--- a/plugins/claude/tests/bridge.test.mjs
+++ b/plugins/claude/tests/bridge.test.mjs
@@ -13,19 +13,28 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { join, dirname, delimiter } from 'node:path';
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import {
+  createFakeOpenLoomiBin,
+  makePath,
+  mergeEnv,
+  withIsolatedHome,
+} from './helpers/platform-fixtures.mjs';
 
 const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
 const BRIDGE = join(PLUGIN_DIR, 'scripts', 'loomi-bridge.mjs');
 
-function run(args, { env = {} } = {}) {
+function run(args, options = {}) {
+  const env = options && Object.prototype.hasOwnProperty.call(options, 'env')
+    ? options.env
+    : options;
   try {
     return execFileSync('node', [BRIDGE, ...args], {
       encoding: 'utf8',
-      env: { ...process.env, ...env },
+      env: mergeEnv(process.env, env),
     });
   } catch (e) {
     // Bridge intentionally exits with non-zero for known error cases
@@ -48,7 +57,7 @@ function runOutcome(args, env) {
   try {
     const stdout = execFileSync('node', [BRIDGE, ...args], {
       encoding: 'utf8',
-      env: { ...process.env, ...env },
+      env: mergeEnv(process.env, env),
     });
     return { code: 0, stdout, stderr: '' };
   } catch (e) {
@@ -65,37 +74,7 @@ function runJson(args, env) {
 }
 
 function withClaHome(fn) {
-  const tmp = mkdtempSync(join(tmpdir(), 'openloomi-test-'));
-  // Preserve PATH but GUARANTEE that the directory holding the current
-  // `node` binary is included, so spawned `node` is always discoverable.
-  const nodeDir = dirname(process.execPath);
-  const preservedPath = process.env.PATH || '/usr/bin:/bin';
-  const pathWithNode = preservedPath.includes(nodeDir)
-    ? preservedPath
-    : `${nodeDir}${delimiter}${preservedPath}`;
-  const homeEnv = {
-    HOME: tmp,
-    USERPROFILE: tmp,
-    PATH: pathWithNode,
-    OPENLOOMI_BIN: '',
-    OPENLOOMI_HOME: '',
-    OPENLOOMI_REPO_DIR: '',
-    OPENLOOMI_AUTH_TOKEN: '',
-    OPENLOOMI_BASE_URL: '',
-    CLAUDE_PLUGIN_DATA: '',
-    // Bridge reads these for sync-claude-env; test must wipe so leak
-    // tests can prove they don't accidentally pass when the user has
-    // real Anthropic credentials on the host.
-    ANTHROPIC_API_KEY: '',
-    ANTHROPIC_AUTH_TOKEN: '',
-    ANTHROPIC_BASE_URL: '',
-    ANTHROPIC_MODEL: '',
-  };
-  try {
-    return fn({ ...homeEnv, TMPDIR: tmp });
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+  return withIsolatedHome(fn);
 }
 
 test('version subcommand emits plugin metadata', () => {
@@ -162,35 +141,13 @@ test('discovery: OPENLOOMI_NOT_INSTALLED when no helper is reachable', () => {
 
 test('discovery: respects OPENLOOMI_BIN env when binary present', () => {
   withClaHome((env) => {
-    // Spawn a fake helper by writing it to a temp dir. The fake prints just
-    // a version string — the bridge's version regex matches any X.Y.Z, so we
-    // don't need to mimic the real binary's full "name version" output.
-    const fake = join(env.HOME, 'fake-helper');
-    writeFileSync(fake, '#!/bin/sh\necho 9.9.9\n');
-    try { execFileSync('chmod', ['+x', fake]); } catch { /* noop */ }
-
-    // Build a PATH that has only the node binary's directory + minimal
-    // platform paths. This guarantees no real helper binary from the user's
-    // PATH interferes with the test.
-    const nodeDir = dirname(process.execPath);
-    const safePath = [nodeDir, '/usr/bin', '/bin'].join(delimiter);
+    const fake = createFakeOpenLoomiBin(join(env.HOME, 'fake-bin'), { name: 'fake-helper' });
 
     // Pass the env as a single object literal so it's easier to debug
     // what's actually being handed to execFileSync.
     const envPass = {
-      HOME: env.HOME,
-      USERPROFILE: env.USERPROFILE,
-      PATH: safePath,
-      OPENLOOMI_BIN: fake,
-      OPENLOOMI_HOME: '',
-      OPENLOOMI_REPO_DIR: '',
-      OPENLOOMI_AUTH_TOKEN: '',
-      OPENLOOMI_BASE_URL: '',
-      CLAUDE_PLUGIN_DATA: '',
-      ANTHROPIC_API_KEY: '',
-      ANTHROPIC_AUTH_TOKEN: '',
-      ANTHROPIC_BASE_URL: '',
-      ANTHROPIC_MODEL: '',
+      ...env,
+      OPENLOOMI_BIN: fake.binPath,
     };
 
     assert.equal(envPass.ANTHROPIC_AUTH_TOKEN, '', 'test must clear ANTHROPIC_AUTH_TOKEN');
@@ -210,8 +167,8 @@ test('discovery: respects OPENLOOMI_BIN env when binary present', () => {
       throw new Error(`expected installed; got: ${JSON.stringify(j, null, 2)}`);
     }
     assert.equal(j.installed, true);
-    assert.equal(j.binPath, fake);
-    assert.match(j.version, /9\.9\.9/);
+    assert.equal(j.binPath, fake.binPath);
+    assert.match(j.version, new RegExp(fake.expectedVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.equal(j.source, 'OPENLOOMI_BIN');
   });
 });
@@ -222,17 +179,13 @@ test('discovery: SOURCE_FOUND_CLI_NOT_BUILT when repo dir set without built ctl'
     mkdirSync(join(repo, 'apps', 'web', 'src-tauri'), { recursive: true });
     writeFileSync(join(repo, 'package.json'), '{}');
     writeFileSync(join(repo, 'apps', 'web', 'src-tauri', 'Cargo.toml'), '');
-    const nodeDir = dirname(process.execPath);
-    const safePath = [nodeDir, '/usr/bin', '/bin'].join(delimiter);
-
     let out;
     try {
       out = execFileSync('node', [BRIDGE, 'setup-status'], {
         encoding: 'utf8',
         env: {
-          HOME: env.HOME,
-          USERPROFILE: env.USERPROFILE,
-          PATH: safePath,
+          ...env,
+          PATH: makePath(),
           OPENLOOMI_REPO_DIR: repo,
           OPENLOOMI_BIN: '',
           OPENLOOMI_HOME: '',
@@ -264,17 +217,13 @@ test('claudeEnvSyncable reflects env presence without printing values', () => {
     return;
   }
   withClaHome((env) => {
-    const nodeDir = dirname(process.execPath);
-    const safePath = [nodeDir, '/usr/bin', '/bin'].join(delimiter);
-
     let out;
     try {
       out = execFileSync('node', [BRIDGE, 'setup-status'], {
         encoding: 'utf8',
         env: {
-          HOME: env.HOME,
-          USERPROFILE: env.USERPROFILE,
-          PATH: safePath,
+          ...env,
+          PATH: makePath(),
           OPENLOOMI_BIN: '/nonexistent-ctl',
           OPENLOOMI_HOME: '',
           OPENLOOMI_REPO_DIR: '',
@@ -445,7 +394,7 @@ test('hooks-merge.cjs install merges per-event into settings.hooks; uninstall re
     const settingsPath = join(env.HOME, '.claude', 'settings.json');
 
     // Make sure the dir exists for the atomic writer.
-    execFileSync('mkdir', ['-p', join(env.HOME, '.claude')]);
+    mkdirSync(join(env.HOME, '.claude'), { recursive: true });
 
     const installOut = execFileSync('node', [merge, 'install'], {
       env,
@@ -540,15 +489,13 @@ test('setup-status exposes canGuestLogin=false when API is unreachable', () => {
     return;
   }
   withClaHome((env) => {
-    const nodeDir = dirname(process.execPath);
-    const safePath = [nodeDir, '/usr/bin', '/bin'].join(delimiter);
     let out;
     try {
       out = execFileSync('node', [BRIDGE, 'setup-status'], {
         encoding: 'utf8',
         env: {
           ...env,
-          PATH: safePath,
+          PATH: makePath(),
           OPENLOOMI_BIN: '/nonexistent-ctl',
           OPENLOOMI_BASE_URL: 'http://127.0.0.1:1',
         },

--- a/plugins/claude/tests/bridge.windows.test.mjs
+++ b/plugins/claude/tests/bridge.windows.test.mjs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Windows-only discovery tests for the Claude plugin bridge. These tests keep
+// Windows path/layout coverage isolated from the cross-platform bridge suite.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createFakeOpenLoomiBin,
+  isWindows,
+  makePath,
+  mergeEnv,
+  withIsolatedHome,
+} from './helpers/platform-fixtures.mjs';
+
+const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+const BRIDGE = join(PLUGIN_DIR, 'scripts', 'loomi-bridge.mjs');
+
+function runJson(args, env = {}) {
+  const out = execFileSync('node', [BRIDGE, ...args], {
+    encoding: 'utf8',
+    env: mergeEnv(process.env, env),
+  });
+  return JSON.parse(out);
+}
+
+test('windows discovery: OPENLOOMI_BIN can point at a Windows executable', { skip: !isWindows }, () => {
+  withIsolatedHome((env) => {
+    const fake = createFakeOpenLoomiBin(join(env.HOME, 'fake-bin'), {
+      name: 'fake-openloomi',
+    });
+    const j = runJson(['setup-status'], {
+      ...env,
+      OPENLOOMI_BIN: fake.binPath,
+    });
+
+    assert.equal(j.installed, true);
+    assert.equal(j.binPath, fake.binPath);
+    assert.equal(j.source, 'OPENLOOMI_BIN');
+    assert.match(j.version, /^\d+\.\d+\.\d+/);
+  });
+});
+
+test('windows discovery: LOCALAPPDATA platform default is isolated', { skip: !isWindows }, () => {
+  withIsolatedHome((env) => {
+    const installDir = join(env.LOCALAPPDATA, 'OpenLoomi');
+    const fake = createFakeOpenLoomiBin(installDir, { name: 'openloomi.exe' });
+    const j = runJson(['setup-status'], env);
+
+    assert.equal(j.installed, true);
+    assert.equal(j.binPath, fake.binPath);
+    assert.equal(j.source, 'platform-default');
+  });
+});
+
+test('windows discovery: LOCALAPPDATA desktop marker without binary reports finalization state', { skip: !isWindows }, () => {
+  withIsolatedHome((env) => {
+    const installDir = join(env.LOCALAPPDATA, 'OpenLoomi');
+    mkdirSync(installDir, { recursive: true });
+    const j = runJson(['setup-status'], env);
+
+    assert.equal(j.installed, true);
+    assert.equal(j.binPath, null);
+    assert.equal(j.source, 'desktop-only');
+    assert.equal(j.reason, 'OPENLOOMI_NOT_FINALIZED');
+    assert.equal(j.nextAction, 'launch_openloomi_to_finalize');
+    assert.equal(j.desktopMarker, installDir);
+  });
+});
+
+test('windows discovery: PATH lookup is isolated', { skip: !isWindows }, () => {
+  withIsolatedHome((env) => {
+    const pathDir = join(env.HOME, 'path-bin');
+    const fake = createFakeOpenLoomiBin(pathDir, { name: 'openloomi.exe' });
+    const j = runJson(['setup-status'], {
+      ...env,
+      PATH: makePath([pathDir]),
+    });
+
+    assert.equal(j.installed, true);
+    assert.equal(j.binPath, fake.binPath);
+    assert.equal(j.source, 'PATH');
+  });
+});
+
+test('windows discovery: no candidates reports not installed without touching host paths', { skip: !isWindows }, () => {
+  withIsolatedHome((env) => {
+    const j = runJson(['setup-status'], env);
+
+    assert.equal(j.installed, false);
+    assert.equal(j.binPath, null);
+    assert.equal(j.reason, 'OPENLOOMI_NOT_INSTALLED');
+    assert.equal(j.nextAction, 'install_openloomi');
+  });
+});

--- a/plugins/claude/tests/encoding.test.mjs
+++ b/plugins/claude/tests/encoding.test.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Guard against mojibake in copied plugin text. The Claude plugin intentionally
+// contains some non-ASCII text (arrows, emoji, Chinese platform names), so this
+// checks for known corruption markers instead of banning Unicode outright.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { TextDecoder } from 'node:util';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+const TEXT_EXTENSIONS = new Set([
+  '',
+  '.cjs',
+  '.gitignore',
+  '.json',
+  '.md',
+  '.mjs',
+  '.ps1',
+  '.sh',
+]);
+
+const SKIP_DIRS = new Set(['assets']);
+
+const cp = (...codes) => String.fromCodePoint(...codes);
+
+const MOJIBAKE_MARKERS = [
+  cp(0xfffd),
+  cp(0x9225),
+  cp(0x922b),
+  cp(0x9239),
+  cp(0x6402),
+  cp(0x8133),
+  cp(0x951f),
+  cp(0x00e2, 0x20ac),
+  cp(0x00c3),
+  cp(0x00c2),
+];
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walk(path, out);
+      continue;
+    }
+    if (stat.isFile() && TEXT_EXTENSIONS.has(extname(path))) out.push(path);
+  }
+  return out;
+}
+
+function lineForIndex(text, index) {
+  return text.slice(0, index).split(/\r?\n/).length;
+}
+
+test('Claude plugin text files are valid UTF-8 and free of known mojibake markers', () => {
+  const failures = [];
+
+  for (const file of walk(PLUGIN_DIR)) {
+    const rel = relative(PLUGIN_DIR, file);
+    let text;
+    try {
+      text = decoder.decode(readFileSync(file));
+    } catch (error) {
+      failures.push(`${rel}: invalid UTF-8 (${error.message})`);
+      continue;
+    }
+
+    for (const marker of MOJIBAKE_MARKERS) {
+      const index = text.indexOf(marker);
+      if (index >= 0) {
+        failures.push(`${rel}:${lineForIndex(text, index)} contains mojibake marker ${JSON.stringify(marker)}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/plugins/claude/tests/helpers/platform-fixtures.mjs
+++ b/plugins/claude/tests/helpers/platform-fixtures.mjs
@@ -1,0 +1,103 @@
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+
+export const isWindows = process.platform === 'win32';
+
+export function nodeBinDir() {
+  return dirname(process.execPath);
+}
+
+export function makePath(dirs = []) {
+  return [nodeBinDir(), ...dirs].join(delimiter);
+}
+
+export function mergeEnv(base, overrides = {}) {
+  const env = { ...base };
+  if (isWindows) {
+    for (const key of Object.keys(overrides)) {
+      for (const existing of Object.keys(env)) {
+        if (existing !== key && existing.toLowerCase() === key.toLowerCase()) {
+          delete env[existing];
+        }
+      }
+    }
+  }
+  return { ...env, ...overrides };
+}
+
+function inheritedWindowsEnv() {
+  if (!isWindows) return {};
+  const env = {};
+  for (const key of ['SystemRoot', 'WINDIR', 'ComSpec', 'PATHEXT']) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  return env;
+}
+
+export function makeIsolatedEnv(home, { pathDirs = [], overrides = {} } = {}) {
+  const localAppData = join(home, 'LocalAppData');
+  const programFiles = join(home, 'ProgramFiles');
+  mkdirSync(localAppData, { recursive: true });
+  mkdirSync(programFiles, { recursive: true });
+
+  return {
+    ...inheritedWindowsEnv(),
+    HOME: home,
+    USERPROFILE: home,
+    TMPDIR: home,
+    TEMP: home,
+    TMP: home,
+    PATH: makePath(pathDirs),
+    LOCALAPPDATA: localAppData,
+    PROGRAMFILES: programFiles,
+    OPENLOOMI_BIN: '',
+    OPENLOOMI_HOME: '',
+    OPENLOOMI_INSTALL_DIR: '',
+    OPENLOOMI_REPO_DIR: '',
+    OPENLOOMI_AUTH_TOKEN: '',
+    OPENLOOMI_BASE_URL: '',
+    CLAUDE_PLUGIN_DATA: join(home, '.claude', 'plugins', 'openloomi'),
+    ANTHROPIC_API_KEY: '',
+    ANTHROPIC_AUTH_TOKEN: '',
+    ANTHROPIC_BASE_URL: '',
+    ANTHROPIC_MODEL: '',
+    ...overrides,
+  };
+}
+
+export function withIsolatedHome(fn, options = {}) {
+  const home = mkdtempSync(join(tmpdir(), 'openloomi-test-'));
+  try {
+    const env = makeIsolatedEnv(home, options);
+    return fn(env, { home });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+export function createFakeOpenLoomiBin(dir, { name = 'openloomi', version = '9.9.9' } = {}) {
+  mkdirSync(dir, { recursive: true });
+
+  if (isWindows) {
+    const fileName = name.toLowerCase().endsWith('.exe') ? name : `${name}.exe`;
+    const binPath = join(dir, fileName);
+    copyFileSync(process.execPath, binPath);
+    return {
+      binPath,
+      expectedVersion: process.version.replace(/^v/, ''),
+    };
+  }
+
+  const binPath = join(dir, name);
+  writeFileSync(binPath, `#!/bin/sh\necho ${version}\n`, { mode: 0o755 });
+  chmodSync(binPath, 0o755);
+  return { binPath, expectedVersion: version };
+}

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -7,24 +7,16 @@
   },
   "homepage": "https://openloomi.ai/docs/getting-started",
   "license": "Apache-2.0",
-  "keywords": [
-    "openloomi",
-    "loomi",
-    "assistant",
-    "memory",
-    "codex"
-  ],
+  "keywords": ["openloomi", "loomi", "assistant", "memory", "codex"],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "OpenLoomi",
     "shortDescription": "Use your local OpenLoomi assistant from Codex",
     "longDescription": "Connect Codex to a local OpenLoomi runtime for setup readiness, personal memory workflows, and future one-shot task execution.",
     "developerName": "OpenLoomi",
     "category": "Productivity",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "defaultPrompt": [
       "Check whether OpenLoomi is ready",
       "Show OpenLoomi setup next steps",

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -775,7 +775,9 @@ The bridge ships a `pet <state>` command that mirrors
 `plugins/claude/scripts/loomi-bridge.mjs::cmdPet`. It validates against the
 same 9-state sprite vocabulary and POSTs `{state, source: "codex-plugin"}`
 to `/api/pet/state` on the local OpenLoomi runtime with the bearer token
-from `~/.openloomi/token`.
+from `~/.openloomi/token`. The command tries every local OpenLoomi API URL
+in priority order, so a closed 3414 port can still fall back to a source
+runtime on 3515.
 
 ```bash
 node plugins/codex/scripts/loomi-bridge.mjs pet happy
@@ -802,35 +804,35 @@ Failure modes (all return structured JSON, never throw):
   every URL the bridge tried.
 - `PET_FAILED` - runtime answered but with a non-success status code.
 
-The Codex plugin deliberately does **not** ship lifecycle-driven Pet
-transitions. The Claude Code plugin wires `SessionStart` / `Stop` /
-`PreToolUse` / etc. to Pet states via `hooks/hooks.json`; the Codex plugin
-platform does not yet expose an equivalent event surface (see next
-section), so `pet` is user-driven only. Do not introduce a polling loop
-inside the Codex plugin to fake lifecycle hooks.
+The bridge also exposes an internal `state <state> --event <event>` command
+for Codex lifecycle hooks. This path is hook-safe: it never fails the Codex
+turn, never prompts, and returns `hook: "skipped"` when OpenLoomi is not
+ready, the token is missing, or the Pet endpoint is unavailable.
 
-## Optional Codex Hooks
+## Codex Pet Lifecycle Hooks
 
-Status: deferred pending Codex platform support.
+Status: implemented as a non-blocking Pet mirror.
 
-The Codex plugin surface does not currently expose Claude-style lifecycle
-hooks (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
-`Stop`, `SubagentStart`, `SubagentStop`, `Notification`). The Claude Code
-plugin (`plugins/claude`) implements these via `hooks/hooks.json` plus
-`scripts/hooks-merge.cjs`; there is no equivalent mechanism on the Codex
-side as of the current Codex plugin API.
+The Codex plugin ships `plugins/codex/hooks/hooks.json` and declares it in
+`.codex-plugin/plugin.json`. The hook bundle mirrors Codex lifecycle events
+onto the OpenLoomi Pet without making authorization or control-flow
+decisions.
 
-The intended Pet notification surface is:
+Current mapping:
 
-- a Codex task completes - Pet `happy`;
-- a Codex task needs user input - Pet `needsinput`;
-- a handoff has been queued for Loomi follow-up - Pet `working`;
-- OpenLoomi connector or model setup is blocking a task - Pet `thinking`.
+- `SessionStart` - Pet `presenting`;
+- `UserPromptSubmit` - Pet `thinking`;
+- `PreToolUse` - Pet `working`;
+- `PermissionRequest` - Pet `needsinput`;
+- `PostToolUse` - Pet `thinking`;
+- `SubagentStart` - Pet `juggling`;
+- `SubagentStop` - Pet `thinking`;
+- `Stop` - Pet `happy`.
 
-Until Codex adds an official lifecycle event surface, this section stays
-open. Do not ship a hand-rolled polling loop inside the Codex plugin to
-fake hooks - it would duplicate Claude-only state and conflict with the
-"thin wrapper, no business logic" rule.
+Hooks use the same runtime-accepted `source: "codex-plugin"` value when
+posting to `/api/pet/state`. They are best-effort UI feedback only. Memory
+archive, follow-up scheduling, permission decisions, and connector behavior
+stay inside OpenLoomi-owned runtime surfaces.
 
 ## Secret Handling
 

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -5,8 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state presenting --event SessionStart",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state presenting --event SessionStart",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state presenting --event SessionStart --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state presenting --event SessionStart --quiet",
             "timeout": 5
           }
         ]
@@ -17,8 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event UserPromptSubmit",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event UserPromptSubmit",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event UserPromptSubmit --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state thinking --event UserPromptSubmit --quiet",
             "timeout": 5
           }
         ]
@@ -29,8 +29,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state working --event PreToolUse",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state working --event PreToolUse",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state working --event PreToolUse --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state working --event PreToolUse --quiet",
             "timeout": 5
           }
         ]
@@ -41,8 +41,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state needsinput --event PermissionRequest",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state needsinput --event PermissionRequest",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state needsinput --event PermissionRequest --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state needsinput --event PermissionRequest --quiet",
             "timeout": 5
           }
         ]
@@ -53,8 +53,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event PostToolUse",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event PostToolUse",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event PostToolUse --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state thinking --event PostToolUse --quiet",
             "timeout": 5
           }
         ]
@@ -65,8 +65,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state juggling --event SubagentStart",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state juggling --event SubagentStart",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state juggling --event SubagentStart --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state juggling --event SubagentStart --quiet",
             "timeout": 5
           }
         ]
@@ -77,8 +77,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event SubagentStop",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event SubagentStop",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event SubagentStop --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state thinking --event SubagentStop --quiet",
             "timeout": 5
           }
         ]
@@ -89,8 +89,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state happy --event Stop",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state happy --event Stop",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state happy --event Stop --quiet",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\scripts\\loomi-bridge.mjs\" state happy --event Stop --quiet",
             "timeout": 5
           }
         ]

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,0 +1,100 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state presenting --event SessionStart",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state presenting --event SessionStart",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event UserPromptSubmit",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event UserPromptSubmit",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state working --event PreToolUse",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state working --event PreToolUse",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state needsinput --event PermissionRequest",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state needsinput --event PermissionRequest",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event PostToolUse",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event PostToolUse",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state juggling --event SubagentStart",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state juggling --event SubagentStart",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state thinking --event SubagentStop",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state thinking --event SubagentStop",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/loomi-bridge.mjs\" state happy --event Stop",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\loomi-bridge.mjs\" state happy --event Stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -4653,22 +4653,34 @@ async function petCommand(args) {
 }
 
 function parseStateCommandArgs(args) {
-  const out = { state: args && args.length > 0 ? args[0] : null, event: null };
+  const out = {
+    state: args && args.length > 0 ? args[0] : null,
+    event: null,
+    quiet: false,
+  };
   for (let i = 1; i < (args || []).length; i += 1) {
     const arg = args[i];
     if (arg === "--event" && args[i + 1]) {
       out.event = args[i + 1];
       i += 1;
+    } else if (arg === "--quiet") {
+      out.quiet = true;
     }
   }
   return out;
 }
 
 async function stateCommand(args) {
-  const { state, event } = parseStateCommandArgs(args || []);
+  const { state, event, quiet } = parseStateCommandArgs(args || []);
+  const finish = (payload) => {
+    if (quiet) {
+      return;
+    }
+    return writeJson(payload);
+  };
 
   if (!state) {
-    return writeJson({
+    return finish({
       ok: false,
       state: null,
       event,
@@ -4679,7 +4691,7 @@ async function stateCommand(args) {
   }
 
   if (!CAPYBARA_STATES.has(state)) {
-    return writeJson({
+    return finish({
       ok: false,
       state,
       event,
@@ -4692,7 +4704,7 @@ async function stateCommand(args) {
   const tokenStatus = getTokenStatus();
   const token = readOpenLoomiAuthToken(tokenStatus);
   if (!token) {
-    return writeJson({
+    return finish({
       ok: false,
       state,
       event,
@@ -4712,7 +4724,7 @@ async function stateCommand(args) {
     attempts.push(result.attempt);
 
     if (result.ok) {
-      return writeJson({
+      return finish({
         ok: true,
         state,
         event,
@@ -4722,7 +4734,7 @@ async function stateCommand(args) {
     }
 
     if (result.code === "ENDPOINT_MISSING") {
-      return writeJson({
+      return finish({
         ok: false,
         state,
         event,
@@ -4734,7 +4746,7 @@ async function stateCommand(args) {
     }
 
     if (result.code === "PET_FAILED") {
-      return writeJson({
+      return finish({
         ok: false,
         state,
         event,
@@ -4746,7 +4758,7 @@ async function stateCommand(args) {
     }
   }
 
-  return writeJson({
+  return finish({
     ok: false,
     state,
     event,

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -58,6 +58,7 @@ const COMMANDS = new Set([
   "set-codex-runtime-env",
   "setup",
   "setup-status",
+  "state",
   "version",
   "workflow-guidance",
 ]);
@@ -2696,110 +2697,19 @@ function version() {
   });
 }
 
-// -----------------------------------------------------------------------------
-// pet
-// -----------------------------------------------------------------------------
+async function postPetState(
+  baseUrl,
+  state,
+  token,
+  {
+    source = "codex-plugin",
+    event = null,
+    timeoutMs = PET_HTTP_TIMEOUT_MS,
+  } = {},
+) {
+  const body = { state, source };
+  if (event) body.event = event;
 
-const PET_STATES = [
-  "happy",
-  "idle",
-  "juggling",
-  "needsinput",
-  "presenting",
-  "sleeping",
-  "sweeping",
-  "thinking",
-  "working",
-];
-
-const PET_STATE_SET = new Set(PET_STATES);
-
-async function pet(args) {
-  const state = args[0];
-
-  if (!hasValue(state)) {
-    writeJson({
-      ok: false,
-      code: "MISSING_STATE",
-      validStates: PET_STATES,
-    });
-    return;
-  }
-
-  if (!PET_STATE_SET.has(state)) {
-    writeJson({
-      ok: false,
-      code: "INVALID_STATE",
-      received: state,
-      validStates: PET_STATES,
-    });
-    return;
-  }
-
-  const tokenStatus = getTokenStatus();
-  const token = readOpenLoomiAuthToken(tokenStatus);
-
-  if (!hasValue(token)) {
-    writeJson({
-      ok: false,
-      code: "TOKEN_MISSING",
-      validStates: PET_STATES,
-      message:
-        "OpenLoomi needs a local guest/session token before the Codex plugin can update Pet state.",
-    });
-    return;
-  }
-
-  const attempts = [];
-
-  for (const baseUrl of getLocalApiBaseUrls()) {
-    const result = await postPetState(baseUrl, state, token);
-    attempts.push(result.attempt);
-
-    if (result.ok) {
-      writeJson({
-        ok: true,
-        code: "PET_STATE_SET",
-        state,
-        baseUrl,
-      });
-      return;
-    }
-
-    if (result.code === "ENDPOINT_MISSING") {
-      writeJson({
-        ok: false,
-        code: "ENDPOINT_MISSING",
-        state,
-        baseUrl,
-        attempts,
-        message:
-          "OpenLoomi runtime is reachable, but the Pet state endpoint is not available in this build.",
-      });
-      return;
-    }
-
-    if (result.code === "PET_FAILED") {
-      writeJson({
-        ok: false,
-        code: "PET_FAILED",
-        state,
-        baseUrl,
-        attempts,
-      });
-      return;
-    }
-  }
-
-  writeJson({
-    ok: false,
-    code: "API_UNREACHABLE",
-    state,
-    attempts,
-  });
-}
-
-async function postPetState(baseUrl, state, token) {
   try {
     const response = await fetchWithTimeout(
       `${baseUrl}/api/pet/state`,
@@ -2808,14 +2718,20 @@ async function postPetState(baseUrl, state, token) {
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
-        body: JSON.stringify({
-          state,
-          source: "codex-plugin",
-        }),
+        body: JSON.stringify(body),
       },
-      SESSION_API_TIMEOUT_MS,
+      timeoutMs,
     );
+
+    const text = await response.text().catch(() => "");
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = { raw: text };
+    }
 
     const attempt = {
       baseUrl,
@@ -2824,21 +2740,24 @@ async function postPetState(baseUrl, state, token) {
     };
 
     if (response.ok) {
-      return { ok: true, attempt };
+      return { ok: true, response: json, attempt };
     }
 
     return {
       ok: false,
       code: response.status === 404 ? "ENDPOINT_MISSING" : "PET_FAILED",
+      response: json,
       attempt,
     };
   } catch (error) {
     return {
       ok: false,
       code: "API_UNREACHABLE",
+      message: error?.message || String(error),
       attempt: {
         baseUrl,
         reason: error?.name === "AbortError" ? "TIMEOUT" : "NETWORK_ERROR",
+        message: error?.message || String(error),
       },
     };
   }
@@ -2856,7 +2775,7 @@ async function postPetState(baseUrl, state, token) {
 //
 // The runtime resolution logic here intentionally mirrors
 // `apps/web/lib/ai/native-agent/provider-env.ts`:
-//   * empty / whitespace / unsupported value -> "claude"
+//   * empty, whitespace, or unsupported values resolve to "claude"
 //   * normalized lower-case otherwise
 // Anything else (e.g. unknown value) is surfaced verbatim so the caller
 // can spot a typo.
@@ -2963,7 +2882,7 @@ function codexRuntimeInfo() {
     envProviderKey: CODEX_RUNTIME_INFO_KEY,
     platform,
     switch: {
-      // Current-platform snippets - kept as strings so most callers
+      // Current-platform snippets are kept as strings so most callers
       // can copy-paste directly. Field name is unchanged; type just
       // narrows from `object` to `string`.
       oneOff: oneOffByPlatform[platform] || oneOffByPlatform.darwin,
@@ -4672,72 +4591,169 @@ async function petCommand(args) {
     );
   }
 
-  const baseUrl = getLocalApiBaseUrls()[0];
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), PET_HTTP_TIMEOUT_MS);
+  const attempts = [];
 
-  try {
-    const res = await fetch(`${baseUrl}/api/pet/state`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ state, source: "codex-plugin" }),
-      signal: ctrl.signal,
+  for (const baseUrl of getLocalApiBaseUrls()) {
+    const result = await postPetState(baseUrl, state, token, {
+      source: "codex-plugin",
     });
+    attempts.push(result.attempt);
 
-    if (res.status === 404) {
+    if (result.ok) {
+      return writeJson({
+        ok: true,
+        code: "PET_STATE_SET",
+        state,
+        baseUrl,
+        attempts,
+        response: result.response,
+      });
+    }
+
+    if (result.code === "ENDPOINT_MISSING") {
       return writeJson(
         {
           ok: false,
           code: "ENDPOINT_MISSING",
-          message: `OpenLoomi runtime does not yet expose POST /api/pet/state. Pending endpoint - would have set state to '${state}'.`,
           state,
+          baseUrl,
+          attempts,
+          message:
+            "OpenLoomi runtime is reachable, but the Pet state endpoint is not available in this build.",
         },
         0,
       );
     }
 
-    const text = await res.text().catch(() => "");
-    let json = null;
-    try {
-      json = text ? JSON.parse(text) : null;
-    } catch {
-      json = { raw: text };
-    }
-
-    if (!res.ok) {
+    if (result.code === "PET_FAILED") {
       return writeJson(
         {
           ok: false,
           code: "PET_FAILED",
           state,
-          status: res.status,
-          response: json,
+          baseUrl,
+          attempts,
+          response: result.response,
         },
         0,
       );
     }
-
-    return writeJson({ ok: true, state, response: json });
-  } catch (e) {
-    const isAbort = e && (e.name === "AbortError" || e.name === "TimeoutError");
-    return writeJson(
-      {
-        ok: false,
-        code: "API_UNREACHABLE",
-        message:
-          (e && (e.message || String(e))) ||
-          `Could not reach ${baseUrl}/api/pet/state.`,
-        state,
-      },
-      0,
-    );
-  } finally {
-    clearTimeout(timer);
   }
+
+  return writeJson(
+    {
+      ok: false,
+      code: "API_UNREACHABLE",
+      state,
+      attempts,
+      message: "Could not reach OpenLoomi Pet state API on any local URL.",
+    },
+    0,
+  );
+}
+
+function parseStateCommandArgs(args) {
+  const out = { state: args && args.length > 0 ? args[0] : null, event: null };
+  for (let i = 1; i < (args || []).length; i += 1) {
+    const arg = args[i];
+    if (arg === "--event" && args[i + 1]) {
+      out.event = args[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+async function stateCommand(args) {
+  const { state, event } = parseStateCommandArgs(args || []);
+
+  if (!state) {
+    return writeJson({
+      ok: false,
+      state: null,
+      event,
+      hook: "skipped",
+      reason: "missing_state",
+      validStates: CAPYBARA_STATES_LIST,
+    });
+  }
+
+  if (!CAPYBARA_STATES.has(state)) {
+    return writeJson({
+      ok: false,
+      state,
+      event,
+      hook: "skipped",
+      reason: "invalid_state",
+      validStates: CAPYBARA_STATES_LIST,
+    });
+  }
+
+  const tokenStatus = getTokenStatus();
+  const token = readOpenLoomiAuthToken(tokenStatus);
+  if (!token) {
+    return writeJson({
+      ok: false,
+      state,
+      event,
+      hook: "skipped",
+      reason: "token_missing",
+    });
+  }
+
+  const attempts = [];
+
+  for (const baseUrl of getLocalApiBaseUrls()) {
+    const result = await postPetState(baseUrl, state, token, {
+      source: "codex-plugin",
+      event,
+      timeoutMs: PET_HTTP_TIMEOUT_MS,
+    });
+    attempts.push(result.attempt);
+
+    if (result.ok) {
+      return writeJson({
+        ok: true,
+        state,
+        event,
+        hook: "sent",
+        baseUrl,
+      });
+    }
+
+    if (result.code === "ENDPOINT_MISSING") {
+      return writeJson({
+        ok: false,
+        state,
+        event,
+        hook: "skipped",
+        reason: "endpoint_missing",
+        baseUrl,
+        attempts,
+      });
+    }
+
+    if (result.code === "PET_FAILED") {
+      return writeJson({
+        ok: false,
+        state,
+        event,
+        hook: "skipped",
+        reason: "pet_failed",
+        baseUrl,
+        attempts,
+      });
+    }
+  }
+
+  return writeJson({
+    ok: false,
+    state,
+    event,
+    hook: "skipped",
+    reason: "api_unreachable",
+    attempts,
+  });
 }
 
 async function main() {
@@ -4788,6 +4804,9 @@ async function main() {
       break;
     case "setup-status":
       await setupStatus();
+      break;
+    case "state":
+      await stateCommand(process.argv.slice(3));
       break;
     case "version":
       version();

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import { join, dirname, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -831,6 +831,44 @@ test("state hook command posts non-blocking pet state metadata", async () => {
   );
 });
 
+test("state hook command can run quietly for Codex hooks", async () => {
+  await withPetApiServer(
+    (req, res, request) => {
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/pet/state");
+      assert.deepEqual(request.json, {
+        state: "working",
+        source: "codex-plugin",
+        event: "PreToolUse",
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    },
+    async ({ baseUrl }) => {
+      await withFakeHomeAsync(async (env) => {
+        writeFakeToken(env.HOME);
+        const result = spawnSync(
+          process.execPath,
+          [BRIDGE, "state", "working", "--event", "PreToolUse", "--quiet"],
+          {
+            cwd: PLUGIN_DIR,
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              ...env,
+              OPENLOOMI_API_URL: baseUrl,
+              OPENLOOMI_BASE_URL: "",
+            },
+          },
+        );
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, "");
+        assert.equal(result.stderr, "");
+      });
+    },
+  );
+});
+
 test("state hook command skips without failing when token is missing", () => {
   withFakeHome((env) => {
     const r = runOutcome(["state", "working", "--event", "PreToolUse"], env);
@@ -865,7 +903,11 @@ test("plugin manifest declares Codex hook bundle", () => {
     assert.ok(Array.isArray(hooks.hooks[event]), `missing hook event ${event}`);
     const command = hooks.hooks[event][0].hooks[0];
     assert.match(command.command, /loomi-bridge\.mjs/);
+    assert.match(command.command, /--quiet/);
     assert.match(command.commandWindows, /loomi-bridge\.mjs/);
+    assert.match(command.commandWindows, /\$env:PLUGIN_ROOT/);
+    assert.doesNotMatch(command.commandWindows, /%PLUGIN_ROOT%/);
+    assert.match(command.commandWindows, /--quiet/);
     assert.equal(command.timeout, 5);
   }
 });

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -10,24 +10,35 @@
 // Or from the repo root:
 //   node --test plugins/codex/tests/
 
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { join, dirname, delimiter } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile, execFileSync } from "node:child_process";
+import { createServer } from "node:http";
+import { join, dirname, delimiter } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { promisify } from "node:util";
 
 const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
-const BRIDGE = join(PLUGIN_DIR, 'scripts', 'loomi-bridge.mjs');
+const BRIDGE = join(PLUGIN_DIR, "scripts", "loomi-bridge.mjs");
+const execFileAsync = promisify(execFile);
 
 // Accept env directly (positional) so callers can write `run(args, env)`
 // without wrapping it in `{ env }`. This matches the convention used
 // throughout the file (see `withFakeHome` → `runOutcome(... , env)` and
 // `runJson(args, env)`).
 function run(args, env = {}) {
-  return execFileSync('node', [BRIDGE, ...args], {
-    encoding: 'utf8',
+  return execFileSync("node", [BRIDGE, ...args], {
+    encoding: "utf8",
     env: { ...process.env, ...env },
     cwd: env.BRIDGE_TEST_CWD || process.cwd(),
   });
@@ -35,35 +46,35 @@ function run(args, env = {}) {
 
 function runOutcome(args, env) {
   try {
-    const stdout = execFileSync('node', [BRIDGE, ...args], {
-      encoding: 'utf8',
+    const stdout = execFileSync("node", [BRIDGE, ...args], {
+      encoding: "utf8",
       env: { ...process.env, ...env },
       cwd: env.BRIDGE_TEST_CWD || process.cwd(),
     });
-    return { code: 0, stdout, stderr: '' };
+    return { code: 0, stdout, stderr: "" };
   } catch (e) {
     return {
       code: e.status ?? 1,
-      stdout: String(e.stdout ?? ''),
-      stderr: String(e.stderr ?? ''),
+      stdout: String(e.stdout ?? ""),
+      stderr: String(e.stderr ?? ""),
     };
   }
 }
 
 function runOutcomeWithInput(args, env, input) {
   try {
-    const stdout = execFileSync('node', [BRIDGE, ...args], {
-      encoding: 'utf8',
+    const stdout = execFileSync("node", [BRIDGE, ...args], {
+      encoding: "utf8",
       env: { ...process.env, ...env },
       input,
       cwd: env.BRIDGE_TEST_CWD || process.cwd(),
     });
-    return { code: 0, stdout, stderr: '' };
+    return { code: 0, stdout, stderr: "" };
   } catch (e) {
     return {
       code: e.status ?? 1,
-      stdout: String(e.stdout ?? ''),
-      stderr: String(e.stderr ?? ''),
+      stdout: String(e.stdout ?? ""),
+      stderr: String(e.stderr ?? ""),
     };
   }
 }
@@ -72,43 +83,56 @@ function runJson(args, env) {
   return JSON.parse(run(args, env));
 }
 
+async function runAsync(args, env = {}) {
+  const { stdout } = await execFileAsync("node", [BRIDGE, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    cwd: env.BRIDGE_TEST_CWD || process.cwd(),
+  });
+  return stdout;
+}
+
+async function runJsonAsync(args, env) {
+  return JSON.parse(await runAsync(args, env));
+}
+
 // Run a child command with HOME pointed at a fresh temp dir and PATH that
 // still resolves to the current node binary. Avoids touching the user's
 // real ~/.openloomi/ token.
 function withFakeHome(fn) {
-  const tmp = mkdtempSync(join(tmpdir(), 'openloomi-codex-test-'));
+  const tmp = mkdtempSync(join(tmpdir(), "openloomi-codex-test-"));
   const nodeDir = dirname(process.execPath);
-  const preservedPath = process.env.PATH || '/usr/bin:/bin';
+  const preservedPath = process.env.PATH || "/usr/bin:/bin";
   const pathWithNode = preservedPath.includes(nodeDir)
     ? preservedPath
     : `${nodeDir}${delimiter}${preservedPath}`;
   const env = {
     HOME: tmp,
     USERPROFILE: tmp,
-    LOCALAPPDATA: join(tmp, 'AppData', 'Local'),
-    APPDATA: join(tmp, 'AppData', 'Roaming'),
-    PROGRAMFILES: join(tmp, 'Program Files'),
-    'ProgramFiles(x86)': join(tmp, 'Program Files (x86)'),
+    LOCALAPPDATA: join(tmp, "AppData", "Local"),
+    APPDATA: join(tmp, "AppData", "Roaming"),
+    PROGRAMFILES: join(tmp, "Program Files"),
+    "ProgramFiles(x86)": join(tmp, "Program Files (x86)"),
     BRIDGE_TEST_CWD: tmp,
     PATH: pathWithNode,
-    OPENLOOMI_BIN: '',
-    OPENLOOMI_CTL: '',
-    OPENLOOMI_HOME: '',
-    OPENLOOMI_INSTALL_DIR: '',
-    OPENLOOMI_REPO_DIR: '',
-    OPENLOOMI_API_URL: '',
-    OPENLOOMI_BASE_URL: 'http://127.0.0.1:1',
-    OPENLOOMI_AUTH_TOKEN: '',
-    OPENAI_API_KEY: '',
-    ANTHROPIC_API_KEY: '',
-    OPENROUTER_API_KEY: '',
-    OPENLOOMI_AI_API_KEY: '',
-    OPENAI_BASE_URL: '',
-    ANTHROPIC_BASE_URL: '',
-    OPENROUTER_BASE_URL: '',
-    OPENLOOMI_AI_BASE_URL: '',
-    OPENLOOMI_AI_MODEL: '',
-    OPENLOOMI_DEBUG_DISCOVERY: '1',
+    OPENLOOMI_BIN: "",
+    OPENLOOMI_CTL: "",
+    OPENLOOMI_HOME: "",
+    OPENLOOMI_INSTALL_DIR: "",
+    OPENLOOMI_REPO_DIR: "",
+    OPENLOOMI_API_URL: "",
+    OPENLOOMI_BASE_URL: "http://127.0.0.1:1",
+    OPENLOOMI_AUTH_TOKEN: "",
+    OPENAI_API_KEY: "",
+    ANTHROPIC_API_KEY: "",
+    OPENROUTER_API_KEY: "",
+    OPENLOOMI_AI_API_KEY: "",
+    OPENAI_BASE_URL: "",
+    ANTHROPIC_BASE_URL: "",
+    OPENROUTER_BASE_URL: "",
+    OPENLOOMI_AI_BASE_URL: "",
+    OPENLOOMI_AI_MODEL: "",
+    OPENLOOMI_DEBUG_DISCOVERY: "1",
   };
   try {
     return fn(env);
@@ -117,14 +141,59 @@ function withFakeHome(fn) {
   }
 }
 
+async function withFakeHomeAsync(fn) {
+  const tmp = mkdtempSync(join(tmpdir(), "openloomi-codex-test-"));
+  const nodeDir = dirname(process.execPath);
+  const preservedPath = process.env.PATH || "/usr/bin:/bin";
+  const pathWithNode = preservedPath.includes(nodeDir)
+    ? preservedPath
+    : `${nodeDir}${delimiter}${preservedPath}`;
+  const env = {
+    HOME: tmp,
+    USERPROFILE: tmp,
+    LOCALAPPDATA: join(tmp, "AppData", "Local"),
+    APPDATA: join(tmp, "AppData", "Roaming"),
+    PROGRAMFILES: join(tmp, "Program Files"),
+    "ProgramFiles(x86)": join(tmp, "Program Files (x86)"),
+    BRIDGE_TEST_CWD: tmp,
+    PATH: pathWithNode,
+    OPENLOOMI_BIN: "",
+    OPENLOOMI_CTL: "",
+    OPENLOOMI_HOME: "",
+    OPENLOOMI_INSTALL_DIR: "",
+    OPENLOOMI_REPO_DIR: "",
+    OPENLOOMI_API_URL: "",
+    OPENLOOMI_BASE_URL: "http://127.0.0.1:1",
+    OPENLOOMI_AUTH_TOKEN: "",
+    OPENAI_API_KEY: "",
+    ANTHROPIC_API_KEY: "",
+    OPENROUTER_API_KEY: "",
+    OPENLOOMI_AI_API_KEY: "",
+    OPENAI_BASE_URL: "",
+    ANTHROPIC_BASE_URL: "",
+    OPENROUTER_BASE_URL: "",
+    OPENLOOMI_AI_BASE_URL: "",
+    OPENLOOMI_AI_MODEL: "",
+    OPENLOOMI_DEBUG_DISCOVERY: "1",
+  };
+  try {
+    return await fn(env);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 function writeFakeToken(home) {
-  const dir = join(home, '.openloomi');
+  const dir = join(home, ".openloomi");
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, 'token'), Buffer.from('fake-openloomi-token', 'utf8').toString('base64'));
+  writeFileSync(
+    join(dir, "token"),
+    Buffer.from("fake-openloomi-token", "utf8").toString("base64"),
+  );
 }
 
 function getRunLockPath(home) {
-  return join(home, '.openloomi', 'codex-plugin-run.lock');
+  return join(home, ".openloomi", "codex-plugin-run.lock");
 }
 
 function writeRunLock(home, { startedAt = Date.now(), pid = 99999 } = {}) {
@@ -136,14 +205,49 @@ function writeRunLock(home, { startedAt = Date.now(), pid = 99999 } = {}) {
       id: `test-lock-${startedAt}`,
       pid,
       startedAt,
-      command: 'run',
+      command: "run",
     }),
   );
   return lockPath;
 }
 
+async function withPetApiServer(handler, fn) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      let json = null;
+      try {
+        json = raw ? JSON.parse(raw) : null;
+      } catch {
+        json = { raw };
+      }
+      const request = {
+        method: req.method,
+        url: req.url,
+        authorization: req.headers.authorization || null,
+        json,
+      };
+      requests.push(request);
+      handler(req, res, request);
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    return await fn({ baseUrl: `http://127.0.0.1:${port}`, requests });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
 function writeFakeCtl(home) {
-  const nodeScript = join(home, 'fake-openloomi-ctl.mjs');
+  const nodeScript = join(home, "fake-openloomi-ctl.mjs");
   writeFileSync(
     nodeScript,
     [
@@ -161,16 +265,19 @@ function writeFakeCtl(home) {
       "    prompt: input,",
       "  }));",
       "});",
-    ].join('\n'),
+    ].join("\n"),
   );
 
-  if (process.platform === 'win32') {
-    const cmd = join(home, 'openloomi-ctl.cmd');
-    writeFileSync(cmd, `@"${process.execPath}" "%~dp0fake-openloomi-ctl.mjs" %*\r\n`);
+  if (process.platform === "win32") {
+    const cmd = join(home, "openloomi-ctl.cmd");
+    writeFileSync(
+      cmd,
+      `@"${process.execPath}" "%~dp0fake-openloomi-ctl.mjs" %*\r\n`,
+    );
     return cmd;
   }
 
-  const shim = join(home, 'openloomi-ctl');
+  const shim = join(home, "openloomi-ctl");
   const nodePath = process.execPath.replace(/'/g, "'\\''");
   writeFileSync(
     shim,
@@ -184,26 +291,26 @@ function writeFakeCtl(home) {
 // version
 // -----------------------------------------------------------------------------
 
-test('version returns bridge identity and command list', () => {
-  const j = runJson(['version']);
-  assert.equal(j.name, 'openloomi-codex-bridge');
-  assert.equal(typeof j.version, 'string');
+test("version returns bridge identity and command list", () => {
+  const j = runJson(["version"]);
+  assert.equal(j.name, "openloomi-codex-bridge");
+  assert.equal(typeof j.version, "string");
   assert.ok(j.version.length > 0);
-  assert.equal(j.pluginPhase, 'runtime-provider-readiness');
+  assert.equal(j.pluginPhase, "runtime-provider-readiness");
   assert.ok(Array.isArray(j.commands));
   // Must include the bridge's public commands.
   for (const cmd of [
-    'setup-status',
-    'setup',
-    'install-openloomi',
-    'install-instructions',
-    'initialize-session',
-    'configure-ai-provider',
-    'workflow-guidance',
-    'version',
-    'help',
-    'run',
-    'codex-runtime-info',
+    "setup-status",
+    "setup",
+    "install-openloomi",
+    "install-instructions",
+    "initialize-session",
+    "configure-ai-provider",
+    "workflow-guidance",
+    "version",
+    "help",
+    "run",
+    "codex-runtime-info",
   ]) {
     assert.ok(j.commands.includes(cmd), `version.commands missing ${cmd}`);
   }
@@ -213,18 +320,18 @@ test('version returns bridge identity and command list', () => {
 // setup-status shape contract
 // -----------------------------------------------------------------------------
 
-test('setup-status apiProbe field is present and well-formed', () => {
-  const j = runJson(['setup-status']);
-  assert.ok(j.apiProbe, 'setup-status must include apiProbe field');
+test("setup-status apiProbe field is present and well-formed", () => {
+  const j = runJson(["setup-status"]);
+  assert.ok(j.apiProbe, "setup-status must include apiProbe field");
   // Top-level apiReachable boolean mirrors the apiProbe summary.
-  assert.equal(typeof j.apiReachable, 'boolean');
+  assert.equal(typeof j.apiReachable, "boolean");
   assert.equal(j.apiReachable, Boolean(j.apiProbe.reachableUrl));
   assert.ok(Array.isArray(j.apiProbe.attempts));
   for (const entry of j.apiProbe.attempts) {
-    assert.equal(typeof entry.baseUrl, 'string');
+    assert.equal(typeof entry.baseUrl, "string");
     assert.ok(
-      ['NETWORK_ERROR', 'TIMEOUT', 'HTTP_RESPONSE'].includes(entry.reason) ||
-        typeof entry.status === 'number',
+      ["NETWORK_ERROR", "TIMEOUT", "HTTP_RESPONSE"].includes(entry.reason) ||
+        typeof entry.status === "number",
       `unexpected apiProbe attempt reason: ${entry.reason}`,
     );
   }
@@ -233,70 +340,77 @@ test('setup-status apiProbe field is present and well-formed', () => {
   assert.ok(Array.isArray(j.checks.apiProbe));
 });
 
-test('setup-status reports OPENLOOMI_API_UNREACHABLE when API down and no token', () => {
+test("setup-status reports OPENLOOMI_API_UNREACHABLE when API down and no token", () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     // Make sure no token file is present and no local API is reachable
     // (fake HOME guarantees ~/.openloomi/token does not exist; the fake
     // env forces OPENLOOMI_BASE_URL to a closed port).
-    const j = runJson(['setup-status'], {
+    const j = runJson(["setup-status"], {
       ...env,
       OPENLOOMI_CTL: ctl,
     });
     assert.equal(j.apiReachable, false);
     if (!j.tokenPresent) {
       assert.equal(j.ready, false);
-      assert.equal(j.nextAction, 'open_openloomi');
-      assert.equal(j.reason, 'OPENLOOMI_API_UNREACHABLE');
+      assert.equal(j.nextAction, "open_openloomi");
+      assert.equal(j.reason, "OPENLOOMI_API_UNREACHABLE");
     }
   });
 });
 
-test('setup-status exposes the protocol contract fields', () => {
-  const j = runJson(['setup-status']);
+test("setup-status exposes the protocol contract fields", () => {
+  const j = runJson(["setup-status"]);
   for (const key of [
-    'mode',
-    'installed',
-    'ctlPath',
-    'version',
-    'tokenPresent',
-    'aiProviderConfigured',
-    'apiReachable',
-    'ready',
-    'nextAction',
-    'reason',
+    "mode",
+    "installed",
+    "ctlPath",
+    "version",
+    "tokenPresent",
+    "aiProviderConfigured",
+    "apiReachable",
+    "ready",
+    "nextAction",
+    "reason",
   ]) {
     assert.ok(key in j, `setup-status missing required key: ${key}`);
   }
-  assert.equal(typeof j.ready, 'boolean');
-  assert.equal(typeof j.tokenPresent, 'boolean');
-  assert.equal(typeof j.installed, 'boolean');
-  assert.equal(typeof j.apiReachable, 'boolean');
+  assert.equal(typeof j.ready, "boolean");
+  assert.equal(typeof j.tokenPresent, "boolean");
+  assert.equal(typeof j.installed, "boolean");
+  assert.equal(typeof j.apiReachable, "boolean");
   // Either an installed OpenLoomi has a ctlPath, or nextAction must point
   // the user at install_openloomi / provide_install_or_repo_path.
   if (!j.installed) {
     assert.ok(
-      ['install_openloomi', 'provide_install_or_repo_path', 'build_or_stage_openloomi_ctl'].includes(j.nextAction),
+      [
+        "install_openloomi",
+        "provide_install_or_repo_path",
+        "build_or_stage_openloomi_ctl",
+      ].includes(j.nextAction),
       `unexpected nextAction when not installed: ${j.nextAction}`,
     );
   }
 });
 
-test('setup-status aiProvider checks only report presence, never values', () => {
+test("setup-status aiProvider checks only report presence, never values", () => {
   withFakeHome((env) => {
-    const j = runJson(['setup-status'], env);
+    const j = runJson(["setup-status"], env);
     // Every check entry must have {key, present, source}; no value field.
     for (const entry of j.checks.aiProvider || []) {
-      assert.equal(typeof entry.key, 'string');
-      assert.equal(typeof entry.present, 'boolean');
-      assert.equal(typeof entry.source, 'string');
-      assert.ok(!('value' in entry), `aiProvider check leaked a value: ${entry.key}`);
+      assert.equal(typeof entry.key, "string");
+      assert.equal(typeof entry.present, "boolean");
+      assert.equal(typeof entry.source, "string");
+      assert.ok(
+        !("value" in entry),
+        `aiProvider check leaked a value: ${entry.key}`,
+      );
     }
     for (const entry of j.checks.auth || []) {
-      assert.equal(typeof entry.key, 'string');
-      assert.equal(typeof entry.present, 'boolean');
-      assert.equal(typeof entry.source, 'string');
-      assert.ok(!('value' in entry), `auth check leaked a value: ${entry.key}`);
+      assert.equal(typeof entry.key, "string");
+      assert.equal(typeof entry.present, "boolean");
+      assert.equal(typeof entry.source, "string");
+      assert.ok(!("value" in entry), `auth check leaked a value: ${entry.key}`);
     }
   });
 });
@@ -306,15 +420,15 @@ test('run preserves the direct runner by not synthesizing OPENLOOMI_API_URL', ()
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
     const r = runOutcomeWithInput(
-      ['run'],
+      ["run"],
       {
         ...env,
         OPENLOOMI_CTL: ctl,
-        OPENLOOMI_BASE_URL: 'http://localhost:3515',
-        OPENLOOMI_API_URL: '',
-        ANTHROPIC_API_KEY: 'sk-test-never-print',
+        OPENLOOMI_BASE_URL: "http://localhost:3515",
+        OPENLOOMI_API_URL: "",
+        ANTHROPIC_API_KEY: "sk-test-never-print",
       },
-      'Reply with exactly: OpenLoomi ready.',
+      "Reply with exactly: OpenLoomi ready.",
     );
     assert.equal(r.code, 0, r.stderr || r.stdout);
     const j = JSON.parse(r.stdout);
@@ -350,31 +464,31 @@ test('run preserves an explicitly configured OPENLOOMI_API_URL', () => {
   });
 });
 
-test('run refuses nested bridge invocation when an active run lock exists', () => {
+test("run refuses nested bridge invocation when an active run lock exists", () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
     writeRunLock(env.HOME);
     const r = runOutcomeWithInput(
-      ['run'],
+      ["run"],
       {
         ...env,
         OPENLOOMI_CTL: ctl,
-        ANTHROPIC_API_KEY: 'sk-test-never-print',
+        ANTHROPIC_API_KEY: "sk-test-never-print",
       },
-      'Nested request should be refused.',
+      "Nested request should be refused.",
     );
     assert.equal(r.code, 1);
     const j = JSON.parse(r.stdout);
-    assert.equal(j.reason, 'RECURSION_GUARD');
+    assert.equal(j.reason, "RECURSION_GUARD");
     assert.equal(j.ran, false);
-    assert.equal(j.command, 'run');
-    assert.equal(j.nextAction, 'return_without_bridge');
-    assert.ok(!r.stdout.includes('sk-test-never-print'));
+    assert.equal(j.command, "run");
+    assert.equal(j.nextAction, "return_without_bridge");
+    assert.ok(!r.stdout.includes("sk-test-never-print"));
   });
 });
 
-test('run cleans stale lock and proceeds', () => {
+test("run cleans stale lock and proceeds", () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
@@ -382,29 +496,29 @@ test('run cleans stale lock and proceeds', () => {
       startedAt: Date.now() - 10_000,
     });
     const r = runOutcomeWithInput(
-      ['run'],
+      ["run"],
       {
         ...env,
         OPENLOOMI_CTL: ctl,
-        OPENLOOMI_CODEX_BRIDGE_RUN_LOCK_TTL_MS: '1',
-        ANTHROPIC_API_KEY: 'sk-test-never-print',
+        OPENLOOMI_CODEX_BRIDGE_RUN_LOCK_TTL_MS: "1",
+        ANTHROPIC_API_KEY: "sk-test-never-print",
       },
-      'Stale lock should be ignored.',
+      "Stale lock should be ignored.",
     );
     assert.equal(r.code, 0, r.stderr || r.stdout);
     const j = JSON.parse(r.stdout);
-    assert.equal(j.reason, 'RUN_COMPLETE');
-    assert.equal(j.result.prompt, 'Stale lock should be ignored.');
-    assert.equal(existsSync(lockPath), false, 'run lock should be released');
+    assert.equal(j.reason, "RUN_COMPLETE");
+    assert.equal(j.result.prompt, "Stale lock should be ignored.");
+    assert.equal(existsSync(lockPath), false, "run lock should be released");
   });
 });
 
-test('setup-status is not blocked by an active run lock', () => {
+test("setup-status is not blocked by an active run lock", () => {
   withFakeHome((env) => {
     writeRunLock(env.HOME);
-    const j = runJson(['setup-status'], env);
-    assert.notEqual(j.reason, 'RECURSION_GUARD');
-    assert.ok('ready' in j);
+    const j = runJson(["setup-status"], env);
+    assert.notEqual(j.reason, "RECURSION_GUARD");
+    assert.ok("ready" in j);
   });
 });
 
@@ -412,32 +526,35 @@ test('setup-status is not blocked by an active run lock', () => {
 // install-instructions / workflow-guidance
 // -----------------------------------------------------------------------------
 
-test('install-instructions returns a supported install plan on darwin', () => {
-  if (process.platform !== 'darwin' && process.platform !== 'linux') return;
-  const j = runJson(['install-instructions']);
-  assert.equal(j.nextAction, 'install_openloomi');
-  assert.equal(j.reason, 'INSTALL_REQUIRED');
+test("install-instructions returns a supported install plan on darwin", () => {
+  if (process.platform !== "darwin" && process.platform !== "linux") return;
+  const j = runJson(["install-instructions"]);
+  assert.equal(j.nextAction, "install_openloomi");
+  assert.equal(j.reason, "INSTALL_REQUIRED");
   assert.equal(j.installPlan.platform, process.platform);
   assert.equal(j.installPlan.arch, process.arch);
   assert.equal(j.installPlan.supported, true);
-  assert.match(j.installPlan.officialReleaseApi, /^https:\/\/api\.github\.com\//);
+  assert.match(
+    j.installPlan.officialReleaseApi,
+    /^https:\/\/api\.github\.com\//,
+  );
   // Safety reminder must be present.
   assert.ok(Array.isArray(j.installPlan.safety));
   assert.ok(
-    j.installPlan.safety.some((s) => s.includes('--confirm')),
-    'install plan should mention --confirm',
+    j.installPlan.safety.some((s) => s.includes("--confirm")),
+    "install plan should mention --confirm",
   );
 });
 
-test('workflow-guidance lists the four openloomi workflows', () => {
-  const j = runJson(['workflow-guidance']);
+test("workflow-guidance lists the four openloomi workflows", () => {
+  const j = runJson(["workflow-guidance"]);
   assert.ok(j.ready);
   const ids = (j.workflows || []).map((w) => w.id);
   for (const id of [
-    'openloomi-loop',
-    'openloomi-memory',
-    'openloomi-connectors',
-    'openloomi-handoff',
+    "openloomi-loop",
+    "openloomi-memory",
+    "openloomi-connectors",
+    "openloomi-handoff",
   ]) {
     assert.ok(ids.includes(id), `workflow-guidance missing ${id}`);
   }
@@ -447,10 +564,14 @@ test('workflow-guidance lists the four openloomi workflows', () => {
 // Secrets contract — the plugin must never echo API key / token values
 // -----------------------------------------------------------------------------
 
-test('workflow-guidance uses runtime-safe run prompts for agent workflows', () => {
-  for (const workflow of ['openloomi-loop', 'openloomi-memory', 'openloomi-handoff']) {
-    const j = runJson(['workflow-guidance', '--workflow', workflow]);
-    const prefix = j.workflow?.taskPromptPrefix || '';
+test("workflow-guidance uses runtime-safe run prompts for agent workflows", () => {
+  for (const workflow of [
+    "openloomi-loop",
+    "openloomi-memory",
+    "openloomi-handoff",
+  ]) {
+    const j = runJson(["workflow-guidance", "--workflow", workflow]);
+    const prefix = j.workflow?.taskPromptPrefix || "";
     assert.match(prefix, /already inside the OpenLoomi runtime/);
     assert.match(prefix, /Do not call tools, shell, skills/);
     assert.match(prefix, /loomi-bridge/);
@@ -458,55 +579,55 @@ test('workflow-guidance uses runtime-safe run prompts for agent workflows', () =
   }
 });
 
-test('secrets contract: fake key value never appears in any subcommand output', () => {
+test("secrets contract: fake key value never appears in any subcommand output", () => {
   withFakeHome((env) => {
-    const fake = 'sk-leaktest-ThisShouldNeverAppear-12345';
+    const fake = "sk-leaktest-ThisShouldNeverAppear-12345";
     const inputs = {
       ...env,
       OPENLOOMI_AUTH_TOKEN: fake,
       OPENAI_API_KEY: fake,
       ANTHROPIC_API_KEY: fake,
       OPENLOOMI_AI_API_KEY: fake,
-      ANTHROPIC_BASE_URL: 'http://127.0.0.1:1',
-      OPENLOOMI_AI_BASE_URL: 'http://127.0.0.1:1',
-      OPENLOOMI_AI_MODEL: 'leaktest-model',
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:1",
+      OPENLOOMI_AI_BASE_URL: "http://127.0.0.1:1",
+      OPENLOOMI_AI_MODEL: "leaktest-model",
     };
     for (const sub of [
-      ['version'],
-      ['setup-status'],
-      ['install-instructions'],
-      ['workflow-guidance'],
-      ['configure-ai-provider'],
-      ['help'],
+      ["version"],
+      ["setup-status"],
+      ["install-instructions"],
+      ["workflow-guidance"],
+      ["configure-ai-provider"],
+      ["help"],
     ]) {
       const r = runOutcome(sub, inputs);
       assert.ok(
-        !r.stdout.includes('sk-leaktest'),
-        `${sub.join(' ')} stdout leaked sk-leaktest`,
+        !r.stdout.includes("sk-leaktest"),
+        `${sub.join(" ")} stdout leaked sk-leaktest`,
       );
       assert.ok(
-        !r.stdout.includes('ThisShouldNeverAppear'),
-        `${sub.join(' ')} stdout leaked ThisShouldNeverAppear`,
+        !r.stdout.includes("ThisShouldNeverAppear"),
+        `${sub.join(" ")} stdout leaked ThisShouldNeverAppear`,
       );
       assert.ok(
-        !r.stderr.includes('sk-leaktest'),
-        `${sub.join(' ')} stderr leaked sk-leaktest`,
+        !r.stderr.includes("sk-leaktest"),
+        `${sub.join(" ")} stderr leaked sk-leaktest`,
       );
     }
   });
 });
 
-test('secrets contract: install-openloomi refuses without --confirm and never reveals values', () => {
+test("secrets contract: install-openloomi refuses without --confirm and never reveals values", () => {
   withFakeHome((env) => {
-    const r = runOutcome(
-      ['install-openloomi'],
-      { ...env, OPENLOOMI_AUTH_TOKEN: 'sk-leaktest-INSTALL-x' },
-    );
+    const r = runOutcome(["install-openloomi"], {
+      ...env,
+      OPENLOOMI_AUTH_TOKEN: "sk-leaktest-INSTALL-x",
+    });
     // No confirm, no install attempted. Either succeeds with a "needs
     // confirmation" payload, or returns INSTALL_CONFIRMATION_REQUIRED. We
     // accept both; the absolute requirement is no value leak.
-    assert.ok(!r.stdout.includes('sk-leaktest-INSTALL-x'));
-    assert.ok(!r.stderr.includes('sk-leaktest-INSTALL-x'));
+    assert.ok(!r.stdout.includes("sk-leaktest-INSTALL-x"));
+    assert.ok(!r.stderr.includes("sk-leaktest-INSTALL-x"));
   });
 });
 
@@ -514,22 +635,22 @@ test('secrets contract: install-openloomi refuses without --confirm and never re
 // setup state machine — the new end-to-end command
 // -----------------------------------------------------------------------------
 
-test('setup without --yes returns awaiting_user_action when install is required', () => {
+test("setup without --yes returns awaiting_user_action when install is required", () => {
   withFakeHome((env) => {
     // Force "not installed" by pointing discovery at a non-existent ctl.
-    const r = runOutcome(
-      ['setup'],
-      {
-        ...env,
-        OPENLOOMI_BIN: '/nonexistent-ctl-please-ignore',
-        OPENLOOMI_HOME: '/nonexistent-home',
-        OPENLOOMI_REPO_DIR: '/nonexistent-repo',
-        PATH: dirname(process.execPath),
-      },
-    );
+    const r = runOutcome(["setup"], {
+      ...env,
+      OPENLOOMI_BIN: "/nonexistent-ctl-please-ignore",
+      OPENLOOMI_HOME: "/nonexistent-home",
+      OPENLOOMI_REPO_DIR: "/nonexistent-repo",
+      PATH: dirname(process.execPath),
+    });
     const j = JSON.parse(r.stdout);
-    assert.ok(j.steps && j.steps.length > 0, 'setup must record at least one step');
-    if (j.setup === 'awaiting_user_action') {
+    assert.ok(
+      j.steps && j.steps.length > 0,
+      "setup must record at least one step",
+    );
+    if (j.setup === "awaiting_user_action") {
       // The state machine may now surface a new "open_openloomi" branch
       // when the local OpenLoomi API is unreachable even though a ctl was
       // explicitly disabled via OPENLOOMI_BIN. Accept that as an
@@ -537,10 +658,10 @@ test('setup without --yes returns awaiting_user_action when install is required'
       // desktop app before the wizard can continue.
       assert.ok(
         [
-          'confirm_install_openloomi',
-          'install_openloomi',
-          'build_or_stage_openloomi_ctl',
-          'open_openloomi',
+          "confirm_install_openloomi",
+          "install_openloomi",
+          "build_or_stage_openloomi_ctl",
+          "open_openloomi",
         ].includes(j.nextAction),
         `unexpected nextAction: ${j.nextAction}`,
       );
@@ -548,15 +669,15 @@ test('setup without --yes returns awaiting_user_action when install is required'
       // If the test environment happens to have OpenLoomi installed, the
       // state machine may continue to session init. That's fine — we only
       // require the machine not to crash and to expose {steps, status}.
-      assert.equal(typeof j.steps, 'object');
-      assert.equal(typeof j.status, 'object');
+      assert.equal(typeof j.steps, "object");
+      assert.equal(typeof j.status, "object");
     }
   });
 });
 
-test('setup records steps in chronological order and timestamps are monotonic', () => {
+test("setup records steps in chronological order and timestamps are monotonic", () => {
   withFakeHome((env) => {
-    const r = runOutcome(['setup'], env);
+    const r = runOutcome(["setup"], env);
     const j = JSON.parse(r.stdout);
     if (!j.steps || j.steps.length < 2) return; // single-step state is acceptable
     for (let i = 1; i < j.steps.length; i += 1) {
@@ -564,18 +685,26 @@ test('setup records steps in chronological order and timestamps are monotonic', 
         j.steps[i].at >= j.steps[i - 1].at,
         `steps[${i}].at (${j.steps[i].at}) < steps[${i - 1}].at (${j.steps[i - 1].at})`,
       );
-      assert.equal(typeof j.steps[i].step, 'string');
-      assert.equal(typeof j.steps[i].ok, 'boolean');
+      assert.equal(typeof j.steps[i].step, "string");
+      assert.equal(typeof j.steps[i].ok, "boolean");
     }
   });
 });
 
-test('setup status field mirrors setup-status when the loop exits', () => {
+test("setup status field mirrors setup-status when the loop exits", () => {
   withFakeHome((env) => {
-    const r = runOutcome(['setup'], env);
+    const r = runOutcome(["setup"], env);
     const j = JSON.parse(r.stdout);
     assert.ok(j.status);
-    for (const key of ['installed', 'tokenPresent', 'aiProviderConfigured', 'apiReachable', 'ready', 'nextAction', 'reason']) {
+    for (const key of [
+      "installed",
+      "tokenPresent",
+      "aiProviderConfigured",
+      "apiReachable",
+      "ready",
+      "nextAction",
+      "reason",
+    ]) {
       assert.ok(key in j.status, `setup response.status missing ${key}`);
     }
   });
@@ -589,118 +718,248 @@ test('setup status field mirrors setup-status when the loop exits', () => {
 // pet <state>
 // -----------------------------------------------------------------------------
 
-test('pet without state argument returns MISSING_STATE with validStates list', () => {
-  const j = runJson(['pet']);
+test("pet without state argument returns MISSING_STATE with validStates list", () => {
+  const j = runJson(["pet"]);
   assert.equal(j.ok, false);
-  assert.equal(j.code, 'MISSING_STATE');
+  assert.equal(j.code, "MISSING_STATE");
   assert.ok(Array.isArray(j.validStates));
   assert.equal(j.validStates.length, 9);
-  for (const s of ['happy', 'idle', 'juggling', 'needsinput', 'presenting', 'sleeping', 'sweeping', 'thinking', 'working']) {
+  for (const s of [
+    "happy",
+    "idle",
+    "juggling",
+    "needsinput",
+    "presenting",
+    "sleeping",
+    "sweeping",
+    "thinking",
+    "working",
+  ]) {
     assert.ok(j.validStates.includes(s), `validStates missing ${s}`);
   }
 });
 
-test('pet with invalid state returns INVALID_STATE', () => {
-  const j = runJson(['pet', 'dancing']);
+test("pet with invalid state returns INVALID_STATE", () => {
+  const j = runJson(["pet", "dancing"]);
   assert.equal(j.ok, false);
-  assert.equal(j.code, 'INVALID_STATE');
-  assert.equal(j.received, 'dancing');
-  assert.ok(j.validStates.includes('happy'));
+  assert.equal(j.code, "INVALID_STATE");
+  assert.equal(j.received, "dancing");
+  assert.ok(j.validStates.includes("happy"));
 });
 
-test('pet with token missing returns TOKEN_MISSING under fake HOME', () => {
+test("pet with token missing returns TOKEN_MISSING under fake HOME", () => {
   withFakeHome((env) => {
-    const j = runJson(['pet', 'happy'], env);
+    const j = runJson(["pet", "happy"], env);
     assert.equal(j.ok, false);
     // Either TOKEN_MISSING (no ~/.openloomi/token) or API_UNREACHABLE
     // (would-be call hits a closed port). Both are valid first-line
     // errors when neither the token nor the runtime are available.
     assert.ok(
-      ['TOKEN_MISSING', 'API_UNREACHABLE'].includes(j.code),
+      ["TOKEN_MISSING", "API_UNREACHABLE"].includes(j.code),
       `unexpected pet code: ${j.code}`,
     );
   });
 });
 
-test('argv hardening: unknown flags are not silently accepted as secrets', () => {
+test("pet posts state to explicit OpenLoomi API URL", async () => {
+  await withPetApiServer(
+    (req, res, request) => {
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/pet/state");
+      assert.equal(request.authorization, "Bearer fake-openloomi-token");
+      assert.deepEqual(request.json, {
+        state: "working",
+        source: "codex-plugin",
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          ok: true,
+          state: request.json.state,
+          source: request.json.source,
+        }),
+      );
+    },
+    async ({ baseUrl }) => {
+      await withFakeHomeAsync(async (env) => {
+        writeFakeToken(env.HOME);
+        const j = await runJsonAsync(["pet", "working"], {
+          ...env,
+          OPENLOOMI_API_URL: baseUrl,
+          OPENLOOMI_BASE_URL: "",
+        });
+        assert.equal(j.ok, true);
+        assert.equal(j.code, "PET_STATE_SET");
+        assert.equal(j.state, "working");
+        assert.equal(j.baseUrl, baseUrl);
+        assert.equal(j.response.source, "codex-plugin");
+      });
+    },
+  );
+});
+
+test("state hook command posts non-blocking pet state metadata", async () => {
+  await withPetApiServer(
+    (req, res, request) => {
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/pet/state");
+      assert.deepEqual(request.json, {
+        state: "needsinput",
+        source: "codex-plugin",
+        event: "PermissionRequest",
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    },
+    async ({ baseUrl }) => {
+      await withFakeHomeAsync(async (env) => {
+        writeFakeToken(env.HOME);
+        const j = await runJsonAsync(
+          ["state", "needsinput", "--event", "PermissionRequest"],
+          {
+            ...env,
+            OPENLOOMI_API_URL: baseUrl,
+            OPENLOOMI_BASE_URL: "",
+          },
+        );
+        assert.equal(j.ok, true);
+        assert.equal(j.hook, "sent");
+        assert.equal(j.state, "needsinput");
+        assert.equal(j.event, "PermissionRequest");
+      });
+    },
+  );
+});
+
+test("state hook command skips without failing when token is missing", () => {
+  withFakeHome((env) => {
+    const r = runOutcome(["state", "working", "--event", "PreToolUse"], env);
+    const j = JSON.parse(r.stdout);
+    assert.equal(r.code, 0);
+    assert.equal(j.ok, false);
+    assert.equal(j.hook, "skipped");
+    assert.equal(j.reason, "token_missing");
+    assert.equal(j.state, "working");
+  });
+});
+
+test("plugin manifest declares Codex hook bundle", () => {
+  const manifest = JSON.parse(
+    readFileSync(join(PLUGIN_DIR, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.equal(manifest.hooks, "./hooks/hooks.json");
+
+  const hooks = JSON.parse(
+    readFileSync(join(PLUGIN_DIR, "hooks", "hooks.json"), "utf8"),
+  );
+  for (const event of [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
+  ]) {
+    assert.ok(Array.isArray(hooks.hooks[event]), `missing hook event ${event}`);
+    const command = hooks.hooks[event][0].hooks[0];
+    assert.match(command.command, /loomi-bridge\.mjs/);
+    assert.match(command.commandWindows, /loomi-bridge\.mjs/);
+    assert.equal(command.timeout, 5);
+  }
+});
+
+test("argv hardening: unknown flags are not silently accepted as secrets", () => {
   withFakeHome((env) => {
     // If --api-key were a real flag, the bridge might echo or store it. We
     // verify it does NOT appear in stdout/stderr of any subcommand. This
     // is a structural test: a future PR adding --api-key would have to
     // also update the secrets contract.
-    const fake = 'sk-leaktest-ARGV-12345';
+    const fake = "sk-leaktest-ARGV-12345";
     for (const sub of [
-      ['setup-status', '--api-key', fake],
-      ['install-instructions', '--api-key', fake],
-      ['configure-ai-provider', '--api-key', fake],
+      ["setup-status", "--api-key", fake],
+      ["install-instructions", "--api-key", fake],
+      ["configure-ai-provider", "--api-key", fake],
     ]) {
       const r = runOutcome(sub, env);
       assert.ok(
-        !r.stdout.includes('sk-leaktest-ARGV'),
-        `${sub.join(' ')} echoed --api-key value in stdout`,
+        !r.stdout.includes("sk-leaktest-ARGV"),
+        `${sub.join(" ")} echoed --api-key value in stdout`,
       );
       assert.ok(
-        !r.stderr.includes('sk-leaktest-ARGV'),
-        `${sub.join(' ')} echoed --api-key value in stderr`,
+        !r.stderr.includes("sk-leaktest-ARGV"),
+        `${sub.join(" ")} echoed --api-key value in stderr`,
       );
     }
   });
 });
 
-
 // -----------------------------------------------------------------------------
 // codex-runtime-info
 // -----------------------------------------------------------------------------
 
-test('codex-runtime-info returns the desktop-app Codex runtime switch plan', () => {
-  const j = runJson(['codex-runtime-info']);
-  assert.equal(j.purpose.startsWith('Switch the OpenLoomi desktop app'), true);
-  assert.equal(j.envProviderKey, 'OPENLOOMI_AGENT_PROVIDER');
-  assert.equal(typeof j.switch.oneOff, 'string');
-  assert.equal(typeof j.switch.permanent, 'string');
-  assert.equal(typeof j.switch.perPlatform.oneOff, 'object');
-  assert.match(j.switch.perPlatform.oneOff.darwin, /OPENLOOMI_AGENT_PROVIDER codex/);
-  assert.match(j.switch.perPlatform.oneOff.darwin, /\/Applications\/openloomi\.app/);
-  assert.match(j.switch.perPlatform.oneOff.linux, /OPENLOOMI_AGENT_PROVIDER=codex/);
-  assert.match(j.switch.perPlatform.oneOff.win32, /OPENLOOMI_AGENT_PROVIDER codex/);
-  assert.equal(typeof j.switch.perPlatform.permanent, 'object');
+test("codex-runtime-info returns the desktop-app Codex runtime switch plan", () => {
+  const j = runJson(["codex-runtime-info"]);
+  assert.equal(j.purpose.startsWith("Switch the OpenLoomi desktop app"), true);
+  assert.equal(j.envProviderKey, "OPENLOOMI_AGENT_PROVIDER");
+  assert.equal(typeof j.switch.oneOff, "string");
+  assert.equal(typeof j.switch.permanent, "string");
+  assert.equal(typeof j.switch.perPlatform.oneOff, "object");
+  assert.match(
+    j.switch.perPlatform.oneOff.darwin,
+    /OPENLOOMI_AGENT_PROVIDER codex/,
+  );
+  assert.match(
+    j.switch.perPlatform.oneOff.darwin,
+    /\/Applications\/openloomi\.app/,
+  );
+  assert.match(
+    j.switch.perPlatform.oneOff.linux,
+    /OPENLOOMI_AGENT_PROVIDER=codex/,
+  );
+  assert.match(
+    j.switch.perPlatform.oneOff.win32,
+    /OPENLOOMI_AGENT_PROVIDER codex/,
+  );
+  assert.equal(typeof j.switch.perPlatform.permanent, "object");
   assert.match(j.switch.perPlatform.permanent.darwin, /~\/\.zshrc/);
   assert.match(j.switch.perPlatform.permanent.linux, /environment\.d/);
   assert.match(j.switch.perPlatform.permanent.win32, /environment variables/i);
   assert.ok(Array.isArray(j.prerequisites) && j.prerequisites.length >= 3);
   const varNames = j.companionEnvVars.map((entry) => entry.name);
   for (const expected of [
-    'OPENLOOMI_AGENT_CODEX_COMMAND',
-    'OPENLOOMI_AGENT_CODEX_MODEL',
-    'OPENLOOMI_AGENT_CODEX_SANDBOX',
-    'OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL',
-    'OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK',
-    'OPENLOOMI_AGENT_CODEX_FULL_AUTO',
-    'OPENLOOMI_AGENT_CODEX_TIMEOUT_MS',
+    "OPENLOOMI_AGENT_CODEX_COMMAND",
+    "OPENLOOMI_AGENT_CODEX_MODEL",
+    "OPENLOOMI_AGENT_CODEX_SANDBOX",
+    "OPENLOOMI_AGENT_CODEX_ASK_FOR_APPROVAL",
+    "OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK",
+    "OPENLOOMI_AGENT_CODEX_FULL_AUTO",
+    "OPENLOOMI_AGENT_CODEX_TIMEOUT_MS",
   ]) {
     assert.ok(varNames.includes(expected), `missing companion var ${expected}`);
   }
-  assert.equal(j.verify.expectDefaultAgent, 'codex');
-  assert.equal(j.verify.expectAgentType, 'codex');
+  assert.equal(j.verify.expectDefaultAgent, "codex");
+  assert.equal(j.verify.expectAgentType, "codex");
   assert.match(j.verify.endpoint, /\/api\/native\/providers/);
-  assert.equal(j.bridge.name, 'openloomi-codex-bridge');
-  assert.equal(typeof j.bridge.version, 'string');
+  assert.equal(j.bridge.name, "openloomi-codex-bridge");
+  assert.equal(typeof j.bridge.version, "string");
 });
 
-test('codex-runtime-info reflects OPENLOOMI_AGENT_PROVIDER env in defaults', () => {
-  const j = runJson(['codex-runtime-info'], {
-    OPENLOOMI_AGENT_PROVIDER: 'codex',
+test("codex-runtime-info reflects OPENLOOMI_AGENT_PROVIDER env in defaults", () => {
+  const j = runJson(["codex-runtime-info"], {
+    OPENLOOMI_AGENT_PROVIDER: "codex",
   });
-  assert.equal(j.defaults.currentDefaultProvider, 'codex');
+  assert.equal(j.defaults.currentDefaultProvider, "codex");
 });
 
-test('codex-runtime-info defaults to claude when env is unset', () => {
+test("codex-runtime-info defaults to claude when env is unset", () => {
   const j = withFakeHome((env) =>
-    runJson(['codex-runtime-info'], {
+    runJson(["codex-runtime-info"], {
       ...env,
-      OPENLOOMI_AGENT_PROVIDER: '',
+      OPENLOOMI_AGENT_PROVIDER: "",
     }),
   );
   // Empty string should fall back to claude (resolver treats empty as unset).
-  assert.equal(j.defaults.currentDefaultProvider, 'claude');
+  assert.equal(j.defaults.currentDefaultProvider, "claude");
 });


### PR DESCRIPTION
## Summary

This PR improves OpenLoomi plugin reliability across both Claude Code and Codex integrations.

It adds cross-platform Claude plugin bridge coverage, introduces Codex lifecycle hooks for mirroring task activity into OpenLoomi pet state, and fixes Windows hook execution so Codex plugin hooks can run successfully in the Codex CLI.

## Changes

### Claude plugin test coverage

- Added cross-platform bridge test fixtures.
- Added Windows-specific discovery coverage for local OpenLoomi binaries and platform paths.
- Added UTF-8 / mojibake safeguards for Claude plugin text files.
- Expanded bridge behavior tests without changing runtime behavior.

### Codex plugin lifecycle hooks

- Added a Codex hook bundle under `plugins/codex/hooks/hooks.json`.
- Registered the hook bundle through the Codex plugin manifest.
- Added lifecycle-to-pet-state mappings:
  - `SessionStart` -> `presenting`
  - `UserPromptSubmit` -> `thinking`
  - `PreToolUse` -> `working`
  - `PermissionRequest` -> `needsinput`
  - `PostToolUse` -> `thinking`
  - `SubagentStart` -> `juggling`
  - `SubagentStop` -> `thinking`
  - `Stop` -> `happy`
- Added a hook-safe `state` bridge command for non-blocking pet updates.
- Kept pet persistence inside OpenLoomi runtime instead of duplicating runtime logic inside Codex.

### Codex bridge robustness

- Added a run lock to prevent nested OpenLoomi bridge recursion.
- Allows stale run locks to be cleaned up safely.
- Keeps setup/status commands independent from run locks.
- Uses runtime-safe workflow prompts for agent-facing workflow guidance.
- Improves pet state posting through explicit/local API fallback handling.
- Adds quiet hook mode so Codex hooks can exit cleanly without emitting unsupported stdout.
- Fixes Windows hook commands to use PowerShell-compatible `PLUGIN_ROOT` expansion.

### Documentation

- Updated Codex plugin documentation for lifecycle hooks, source-runtime testing, readiness behavior, and Codex runtime usage.
- Clarified the readiness contract and guest/session behavior.
- Documented the expected Codex plugin flow without requiring users to paste secrets into Codex.

## Validation

Automated validation:

- `node --test plugins\codex\tests\bridge.test.mjs`
- `node --test plugins\claude\tests\bridge.test.mjs plugins\claude\tests\bridge.windows.test.mjs plugins\claude\tests\encoding.test.mjs`
- `node --check plugins\codex\scripts\loomi-bridge.mjs`
- `pnpm exec prettier --check plugins/codex/hooks/hooks.json plugins/codex/scripts/loomi-bridge.mjs plugins/codex/tests/bridge.test.mjs`
- `git diff --check`

Manual validation:

- Verified source-runtime setup against local OpenLoomi.
- Verified Codex CLI can discover installed plugin hooks through `/hooks`.
- Verified hook trust flow in interactive Codex CLI.
- Verified Codex lifecycle hooks execute without `hook exited with code 1`.
- Verified pet state updates from Codex hooks through the OpenLoomi runtime API.
- Verified a real shell-command prompt completes successfully while hooks run.