### PR TITLE
feat(pet): distinguish memory retrieval activity

### DIFF
--- a/apps/web/components/pet/pet-runtime-bridge.tsx
+++ b/apps/web/components/pet/pet-runtime-bridge.tsx
@@ -5,10 +5,10 @@ import { useEffect, useMemo, useRef } from "react";
 import { useChatContext } from "@/components/chat-context";
 import { isTauri } from "@/lib/tauri";
 import {
-  derivePetSettleState,
-  derivePetRuntimeState,
-  getLatestAssistantActivity,
   type PetRuntimeState,
+  derivePetRuntimeState,
+  derivePetSettleState,
+  getLatestAssistantActivity,
 } from "./pet-runtime-state";
 
 type RuntimePayloadState =
@@ -45,6 +45,8 @@ export function PetRuntimeBridge() {
     activeChatRunning: isAgentRunning,
     runningChatCount,
     executingToolCount: activity.executingToolCount,
+    executingMemoryRetrievalCount: activity.executingMemoryRetrievalCount,
+    executingOtherToolCount: activity.executingOtherToolCount,
     hasAssistantOutput: activity.hasAssistantOutput,
   });
 
@@ -82,7 +84,13 @@ export function PetRuntimeBridge() {
 
     const resultIsVisible =
       document.visibilityState === "visible" && document.hasFocus();
-    const settle = derivePetSettleState(activity, resultIsVisible);
+    const settle = derivePetSettleState(
+      {
+        hasAssistantOutput: activity.hasAssistantOutput,
+        hasError: activity.hasError,
+      },
+      resultIsVisible,
+    );
     emitOnce(settle.state, settle.monologue);
     if (settle.durationMs > 0) {
       settleTimerRef.current = setTimeout(

--- a/apps/web/components/pet/pet-runtime-state.ts
+++ b/apps/web/components/pet/pet-runtime-state.ts
@@ -7,11 +7,15 @@ export interface PetRuntimeSnapshot {
   activeChatRunning: boolean;
   runningChatCount: number;
   executingToolCount: number;
+  executingMemoryRetrievalCount: number;
+  executingOtherToolCount: number;
   hasAssistantOutput: boolean;
 }
 
 export interface AssistantActivity {
   executingToolCount: number;
+  executingMemoryRetrievalCount: number;
+  executingOtherToolCount: number;
   hasAssistantOutput: boolean;
   hasError: boolean;
 }
@@ -25,9 +29,31 @@ export interface PetSettleState {
 interface ActivityPart {
   type?: string;
   status?: string;
+  toolName?: string;
   toolOutput?: unknown;
   isError?: boolean;
   text?: unknown;
+}
+
+const MEMORY_RETRIEVAL_TOOL_NAMES = new Set([
+  "searchUnifiedMemory",
+  "searchMemoryPath",
+  "getRawMessages",
+  "searchRawMessages",
+  "searchKnowledgeBase",
+  "getFullDocumentContent",
+]);
+
+function normalizeToolName(toolName: string): string {
+  const segments = toolName.split("__");
+  return segments[segments.length - 1] || toolName;
+}
+
+export function isMemoryRetrievalTool(toolName: unknown): boolean {
+  return (
+    typeof toolName === "string" &&
+    MEMORY_RETRIEVAL_TOOL_NAMES.has(normalizeToolName(toolName))
+  );
 }
 
 export function derivePetRuntimeState(
@@ -43,8 +69,15 @@ export function derivePetRuntimeState(
     snapshot.runningChatCount > 0;
   if (!isBusy) return "idle";
 
+  if (snapshot.executingOtherToolCount > 0) {
+    return "working";
+  }
+
+  if (snapshot.executingMemoryRetrievalCount > 0) {
+    return "thinking";
+  }
+
   if (
-    snapshot.executingToolCount > 0 ||
     snapshot.hasAssistantOutput ||
     (snapshot.runningChatCount > 0 && !snapshot.activeChatRunning)
   ) {
@@ -63,12 +96,21 @@ export function getLatestAssistantActivity(
   const parts = Array.isArray(latest?.parts) ? latest.parts : [];
 
   let executingToolCount = 0;
+  let executingMemoryRetrievalCount = 0;
+  let executingOtherToolCount = 0;
   let hasAssistantOutput = false;
   let hasError = false;
 
   for (const part of parts as ActivityPart[]) {
     if (part?.type === "tool-native") {
-      if (part.status === "executing") executingToolCount += 1;
+      if (part.status === "executing") {
+        executingToolCount += 1;
+        if (isMemoryRetrievalTool(part.toolName)) {
+          executingMemoryRetrievalCount += 1;
+        } else {
+          executingOtherToolCount += 1;
+        }
+      }
       if (part.status === "completed" || part.toolOutput) {
         hasAssistantOutput = true;
       }
@@ -84,7 +126,13 @@ export function getLatestAssistantActivity(
     }
   }
 
-  return { executingToolCount, hasAssistantOutput, hasError };
+  return {
+    executingToolCount,
+    executingMemoryRetrievalCount,
+    executingOtherToolCount,
+    hasAssistantOutput,
+    hasError,
+  };
 }
 
 export function derivePetSettleState(

--- a/apps/web/tests/unit/pet-runtime-state.test.ts
+++ b/apps/web/tests/unit/pet-runtime-state.test.ts
@@ -1,9 +1,11 @@
+import type { ChatMessage } from "@openloomi/shared";
 import { describe, expect, it } from "vitest";
 
 import {
-  derivePetSettleState,
   derivePetRuntimeState,
+  derivePetSettleState,
   getLatestAssistantActivity,
+  isMemoryRetrievalTool,
 } from "@/components/pet/pet-runtime-state";
 
 describe("derivePetRuntimeState", () => {
@@ -14,6 +16,8 @@ describe("derivePetRuntimeState", () => {
         activeChatRunning: false,
         runningChatCount: 0,
         executingToolCount: 0,
+        executingMemoryRetrievalCount: 0,
+        executingOtherToolCount: 0,
         hasAssistantOutput: false,
       }),
     ).toBe("idle");
@@ -26,6 +30,8 @@ describe("derivePetRuntimeState", () => {
         activeChatRunning: false,
         runningChatCount: 0,
         executingToolCount: 0,
+        executingMemoryRetrievalCount: 0,
+        executingOtherToolCount: 0,
         hasAssistantOutput: false,
       }),
     ).toBe("thinking");
@@ -38,6 +44,8 @@ describe("derivePetRuntimeState", () => {
         activeChatRunning: true,
         runningChatCount: 1,
         executingToolCount: 1,
+        executingMemoryRetrievalCount: 0,
+        executingOtherToolCount: 1,
         hasAssistantOutput: false,
       }),
     ).toBe("working");
@@ -50,6 +58,8 @@ describe("derivePetRuntimeState", () => {
         activeChatRunning: true,
         runningChatCount: 1,
         executingToolCount: 2,
+        executingMemoryRetrievalCount: 1,
+        executingOtherToolCount: 1,
         hasAssistantOutput: true,
       }),
     ).toBe("juggling");
@@ -62,9 +72,66 @@ describe("derivePetRuntimeState", () => {
         activeChatRunning: true,
         runningChatCount: 2,
         executingToolCount: 0,
+        executingMemoryRetrievalCount: 0,
+        executingOtherToolCount: 0,
         hasAssistantOutput: false,
       }),
     ).toBe("juggling");
+  });
+
+  it("uses thinking for one executing memory retrieval tool", () => {
+    expect(
+      derivePetRuntimeState({
+        isSending: false,
+        activeChatRunning: true,
+        runningChatCount: 1,
+        executingToolCount: 1,
+        executingMemoryRetrievalCount: 1,
+        executingOtherToolCount: 0,
+        hasAssistantOutput: false,
+      }),
+    ).toBe("thinking");
+  });
+
+  it("uses juggling for two executing memory retrieval tools", () => {
+    expect(
+      derivePetRuntimeState({
+        isSending: false,
+        activeChatRunning: true,
+        runningChatCount: 1,
+        executingToolCount: 2,
+        executingMemoryRetrievalCount: 2,
+        executingOtherToolCount: 0,
+        hasAssistantOutput: false,
+      }),
+    ).toBe("juggling");
+  });
+});
+
+describe("isMemoryRetrievalTool", () => {
+  it("recognizes every supported memory retrieval tool", () => {
+    for (const toolName of [
+      "searchUnifiedMemory",
+      "searchMemoryPath",
+      "getRawMessages",
+      "searchRawMessages",
+      "searchKnowledgeBase",
+      "getFullDocumentContent",
+    ]) {
+      expect(isMemoryRetrievalTool(toolName)).toBe(true);
+    }
+  });
+
+  it("normalizes MCP-prefixed memory retrieval tools", () => {
+    expect(
+      isMemoryRetrievalTool("mcp__business-tools__searchUnifiedMemory"),
+    ).toBe(true);
+  });
+
+  it("rejects unknown and non-memory tools", () => {
+    expect(isMemoryRetrievalTool("Bash")).toBe(false);
+    expect(isMemoryRetrievalTool("futureUnknownTool")).toBe(false);
+    expect(isMemoryRetrievalTool(undefined)).toBe(false);
   });
 });
 
@@ -100,6 +167,36 @@ describe("derivePetSettleState", () => {
 });
 
 describe("getLatestAssistantActivity", () => {
+  it("maps an executing memory tool stream to thinking end to end", () => {
+    const activity = getLatestAssistantActivity([
+      {
+        id: "assistant-memory-thinking",
+        role: "assistant",
+        content: "",
+        parts: [
+          {
+            type: "tool-native",
+            toolName: "mcp__business-tools__searchUnifiedMemory",
+            status: "executing",
+            toolUseId: "memory",
+          },
+        ],
+      } as unknown as ChatMessage,
+    ]);
+
+    expect(
+      derivePetRuntimeState({
+        isSending: false,
+        activeChatRunning: true,
+        runningChatCount: 1,
+        executingToolCount: activity.executingToolCount,
+        executingMemoryRetrievalCount: activity.executingMemoryRetrievalCount,
+        executingOtherToolCount: activity.executingOtherToolCount,
+        hasAssistantOutput: activity.hasAssistantOutput,
+      }),
+    ).toBe("thinking");
+  });
+
   it("counts executing tools and detects output", () => {
     const activity = getLatestAssistantActivity([
       {
@@ -111,14 +208,113 @@ describe("getLatestAssistantActivity", () => {
           { type: "tool-native", status: "executing", toolUseId: "b" },
           { type: "text", text: "Working on it" },
         ],
-      } as any,
+      } as unknown as ChatMessage,
     ]);
 
     expect(activity).toEqual({
       executingToolCount: 2,
+      executingMemoryRetrievalCount: 0,
+      executingOtherToolCount: 2,
       hasAssistantOutput: true,
       hasError: false,
     });
+  });
+
+  it("separates memory retrieval from other executing tools", () => {
+    const activity = getLatestAssistantActivity([
+      {
+        id: "assistant-memory",
+        role: "assistant",
+        content: "",
+        parts: [
+          {
+            type: "tool-native",
+            toolName: "mcp__business-tools__searchUnifiedMemory",
+            status: "executing",
+            toolUseId: "memory",
+          },
+          {
+            type: "tool-native",
+            toolName: "Bash",
+            status: "executing",
+            toolUseId: "shell",
+          },
+        ],
+      } as unknown as ChatMessage,
+    ]);
+
+    expect(activity).toEqual({
+      executingToolCount: 2,
+      executingMemoryRetrievalCount: 1,
+      executingOtherToolCount: 1,
+      hasAssistantOutput: false,
+      hasError: false,
+    });
+  });
+
+  it("treats an unknown executing tool as other tool activity", () => {
+    const activity = getLatestAssistantActivity([
+      {
+        id: "assistant-unknown",
+        role: "assistant",
+        content: "",
+        parts: [
+          {
+            type: "tool-native",
+            toolName: "futureUnknownTool",
+            status: "executing",
+            toolUseId: "unknown",
+          },
+        ],
+      } as unknown as ChatMessage,
+    ]);
+
+    expect(activity.executingMemoryRetrievalCount).toBe(0);
+    expect(activity.executingOtherToolCount).toBe(1);
+  });
+
+  it("keeps completed memory output and errors in settle activity", () => {
+    const completed = getLatestAssistantActivity([
+      {
+        id: "assistant-completed-memory",
+        role: "assistant",
+        content: "",
+        parts: [
+          {
+            type: "tool-native",
+            toolName: "searchUnifiedMemory",
+            status: "completed",
+            toolOutput: { results: [] },
+            toolUseId: "memory",
+          },
+        ],
+      } as unknown as ChatMessage,
+    ]);
+    expect(completed).toEqual({
+      executingToolCount: 0,
+      executingMemoryRetrievalCount: 0,
+      executingOtherToolCount: 0,
+      hasAssistantOutput: true,
+      hasError: false,
+    });
+
+    const failed = getLatestAssistantActivity([
+      {
+        id: "assistant-failed-memory",
+        role: "assistant",
+        content: "",
+        parts: [
+          {
+            type: "tool-native",
+            toolName: "searchUnifiedMemory",
+            status: "error",
+            isError: true,
+            toolUseId: "memory",
+          },
+        ],
+      } as unknown as ChatMessage,
+    ]);
+    expect(derivePetSettleState(failed, true).state).toBe("needsinput");
   });
 
   it("detects terminal assistant errors", () => {
@@ -128,7 +324,7 @@ describe("getLatestAssistantActivity", () => {
         role: "assistant",
         content: "error",
         parts: [{ type: "error", content: "failed" }],
-      } as any,
+      } as unknown as ChatMessage,
     ]);
     expect(activity.hasError).toBe(true);
   });


### PR DESCRIPTION
## Summary

- classify Agent tool activity into memory retrieval and other tool work
- show `thinking` while a single memory retrieval tool is running
- preserve `working`, `juggling`, and the existing settle-state behavior for other activity
- support plain and MCP-prefixed tool names without changing the Tauri state protocol

This is a small implementation slice of #332 and builds on the existing `PetRuntimeBridge` and `StateCoordinator` rather than adding another state system.

## Supported memory retrieval tools

- `searchUnifiedMemory`
- `searchMemoryPath`
- `getRawMessages`
- `searchRawMessages`
- `searchKnowledgeBase`
- `getFullDocumentContent`

Unknown tools continue to use the normal `working` behavior.

## Verification

- `vitest run --root apps/web tests/unit/pet-runtime-state.test.ts` — 19 passed
- Biome lint on the three changed files — passed
- `git diff --check` — passed
- Web TypeScript check reports no errors in the changed files; the full command remains blocked by existing `cross-spawn` declaration and CLI integration-test errors