### PR TITLE
New evidence evolves the memory graph

### DIFF
--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -11,6 +11,10 @@ import type {
   RawMessageQuery,
 } from "@openloomi/indexeddb";
 import {
+  parseRawMessageGraphEvolutionOptions,
+  storeRawMessagesWithGraphEvolution,
+} from "@openloomi/indexeddb";
+import {
   queryMemoryWithFallback,
   runMemoryForgettingCycle,
 } from "@openloomi/indexeddb/forgetting";
@@ -308,12 +312,19 @@ export async function POST(request: NextRequest) {
           userId,
           createdAt: message.createdAt ?? now,
         })) as RawMessage[];
-        const ids = await manager.storeMessages(normalized);
+        const stored = await storeRawMessagesWithGraphEvolution({
+          storage: manager,
+          messages: normalized,
+          graphEvolution: parseRawMessageGraphEvolutionOptions(
+            body.graphEvolution,
+          ),
+        });
         await upsertRawMessagesToChroma(normalized);
         return Response.json({
           success: true,
-          stored: ids.length,
+          stored: stored.ids.length,
           errors: 0,
+          graphEvolution: stored.graphEvolution,
         });
       }
 

--- a/apps/web/app/api/messages/raw/route.ts
+++ b/apps/web/app/api/messages/raw/route.ts
@@ -3,6 +3,10 @@ import {
   getRawMessageManager,
   getRawMessageStorageBackend,
 } from "@/lib/memory/raw-message-store";
+import {
+  parseRawMessageGraphEvolutionOptions,
+  storeRawMessagesWithGraphEvolution,
+} from "@openloomi/indexeddb";
 import { AppError } from "@openloomi/shared/errors";
 import type { NextRequest } from "next/server";
 
@@ -20,7 +24,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    const { messages } = body as {
+    const { messages, graphEvolution } = body as {
       messages: Array<{
         messageId: string;
         platform: string;
@@ -37,6 +41,7 @@ export async function POST(request: NextRequest) {
         }>;
         metadata?: Record<string, any>;
       }>;
+      graphEvolution?: unknown;
     };
 
     if (!Array.isArray(messages) || messages.length === 0) {
@@ -65,13 +70,18 @@ export async function POST(request: NextRequest) {
 
     const manager = await getRawMessageManager();
     const storage = getRawMessageStorageBackend();
-    const ids = await manager.storeMessages(messagesWithUserId as any);
+    const stored = await storeRawMessagesWithGraphEvolution({
+      storage: manager,
+      messages: messagesWithUserId as any,
+      graphEvolution: parseRawMessageGraphEvolutionOptions(graphEvolution),
+    });
     return Response.json({
       success: true,
       message: `Messages stored in ${storage}`,
       storage,
-      stored: ids.length,
-      count: ids.length,
+      stored: stored.ids.length,
+      count: stored.ids.length,
+      graphEvolution: stored.graphEvolution,
     });
   } catch (error) {
     console.error("[Raw Messages API] Error:", error);

--- a/apps/web/tests/unit/memory-graph-evolution-runtime.test.ts
+++ b/apps/web/tests/unit/memory-graph-evolution-runtime.test.ts
@@ -1,0 +1,559 @@
+import {
+	type RawMessage,
+	type RawMessageGraphEvolutionStorage,
+	type RawMessageQuery,
+	createRawMessageMemoryGraphStore,
+	memoryGraphLedgerMessageId,
+	storeRawMessagesWithGraphEvolution,
+} from "@openloomi/indexeddb";
+import {
+	type MemoryGraphSnapshot,
+	type OwnerScope,
+	buildMemoryGraphEvolutionPlan,
+} from "@openloomi/memory-consolidation";
+import { describe, expect, it } from "vitest";
+
+const NOW = 1_700_000_000_000;
+const OWNER = { userId: "user-1" } satisfies OwnerScope;
+
+class InMemoryRawMessageStorage implements RawMessageGraphEvolutionStorage {
+	readonly messages = new Map<string, RawMessage>();
+	failLedgerWrites = 0;
+	leakCrossScopeQueries = false;
+	nextId = 1;
+
+	async storeMessage(message: RawMessage): Promise<number> {
+		if (
+			message.messageId.startsWith("__openloomi_memory_graph__") &&
+			this.failLedgerWrites > 0
+		) {
+			this.failLedgerWrites -= 1;
+			throw new Error("ledger write failed");
+		}
+		const existing = this.messages.get(message.messageId);
+		const id = existing?.id ?? this.nextId++;
+		this.messages.set(message.messageId, { ...message, id });
+		return id;
+	}
+
+	async storeMessages(messages: RawMessage[]): Promise<number[]> {
+		const ids: number[] = [];
+		for (const message of messages) ids.push(await this.storeMessage(message));
+		return ids;
+	}
+
+	async getMessageById(messageId: string): Promise<RawMessage | null> {
+		return this.messages.get(messageId) ?? null;
+	}
+
+	async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+		let items = [...this.messages.values()];
+		if (query.userId && !this.leakCrossScopeQueries) {
+			items = items.filter((message) => message.userId === query.userId);
+		}
+		if (!query.includeArchived) {
+			items = items.filter((message) => message.archivedAt === undefined);
+		}
+		if (!query.includeDeprecated) {
+			items = items.filter((message) => message.deprecatedAt === undefined);
+		}
+		items.sort((left, right) =>
+			query.reverse === false
+				? left.timestamp - right.timestamp
+				: right.timestamp - left.timestamp,
+		);
+		return items.slice(0, query.limit ?? query.pageSize ?? items.length);
+	}
+}
+
+function rawMessage(
+	messageId: string,
+	input: {
+		userId?: string;
+		relationGroup?: string;
+		relationValue?: string;
+		sourceIdentity?: string;
+		applicability?: Record<string, unknown>;
+		topicKeys?: string[];
+		channel?: string;
+		timestamp?: number;
+	} = {},
+): RawMessage {
+	return {
+		messageId,
+		platform: "slack",
+		botId: "bot-1",
+		userId: input.userId ?? OWNER.userId,
+		channel: input.channel,
+		timestamp: input.timestamp ?? Math.floor(NOW / 1000),
+		content: `memory ${messageId}`,
+		attachments: [],
+		metadata: {
+			relationGroup: input.relationGroup,
+			relationValue: input.relationValue,
+			sourceIdentity: input.sourceIdentity,
+			memoryApplicability: input.applicability,
+			memoryTopicKeys: input.topicKeys,
+		},
+		createdAt: Math.floor(NOW / 1000),
+		memoryStage: "short",
+	};
+}
+
+async function readSnapshot(
+	storage: InMemoryRawMessageStorage,
+	ownerScope: OwnerScope = OWNER,
+): Promise<MemoryGraphSnapshot> {
+	return createRawMessageMemoryGraphStore({
+		storage,
+		ownerScope,
+		now: () => NOW,
+	}).readSnapshot({ ownerScope, includeAuditOnly: true });
+}
+
+describe("raw-message memory graph evolution runtime", () => {
+	it("preserves baseline storage when graph evolution is disabled or dry-run", async () => {
+		const storage = new InMemoryRawMessageStorage();
+
+		const disabled = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [rawMessage("disabled")],
+			now: NOW,
+		});
+		expect(disabled.graphEvolution.status).toBe("disabled");
+		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+
+		const dryRun = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("dry-run", {
+					relationGroup: "language",
+					relationValue: "zh",
+				}),
+			],
+			graphEvolution: { enabled: true, dryRun: true },
+			now: NOW,
+		});
+		expect(dryRun.graphEvolution.status).toBe("planned");
+		expect(dryRun.graphEvolution.plan?.persistence).toEqual({
+			mode: "dry-run",
+			enabled: false,
+		});
+		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+	});
+
+	it("reinforces one cluster and ignores duplicate source identities", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("language-1", {
+					relationGroup: "language",
+					relationValue: "zh",
+					sourceIdentity: "source:language-1",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		const reinforced = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("language-2", {
+					relationGroup: "language",
+					relationValue: "zh",
+					sourceIdentity: "source:language-2",
+					applicability: { scope: "global" },
+					timestamp: Math.floor(NOW / 1000) + 1,
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW + 1000,
+		});
+
+		expect(reinforced.graphEvolution.status).toBe("applied");
+		const reinforcedSnapshot = await readSnapshot(storage);
+		expect(reinforcedSnapshot.edges).toEqual([
+			expect.objectContaining({ kind: "support" }),
+		]);
+		expect(reinforcedSnapshot.clusters).toHaveLength(1);
+		expect(reinforcedSnapshot.clusters[0].nodeIds.sort()).toEqual([
+			"language-1",
+			"language-2",
+		]);
+		expect(reinforcedSnapshot.clusters[0].supportScore).toBeGreaterThan(0);
+
+		const duplicate = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("language-import-copy", {
+					relationGroup: "language",
+					relationValue: "zh",
+					sourceIdentity: "source:language-2",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW + 2000,
+		});
+		expect(duplicate.graphEvolution.status).toBe("no-op");
+		const duplicateSnapshot = await readSnapshot(storage);
+		expect(duplicateSnapshot.nodes).toHaveLength(2);
+		expect(duplicateSnapshot.edges[0].weight).toBe(
+			reinforcedSnapshot.edges[0].weight,
+		);
+	});
+
+	it("creates competition without merging or superseding contextual evidence", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("language-global", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("language-task", {
+					relationGroup: "language",
+					relationValue: "en",
+					applicability: { scope: "task", key: "task-42" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW + 1000,
+		});
+
+		const snapshot = await readSnapshot(storage);
+		expect(snapshot.edges).toEqual([
+			expect.objectContaining({ kind: "compete" }),
+		]);
+		expect(snapshot.clusters).toHaveLength(2);
+		expect(snapshot.clusters.every((cluster) => cluster.competitionKey)).toBe(
+			true,
+		);
+		expect(snapshot.nodes.find((node) => node.id === "language-task")).toEqual(
+			expect.objectContaining({
+				applicability: { scope: "task", key: "task-42" },
+				visibility: "default",
+			}),
+		);
+		expect(
+			snapshot.nodes.some((node) => node.visibility === "deprecated"),
+		).toBe(false);
+	});
+
+	it("keeps non-overlapping applicability and unrelated evidence separate", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("task-a", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "task", key: "task-a" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("task-b", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "task", key: "task-b" },
+				}),
+				rawMessage("project-fact", {
+					relationGroup: "project-status",
+					relationValue: "ready",
+					applicability: { scope: "project", key: "project-1" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW + 1000,
+		});
+
+		const snapshot = await readSnapshot(storage);
+		expect(snapshot.edges).toEqual([]);
+		expect(snapshot.clusters).toHaveLength(3);
+	});
+
+	it("records topical relation without forcing cluster membership", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("deployment-fact", {
+					topicKeys: ["deployment", "project-alpha"],
+					applicability: { scope: "project", key: "project-alpha" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("deployment-note", {
+					topicKeys: ["deployment", "project-alpha"],
+					applicability: { scope: "project", key: "project-alpha" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW + 1000,
+		});
+
+		const snapshot = await readSnapshot(storage);
+		expect(snapshot.edges).toEqual([
+			expect.objectContaining({ kind: "related" }),
+		]);
+		expect(snapshot.clusters).toHaveLength(2);
+	});
+
+	it("rejects leaked cross-scope candidates before planning relations", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		storage.leakCrossScopeQueries = true;
+		await storage.storeMessage(
+			rawMessage("foreign", {
+				userId: "other-user",
+				relationGroup: "language",
+				relationValue: "zh",
+				applicability: { scope: "global" },
+			}),
+		);
+
+		const result = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("local", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+
+		expect(result.graphEvolution.status).toBe("applied");
+		expect(result.graphEvolution.consideredCandidateIds).not.toContain(
+			"foreign",
+		);
+		const snapshot = await readSnapshot(storage);
+		expect(snapshot.nodes.map((node) => node.id)).toEqual(["local"]);
+		expect(snapshot.edges).toEqual([]);
+	});
+
+	it("stores but refuses to evolve a mixed-owner batch", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		const result = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("local"),
+				rawMessage("foreign", { userId: "user-2" }),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+
+		expect(result.ids).toHaveLength(2);
+		expect(result.graphEvolution.status).toBe("failed");
+		expect(result.graphEvolution.reasonCodes).toContain(
+			"memory_graph_scope_mismatch",
+		);
+		expect(storage.messages.get("foreign")?.metadata?.memoryOwnerScope).toEqual(
+			{
+				userId: "user-2",
+				workspaceId: undefined,
+				tenantId: undefined,
+			},
+		);
+		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+	});
+
+	it("isolates graph candidates and ledgers by workspace within one user", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		const workspaceA = { userId: OWNER.userId, workspaceId: "workspace-a" };
+		const workspaceB = { userId: OWNER.userId, workspaceId: "workspace-b" };
+		await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("workspace-a-memory", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true, workspaceId: "workspace-a" },
+			now: NOW,
+		});
+		const result = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("workspace-b-memory", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true, workspaceId: "workspace-b" },
+			now: NOW + 1000,
+		});
+
+		expect(result.graphEvolution.consideredCandidateIds).not.toContain(
+			"workspace-a-memory",
+		);
+		expect(
+			(await readSnapshot(storage, workspaceA)).nodes.map((node) => node.id),
+		).toEqual(["workspace-a-memory"]);
+		expect(
+			(await readSnapshot(storage, workspaceB)).nodes.map((node) => node.id),
+		).toEqual(["workspace-b-memory"]);
+		expect(memoryGraphLedgerMessageId(workspaceA)).not.toBe(
+			memoryGraphLedgerMessageId(workspaceB),
+		);
+	});
+
+	it("recovers after a ledger write failure without duplicate reinforcement", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		storage.failLedgerWrites = 1;
+		const message = rawMessage("retry", {
+			relationGroup: "language",
+			relationValue: "zh",
+			applicability: { scope: "global" },
+		});
+
+		const failed = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [message],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		expect(failed.graphEvolution.status).toBe("failed");
+		expect(storage.messages.has("retry")).toBe(true);
+		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+
+		const retried = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [message],
+			graphEvolution: { enabled: true },
+			now: NOW + 1000,
+		});
+		expect(retried.graphEvolution.status).toBe("applied");
+		const replayed = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [message],
+			graphEvolution: { enabled: true },
+			now: NOW + 2000,
+		});
+		expect(replayed.graphEvolution.status).toBe("no-op");
+		expect((await readSnapshot(storage)).nodes).toHaveLength(1);
+	});
+
+	it("treats completed operation replay as no-op and rejects stale new plans", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		const initial = await storeRawMessagesWithGraphEvolution({
+			storage,
+			messages: [
+				rawMessage("versioned", {
+					relationGroup: "language",
+					relationValue: "zh",
+					applicability: { scope: "global" },
+				}),
+			],
+			graphEvolution: { enabled: true },
+			now: NOW,
+		});
+		const store = createRawMessageMemoryGraphStore({
+			storage,
+			ownerScope: OWNER,
+			now: () => NOW + 1000,
+		});
+		const initialPlan = initial.graphEvolution.plan;
+		expect(initialPlan).toBeDefined();
+		if (!initialPlan) throw new Error("expected persisted graph plan");
+		const replay = await store.persistPlan(initialPlan);
+		expect(replay.replayed).toBe(true);
+		expect(replay.mutatesGraph).toBe(false);
+
+		const stalePlan = buildMemoryGraphEvolutionPlan({
+			ownerScope: OWNER,
+			newEvidence: [
+				{
+					id: "stale-new",
+					ownerScope: OWNER,
+					timestamp: NOW + 1000,
+					relationGroup: "language",
+					relationValue: "en",
+					applicability: { scope: "global" },
+				},
+			],
+			candidateEvidence: [],
+			snapshot: {
+				ownerScope: OWNER,
+				nodes: [],
+				edges: [],
+				clusters: [],
+				version: "0",
+				capturedAt: NOW,
+			},
+			now: NOW + 1000,
+			persistence: { mode: "write", enabled: true },
+		});
+		const conflict = await store.persistPlan(stalePlan);
+		expect(conflict.conflict).toBe(true);
+		expect(conflict.diagnostics).toContain("memory_graph_version_conflict");
+		expect((await readSnapshot(storage)).nodes.map((node) => node.id)).toEqual([
+			"versioned",
+		]);
+	});
+
+	it("serializes same-owner writes so concurrent stale plans cannot both apply", async () => {
+		const storage = new InMemoryRawMessageStorage();
+		const store = createRawMessageMemoryGraphStore({
+			storage,
+			ownerScope: OWNER,
+			now: () => NOW,
+		});
+		const empty = await store.readSnapshot({
+			ownerScope: OWNER,
+			includeAuditOnly: true,
+		});
+		const buildPlan = (id: string) =>
+			buildMemoryGraphEvolutionPlan({
+				ownerScope: OWNER,
+				newEvidence: [
+					{
+						id,
+						ownerScope: OWNER,
+						timestamp: NOW,
+						relationGroup: "language",
+						relationValue: id,
+						applicability: { scope: "global" },
+					},
+				],
+				candidateEvidence: [],
+				snapshot: empty,
+				now: NOW,
+				persistence: { mode: "write", enabled: true },
+			});
+
+		const results = await Promise.all([
+			store.persistPlan(buildPlan("concurrent-a")),
+			store.persistPlan(buildPlan("concurrent-b")),
+		]);
+		expect(results.filter((result) => result.mutatesGraph)).toHaveLength(1);
+		expect(results.filter((result) => result.conflict)).toHaveLength(1);
+		expect((await readSnapshot(storage)).nodes).toHaveLength(1);
+	});
+});

--- a/apps/web/tests/unit/memory-graph-evolution-runtime.test.ts
+++ b/apps/web/tests/unit/memory-graph-evolution-runtime.test.ts
@@ -1,15 +1,15 @@
 import {
-	type RawMessage,
-	type RawMessageGraphEvolutionStorage,
-	type RawMessageQuery,
-	createRawMessageMemoryGraphStore,
-	memoryGraphLedgerMessageId,
-	storeRawMessagesWithGraphEvolution,
+  type RawMessage,
+  type RawMessageGraphEvolutionStorage,
+  type RawMessageQuery,
+  createRawMessageMemoryGraphStore,
+  memoryGraphLedgerMessageId,
+  storeRawMessagesWithGraphEvolution,
 } from "@openloomi/indexeddb";
 import {
-	type MemoryGraphSnapshot,
-	type OwnerScope,
-	buildMemoryGraphEvolutionPlan,
+  type MemoryGraphSnapshot,
+  type OwnerScope,
+  buildMemoryGraphEvolutionPlan,
 } from "@openloomi/memory-consolidation";
 import { describe, expect, it } from "vitest";
 
@@ -17,543 +17,639 @@ const NOW = 1_700_000_000_000;
 const OWNER = { userId: "user-1" } satisfies OwnerScope;
 
 class InMemoryRawMessageStorage implements RawMessageGraphEvolutionStorage {
-	readonly messages = new Map<string, RawMessage>();
-	failLedgerWrites = 0;
-	leakCrossScopeQueries = false;
-	nextId = 1;
+  readonly messages = new Map<string, RawMessage>();
+  failLedgerWrites = 0;
+  leakCrossScopeQueries = false;
+  nextId = 1;
 
-	async storeMessage(message: RawMessage): Promise<number> {
-		if (
-			message.messageId.startsWith("__openloomi_memory_graph__") &&
-			this.failLedgerWrites > 0
-		) {
-			this.failLedgerWrites -= 1;
-			throw new Error("ledger write failed");
-		}
-		const existing = this.messages.get(message.messageId);
-		const id = existing?.id ?? this.nextId++;
-		this.messages.set(message.messageId, { ...message, id });
-		return id;
-	}
+  async storeMessage(message: RawMessage): Promise<number> {
+    if (
+      message.messageId.startsWith("__openloomi_memory_graph__") &&
+      this.failLedgerWrites > 0
+    ) {
+      this.failLedgerWrites -= 1;
+      throw new Error("ledger write failed");
+    }
+    const existing = this.messages.get(message.messageId);
+    const id = existing?.id ?? this.nextId++;
+    this.messages.set(message.messageId, { ...message, id });
+    return id;
+  }
 
-	async storeMessages(messages: RawMessage[]): Promise<number[]> {
-		const ids: number[] = [];
-		for (const message of messages) ids.push(await this.storeMessage(message));
-		return ids;
-	}
+  async storeMessages(messages: RawMessage[]): Promise<number[]> {
+    const ids: number[] = [];
+    for (const message of messages) ids.push(await this.storeMessage(message));
+    return ids;
+  }
 
-	async getMessageById(messageId: string): Promise<RawMessage | null> {
-		return this.messages.get(messageId) ?? null;
-	}
+  async getMessageById(messageId: string): Promise<RawMessage | null> {
+    return this.messages.get(messageId) ?? null;
+  }
 
-	async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
-		let items = [...this.messages.values()];
-		if (query.userId && !this.leakCrossScopeQueries) {
-			items = items.filter((message) => message.userId === query.userId);
-		}
-		if (!query.includeArchived) {
-			items = items.filter((message) => message.archivedAt === undefined);
-		}
-		if (!query.includeDeprecated) {
-			items = items.filter((message) => message.deprecatedAt === undefined);
-		}
-		items.sort((left, right) =>
-			query.reverse === false
-				? left.timestamp - right.timestamp
-				: right.timestamp - left.timestamp,
-		);
-		return items.slice(0, query.limit ?? query.pageSize ?? items.length);
-	}
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    let items = [...this.messages.values()];
+    if (query.userId && !this.leakCrossScopeQueries) {
+      items = items.filter((message) => message.userId === query.userId);
+    }
+    if (!query.includeArchived) {
+      items = items.filter((message) => message.archivedAt === undefined);
+    }
+    if (!query.includeDeprecated) {
+      items = items.filter((message) => message.deprecatedAt === undefined);
+    }
+    items.sort((left, right) =>
+      query.reverse === false
+        ? left.timestamp - right.timestamp
+        : right.timestamp - left.timestamp,
+    );
+    return items.slice(0, query.limit ?? query.pageSize ?? items.length);
+  }
 }
 
 function rawMessage(
-	messageId: string,
-	input: {
-		userId?: string;
-		relationGroup?: string;
-		relationValue?: string;
-		sourceIdentity?: string;
-		applicability?: Record<string, unknown>;
-		topicKeys?: string[];
-		channel?: string;
-		timestamp?: number;
-	} = {},
+  messageId: string,
+  input: {
+    userId?: string;
+    relationGroup?: string;
+    relationValue?: string;
+    sourceIdentity?: string;
+    applicability?: Record<string, unknown>;
+    topicKeys?: string[];
+    channel?: string;
+    timestamp?: number;
+  } = {},
 ): RawMessage {
-	return {
-		messageId,
-		platform: "slack",
-		botId: "bot-1",
-		userId: input.userId ?? OWNER.userId,
-		channel: input.channel,
-		timestamp: input.timestamp ?? Math.floor(NOW / 1000),
-		content: `memory ${messageId}`,
-		attachments: [],
-		metadata: {
-			relationGroup: input.relationGroup,
-			relationValue: input.relationValue,
-			sourceIdentity: input.sourceIdentity,
-			memoryApplicability: input.applicability,
-			memoryTopicKeys: input.topicKeys,
-		},
-		createdAt: Math.floor(NOW / 1000),
-		memoryStage: "short",
-	};
+  return {
+    messageId,
+    platform: "slack",
+    botId: "bot-1",
+    userId: input.userId ?? OWNER.userId,
+    channel: input.channel,
+    timestamp: input.timestamp ?? Math.floor(NOW / 1000),
+    content: `memory ${messageId}`,
+    attachments: [],
+    metadata: {
+      relationGroup: input.relationGroup,
+      relationValue: input.relationValue,
+      sourceIdentity: input.sourceIdentity,
+      memoryApplicability: input.applicability,
+      memoryTopicKeys: input.topicKeys,
+    },
+    createdAt: Math.floor(NOW / 1000),
+    memoryStage: "short",
+  };
 }
 
 async function readSnapshot(
-	storage: InMemoryRawMessageStorage,
-	ownerScope: OwnerScope = OWNER,
+  storage: InMemoryRawMessageStorage,
+  ownerScope: OwnerScope = OWNER,
 ): Promise<MemoryGraphSnapshot> {
-	return createRawMessageMemoryGraphStore({
-		storage,
-		ownerScope,
-		now: () => NOW,
-	}).readSnapshot({ ownerScope, includeAuditOnly: true });
+  return createRawMessageMemoryGraphStore({
+    storage,
+    ownerScope,
+    now: () => NOW,
+  }).readSnapshot({ ownerScope, includeAuditOnly: true });
 }
 
 describe("raw-message memory graph evolution runtime", () => {
-	it("preserves baseline storage when graph evolution is disabled or dry-run", async () => {
-		const storage = new InMemoryRawMessageStorage();
+  it("preserves baseline storage when graph evolution is disabled or dry-run", async () => {
+    const storage = new InMemoryRawMessageStorage();
 
-		const disabled = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [rawMessage("disabled")],
-			now: NOW,
-		});
-		expect(disabled.graphEvolution.status).toBe("disabled");
-		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+    const disabled = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [rawMessage("disabled")],
+      now: NOW,
+    });
+    expect(disabled.graphEvolution.status).toBe("disabled");
+    expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
 
-		const dryRun = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("dry-run", {
-					relationGroup: "language",
-					relationValue: "zh",
-				}),
-			],
-			graphEvolution: { enabled: true, dryRun: true },
-			now: NOW,
-		});
-		expect(dryRun.graphEvolution.status).toBe("planned");
-		expect(dryRun.graphEvolution.plan?.persistence).toEqual({
-			mode: "dry-run",
-			enabled: false,
-		});
-		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
-	});
+    const dryRun = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("dry-run", {
+          relationGroup: "language",
+          relationValue: "zh",
+        }),
+      ],
+      graphEvolution: { enabled: true, dryRun: true },
+      now: NOW,
+    });
+    expect(dryRun.graphEvolution.status).toBe("planned");
+    expect(dryRun.graphEvolution.plan?.persistence).toEqual({
+      mode: "dry-run",
+      enabled: false,
+    });
+    expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+  });
 
-	it("reinforces one cluster and ignores duplicate source identities", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("language-1", {
-					relationGroup: "language",
-					relationValue: "zh",
-					sourceIdentity: "source:language-1",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		const reinforced = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("language-2", {
-					relationGroup: "language",
-					relationValue: "zh",
-					sourceIdentity: "source:language-2",
-					applicability: { scope: "global" },
-					timestamp: Math.floor(NOW / 1000) + 1,
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW + 1000,
-		});
+  it("protects the internal graph ledger namespace from raw-message writes", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [rawMessage("valid")],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    const ledgerId = memoryGraphLedgerMessageId(OWNER);
+    const ledgerBefore = storage.messages.get(ledgerId);
 
-		expect(reinforced.graphEvolution.status).toBe("applied");
-		const reinforcedSnapshot = await readSnapshot(storage);
-		expect(reinforcedSnapshot.edges).toEqual([
-			expect.objectContaining({ kind: "support" }),
-		]);
-		expect(reinforcedSnapshot.clusters).toHaveLength(1);
-		expect(reinforcedSnapshot.clusters[0].nodeIds.sort()).toEqual([
-			"language-1",
-			"language-2",
-		]);
-		expect(reinforcedSnapshot.clusters[0].supportScore).toBeGreaterThan(0);
+    await expect(
+      storeRawMessagesWithGraphEvolution({
+        storage,
+        messages: [rawMessage(ledgerId)],
+        now: NOW + 1000,
+      }),
+    ).rejects.toThrow("internal memory graph namespace");
+    await expect(
+      storeRawMessagesWithGraphEvolution({
+        storage,
+        messages: [
+          {
+            ...rawMessage("forged-ledger-metadata"),
+            metadata: { memoryGraphLedger: { schemaVersion: 1 } },
+          },
+        ],
+        now: NOW + 2000,
+      }),
+    ).rejects.toThrow("internal memory graph namespace");
 
-		const duplicate = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("language-import-copy", {
-					relationGroup: "language",
-					relationValue: "zh",
-					sourceIdentity: "source:language-2",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW + 2000,
-		});
-		expect(duplicate.graphEvolution.status).toBe("no-op");
-		const duplicateSnapshot = await readSnapshot(storage);
-		expect(duplicateSnapshot.nodes).toHaveLength(2);
-		expect(duplicateSnapshot.edges[0].weight).toBe(
-			reinforcedSnapshot.edges[0].weight,
-		);
-	});
+    expect(storage.messages.get(ledgerId)).toEqual(ledgerBefore);
+    expect(storage.messages.has("forged-ledger-metadata")).toBe(false);
+  });
 
-	it("creates competition without merging or superseding contextual evidence", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("language-global", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("language-task", {
-					relationGroup: "language",
-					relationValue: "en",
-					applicability: { scope: "task", key: "task-42" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW + 1000,
-		});
+  it("rejects a ledger containing nested cross-scope graph objects", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [rawMessage("scoped-node")],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    const ledgerId = memoryGraphLedgerMessageId(OWNER);
+    const ledger = storage.messages.get(ledgerId);
+    if (!ledger) throw new Error("expected graph ledger");
+    const payload = ledger.metadata?.memoryGraphLedger as {
+      snapshot: MemoryGraphSnapshot;
+    };
+    payload.snapshot.nodes[0].ownerScope = { userId: "other-user" };
 
-		const snapshot = await readSnapshot(storage);
-		expect(snapshot.edges).toEqual([
-			expect.objectContaining({ kind: "compete" }),
-		]);
-		expect(snapshot.clusters).toHaveLength(2);
-		expect(snapshot.clusters.every((cluster) => cluster.competitionKey)).toBe(
-			true,
-		);
-		expect(snapshot.nodes.find((node) => node.id === "language-task")).toEqual(
-			expect.objectContaining({
-				applicability: { scope: "task", key: "task-42" },
-				visibility: "default",
-			}),
-		);
-		expect(
-			snapshot.nodes.some((node) => node.visibility === "deprecated"),
-		).toBe(false);
-	});
+    await expect(readSnapshot(storage)).rejects.toThrow(
+      "Invalid owner-scoped memory graph ledger payload",
+    );
+  });
 
-	it("keeps non-overlapping applicability and unrelated evidence separate", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("task-a", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "task", key: "task-a" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("task-b", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "task", key: "task-b" },
-				}),
-				rawMessage("project-fact", {
-					relationGroup: "project-status",
-					relationValue: "ready",
-					applicability: { scope: "project", key: "project-1" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW + 1000,
-		});
+  it("reinforces one cluster and ignores duplicate source identities", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-1", {
+          relationGroup: "language",
+          relationValue: "zh",
+          sourceIdentity: "source:language-1",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    const reinforced = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-2", {
+          relationGroup: "language",
+          relationValue: "zh",
+          sourceIdentity: "source:language-2",
+          applicability: { scope: "global" },
+          timestamp: Math.floor(NOW / 1000) + 1,
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
 
-		const snapshot = await readSnapshot(storage);
-		expect(snapshot.edges).toEqual([]);
-		expect(snapshot.clusters).toHaveLength(3);
-	});
+    expect(reinforced.graphEvolution.status).toBe("applied");
+    const reinforcedSnapshot = await readSnapshot(storage);
+    expect(reinforcedSnapshot.edges).toEqual([
+      expect.objectContaining({ kind: "support" }),
+    ]);
+    expect(reinforcedSnapshot.clusters).toHaveLength(1);
+    expect(reinforcedSnapshot.clusters[0].nodeIds.sort()).toEqual([
+      "language-1",
+      "language-2",
+    ]);
+    expect(reinforcedSnapshot.clusters[0].supportScore).toBeGreaterThan(0);
 
-	it("records topical relation without forcing cluster membership", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("deployment-fact", {
-					topicKeys: ["deployment", "project-alpha"],
-					applicability: { scope: "project", key: "project-alpha" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("deployment-note", {
-					topicKeys: ["deployment", "project-alpha"],
-					applicability: { scope: "project", key: "project-alpha" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW + 1000,
-		});
+    const duplicate = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-import-copy", {
+          relationGroup: "language",
+          relationValue: "zh",
+          sourceIdentity: "source:language-2",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 2000,
+    });
+    expect(duplicate.graphEvolution.status).toBe("no-op");
+    const duplicateSnapshot = await readSnapshot(storage);
+    expect(duplicateSnapshot.nodes).toHaveLength(2);
+    expect(duplicateSnapshot.edges[0].weight).toBe(
+      reinforcedSnapshot.edges[0].weight,
+    );
+  });
 
-		const snapshot = await readSnapshot(storage);
-		expect(snapshot.edges).toEqual([
-			expect.objectContaining({ kind: "related" }),
-		]);
-		expect(snapshot.clusters).toHaveLength(2);
-	});
+  it("does not inflate support when graph evolution is enabled after a duplicate raw import", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-original", {
+          relationGroup: "language",
+          relationValue: "zh",
+          sourceIdentity: "source:language-original",
+          applicability: { scope: "global" },
+        }),
+      ],
+      now: NOW,
+    });
 
-	it("rejects leaked cross-scope candidates before planning relations", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		storage.leakCrossScopeQueries = true;
-		await storage.storeMessage(
-			rawMessage("foreign", {
-				userId: "other-user",
-				relationGroup: "language",
-				relationValue: "zh",
-				applicability: { scope: "global" },
-			}),
-		);
+    const enabled = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-import-copy", {
+          relationGroup: "language",
+          relationValue: "zh",
+          sourceIdentity: "source:language-original",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
 
-		const result = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("local", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
+    expect(enabled.graphEvolution.status).toBe("applied");
+    const snapshot = await readSnapshot(storage);
+    expect(snapshot.nodes.map((node) => node.id)).toEqual([
+      "language-original",
+    ]);
+    expect(snapshot.edges).toEqual([]);
+    expect(snapshot.clusters).toEqual([
+      expect.objectContaining({ nodeIds: ["language-original"] }),
+    ]);
+  });
 
-		expect(result.graphEvolution.status).toBe("applied");
-		expect(result.graphEvolution.consideredCandidateIds).not.toContain(
-			"foreign",
-		);
-		const snapshot = await readSnapshot(storage);
-		expect(snapshot.nodes.map((node) => node.id)).toEqual(["local"]);
-		expect(snapshot.edges).toEqual([]);
-	});
+  it("creates competition without merging or superseding contextual evidence", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-global", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("language-task", {
+          relationGroup: "language",
+          relationValue: "en",
+          applicability: { scope: "task", key: "task-42" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
 
-	it("stores but refuses to evolve a mixed-owner batch", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		const result = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("local"),
-				rawMessage("foreign", { userId: "user-2" }),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
+    const snapshot = await readSnapshot(storage);
+    expect(snapshot.edges).toEqual([
+      expect.objectContaining({ kind: "compete" }),
+    ]);
+    expect(snapshot.clusters).toHaveLength(2);
+    expect(snapshot.clusters.every((cluster) => cluster.competitionKey)).toBe(
+      true,
+    );
+    expect(snapshot.nodes.find((node) => node.id === "language-task")).toEqual(
+      expect.objectContaining({
+        applicability: { scope: "task", key: "task-42" },
+        visibility: "default",
+      }),
+    );
+    expect(
+      snapshot.nodes.some((node) => node.visibility === "deprecated"),
+    ).toBe(false);
+  });
 
-		expect(result.ids).toHaveLength(2);
-		expect(result.graphEvolution.status).toBe("failed");
-		expect(result.graphEvolution.reasonCodes).toContain(
-			"memory_graph_scope_mismatch",
-		);
-		expect(storage.messages.get("foreign")?.metadata?.memoryOwnerScope).toEqual(
-			{
-				userId: "user-2",
-				workspaceId: undefined,
-				tenantId: undefined,
-			},
-		);
-		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
-	});
+  it("keeps non-overlapping applicability and unrelated evidence separate", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("task-a", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "task", key: "task-a" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("task-b", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "task", key: "task-b" },
+        }),
+        rawMessage("project-fact", {
+          relationGroup: "project-status",
+          relationValue: "ready",
+          applicability: { scope: "project", key: "project-1" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
 
-	it("isolates graph candidates and ledgers by workspace within one user", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		const workspaceA = { userId: OWNER.userId, workspaceId: "workspace-a" };
-		const workspaceB = { userId: OWNER.userId, workspaceId: "workspace-b" };
-		await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("workspace-a-memory", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true, workspaceId: "workspace-a" },
-			now: NOW,
-		});
-		const result = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("workspace-b-memory", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true, workspaceId: "workspace-b" },
-			now: NOW + 1000,
-		});
+    const snapshot = await readSnapshot(storage);
+    expect(snapshot.edges).toEqual([]);
+    expect(snapshot.clusters).toHaveLength(3);
+  });
 
-		expect(result.graphEvolution.consideredCandidateIds).not.toContain(
-			"workspace-a-memory",
-		);
-		expect(
-			(await readSnapshot(storage, workspaceA)).nodes.map((node) => node.id),
-		).toEqual(["workspace-a-memory"]);
-		expect(
-			(await readSnapshot(storage, workspaceB)).nodes.map((node) => node.id),
-		).toEqual(["workspace-b-memory"]);
-		expect(memoryGraphLedgerMessageId(workspaceA)).not.toBe(
-			memoryGraphLedgerMessageId(workspaceB),
-		);
-	});
+  it("records topical relation without forcing cluster membership", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("deployment-fact", {
+          topicKeys: ["deployment", "project-alpha"],
+          applicability: { scope: "project", key: "project-alpha" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("deployment-note", {
+          topicKeys: ["deployment", "project-alpha"],
+          applicability: { scope: "project", key: "project-alpha" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
 
-	it("recovers after a ledger write failure without duplicate reinforcement", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		storage.failLedgerWrites = 1;
-		const message = rawMessage("retry", {
-			relationGroup: "language",
-			relationValue: "zh",
-			applicability: { scope: "global" },
-		});
+    const snapshot = await readSnapshot(storage);
+    expect(snapshot.edges).toEqual([
+      expect.objectContaining({ kind: "related" }),
+    ]);
+    expect(snapshot.clusters).toHaveLength(2);
+  });
 
-		const failed = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [message],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		expect(failed.graphEvolution.status).toBe("failed");
-		expect(storage.messages.has("retry")).toBe(true);
-		expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+  it("rejects leaked cross-scope candidates before planning relations", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    storage.leakCrossScopeQueries = true;
+    await storage.storeMessage(
+      rawMessage("foreign", {
+        userId: "other-user",
+        relationGroup: "language",
+        relationValue: "zh",
+        applicability: { scope: "global" },
+      }),
+    );
 
-		const retried = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [message],
-			graphEvolution: { enabled: true },
-			now: NOW + 1000,
-		});
-		expect(retried.graphEvolution.status).toBe("applied");
-		const replayed = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [message],
-			graphEvolution: { enabled: true },
-			now: NOW + 2000,
-		});
-		expect(replayed.graphEvolution.status).toBe("no-op");
-		expect((await readSnapshot(storage)).nodes).toHaveLength(1);
-	});
+    const result = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("local", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
 
-	it("treats completed operation replay as no-op and rejects stale new plans", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		const initial = await storeRawMessagesWithGraphEvolution({
-			storage,
-			messages: [
-				rawMessage("versioned", {
-					relationGroup: "language",
-					relationValue: "zh",
-					applicability: { scope: "global" },
-				}),
-			],
-			graphEvolution: { enabled: true },
-			now: NOW,
-		});
-		const store = createRawMessageMemoryGraphStore({
-			storage,
-			ownerScope: OWNER,
-			now: () => NOW + 1000,
-		});
-		const initialPlan = initial.graphEvolution.plan;
-		expect(initialPlan).toBeDefined();
-		if (!initialPlan) throw new Error("expected persisted graph plan");
-		const replay = await store.persistPlan(initialPlan);
-		expect(replay.replayed).toBe(true);
-		expect(replay.mutatesGraph).toBe(false);
+    expect(result.graphEvolution.status).toBe("applied");
+    expect(result.graphEvolution.consideredCandidateIds).not.toContain(
+      "foreign",
+    );
+    const snapshot = await readSnapshot(storage);
+    expect(snapshot.nodes.map((node) => node.id)).toEqual(["local"]);
+    expect(snapshot.edges).toEqual([]);
+  });
 
-		const stalePlan = buildMemoryGraphEvolutionPlan({
-			ownerScope: OWNER,
-			newEvidence: [
-				{
-					id: "stale-new",
-					ownerScope: OWNER,
-					timestamp: NOW + 1000,
-					relationGroup: "language",
-					relationValue: "en",
-					applicability: { scope: "global" },
-				},
-			],
-			candidateEvidence: [],
-			snapshot: {
-				ownerScope: OWNER,
-				nodes: [],
-				edges: [],
-				clusters: [],
-				version: "0",
-				capturedAt: NOW,
-			},
-			now: NOW + 1000,
-			persistence: { mode: "write", enabled: true },
-		});
-		const conflict = await store.persistPlan(stalePlan);
-		expect(conflict.conflict).toBe(true);
-		expect(conflict.diagnostics).toContain("memory_graph_version_conflict");
-		expect((await readSnapshot(storage)).nodes.map((node) => node.id)).toEqual([
-			"versioned",
-		]);
-	});
+  it("stores but refuses to evolve a mixed-owner batch", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    const result = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("local"),
+        rawMessage("foreign", { userId: "user-2" }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
 
-	it("serializes same-owner writes so concurrent stale plans cannot both apply", async () => {
-		const storage = new InMemoryRawMessageStorage();
-		const store = createRawMessageMemoryGraphStore({
-			storage,
-			ownerScope: OWNER,
-			now: () => NOW,
-		});
-		const empty = await store.readSnapshot({
-			ownerScope: OWNER,
-			includeAuditOnly: true,
-		});
-		const buildPlan = (id: string) =>
-			buildMemoryGraphEvolutionPlan({
-				ownerScope: OWNER,
-				newEvidence: [
-					{
-						id,
-						ownerScope: OWNER,
-						timestamp: NOW,
-						relationGroup: "language",
-						relationValue: id,
-						applicability: { scope: "global" },
-					},
-				],
-				candidateEvidence: [],
-				snapshot: empty,
-				now: NOW,
-				persistence: { mode: "write", enabled: true },
-			});
+    expect(result.ids).toHaveLength(2);
+    expect(result.graphEvolution.status).toBe("failed");
+    expect(result.graphEvolution.reasonCodes).toContain(
+      "memory_graph_scope_mismatch",
+    );
+    expect(storage.messages.get("foreign")?.metadata?.memoryOwnerScope).toEqual(
+      {
+        userId: "user-2",
+        workspaceId: undefined,
+        tenantId: undefined,
+      },
+    );
+    expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+  });
 
-		const results = await Promise.all([
-			store.persistPlan(buildPlan("concurrent-a")),
-			store.persistPlan(buildPlan("concurrent-b")),
-		]);
-		expect(results.filter((result) => result.mutatesGraph)).toHaveLength(1);
-		expect(results.filter((result) => result.conflict)).toHaveLength(1);
-		expect((await readSnapshot(storage)).nodes).toHaveLength(1);
-	});
+  it("isolates graph candidates and ledgers by workspace within one user", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    const workspaceA = { userId: OWNER.userId, workspaceId: "workspace-a" };
+    const workspaceB = { userId: OWNER.userId, workspaceId: "workspace-b" };
+    await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("workspace-a-memory", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true, workspaceId: "workspace-a" },
+      now: NOW,
+    });
+    const result = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("workspace-b-memory", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true, workspaceId: "workspace-b" },
+      now: NOW + 1000,
+    });
+
+    expect(result.graphEvolution.consideredCandidateIds).not.toContain(
+      "workspace-a-memory",
+    );
+    expect(
+      (await readSnapshot(storage, workspaceA)).nodes.map((node) => node.id),
+    ).toEqual(["workspace-a-memory"]);
+    expect(
+      (await readSnapshot(storage, workspaceB)).nodes.map((node) => node.id),
+    ).toEqual(["workspace-b-memory"]);
+    expect(memoryGraphLedgerMessageId(workspaceA)).not.toBe(
+      memoryGraphLedgerMessageId(workspaceB),
+    );
+  });
+
+  it("recovers after a ledger write failure without duplicate reinforcement", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    storage.failLedgerWrites = 1;
+    const message = rawMessage("retry", {
+      relationGroup: "language",
+      relationValue: "zh",
+      applicability: { scope: "global" },
+    });
+
+    const failed = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [message],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    expect(failed.graphEvolution.status).toBe("failed");
+    expect(storage.messages.has("retry")).toBe(true);
+    expect(storage.messages.has(memoryGraphLedgerMessageId(OWNER))).toBe(false);
+
+    const retried = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [message],
+      graphEvolution: { enabled: true },
+      now: NOW + 1000,
+    });
+    expect(retried.graphEvolution.status).toBe("applied");
+    const replayed = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [message],
+      graphEvolution: { enabled: true },
+      now: NOW + 2000,
+    });
+    expect(replayed.graphEvolution.status).toBe("no-op");
+    expect((await readSnapshot(storage)).nodes).toHaveLength(1);
+  });
+
+  it("treats completed operation replay as no-op and rejects stale new plans", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    const initial = await storeRawMessagesWithGraphEvolution({
+      storage,
+      messages: [
+        rawMessage("versioned", {
+          relationGroup: "language",
+          relationValue: "zh",
+          applicability: { scope: "global" },
+        }),
+      ],
+      graphEvolution: { enabled: true },
+      now: NOW,
+    });
+    const store = createRawMessageMemoryGraphStore({
+      storage,
+      ownerScope: OWNER,
+      now: () => NOW + 1000,
+    });
+    const initialPlan = initial.graphEvolution.plan;
+    expect(initialPlan).toBeDefined();
+    if (!initialPlan) throw new Error("expected persisted graph plan");
+    const replay = await store.persistPlan(initialPlan);
+    expect(replay.replayed).toBe(true);
+    expect(replay.mutatesGraph).toBe(false);
+
+    const stalePlan = buildMemoryGraphEvolutionPlan({
+      ownerScope: OWNER,
+      newEvidence: [
+        {
+          id: "stale-new",
+          ownerScope: OWNER,
+          timestamp: NOW + 1000,
+          relationGroup: "language",
+          relationValue: "en",
+          applicability: { scope: "global" },
+        },
+      ],
+      candidateEvidence: [],
+      snapshot: {
+        ownerScope: OWNER,
+        nodes: [],
+        edges: [],
+        clusters: [],
+        version: "0",
+        capturedAt: NOW,
+      },
+      now: NOW + 1000,
+      persistence: { mode: "write", enabled: true },
+    });
+    const conflict = await store.persistPlan(stalePlan);
+    expect(conflict.conflict).toBe(true);
+    expect(conflict.diagnostics).toContain("memory_graph_version_conflict");
+    expect((await readSnapshot(storage)).nodes.map((node) => node.id)).toEqual([
+      "versioned",
+    ]);
+  });
+
+  it("serializes same-owner writes so concurrent stale plans cannot both apply", async () => {
+    const storage = new InMemoryRawMessageStorage();
+    const store = createRawMessageMemoryGraphStore({
+      storage,
+      ownerScope: OWNER,
+      now: () => NOW,
+    });
+    const empty = await store.readSnapshot({
+      ownerScope: OWNER,
+      includeAuditOnly: true,
+    });
+    const buildPlan = (id: string) =>
+      buildMemoryGraphEvolutionPlan({
+        ownerScope: OWNER,
+        newEvidence: [
+          {
+            id,
+            ownerScope: OWNER,
+            timestamp: NOW,
+            relationGroup: "language",
+            relationValue: id,
+            applicability: { scope: "global" },
+          },
+        ],
+        candidateEvidence: [],
+        snapshot: empty,
+        now: NOW,
+        persistence: { mode: "write", enabled: true },
+      });
+
+    const results = await Promise.all([
+      store.persistPlan(buildPlan("concurrent-a")),
+      store.persistPlan(buildPlan("concurrent-b")),
+    ]);
+    expect(results.filter((result) => result.mutatesGraph)).toHaveLength(1);
+    expect(results.filter((result) => result.conflict)).toHaveLength(1);
+    expect((await readSnapshot(storage)).nodes).toHaveLength(1);
+  });
 });

--- a/packages/ai/memory-consolidation/docs/adr/0001-graph-is-the-durable-evolution-model.md
+++ b/packages/ai/memory-consolidation/docs/adr/0001-graph-is-the-durable-evolution-model.md
@@ -1,0 +1,36 @@
+# ADR-0001: Graph Is the Durable Evolution Model
+
+Status: Proposed
+
+Requirements: MR-1, MR-2, MR-3, MR-4, MR-5, MR-7
+
+## Context
+
+Semantic similarity can find potentially related memories, but it cannot explain
+why evidence supports, competes with, or supersedes other evidence. Recomputing
+all relationships at retrieval time would also make memory stability dependent
+on the current search strategy.
+
+## Decision
+
+The memory graph is the durable model of memory evolution.
+
+Semantic, keyword, metadata, and recency search are candidate-discovery inputs.
+They do not define cluster membership, relation strength, competition, or
+lifecycle by themselves.
+
+Graph relations and cluster changes must remain evidence-backed and auditable.
+
+## Consequences
+
+- Retrieval can change candidate-search implementations without erasing memory
+  evolution history.
+- Graph mutation needs explicit persistence and provenance.
+- Similarity results may remain unrelated observations when evidence is weak.
+- The graph can be unavailable while baseline retrieval continues to work.
+
+## Rejected Alternatives
+
+- Treat semantic nearest neighbors as durable clusters.
+- Rebuild all memory relationships during every query.
+- Store only summaries and discard the graph that produced them.

--- a/packages/ai/memory-consolidation/docs/adr/0002-owner-scoped-graph-isolation.md
+++ b/packages/ai/memory-consolidation/docs/adr/0002-owner-scoped-graph-isolation.md
@@ -1,0 +1,37 @@
+# ADR-0002: Owner-scoped Graph Isolation
+
+Status: Proposed
+
+Requirements: MR-1, MR-9, MR-10
+
+## Context
+
+Memory graph operations connect evidence and influence retrieval. An accidental
+cross-user or cross-workspace edge is more damaging than an isolated search hit
+because it can affect future reinforcement, lifecycle, consolidation, and
+visibility decisions.
+
+## Decision
+
+Owner scope is a composite identity required for every node, edge, cluster,
+snapshot, operation, report, and retrieval result. `userId` is required;
+`workspaceId` and `tenantId` are optional narrowing isolation dimensions.
+Workspace or tenant identity does not replace user identity in the current
+product model.
+
+Default candidate discovery, graph mutation, lifecycle evaluation, and retrieval
+must reject cross-scope data. Shared memory requires a separate product decision
+and explicit authorization.
+
+## Consequences
+
+- Scope validation is required at every boundary, not only at storage access.
+- Cross-scope candidates are treated as invalid, not merely low-ranked.
+- Tests and rollout gates must include contamination scenarios.
+- Future shared memory cannot be introduced as an implicit edge type.
+
+## Rejected Alternatives
+
+- Rely only on storage queries to enforce isolation.
+- Allow cross-scope edges and filter them during retrieval.
+- Treat owner scope as optional graph metadata.

--- a/packages/ai/memory-consolidation/docs/adr/0003-plan-before-persist.md
+++ b/packages/ai/memory-consolidation/docs/adr/0003-plan-before-persist.md
@@ -1,0 +1,43 @@
+# ADR-0003: Plan Before Persist
+
+Status: Proposed
+
+Requirements: MR-1, MR-3, MR-4, MR-5, MR-8, MR-10
+
+## Context
+
+Memory evolution can change relation strength, cluster membership, lifecycle,
+representatives, and default visibility. Applying those decisions directly
+during judgment would make dry-run evaluation, partial-failure handling, audit,
+and rollback inconsistent.
+
+## Decision
+
+Every graph, lifecycle, consolidation, correction, and visibility mutation is
+represented as a validated plan before persistence.
+
+Plans include owner scope, affected identities, evidence, reason codes, intended
+operations, expected mutation domains, stable operation identity, expected graph
+version or equivalent concurrency guard, and no-op or rollback information.
+
+Replaying a completed operation is idempotent. Retrying a partially applied plan
+continues only unapplied operations. A version conflict rejects persistence and
+requires the plan to be rebuilt from a current graph snapshot.
+
+Persistence remains explicitly enabled until rollout criteria authorize broader
+automatic behavior.
+
+## Consequences
+
+- The same behavior can run as dry-run, evaluation, or persistence.
+- Reports describe intended and applied operations using the same identity.
+- Dependent operations can stop when an earlier persistence step fails.
+- Retries can converge without duplicating reinforcement or visibility changes.
+- Applied-operation history is required for partial-failure recovery.
+- Mutation interfaces are slightly more explicit than direct helper calls.
+
+## Rejected Alternatives
+
+- Mutate graph state while relation judgment is still running.
+- Use logs as the only representation of intended changes.
+- Maintain separate logic for dry-run and persisted evolution.

--- a/packages/ai/memory-consolidation/docs/adr/0004-evidence-preserving-soft-forgetting.md
+++ b/packages/ai/memory-consolidation/docs/adr/0004-evidence-preserving-soft-forgetting.md
@@ -1,0 +1,35 @@
+# ADR-0004: Evidence-preserving Soft Forgetting
+
+Status: Proposed
+
+Requirements: MR-5, MR-6, MR-7, MR-8, MR-10
+
+## Context
+
+Stable summaries and artifacts reduce retrieval noise, but deleting their source
+records would remove auditability and make incorrect consolidation difficult to
+correct. Keeping all raw evidence in default retrieval would preserve history at
+the cost of duplicate and obsolete context.
+
+## Decision
+
+Forgetting changes lifecycle and default visibility before considering deletion.
+
+A summary or artifact may become the active representative only after successful
+persistence with provenance. Covered raw records may then be soft-deprecated and
+hidden from default retrieval while remaining available to audit and correction.
+
+Hard deletion is outside Memory Graph Evolution.
+
+## Consequences
+
+- Default retrieval can stay concise without losing evidence.
+- Representative persistence and source visibility changes are ordered.
+- Audit retrieval must support deprecated evidence.
+- Storage cost is not solved by graph consolidation alone.
+
+## Rejected Alternatives
+
+- Delete raw records immediately after summary generation.
+- Keep superseded raw records in normal retrieval indefinitely.
+- Treat a summary as sufficient provenance for itself.

--- a/packages/ai/memory-consolidation/docs/adr/0005-competition-before-supersession.md
+++ b/packages/ai/memory-consolidation/docs/adr/0005-competition-before-supersession.md
@@ -1,0 +1,40 @@
+# ADR-0005: Competition Before Supersession
+
+Status: Proposed
+
+Requirements: MR-3, MR-4, MR-5, MR-7, MR-8
+
+## Context
+
+User behavior changes over time and may also contain temporary exceptions. If
+the newest contradictory trace immediately replaces stable memory, a one-off
+instruction can corrupt long-term preferences. If contradictions are simply
+merged, retrieval cannot explain which alternative is active.
+
+## Decision
+
+Contradictory evidence creates or reinforces competition between distinct memory
+structures before any supersession decision.
+
+Supersession requires sustained evidence, policy evaluation, and preserved
+provenance. Temporary or context-specific evidence remains scoped or contested
+unless it accumulates enough support to become the preferred alternative.
+
+Applicability context is preserved independently of owner scope. Evidence from a
+task, conversation, channel, project, or validity interval competes within
+overlapping applicability. It may challenge a broader stable memory only after
+explicit evidence or repeated support across independent contexts justifies
+broader applicability.
+
+## Consequences
+
+- Conflicting alternatives remain inspectable.
+- Retrieval may expose competition when context requires it.
+- Lifecycle policy, not recency alone, decides supersession.
+- Some queries may need contextual selection between active alternatives.
+
+## Rejected Alternatives
+
+- Newest evidence always wins.
+- Merge contradictory evidence into one cluster.
+- Preserve every contradiction without allowing eventual supersession.

--- a/packages/ai/memory-consolidation/docs/adr/README.md
+++ b/packages/ai/memory-consolidation/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Memory Graph Evolution ADR Index
+
+This index lists the active architecture decisions for Memory Graph Evolution.
+PRs should reference only the ADRs that constrain their behavior.
+
+| ADR                                                        | Decision                                                                             | Status   |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
+| [ADR-0001](./0001-graph-is-the-durable-evolution-model.md) | The graph is the durable evolution model; similarity is candidate discovery.         | Proposed |
+| [ADR-0002](./0002-owner-scoped-graph-isolation.md)         | Graph identity and operations are owner-scoped and cross-scope is denied by default. | Proposed |
+| [ADR-0003](./0003-plan-before-persist.md)                  | Evolution changes are planned and reportable before persistence.                     | Proposed |
+| [ADR-0004](./0004-evidence-preserving-soft-forgetting.md)  | Forgetting changes visibility while preserving source evidence.                      | Proposed |
+| [ADR-0005](./0005-competition-before-supersession.md)      | Contradictions create competition before any supersession.                           | Proposed |
+
+## Status Definitions
+
+- `Proposed`: under review and not yet binding.
+- `Accepted`: active and binding for new work.
+- `Superseded`: replaced by another ADR; the replacement must be linked.
+- `Rejected`: considered but not adopted.
+
+## PR Usage
+
+A PR must list the ADRs that apply to its behavior. It should not reproduce ADR
+content in the PR description. If a PR needs to violate an accepted ADR, it must
+first add a replacement ADR and mark the prior decision as superseded.

--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-architecture.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-architecture.md
@@ -1,663 +1,407 @@
-# Memory Graph Evolution: Dynamic Clusters, Reinforcement, and Forgetting
+# Memory Graph Evolution Architecture
 
-Execution plan: [memory-graph-evolution-execution-plan.md](./memory-graph-evolution-execution-plan.md)
+Status: Proposed target architecture for
+[Memory Graph Evolution Requirements](./memory-graph-evolution-requirements.md).
+It becomes binding when accepted and merged upstream.
 
-## Problem
+Decision records: [ADR index](./adr/README.md).
 
-OpenLoomi's long-term memory should not remain a bag of isolated records plus
-semantic similarity search. That model is useful as an initial retrieval layer,
-but it does not explain how memory becomes more stable, more concise, or more
-trustworthy over time.
+Delivery order: [Execution plan](./memory-graph-evolution-execution-plan.md).
 
-The main gaps are:
+## Architecture Objective
 
-- Duplicate memories cannot naturally merge. Similar traces may be retrieved
-  together, but the system has no durable structure that says they support the
-  same belief, preference, fact, or working pattern.
-- New evidence cannot strengthen or weaken older memories. A new trace may be
-  similar to an old trace, but similarity alone does not update confidence,
-  relation weight, cluster status, or competition between alternatives.
-- Forgetting based only on time and per-record value is too coarse. A single old
-  record can be noisy, but an old cluster with repeated activation may still be
-  important. Likewise, a recent record may be noise if it never connects to
-  anything else.
-- Retrieval can return fragment noise. Similarity search can surface several
-  near-duplicate raw records, weak one-off traces, or conflicting records without
-  enough graph context to choose stable memory over evidence fragments.
-- Summary and deprecation are currently sedimentation actions, not a complete
-  graph mechanism. A summary can supersede source records, and soft-deprecation
-  can hide raw evidence by default, but the system still needs an explicit model
-  for how clusters form, stabilize, decay, compete, and remain auditable.
+The architecture adds a write-side memory evolution loop to OpenLoomi's existing
+summary, soft-deprecation, and graph-aware retrieval capabilities.
 
-The desired evolution is a dynamic memory graph: new memories interact with old
-memories, update relations, reshape clusters, and feed forgetting,
-consolidation, retrieval, and audit flows.
+New evidence must be able to change memory structure without turning ingestion
+into an irreversible overwrite operation. The system therefore separates
+candidate discovery, relation judgment, graph mutation, lifecycle policy,
+consolidation, retrieval, and audit.
 
-## Design Goals
+```text
+new evidence
+  -> candidate discovery
+  -> interaction planning
+  -> graph mutation
+  -> cluster lifecycle
+  -> consolidation / weakening
+  -> retrieval
+  -> audit / correction
+```
 
-- Represent memory records as a dynamic graph rather than isolated fragments.
-- Let new memory influence old memory by reinforcing, weakening, contradicting,
-  elaborating, or superseding existing graph structures.
-- Give memory clusters an explicit lifecycle so the system can distinguish
-  forming, active, stable, decaying, superseded, and audit-only memory.
-- Treat forgetting as a graph operation, not simple deletion. Forgetting should
-  hide, decay, archive, or supersede evidence according to graph state and audit
-  constraints.
-- Use graph signals during retrieval, including cluster stability, edge weight,
-  conflict status, summary coverage, recency, and source evidence quality.
-- Preserve audit trails from summaries and artifacts back to source records,
-  relation evidence, and the graph operations that changed visibility.
-- Keep graph state scoped to the owning user, workspace, or tenant. Cross-scope
-  edges should be opt-in product behavior, not a default graph operation.
+Semantic similarity remains a candidate-discovery mechanism. The memory graph
+is the durable explanation of how evidence supports, competes with, or
+supersedes other memory.
 
-## Non-goals
+## Domain Model
 
-- Do not rewrite storage as part of the first architecture step.
-- Do not build UI.
-- Do not require real-time LLM calls for every memory write.
-- Do not implement a complete scheduler in one step.
-- Do not delete the raw audit chain.
-- Do not bind all relation judgment to one embedding strategy. Embeddings,
-  rules, metadata, explicit user feedback, and optional model judgments should
-  all be possible sources of graph evidence.
+### Owner Scope
 
-## Core Concepts
+Every graph object belongs to a composite owner scope:
+
+- `userId` is required
+- `workspaceId` optionally narrows the user's workspace context
+- `tenantId` optionally adds a tenant isolation boundary
+
+The complete tuple is part of identity and authorization, not optional metadata.
+Workspace or tenant identity does not replace user identity in the current
+product model.
+
+### Applicability Context
+
+Applicability describes where and when evidence is valid independently of owner
+scope. It may constrain evidence to:
+
+- a task or interaction
+- a conversation or channel
+- a person, platform, project, or other product context
+- a validity interval
+- global applicability within the owner scope
+
+Applicability is carried by evidence and by relation or cluster decisions that
+depend on that evidence. Context-specific evidence must not become global solely
+through recency. A plan may broaden applicability only when explicit evidence or
+repeated support across independent contexts justifies generalization.
 
 ### Memory Node
 
-A `Memory Node` is a graph-addressable memory unit. It may represent:
+A node is a graph-addressable memory unit:
 
-- `raw`: source traces such as messages, observations, or interaction fragments.
-- `summary`: stable cluster sedimentation used for compact long-term recall.
-- `artifact`: a durable memory product, report, plan, preference profile, or
-  externalized knowledge object.
+- `raw`: source evidence such as messages or observations
+- `summary`: compact representative of a stable cluster
+- `artifact`: durable memory product derived from one or more clusters
 
-Nodes should keep identity, timestamps, source type, visibility state, and
-provenance. A node does not need to know every cluster it belongs to; cluster
-membership can be derived or stored by the graph layer.
-
-Graph identity must include the owning scope, such as user, workspace, or
-tenant. A graph operation should not connect nodes across scopes unless a caller
-explicitly opts into a product feature that permits shared memory.
+A node records identity, owner scope, source identity, timestamps, visibility,
+and provenance metadata. A summary or artifact does not replace its source nodes
+in the audit model.
 
 ### Memory Edge
 
-A `Memory Edge` records a relationship between nodes. The architecture should
-allow at least these relation kinds:
+The operational relation vocabulary is:
 
-- `supports`: two nodes reinforce the same memory pattern.
-- `contradicts`: two nodes conflict or compete.
-- `elaborates`: one node adds detail to another without replacing it.
-- `supersedes`: one node is the preferred canonical representation of another.
-- `co-occurs`: nodes were observed or activated together.
-- `same-topic`: nodes are semantically adjacent but not yet judged as support or
-  conflict.
+- `support`: evidence reinforces a compatible memory structure
+- `compete`: evidence represents a conflicting alternative
+- `related`: evidence is relevant but insufficient for support or competition
+- `supersede`: a preferred representative covers older evidence
 
-Edges should carry weight, confidence, evidence count, last activation time,
-reason codes, and source evidence. Some edges are strong enough to shape
-clusters; others remain weak observations.
-
-Current relation-graph helpers already use a smaller operational vocabulary:
-`support`, `compete`, and `related`. The richer relation kinds above should be
-treated as architecture-level semantics that can project down into those current
-edge classes:
-
-- `supports` maps to `support`.
-- `contradicts` maps to `compete`.
-- `same-topic`, weak `elaborates`, and uncertain co-activation map to `related`.
-- `supersedes` is primarily a consolidation/audit relation and should connect to
-  summary or artifact provenance rather than force raw clusters to merge.
-
-This keeps existing helpers useful while leaving room for later interfaces to
-represent more nuance.
+Edges carry weight, confidence, evidence references, reason codes, activation
+time, and mutation history. Edge weight is not equivalent to embedding
+similarity; it represents accumulated graph evidence.
 
 ### Memory Cluster
 
-A `Memory Cluster` is a stable or forming group of memory nodes connected by
-supporting evidence. A cluster is not just a search result. It is an evolving
-memory structure with its own lifecycle, score, evidence set, relation history,
-and possible competition with other clusters.
+A cluster is an evolving memory structure formed primarily from supporting
+relations. It owns:
 
-Clusters should be able to contain raw nodes, summaries, and artifacts. A
-summary can become the active representative of a stable cluster while raw
-source nodes remain linked for audit.
+- member node identities
+- representative node identity, when one exists
+- support and activation signals
+- competing cluster references
+- lifecycle state
+- provenance and reason codes
 
-### Reinforcement
+Related evidence does not automatically become cluster membership. Competing
+clusters remain distinct.
 
-`Reinforcement` happens when new evidence increases confidence in an existing
-node, edge, or cluster. Examples:
+### Cluster Lifecycle
 
-- a new raw trace supports an existing preference cluster
-- a retrieved memory is reused successfully in an answer
-- multiple source records co-activate in the same task context
-- explicit user feedback confirms a prior memory
+The lifecycle states are:
 
-Reinforcement should update edge weights, cluster stability, activation counts,
-and retrieval priority. It should not automatically overwrite raw evidence.
+- `forming`: insufficient evidence for normal long-term use
+- `active`: useful and still evolving
+- `stable`: eligible for durable representation
+- `decaying`: losing support or activation
+- `superseded`: replaced by a preferred cluster or representative
+- `audit-only`: excluded from default retrieval but retained for traceability
 
-### Weakening / Decay
+Competition is orthogonal to lifecycle. An active or stable cluster may be
+contested and must remain visible to conflict-aware policy.
 
-`Weakening` happens when evidence becomes stale, unsupported, contradicted, or
-unused. `Decay` is time-based weakening, but weakening can also come from new
-contradictory evidence or failed retrieval outcomes.
+## Architectural Invariants
 
-Decay should operate on graph structure:
+### Scope Isolation
 
-- isolated raw nodes decay faster than reinforced clusters
-- weak edges decay when they are not reactivated
-- contradicted clusters can lose active status
-- superseded clusters can move toward audit-only visibility
+No default operation may read, connect, mutate, rank, or return graph objects
+from another owner scope.
 
-### Consolidation
+### Evidence Preservation
 
-`Consolidation` turns stable graph structures into compact durable memory:
-summaries, artifacts, or canonical cluster representatives. Consolidation should
-consume cluster state and source evidence rather than treating records as an
-unordered batch.
+Consolidation and forgetting may change default visibility but must preserve the
+source evidence chain. Hard deletion is outside this architecture.
 
-The consolidation output should preserve provenance: source node ids, relation
-evidence, reason codes, quality/confidence signals, and the cluster lifecycle
-state that justified sedimentation.
+### Plan Before Persist
 
-### Soft Forgetting
+Relation, membership, lifecycle, consolidation, and visibility changes are
+represented as a plan before persistence. The same plan shape supports dry-run,
+evaluation, persistence, and audit.
 
-`Soft Forgetting` hides source raw records from default retrieval after a stable
-summary or artifact supersedes them. It does not delete audit evidence.
+### Idempotent and Versioned Mutation
 
-Soft-forgotten records should keep fields such as deprecation timestamp, reason,
-superseding summary or artifact id, and source linkage. Default retrieval should
-prefer the active summary/cluster representative; audit retrieval should be able
-to include deprecated raw records.
+Every persisted plan has a stable operation identity and an expected graph
+version or equivalent concurrency guard. Replaying a completed operation is a
+no-op. Retrying a partially applied operation resumes the unapplied work without
+duplicating reinforcement, membership, lifecycle, consolidation, or visibility
+changes.
 
-### Audit Trail
+Version conflicts return an observable conflict result and require the plan to
+be rebuilt against a current snapshot.
 
-The `Audit Trail` is the reversible chain from a summary or artifact back to:
+### No Immediate Overwrite
 
-- source raw records
-- relation evidence
-- graph update operations
-- cluster lifecycle decisions
-- deprecation or visibility changes
+A new contradictory trace cannot directly replace a stable cluster. It creates
+competition and contributes evidence toward a later lifecycle or supersession
+decision.
 
-Audit is a first-class requirement. It lets operators answer why a memory exists,
-what evidence supports it, what was hidden by default, and how to recover the raw
-source chain when needed.
+Context-specific evidence competes within overlapping applicability. It cannot
+supersede a broader stable cluster until policy has evidence that the new memory
+also applies more broadly.
 
-## Architecture Layers
+### Representative Is Not the Graph
 
-### Graph Layer
+A summary or artifact is an active cluster representative. It does not become
+the sole source of truth and does not erase the cluster's graph history.
 
-Responsibility: express memory nodes, edges, clusters, lifecycle state, and
-graph snapshots.
+### Retrieval Does Not Own Evolution
 
-The Graph Layer stores or derives:
+Retrieval consumes graph state but does not mutate cluster lifecycle by default.
+Any feedback-based reinforcement is a separate, explicit interaction event.
 
-- node identity and visibility
-- edge kind, weight, confidence, and provenance
-- cluster membership and cluster representatives
-- competition relationships between clusters
-- graph version or operation metadata
-- owner scope, so graph reads and writes stay isolated by user, workspace, or
-  tenant
+### Baseline Compatibility
 
-It should not decide which model/provider judges relation meaning. It should not
-perform final retrieval ranking by itself. It should expose enough graph state
-for interaction, lifecycle, consolidation, retrieval, and audit layers.
+When graph state, policy, or persistence is unavailable, the system falls back
+to existing semantic, keyword, recency, and soft-deprecation behavior.
 
-### Interaction Layer
+## Component Boundaries
 
-Responsibility: let new memory interact with existing memory and produce a graph
-update plan.
+### Candidate Discovery
 
-The Interaction Layer takes new memory nodes plus candidate existing nodes or
-clusters. It proposes:
+Responsibility:
 
-- new edges
-- edge reinforcement
-- edge weakening
-- cluster joins or splits
-- conflict/competition observations
-- reason codes and evidence links
+- find same-scope nodes and clusters that may relate to new evidence
+- combine semantic, metadata, relation-key, recency, and activation signals
+- filter or annotate candidates by applicability overlap
+- return candidates without deciding graph mutation
 
-It should support multiple signal sources: metadata rules, explicit relation
-keys, embeddings, co-activation, user feedback, and optional model judgment. It
-should output a plan before persistence so callers can dry-run, audit, or gate
-graph changes.
+It does not create edges or cluster membership.
 
-### Cluster Lifecycle Layer
+### Graph Interaction Engine
 
-Responsibility: manage cluster state transitions.
+Responsibility:
 
-Suggested lifecycle states:
+- classify candidate relationships as support, compete, related, or none
+- propose new edges and edge reinforcement or weakening
+- propose cluster joins, new clusters, or competition links
+- preserve or propose applicability without silently generalizing context
+- emit evidence-backed reason codes
 
-- `forming`: early evidence exists but is not stable.
-- `active`: the cluster is useful in retrieval and still evolving.
-- `stable`: evidence is strong enough for consolidation.
-- `decaying`: evidence or activation is weakening.
-- `superseded`: another summary, artifact, or cluster is the preferred
-  representative.
-- `audit-only`: hidden from default retrieval but retained for traceability.
+Input:
 
-The lifecycle layer consumes graph state and policy. It should not generate
-summary text, mutate storage directly, or decide UI presentation.
+- normalized new nodes
+- candidate nodes and clusters
+- current same-scope graph snapshot
+- available relation signals
 
-### Forgetting / Consolidation Layer
+Output:
 
-Responsibility: convert stable or decaying cluster state into memory operations.
+- graph update plan
+- skipped or uncertain observations
+- interaction report
 
-Operations can include:
+It does not persist directly or decide final lifecycle transitions.
 
-- generate summary candidates from stable clusters
-- persist summaries or artifacts
-- soft-deprecate source raw records
-- archive source details when policy allows
-- mark weak clusters as decaying or audit-only
-- preserve contested clusters without premature summarization
+### Memory Graph Store
 
-This layer is where current summary plus soft-deprecation behavior belongs. It
-should consume cluster lifecycle decisions and produce auditable actions.
+Responsibility:
 
-### Retrieval Layer
+- read owner-scoped graph snapshots
+- persist validated graph update plans
+- enforce operation identity, version checks, and idempotent replay
+- preserve operation and provenance history
+- provide audit traversal for nodes, edges, clusters, and operations
 
-Responsibility: use graph signals during recall.
+It does not judge relation meaning, generate summaries, or rank retrieval hits.
 
-Retrieval should start with semantic, keyword, recency, or metadata candidates,
-then use graph state to:
+### Cluster Lifecycle Policy
 
-- expand from a raw hit to its active cluster representative
-- suppress deprecated source records by default
-- prefer stable summaries when they cover noisy raw traces
-- include conflicting clusters when contradiction matters
-- rank by relation strength, activation, lifecycle state, and evidence quality
-- support audit mode via `includeDeprecated` and provenance expansion
+Responsibility:
 
-Graph-aware retrieval should not replace all semantic search. It should make
-semantic candidates more contextual and less fragmentary.
+- evaluate support, activation, competition, supersession, applicability, and
+  decay signals
+- propose lifecycle transitions
+- identify stable, contested, decaying, and audit-only candidates
+- suggest representatives and consolidation eligibility
 
-### Observability Layer
+It does not write graph state or storage records directly.
 
-Responsibility: report how the graph changed and why.
+### Consolidation and Forgetting Planner
 
-Reports should include:
+Responsibility:
 
-- graph diffs
-- created/updated edges
-- reinforcement and decay events
-- cluster lifecycle transitions
-- consolidation outputs
-- source soft-deprecation outcomes
-- retrieval changes compared with baseline search
-- audit chain completeness
+- create summary or artifact candidates from stable clusters
+- plan source soft-deprecation after representative persistence
+- preserve contested clusters
+- plan weakening, supersession, archive, or audit-only actions
 
-The observability layer makes the system operable before fully automatic graph
-behavior is enabled.
+It consumes lifecycle decisions and does not re-judge all source relations.
 
-## Data Flows
+### Graph-aware Retriever
 
-### Ingest-time Flow
+Responsibility:
+
+- begin from baseline semantic, keyword, or metadata candidates
+- map candidates to graph nodes and active cluster representatives
+- prefer candidates whose applicability matches the current request
+- apply lifecycle, competition, relation strength, and visibility signals
+- expand source evidence in audit mode
+- explain ranking and filtering changes
+
+It does not replace baseline candidate search or mutate the graph by default.
+
+### Evolution Report and Governance
+
+Responsibility:
+
+- describe proposed and applied graph changes
+- compare graph-aware behavior with baseline behavior
+- expose scope violations, uncertain judgments, and partial failures
+- support correction, rollback, and rollout gates
+
+Reports are outputs of the architecture, not an alternative source of graph
+state.
+
+## Core Flows
+
+### New Evidence Interaction
 
 ```text
-new memory
-  -> normalize node
-  -> retrieve candidate existing nodes/clusters
-  -> infer relation candidates
+normalize new evidence
+  -> resolve owner scope and applicability
+  -> discover same-scope candidates
+  -> classify relations
   -> build graph update plan
-  -> reinforce / weaken / create edges
-  -> update cluster membership and lifecycle signals
-  -> emit GraphEvolutionReport
+  -> validate scope and evidence
+  -> persist when enabled
+  -> evaluate affected clusters
+  -> emit evolution report
 ```
 
-The ingest path should be incremental. It does not need to summarize
-immediately. Its job is to make the new memory interact with existing memory so
-future consolidation and retrieval have graph context.
+Uncertain evidence remains a weak observation or no-op. It must not force a
+cluster merge.
 
-### Batch Consolidation Flow
+### Reinforcement and Competition
 
 ```text
-stable cluster
-  -> consolidation planner
-  -> summary or artifact draft
-  -> persist summary/artifact
-  -> soft-deprecate source raw records
-  -> update cluster representative
-  -> emit consolidation and deprecation diagnostics
+supporting evidence
+  -> reinforce edge
+  -> increase cluster support
+  -> update activation
+  -> evaluate stability
+
+contradictory evidence
+  -> create or reinforce competition
+  -> preserve alternatives
+  -> evaluate relative support over time
+  -> optionally supersede weaker cluster
 ```
 
-This is the sedimentation path. The summary is not a replacement for the graph;
-it is the active compact representation of a stable cluster. Source raw records
-remain audit-linked and can be retrieved with audit options.
+Duplicate source identity must not count as independent reinforcement.
+Repeated support across independent contexts may propose broader applicability;
+repetition inside one context does not automatically generalize memory.
 
-### Retrieval Flow
+### Lifecycle and Consolidation
+
+```text
+affected cluster snapshot
+  -> lifecycle policy
+  -> stable / contested / decaying decision
+  -> consolidation and forgetting plan
+  -> persist representative
+  -> soft-deprecate covered source records
+  -> update representative and visibility
+```
+
+Source visibility changes occur only after representative persistence succeeds.
+
+### Retrieval
 
 ```text
 query
-  -> semantic / keyword / metadata candidates
-  -> graph expansion
+  -> baseline candidates
+  -> graph node mapping
+  -> applicability filtering
+  -> representative and competition expansion
   -> lifecycle and visibility filtering
   -> graph-aware ranking
-  -> active summaries and selected raw records
+  -> explanation
 ```
 
-Default retrieval should hide deprecated raw source records when an active
-summary covers them. When the query needs evidence or conflict, retrieval can
-expand to source records, related clusters, or competing clusters.
+Default retrieval suppresses superseded evidence noise. Audit retrieval can
+recover deprecated raw evidence. Conflict-sensitive retrieval can expose
+competing clusters.
 
-### Audit Flow
+### Correction and Audit
 
 ```text
-summary or artifact
-  -> source record ids
-  -> relation evidence
-  -> graph operations
-  -> lifecycle decisions
-  -> deprecation / visibility history
+memory or cluster
+  -> source evidence
+  -> relation and operation history
+  -> lifecycle and visibility decisions
+  -> correction or rollback plan
+  -> explicit persistence
 ```
 
-Audit mode should prove why a summary exists and why raw records are hidden by
-default. It should recover source evidence without turning audit records back
-into normal retrieval noise.
-
-## Interface Boundary
-
-These names are conceptual boundaries, not final helper names. Each boundary
-should stay small enough to test independently and broad enough to guide future
-implementation.
-
-### MemoryGraphStore
-
-Input:
-
-- node writes and reads
-- edge writes and reads
-- cluster snapshots or cluster update operations
-- graph operation metadata
-- owner scope for every graph read and write
-
-Output:
-
-- graph snapshot for candidate records or clusters
-- persisted graph update result
-- audit provenance for nodes, edges, and clusters
-
-Not responsible for:
-
-- judging relation meaning
-- deciding lifecycle policy
-- generating summaries
-- final retrieval ranking
-
-Consumed by:
-
-- GraphInteractionEngine
-- ClusterLifecyclePolicy
-- MemoryConsolidationPlanner
-- GraphAwareRetriever
-- Observability Layer
-
-### GraphInteractionEngine
-
-Input:
-
-- new memory nodes
-- candidate existing nodes/clusters
-- signal sources such as embeddings, metadata, relation keys, co-activation, or
-  optional model judgments
-
-Output:
-
-- graph update plan
-- relation candidates and judgments
-- reinforcement or weakening events
-- evidence and reason codes
-
-Not responsible for:
-
-- storage schema migration
-- final persistence without caller approval
-- summary generation
-- default retrieval behavior
-
-Consumed by:
-
-- ingest-time memory pipeline
-- batch graph maintenance
-- GraphEvolutionReport
-
-### ClusterLifecyclePolicy
-
-Input:
-
-- graph snapshot
-- cluster scores
-- edge weights
-- activation history
-- conflict and supersession signals
-- policy thresholds
-
-Output:
-
-- lifecycle transitions
-- cluster representative suggestions
-- consolidation eligibility
-- decay or audit-only recommendations
-
-Not responsible for:
-
-- creating raw relation evidence
-- writing summaries
-- deleting raw records
-- ranking query results directly
-
-Consumed by:
-
-- MemoryConsolidationPlanner
-- GraphAwareRetriever
-- Observability Layer
-
-### MemoryConsolidationPlanner
-
-Input:
-
-- stable or decaying cluster state
-- source node ids and evidence
-- lifecycle recommendations
-- summarization or artifact constraints
-
-Output:
-
-- summary/artifact candidates
-- source soft-deprecation plan
-- archive recommendations
-- diagnostics for preserve / observe / decay decisions
-
-Not responsible for:
-
-- judging every relation from scratch
-- direct UI presentation
-- mandatory online writes
-- removing audit evidence
-
-Consumed by:
-
-- forgetting/consolidation runtime
-- summary/artifact generation boundary
-- audit tooling
-
-### GraphAwareRetriever
-
-Input:
-
-- query
-- semantic/keyword candidate hits
-- graph snapshot
-- visibility mode such as default retrieval or audit retrieval
-
-Output:
-
-- ranked memory hits
-- graph expansion explanation
-- active summaries/raw records
-- optional audit source chains
-
-Not responsible for:
-
-- mutating graph state by default
-- deciding cluster lifecycle
-- generating summaries
-- replacing the underlying semantic index
-
-Consumed by:
-
-- agent context assembly
-- memory search APIs
-- evaluation and retrieval dry-runs
-
-### GraphEvolutionReport
-
-Input:
-
-- graph update plan
-- persisted graph update result
-- lifecycle transitions
-- consolidation/deprecation outcomes
-- retrieval diff data
-
-Output:
-
-- human-readable and machine-readable graph diff
-- reinforcement and weakening summary
-- cluster lifecycle summary
-- audit chain completeness
-- warnings and no-op diagnostics
-
-Not responsible for:
-
-- deciding policy
-- mutating storage
-- ranking memories
-- summarizing source content
-
-Consumed by:
-
-- tests and evals
-- operators
-- future UI surfaces
-- rollout gates
-
-## Phased Implementation Plan
-
-### Phase 1: Architecture + Conceptual Contracts
-
-Define the graph architecture, terms, lifecycle states, and interface boundaries.
-Keep this phase documentation-first. Any contracts should be conceptual or
-dry-run only. The success criterion is shared understanding of where graph,
-interaction, lifecycle, consolidation, retrieval, and observability concerns
-belong.
-
-### Phase 2: Ingest-time Graph Interaction
-
-Add an opt-in path where new memory retrieves candidate existing memory and
-produces a graph update plan. Start with explicit metadata/relation keys and
-simple similarity candidates. Persist only behind a controlled boundary, with
-reports showing proposed edges, reinforcement, weakening, and cluster impact.
-
-### Phase 3: Cluster Lifecycle State
-
-Introduce lifecycle state for clusters. Compute forming, active, stable,
-decaying, superseded, and audit-only transitions from graph signals. Keep the
-policy separate from storage and summarization. Add dry-run lifecycle reports
-before changing default runtime behavior.
-
-### Phase 4: Graph-aware Forgetting / Consolidation
-
-Make forgetting and consolidation consume cluster lifecycle state. Stable
-clusters produce summaries or artifacts; source raw records are soft-deprecated
-after successful persistence; weak or unsupported structures decay; contested
-clusters are preserved for observation rather than prematurely summarized.
-
-### Phase 5: Graph-aware Retrieval
-
-Use graph state to improve retrieval. Start with dry-run comparison reports:
-baseline semantic candidates versus graph-expanded and graph-ranked results.
-Then enable controlled retrieval paths where active summaries represent stable
-clusters and deprecated raw source records are hidden by default but available
-for audit.
-
-### Phase 6: Evaluation and Observability
-
-Build evaluation scenarios and reports for:
-
-- duplicate memory reduction
-- stable preference recall
-- conflict handling
-- source evidence traceability
-- noise suppression
-- graph-aware retrieval quality
-- audit chain completeness
-
-Observability should make every graph operation explainable before broad runtime
-enablement.
-
-## Relationship to Existing Work
-
-- Relation graph and relation discovery already form the foundation of the Graph
-  Layer and Interaction Layer. Existing relation candidates, relation judgment,
-  graph assignment, competition groups, and lifecycle signals can be treated as
-  early graph mechanics.
-- Current `support`, `compete`, and `related` relation edges are the operational
-  projection of the broader relation taxonomy proposed here. Future interfaces
-  can add richer relation kinds without invalidating the current graph pipeline.
-- The current forgetting engine is an early Forgetting / Consolidation Layer. It
-  scans eligible memory, groups records, generates summaries, transitions tiers,
-  and provides a place for graph-aware cluster decisions to be consumed later.
-- Summary plus soft-deprecation is the sedimentation action after cluster
-  stabilization. It should eventually be driven by stable cluster lifecycle
-  state rather than only by record age or batch grouping.
-- `includeDeprecated` and audit retrieval are the foundation of the Audit Trail.
-  Default retrieval can hide superseded raw records, while audit retrieval can
-  recover the source chain behind a summary or artifact.
-- Existing semantic retrieval dry-runs and retrieval comparison reports can
-  become the evaluation harness for graph-aware retrieval before changing
-  default ranking.
-
-## Acceptance Criteria
-
-This architecture is sufficient when it can answer the following questions:
-
-- How does new memory affect old memory?
-
-  New memory becomes a node, retrieves candidate neighbors, produces relation
-  updates, reinforces or weakens edges, and can update cluster membership and
-  lifecycle state.
-
-- How do memory clusters form, stabilize, and decay?
-
-  Clusters form from supporting edges, become active through evidence and
-  activation, stabilize when policy thresholds are met, decay when unsupported or
-  contradicted, and move to superseded or audit-only states when a summary or
-  artifact becomes the active representative.
-
-- Why is forgetting a graph operation?
-
-  Forgetting must consider whether a record is isolated noise, part of a stable
-  cluster, contradicted by a stronger cluster, superseded by a summary, or still
-  needed for audit. Those are graph states, not simple per-record age checks.
-
-- Where do summary and deprecation sit in the architecture?
-
-  They are consolidation outputs after cluster stabilization. A summary or
-  artifact becomes the compact active representative; source raw records are
-  soft-deprecated by default but remain linked for audit.
-
-- How does retrieval use graph signals instead of only similarity?
-
-  Retrieval starts from semantic or keyword candidates, then expands and ranks by
-  cluster membership, edge strength, lifecycle state, contradiction,
-  supersession, activation, and visibility mode.
-
-- Which boundaries should future interface design use?
-
-  Future interfaces should center on `MemoryGraphStore`,
-  `GraphInteractionEngine`, `ClusterLifecyclePolicy`,
-  `MemoryConsolidationPlanner`, `GraphAwareRetriever`, and
-  `GraphEvolutionReport`.
+A correction adds an authoritative operation; it does not rewrite historical
+evidence.
+
+## Failure and Degradation Rules
+
+- Missing graph snapshot: keep baseline behavior and report a no-op.
+- Relation judgment failure: preserve candidates without mutation.
+- Scope mismatch: reject the affected result or operation.
+- Applicability mismatch: preserve the evidence without treating it as global
+  support or competition.
+- Version conflict: reject persistence and rebuild the plan from a current graph
+  snapshot.
+- Replayed completed operation: return the prior result without applying the
+  mutation again.
+- Graph persistence failure: do not apply dependent lifecycle or visibility
+  changes.
+- Representative persistence failure: do not soft-deprecate source records.
+- Partial persistence failure: retain applied-operation records and retry only
+  unapplied operations or execute an explicit rollback plan.
+- Partial candidate coverage: preserve non-hidden baseline retrieval hits.
+- Missing audit provenance: block consolidation or rollout when provenance is
+  required by policy.
+- Correction conflict: preserve both the automatic result and correction record
+  until an explicit resolution is applied.
+
+## Current Capability Mapping
+
+Already available:
+
+- summary persistence and source soft-deprecation
+- deprecated-record filtering and `includeDeprecated` audit retrieval
+- graph-aware filtering and ranking of baseline retrieval candidates
+- relation observations and competition-oriented diagnostics
+
+Next architecture gap:
+
+- ingest-time interaction that updates durable graph relations and clusters
+- lifecycle decisions driven by accumulated graph evidence
+- consolidation and weakening driven by lifecycle state
+- explicit correction and rollback of graph evolution
+
+## PR Reference Contract
+
+Every Memory Graph Evolution PR must state:
+
+- requirement identifiers from
+  [memory-graph-evolution-requirements.md](./memory-graph-evolution-requirements.md)
+- applicable ADRs from [adr/README.md](./adr/README.md)
+- architecture components changed
+- invariants that must remain true
+- user-visible behavior added or changed
+- no-op, failure, and rollback behavior
+- focused acceptance scenarios and verification
+
+PR descriptions must reference these documents instead of copying them.

--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
@@ -1,461 +1,162 @@
 # Memory Graph Evolution Execution Plan
 
-## Purpose
+Status: Proposed delivery plan. It becomes active when the referenced
+requirements, architecture, and ADRs are accepted and merged upstream.
 
-This plan turns the
-[Memory Graph Evolution architecture RFC](./memory-graph-evolution-architecture.md)
-into an implementation route. It does not replace the RFC. The RFC defines the
-target architecture and vocabulary; this document defines the order of execution,
-phase gates, review boundaries, and acceptance criteria for future Codex or
-human implementation sessions.
+This document defines delivery order only. It does not restate requirements,
+architecture, or decisions.
 
-The plan is intentionally architecture-first. It should not be read as a helper
-queue or a list of small implementation PRs. Each phase must leave the system
-clearer, more observable, and more reversible before runtime behavior changes.
+Authoritative references:
+
+- [Requirements](./memory-graph-evolution-requirements.md)
+- [Architecture](./memory-graph-evolution-architecture.md)
+- [ADR index](./adr/README.md)
 
 ## Current Baseline
 
-The current codebase already contains pieces that fit into the dynamic memory
-graph direction:
-
-- relation graph assignment
-- relation pipeline execution
-- operational relation kinds: `support`, `compete`, and `related`
-- competition groups
-- diagnostics reports
-- semantic draft candidates
-- forgetting engine
-- summary plus soft-deprecation
-- `includeDeprecated` audit path
-
-These pieces are useful foundation, but they do not yet form a complete runtime
-memory graph. Current graph work is mostly package-local and diagnostic. Current
-forgetting/consolidation work can summarize and soft-hide source records, but it
-is not yet driven by a durable graph lifecycle. Current retrieval can hide
-deprecated records and run semantic draft comparisons, but default ranking is
-not yet graph-aware.
-
-## Execution Principles
-
-- Architecture first, interfaces second, implementation third.
-- Dry-run before persistence.
-- Opt-in before default behavior.
-- Graph state must be scoped by user, workspace, or tenant.
-- Raw audit chain must be preserved.
-- Do not start with a broad storage rewrite.
-- Do not change runtime behavior without observability.
-- Every phase must be independently reviewable.
-- Every phase must describe rollback or no-op behavior before persistence.
-- Existing relation helpers should be assigned to boundaries before new helpers
-  are proposed.
-- Production code should not be written until the phase's contract, report
-  shape, and acceptance criteria are clear.
-
-## Required Execution Order
-
-The work must proceed in this order:
-
-1. Architecture stability
-2. Interface design
-3. Dry-run / report
-4. Opt-in persistence
-5. Runtime integration
-6. Retrieval behavior
-7. Evaluation / rollout
-
-If a future task needs to jump ahead, split it. For example, if a retrieval
-change requires graph persistence, define the persistence boundary first; do not
-silently merge retrieval behavior into an earlier dry-run phase.
-
-## Phase 0: Architecture Stability Gate
-
-Goal: stabilize the architecture RFC and make sure future phases refer to a
-shared vocabulary before any new production behavior is attempted.
-
-Inputs:
-
-- `memory-graph-evolution-architecture.md`
-- current `roadmap.md`
-- current `execution-plan.md`
-- current relation graph, relation pipeline, forgetting, soft-deprecation, and
-  retrieval diagnostics code
-
-Outputs:
-
-- confirmed architecture terms
-- confirmed phase sequence
-- explicit mapping from existing work to architecture layers
-- known open questions
-- decision log for scope boundaries
-
-Acceptance:
-
-- The dynamic memory graph remains the main line, not a collection of isolated
-  helper tasks.
-- The RFC can answer how new memory affects old memory.
-- The RFC can explain cluster formation, stabilization, decay, supersession, and
-  audit-only visibility.
-- The RFC clearly places summary and soft-deprecation after cluster
-  stabilization.
-- The RFC states that graph scope is isolated by user, workspace, or tenant.
-- No production code, tests, storage migrations, UI, scheduler, or helper
-  implementation is required in this phase.
-
-Open questions:
-
-- Which product scope is primary for graph state: user, workspace, tenant, or a
-  composite key?
-- Should cross-workspace memory sharing be impossible by default or represented
-  as an explicit edge type later?
-- Which existing diagnostics should become durable graph operation reports?
-
-## Phase 1: Interface Boundary Design
-
-Goal: turn the RFC boundaries into concrete interface drafts without requiring
-implementation.
-
-Boundaries:
-
-- `MemoryGraphStore`
-- `GraphInteractionEngine`
-- `ClusterLifecyclePolicy`
-- `MemoryConsolidationPlanner`
-- `GraphAwareRetriever`
-- `GraphEvolutionReport`
-
-Each interface draft must describe:
-
-- input
-- output
-- non-responsibilities
-- existing code it maps to
-- expected first consumer
-- open questions
-
-Existing-code mapping:
-
-- `relation-graph.ts` maps mainly to `MemoryGraphStore` read models and
-  `ClusterLifecyclePolicy` inputs.
-- `pipeline.ts` relation candidate and judgment helpers map to
-  `GraphInteractionEngine`.
-- `buildMemoryConsolidationPlan` and summary candidate generation map to
-  `MemoryConsolidationPlanner`.
-- current forgetting engine behavior maps to the early
-  Forgetting / Consolidation runtime consumer.
-- current retrieval comparison and semantic draft retrieval helpers map to
-  `GraphAwareRetriever` dry-run inputs.
-- current diagnostics reports map to `GraphEvolutionReport`.
-
-Acceptance:
-
-- Current helpers can be assigned to one primary boundary.
-- The document can explain how `support`, `compete`, and `related` map to
-  higher-level relation semantics.
-- The graph scope model prevents cross-user or cross-workspace pollution.
-- Each boundary has at least one expected first consumer.
-- Each boundary has explicit non-responsibilities, so future work does not
-  collapse into a broad provider/helper layer.
-
-Review focus:
-
-- Are storage, interaction, policy, consolidation, retrieval, and reporting still
-  separated?
-- Does any boundary accidentally require a real-time LLM?
-- Does any boundary imply deleting raw audit evidence?
-
-## Phase 2: Graph Update Plan Dry Run
-
-Goal: when new memory enters the system, produce a graph update plan without
-persistence.
-
-Inputs:
-
-- new memory node
-- candidate existing records or summaries
-- explicit relation keys, metadata, or similarity candidates
-- current graph snapshot if available
-- owner scope such as user, workspace, or tenant
-
-Outputs:
-
-- proposed edges
-- reinforcement events
-- weakening or decay observations
-- cluster assignment impact
-- `GraphEvolutionReport`
-
-Expected behavior:
-
-- Similar new memory can propose reinforcement for an existing cluster.
-- Unrelated new memory does not pollute an existing cluster.
-- Conflict and competition signals can be represented.
-- Weak `same-topic` or `related` observations do not force cluster merges.
-- All results can be inspected as dry-run report data.
-- Runtime default behavior does not change.
-
-Acceptance:
-
-- A dry-run report can show which existing nodes were considered.
-- A dry-run report can show why an edge was proposed, weakened, or rejected.
-- A dry-run report can show potential cluster impact without writing graph
-  state.
-- The plan remains scoped to the caller's user/workspace/tenant.
-- No storage write is required.
-
-Open questions:
-
-- Should candidate retrieval begin from existing semantic recall, raw candidate
-  listing, relation keys, or a combined strategy?
-- What minimum evidence should be required before a proposed edge becomes
-  persistable?
-- How should explicit user feedback override automatic relation candidates?
-
-## Phase 3: Cluster Lifecycle Policy Dry Run
-
-Goal: make `forming`, `active`, `stable`, `decaying`, `superseded`, and
-`audit-only` computable states before any default persistence or retrieval
-behavior changes.
-
-Inputs:
-
-- graph snapshot
-- edge weights
-- activation history
-- support count
-- `compete` / conflict signals
-- consolidation and deprecation status
-- lifecycle thresholds
-
-Outputs:
-
-- lifecycle transition candidates
-- representative suggestions
-- consolidation eligibility
-- decay recommendations
-- audit-only recommendations
-- lifecycle section in `GraphEvolutionReport`
-
-Acceptance:
-
-- Repeated support can move a cluster from `forming` to `active` to `stable`.
-- Stale isolated nodes can move toward `decaying`.
-- Superseded source records can move toward `audit-only`.
-- Contested clusters are not summarized too early.
-- Lifecycle policy is separated from storage and summarizer behavior.
-- Lifecycle reports can be reviewed without changing persisted state.
-
-Review focus:
-
-- Are thresholds conservative enough to avoid false merges?
-- Can a contested cluster remain useful without becoming a summary?
-- Can the policy explain why a cluster is not eligible for consolidation?
-
-## Phase 4: Opt-in Persistence and Graph-aware Consolidation Planning
-
-Goal: allow graph plans and consolidation plans to persist only through explicit
-opt-in boundaries. Forgetting/consolidation should start consuming cluster
-lifecycle, but default runtime behavior should remain controlled.
-
-Actions:
-
-- persist graph update plans after dry-run approval
-- summarize stable clusters
-- soft-deprecate source raw records after successful summary or artifact
-  persistence
-- preserve contested clusters
-- decay weak structures
-- keep audit provenance
-
-Inputs:
-
-- stable or decaying lifecycle output
-- source record ids
-- relation evidence
-- summary or artifact candidate metadata
-- opt-in persistence mode
-
-Outputs:
-
-- persisted graph operation result
-- summary candidate or artifact candidate
-- soft-deprecation plan and result
-- preservation or decay diagnostics
-- audit provenance links
-
-Acceptance:
-
-- Stable cluster can produce a summary candidate.
-- After summary persistence succeeds, source raw records can be soft-deprecated.
-- `includeDeprecated` can recover the source evidence chain.
-- Deprecation failure becomes diagnostics and does not break the main flow unless
-  policy explicitly requires hard failure.
-- Audit chain is not deleted.
-- Persistence can be disabled or run in no-op mode for old adapters.
-
-Review focus:
-
-- Does the phase preserve raw source records?
-- Are persistence writes opt-in and observable?
-- Are graph operations and memory storage writes distinguishable in reports?
-
-## Phase 5: Controlled Runtime Integration
-
-Goal: gradually connect dry-run and opt-in persistence capabilities to real
-runtime paths without changing default behavior too early.
-
-Suggested stages:
+Already available in the runtime:
+
+- summary persistence and source soft-deprecation
+- default hiding of deprecated raw records
+- `includeDeprecated` audit retrieval
+- opt-in graph-aware ranking and filtering of baseline retrieval candidates
+- relation and competition-oriented diagnostics
+
+The remaining product gap is dynamic write-side evolution: new evidence must
+change graph relations, cluster state, lifecycle, and later consolidation in an
+explainable and reversible way.
+
+## Delivery Rules
+
+- Deliver functional behavior, not isolated helper collections.
+- Every PR must identify requirement IDs, applicable ADRs, affected architecture
+  components, and user-visible acceptance scenarios.
+- Mutation remains controlled until its failure, no-op, audit, and rollback
+  behavior is verified.
+- A later PR must build on the accepted behavior of earlier PRs instead of
+  maintaining parallel implementations.
+- UI, scheduler, broad storage migration, and real-time LLM requirements remain
+  outside this sequence.
+
+## PR 1: New Evidence Evolves the Graph
+
+### Functional Outcome
+
+New memory can interact with existing same-scope memory and produce a durable,
+auditable graph change when explicitly enabled.
+
+The capability includes:
+
+- candidate discovery from existing memory
+- support, competition, related, or no-relation decisions
+- preservation of task, conversation, channel, project, and validity context
+- cluster join or new-cluster decisions
+- reinforcement without duplicate-source inflation
+- competition without immediate overwrite
+- dry-run and opt-in persistence using one evolution plan
+- an explanation of considered evidence and applied operations
+
+### References
+
+- Requirements: MR-1, MR-2, MR-3, MR-4, MR-9, MR-10
+- ADRs: ADR-0001, ADR-0002, ADR-0003, ADR-0005
+- Architecture: Candidate Discovery, Graph Interaction Engine, Memory Graph
+  Store, New Evidence Interaction
+
+### Acceptance Gate
+
+- Repeated compatible evidence reinforces one cluster.
+- Duplicate evidence does not create false independent support.
+- Replaying the same evolution operation does not duplicate reinforcement or
+  membership changes.
+- Unrelated evidence remains separate.
+- Contradictory evidence creates competition and preserves both alternatives.
+- Context-specific evidence does not become global through recency alone.
+- Cross-scope candidates cannot affect the plan or result.
+- Disabled or unavailable graph behavior preserves baseline memory behavior.
+
+## PR 2: Cluster Lifecycle Drives Consolidation and Forgetting
+
+### Functional Outcome
+
+Accumulated graph evidence changes cluster lifecycle, and lifecycle drives
+stable representation, weakening, supersession, and default visibility.
+
+The capability includes:
+
+- forming, active, stable, decaying, superseded, and audit-only transitions
+- competition-aware lifecycle decisions
+- stable cluster representative selection
+- summary or artifact persistence before source soft-deprecation
+- decay of weak isolated structures without weakening supported clusters
+- failure ordering that prevents partial visibility loss
+
+### References
+
+- Requirements: MR-3, MR-4, MR-5, MR-6, MR-9, MR-10
+- ADRs: ADR-0002, ADR-0003, ADR-0004, ADR-0005
+- Architecture: Cluster Lifecycle Policy, Consolidation and Forgetting Planner,
+  Lifecycle and Consolidation
+
+### Acceptance Gate
+
+- Repeated support can move a cluster toward stable.
+- A temporary exception cannot supersede stable memory.
+- Sustained stronger competition can supersede an older cluster.
+- A representative is persisted before source visibility changes.
+- Failed representative persistence leaves source records normally retrievable.
+- Retrying a partially applied plan converges without duplicating lifecycle or
+  visibility changes.
+- Audit retrieval recovers all retained source evidence.
+
+## PR 3: Correction, Evaluation, and Controlled Rollout
+
+### Functional Outcome
+
+Automatic evolution can be inspected, corrected, rolled back, evaluated, and
+enabled through explicit rollout gates.
+
+The capability includes:
+
+- correction of content, status, membership, or preferred representative
+- rollback of persisted graph and visibility operations
+- conflict-sensitive and audit retrieval explanations
+- evaluation scenarios for false merge, false decay, contradiction handling,
+  noise suppression, scope isolation, and audit completeness
+- rollout decisions based on required evidence rather than feature presence
+
+### References
+
+- Requirements: MR-7, MR-8, MR-9, MR-10
+- ADRs: ADR-0002, ADR-0003, ADR-0004, ADR-0005
+- Architecture: Graph-aware Retriever, Evolution Report and Governance,
+  Correction and Audit
+- Rollout governance gate:
+  [memory-graph-rollout-governance.md](./memory-graph-rollout-governance.md)
+
+### Acceptance Gate
+
+- An incorrect automatic merge can be corrected without deleting history.
+- A persisted evolution can be rolled back or explicitly blocked.
+- Default retrieval suppresses superseded noise.
+- Audit retrieval exposes provenance and visibility decisions.
+- Conflict-sensitive retrieval can expose competing alternatives.
+- Missing required evaluation artifacts block broader rollout.
+
+## Completion Gate
+
+The feature is complete when the end-to-end loop defined in the requirements is
+demonstrated under controlled runtime evaluation:
 
 ```text
-off
-dry-run
-log-only
-developer opt-in
-limited rollout
-default-on
+new evidence
+  -> graph evolution
+  -> cluster lifecycle
+  -> consolidation or weakening
+  -> retrieval
+  -> audit or correction
 ```
 
-Runtime integration surfaces:
-
-- ingest-time graph interaction
-- batch graph maintenance
-- forgetting/consolidation runtime
-- audit retrieval path
-- graph evolution reporting
-
-Acceptance:
-
-- Every stage is reversible.
-- Every graph mutation has a report.
-- Default behavior changes only after evaluation data exists.
-- UI is not required.
-- Scheduler is not required all at once.
-- Old adapters without graph/deprecation support degrade to no-op diagnostics.
-
-Review focus:
-
-- Can operators compare runtime behavior with and without graph participation?
-- Is there an escape hatch for each mutation type?
-- Are graph reports sufficient to debug wrong merges or wrong decay?
-
-## Phase 6: Graph-aware Retrieval Behavior
-
-Goal: compare baseline retrieval with graph-aware retrieval before changing
-default ranking, then enable graph-aware behavior only through controlled modes.
-
-Inputs:
-
-- query
-- semantic candidates
-- graph snapshot
-- lifecycle state
-- visibility mode
-
-Outputs:
-
-- baseline result
-- graph-expanded result
-- ranking differences
-- hidden deprecated count
-- audit expansion trace
-- explanation of graph signals used in ranking
-
-Expected behavior:
-
-- Stable summaries can rank ahead of duplicate raw traces.
-- Deprecated raw records are hidden by default.
-- Audit mode can expand source evidence.
-- Contested clusters can be explicitly exposed when conflict matters.
-- Reports can explain why ranking changed.
-
-Acceptance:
-
-- Graph-aware retrieval can run as dry-run comparison before default ranking
-  changes.
-- `includeDeprecated` remains an audit capability, not the normal retrieval path.
-- Retrieval can explain when it selected an active summary instead of source raw
-  records.
-- Retrieval can expose competing clusters intentionally rather than mixing them
-  as noise.
-- Ranking behavior remains feature-gated until evaluated.
-
-Open questions:
-
-- Should graph expansion happen before or after semantic score thresholds?
-- How should recency interact with cluster stability?
-- What should the retriever do when the best semantic hit is deprecated but its
-  summary is missing?
-
-## Phase 7: Evaluation and Rollout Criteria
-
-Goal: define how to prove that the dynamic graph system improves on isolated
-records plus similarity search.
-
-Metrics:
-
-- duplicate memory reduction
-- stable preference recall
-- contradiction handling
-- retrieval noise suppression
-- audit chain completeness
-- graph mutation explainability
-- false merge rate
-- false decay rate
-- runtime cost
-
-Acceptance:
-
-- Every metric has at least one scenario.
-- Reports can compare graph-aware behavior with baseline behavior.
-- Failure modes can be identified and categorized.
-- Rollout gates are explicit.
-- Evaluation includes both quality and safety: better recall should not come at
-  the cost of lost auditability or cross-scope contamination.
-
-Suggested rollout gates:
-
-- No cross-user/workspace graph edges in default mode.
-- No raw audit chain deletion.
-- False merge rate below an agreed threshold.
-- False decay cases are inspectable and reversible.
-- Retrieval dry-run shows noise reduction without hiding necessary evidence.
-- Runtime cost is bounded for expected candidate sizes.
-
-Rollout governance gate:
-[memory-graph-rollout-governance.md](./memory-graph-rollout-governance.md)
-
-## Deliverables
-
-This planning task delivers only documentation:
-
-1. `memory-graph-evolution-execution-plan.md`
-2. A link from `memory-graph-evolution-architecture.md` to this execution plan
-3. No production code
-4. No test changes
-5. No new helper
-
-## Review Checklist
-
-- Does the plan still serve the dynamic memory graph direction?
-- Does it avoid becoming a helper checklist?
-- Does it put interface design before implementation?
-- Does it make the dry-run / persistence / runtime order explicit?
-- Does it preserve the audit chain?
-- Does it clearly isolate graph state by user, workspace, or tenant?
-- Does it leave clear phase boundaries for future Codex execution sessions?
-- Does each phase have reviewable acceptance criteria?
-- Does any phase accidentally require UI, scheduler, storage rewrite, or
-  real-time LLM behavior?
-
-## Final Reporting Template
-
-Future execution sessions should report:
-
-- documents changed
-- phase being advanced
-- phase goal
-- new or changed interface boundary
-- dry-run/report status
-- persistence/runtime status
-- unresolved architecture questions
-- verification performed
-- whether checkpoint/commit is recommended
+Completion requires all requirements to be mapped to accepted behavior and all
+accepted ADRs to remain satisfied. Documentation-only completion, isolated
+helpers, or dry-run reports without a validated runtime path are insufficient.

--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-requirements.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-requirements.md
@@ -1,0 +1,234 @@
+# Memory Graph Evolution Requirements
+
+Status: Proposed requirements for Dynamic Memory Cluster Evolution. They become
+authoritative when accepted and merged upstream.
+
+Related documents:
+
+- [Architecture](./memory-graph-evolution-architecture.md)
+- [ADR index](./adr/README.md)
+- [Execution plan](./memory-graph-evolution-execution-plan.md)
+
+## Product Intent
+
+OpenLoomi memory should evolve through interaction between new and existing
+evidence. Memory must not remain a collection of isolated fragments connected
+only at query time by semantic similarity.
+
+The target capability is a dynamic memory graph in which evidence forms memory
+clusters, repeated support reinforces stable memory, contradictions create
+competition, unsupported structures weaken, and stable clusters become compact
+representatives without destroying their source evidence.
+
+## Current Baseline
+
+The following capabilities already exist and are not the purpose of this work:
+
+- summary persistence can soft-deprecate covered raw records
+- default retrieval can hide deprecated raw records
+- `includeDeprecated` can recover deprecated records for audit
+- graph-aware retrieval can reorder or filter baseline candidates when enabled
+- relation work can represent `support`, `compete`, and `related` observations
+
+The missing capability is the write-side evolution loop: new memory does not yet
+reliably change graph relations, cluster strength, competition, or lifecycle.
+
+## Required User-visible Behavior
+
+The completed capability must produce these outcomes:
+
+- Repeated consistent evidence makes a memory more stable and easier to recall.
+- A temporary instruction does not silently replace a long-term preference.
+- Sustained contradictory evidence can gradually supersede an older memory.
+- Unrelated evidence remains separate instead of polluting an existing cluster.
+- Weak or stale memory becomes less prominent without losing its audit trail.
+- Stable clusters can be represented by summaries or artifacts while source
+  records remain recoverable.
+- Retrieval changes can be explained by cluster state, evidence, competition,
+  and visibility decisions.
+- User correction can override automatic evolution without deleting history.
+
+## Functional Requirements
+
+### MR-1: New Memory Interaction
+
+When a new memory enters the system, it must be evaluated against candidate
+existing memory within the same owner scope.
+
+Candidate evaluation must also preserve applicability context so task-specific
+or time-limited evidence is not compared as though it were globally valid.
+
+The result must distinguish at least:
+
+- support for an existing memory structure
+- competition or contradiction
+- topical relation without enough evidence to merge
+- no meaningful relation
+
+### MR-2: Cluster Formation
+
+Supporting evidence may join an existing cluster or form a new cluster.
+
+Weak similarity alone must not force cluster membership. Unrelated and uncertain
+evidence must remain separate or observational until stronger evidence exists.
+
+### MR-3: Reinforcement
+
+Repeated supporting evidence must be able to increase the strength and stability
+of a relation or cluster.
+
+Reinforcement must remain evidence-backed and explainable. Repetition from a
+single duplicated source must not be treated as independent confirmation.
+
+### MR-4: Competition and Weakening
+
+Contradictory evidence must create an explicit competing state rather than
+immediately overwriting existing memory.
+
+Competition may weaken an older cluster when the newer alternative gains
+sustained, higher-quality support. A one-off exception must not supersede a
+stable cluster by default.
+
+Evidence that is limited to a task, conversation, channel, or validity period
+must retain that applicability. Context-specific evidence competes with memory
+that applies to the same context; it must not become a global preference solely
+because it is newer. Broader applicability requires explicit evidence or
+repeated support across independent contexts.
+
+### MR-5: Cluster Lifecycle
+
+Memory clusters must support the following lifecycle states:
+
+- `forming`
+- `active`
+- `stable`
+- `decaying`
+- `superseded`
+- `audit-only`
+
+Competition is an orthogonal condition and must not be hidden by a lifecycle
+transition.
+
+Lifecycle changes must be based on evidence, activation, competition,
+supersession, and policy. Age alone is insufficient.
+
+### MR-6: Consolidation and Soft Forgetting
+
+A stable cluster may produce a summary or artifact as its active representative.
+
+Source raw records may be hidden from default retrieval only after the
+representative is successfully persisted and provenance is available. Source
+records must remain recoverable through audit retrieval.
+
+### MR-7: Retrieval Participation
+
+Retrieval must be able to use cluster representatives, lifecycle state,
+competition, relation strength, and visibility without replacing the underlying
+semantic or keyword candidate search.
+
+Default retrieval should suppress superseded evidence noise. Audit or
+conflict-sensitive retrieval must be able to expose source and competing memory.
+Context-sensitive retrieval must prefer memory whose applicability matches the
+current request before considering broader or competing alternatives.
+
+### MR-8: Correction and Reversibility
+
+Users or operators must be able to correct memory content, status, or preferred
+representation through an explicit action.
+
+Corrections must preserve prior evidence and record why automatic evolution was
+overridden. A rollback path must exist for persisted graph and visibility
+changes before broad automatic rollout.
+
+### MR-9: Scope Isolation
+
+Every node, edge, cluster, lifecycle decision, retrieval result, and mutation
+must belong to an explicit composite owner scope:
+
+- `userId` is required
+- `workspaceId` is optional and narrows the user scope
+- `tenantId` is optional and provides an additional isolation boundary
+
+Workspace and tenant identity do not replace user identity in the current
+product model.
+
+Cross-user, cross-workspace, or cross-tenant relations are forbidden by default.
+Shared memory requires a separate product decision and explicit authorization.
+
+### MR-10: Explainability and Evaluation
+
+Every proposed or applied evolution must expose:
+
+- affected nodes and clusters
+- evidence used
+- relation and lifecycle changes
+- reason codes
+- whether storage, visibility, or retrieval changed
+- rollback or no-op outcome
+
+The system must support evaluation of false merges, false decay, contradiction
+handling, retrieval noise, audit completeness, and runtime cost.
+
+## Quality Requirements
+
+- Evolution must be incremental; processing new memory must not require a full
+  graph rebuild.
+- Every persisted evolution plan must have stable operation identity and an
+  expected graph version or equivalent concurrency guard.
+- Replaying the same operation must not duplicate reinforcement, membership,
+  lifecycle, consolidation, or visibility changes.
+- Partial persistence failures must remain observable and retryable until the
+  intended plan converges or is explicitly rolled back.
+- Missing graph capabilities must degrade to baseline memory behavior.
+- Automatic mutation must be optional until rollout gates are satisfied.
+- Real-time LLM judgment must not be required for every memory write.
+- Storage, relation judgment, lifecycle policy, consolidation, and retrieval
+  must remain separately replaceable.
+- The raw evidence chain must never be deleted as a consequence of graph
+  consolidation alone.
+
+## Non-goals
+
+- A graph visualization UI.
+- A scheduler redesign.
+- A broad database migration before the evolution behavior is validated.
+- Cross-user or shared organizational memory.
+- Hard deletion of source evidence.
+- Replacing semantic search with graph traversal.
+- Treating every related memory as part of one cluster.
+
+## Acceptance Scenarios
+
+| Scenario                      | Required outcome                                                                                               |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Repeated language preference  | Consistent observations reinforce one cluster and improve its retrieval priority.                              |
+| Temporary language override   | A task-specific exception remains contextual and does not replace the stable preference.                       |
+| Repeated cross-context change | Consistent evidence across independent contexts can broaden applicability and challenge the stable preference. |
+| Sustained preference change   | Repeated contradictory evidence creates competition and can eventually supersede the old cluster.              |
+| Duplicate imported messages   | Duplicate sources do not inflate independent support.                                                          |
+| Unrelated project fact        | The evidence forms or joins a separate cluster.                                                                |
+| Stale isolated trace          | The trace can decay without weakening a supported stable cluster.                                              |
+| Stable cluster consolidation  | A representative is persisted before source records are soft-deprecated.                                       |
+| Retried evolution operation   | Replaying the same operation does not duplicate reinforcement or visibility changes.                           |
+| Audit retrieval               | The representative can be traced back to all retained source evidence.                                         |
+| Incorrect automatic merge     | A correction can separate or override the result while preserving history.                                     |
+| Cross-scope candidate         | The candidate cannot create an edge, join a cluster, or enter a retrieval result.                              |
+
+## Completion Criteria
+
+Dynamic Memory Cluster Evolution is functionally complete when all acceptance
+scenarios pass in controlled runtime evaluation and the system can demonstrate a
+full loop:
+
+```text
+new evidence
+  -> interaction
+  -> graph and cluster evolution
+  -> lifecycle decision
+  -> consolidation or weakening
+  -> graph-aware retrieval
+  -> audit or correction
+```
+
+The loop must remain owner-scoped, explainable, reversible, and compatible with
+baseline retrieval when graph behavior is disabled or unavailable.

--- a/packages/ai/memory-consolidation/docs/roadmap.md
+++ b/packages/ai/memory-consolidation/docs/roadmap.md
@@ -1,5 +1,14 @@
 # Memory Consolidation Roadmap
 
+For the proposed Dynamic Memory Cluster Evolution scope, use the
+[requirements](./memory-graph-evolution-requirements.md),
+[architecture](./memory-graph-evolution-architecture.md),
+[ADR index](./adr/README.md), and
+[execution plan](./memory-graph-evolution-execution-plan.md). This roadmap
+provides broader package history and direction. The linked documents become
+authoritative when accepted and merged upstream, and then override this roadmap
+for Memory Graph Evolution decisions.
+
 ## Goal
 
 The long-term goal of `@openloomi/memory-consolidation` is not to make agents

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -10,6 +10,7 @@
     "./evaluation": "./src/evaluation.ts",
     "./evidence-cluster": "./src/evidence-cluster.ts",
     "./graph-contracts": "./src/graph-contracts.ts",
+    "./graph-evolution": "./src/graph-evolution.ts",
     "./graph-retrieval": "./src/graph-retrieval.ts",
     "./governance": "./src/governance.ts",
     "./persistence": "./src/persistence.ts",

--- a/packages/ai/memory-consolidation/src/graph-contracts.ts
+++ b/packages/ai/memory-consolidation/src/graph-contracts.ts
@@ -4,6 +4,22 @@ export interface OwnerScope {
   tenantId?: string;
 }
 
+export type MemoryApplicabilityScope =
+  | "global"
+  | "task"
+  | "conversation"
+  | "channel"
+  | "project"
+  | "custom";
+
+export interface MemoryApplicabilityContext {
+  scope: MemoryApplicabilityScope;
+  key?: string;
+  validFrom?: number;
+  validUntil?: number;
+  metadata?: Record<string, unknown>;
+}
+
 export type MemoryGraphNodeType = "raw" | "summary" | "artifact";
 
 export type MemoryGraphRelationKind =
@@ -30,6 +46,7 @@ export interface MemoryGraphNode {
   createdAt: number;
   updatedAt?: number;
   visibility: MemoryGraphVisibility;
+  applicability?: MemoryApplicabilityContext;
   metadata?: Record<string, unknown>;
 }
 
@@ -43,6 +60,7 @@ export interface MemoryGraphEdge {
   confidence?: number;
   evidenceNodeIds: string[];
   reasonCodes: string[];
+  applicability?: MemoryApplicabilityContext;
   createdAt: number;
   updatedAt?: number;
   metadata?: Record<string, unknown>;
@@ -58,6 +76,7 @@ export interface MemoryGraphClusterSnapshot {
   competitionKey?: string;
   updatedAt: number;
   reasonCodes: string[];
+  applicability?: MemoryApplicabilityContext;
   metadata?: Record<string, unknown>;
 }
 
@@ -75,6 +94,7 @@ export type MemoryGraphOperationKind =
   | "create-edge"
   | "reinforce-edge"
   | "weaken-edge"
+  | "upsert-cluster"
   | "set-cluster-lifecycle"
   | "set-cluster-representative"
   | "supersede-node";
@@ -99,10 +119,13 @@ export interface MemoryGraphPersistenceMode {
 }
 
 export interface MemoryGraphUpdatePlan {
+  planId?: string;
   ownerScope: OwnerScope;
   candidateNodes: MemoryGraphNode[];
   candidateEdges: MemoryGraphEdge[];
+  candidateClusters?: MemoryGraphClusterSnapshot[];
   operations: MemoryGraphOperation[];
+  expectedVersion?: string;
   persistence: MemoryGraphPersistenceMode;
   reasonCodes: string[];
   metadata?: Record<string, unknown>;
@@ -116,6 +139,9 @@ export interface MemoryGraphUpdateResult {
     reasonCodes: string[];
   }>;
   mutatesGraph: boolean;
+  version?: string;
+  replayed?: boolean;
+  conflict?: boolean;
   diagnostics: string[];
   metadata?: Record<string, unknown>;
 }

--- a/packages/ai/memory-consolidation/src/graph-evolution.ts
+++ b/packages/ai/memory-consolidation/src/graph-evolution.ts
@@ -1,0 +1,631 @@
+import type { MemoryEvidenceRecord } from "./evidence-cluster";
+import type {
+	MemoryApplicabilityContext,
+	MemoryGraphClusterSnapshot,
+	MemoryGraphEdge,
+	MemoryGraphNode,
+	MemoryGraphOperation,
+	MemoryGraphSnapshot,
+	MemoryGraphStore,
+	MemoryGraphUpdatePlan,
+	MemoryGraphUpdateResult,
+	OwnerScope,
+} from "./graph-contracts";
+import {
+	buildMemoryRelationCandidates,
+	judgeMemoryRelationCandidates,
+} from "./pipeline";
+
+export interface MemoryGraphEvolutionEvidence {
+	id: string;
+	ownerScope: OwnerScope;
+	timestamp: number;
+	text?: string;
+	relationGroup?: string;
+	relationValue?: string;
+	topicKeys?: string[];
+	applicability?: MemoryApplicabilityContext;
+	sourceIdentity?: string;
+	accessCount?: number;
+	importanceScore?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export interface BuildMemoryGraphEvolutionPlanInput {
+	ownerScope: OwnerScope;
+	newEvidence: MemoryGraphEvolutionEvidence[];
+	candidateEvidence: MemoryGraphEvolutionEvidence[];
+	snapshot: MemoryGraphSnapshot;
+	now: number;
+	persistence: { mode: "dry-run" | "write"; enabled: boolean };
+}
+
+export type MemoryGraphEvolutionRunStatus =
+	| "disabled"
+	| "planned"
+	| "applied"
+	| "no-op"
+	| "conflict"
+	| "failed";
+
+export interface MemoryGraphEvolutionRunResult {
+	status: MemoryGraphEvolutionRunStatus;
+	ownerScope: OwnerScope;
+	plan?: MemoryGraphUpdatePlan;
+	persistenceResult?: MemoryGraphUpdateResult;
+	consideredCandidateIds: string[];
+	reasonCodes: string[];
+	error?: { name: string; message: string };
+}
+
+export interface RunMemoryGraphEvolutionInput {
+	ownerScope: OwnerScope;
+	newEvidence: MemoryGraphEvolutionEvidence[];
+	candidateEvidence: MemoryGraphEvolutionEvidence[];
+	store: MemoryGraphStore;
+	enabled?: boolean;
+	dryRun?: boolean;
+	now?: number;
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)].sort();
+}
+
+function stablePart(value: string): string {
+	return encodeURIComponent(value).replaceAll("%", "_");
+}
+
+export function ownerScopeKey(scope: OwnerScope): string {
+	return [scope.tenantId ?? "", scope.workspaceId ?? "", scope.userId]
+		.map(stablePart)
+		.join(":");
+}
+
+export function sameOwnerScope(left: OwnerScope, right: OwnerScope): boolean {
+	return ownerScopeKey(left) === ownerScopeKey(right);
+}
+
+function applicabilityKey(
+	applicability: MemoryApplicabilityContext | undefined,
+): string {
+	if (!applicability || applicability.scope === "global") return "global";
+	return `${applicability.scope}:${applicability.key ?? ""}`;
+}
+
+function applicabilityActive(
+	applicability: MemoryApplicabilityContext | undefined,
+	now: number,
+): boolean {
+	if (!applicability) return true;
+	if (applicability.validFrom !== undefined && now < applicability.validFrom) {
+		return false;
+	}
+	if (
+		applicability.validUntil !== undefined &&
+		now > applicability.validUntil
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function applicabilityOverlaps(
+	left: MemoryApplicabilityContext | undefined,
+	right: MemoryApplicabilityContext | undefined,
+	now: number,
+): boolean {
+	if (!applicabilityActive(left, now) || !applicabilityActive(right, now)) {
+		return false;
+	}
+	const leftKey = applicabilityKey(left);
+	const rightKey = applicabilityKey(right);
+	return leftKey === "global" || rightKey === "global" || leftKey === rightKey;
+}
+
+export function applicabilityEquivalent(
+	left: MemoryApplicabilityContext | undefined,
+	right: MemoryApplicabilityContext | undefined,
+): boolean {
+	return applicabilityKey(left) === applicabilityKey(right);
+}
+
+function evidenceToRecord(
+	evidence: MemoryGraphEvolutionEvidence,
+): MemoryEvidenceRecord {
+	return {
+		id: evidence.id,
+		userId: evidence.ownerScope.userId,
+		timestamp: evidence.timestamp,
+		text: evidence.text,
+		tier: "short",
+		accessCount: evidence.accessCount,
+		importanceScore: evidence.importanceScore,
+		metadata: {
+			...evidence.metadata,
+			relationGroup: evidence.relationGroup,
+			relationValue: evidence.relationValue,
+			topicKeys: evidence.topicKeys,
+		},
+	};
+}
+
+function candidateKeys(record: MemoryEvidenceRecord): string[] {
+	const relationGroup = record.metadata?.relationGroup;
+	const topicKeys = Array.isArray(record.metadata?.topicKeys)
+		? record.metadata.topicKeys.filter(
+				(value): value is string => typeof value === "string",
+			)
+		: [];
+	return unique([
+		...(typeof relationGroup === "string" ? [`relation:${relationGroup}`] : []),
+		...topicKeys.map((key) => `topic:${key}`),
+	]);
+}
+
+function graphNode(evidence: MemoryGraphEvolutionEvidence): MemoryGraphNode {
+	return {
+		id: evidence.id,
+		ownerScope: evidence.ownerScope,
+		type: "raw",
+		sourceId: evidence.sourceIdentity ?? evidence.id,
+		createdAt: evidence.timestamp,
+		visibility: "default",
+		applicability: evidence.applicability,
+		metadata: {
+			...evidence.metadata,
+			relationGroup: evidence.relationGroup,
+			relationValue: evidence.relationValue,
+			topicKeys: evidence.topicKeys,
+			sourceIdentity: evidence.sourceIdentity ?? evidence.id,
+		},
+	};
+}
+
+function edgeId(kind: string, left: string, right: string): string {
+	return `edge:${kind}:${[left, right].sort().map(stablePart).join(":")}`;
+}
+
+function singletonCluster(
+	node: MemoryGraphNode,
+	now: number,
+): MemoryGraphClusterSnapshot {
+	return {
+		clusterId: `cluster:${stablePart(node.id)}`,
+		ownerScope: node.ownerScope,
+		nodeIds: [node.id],
+		lifecycleStatus: "forming",
+		supportScore: 0,
+		updatedAt: now,
+		reasonCodes: ["new_evidence_cluster"],
+		applicability: node.applicability,
+	};
+}
+
+function cloneCluster(
+	cluster: MemoryGraphClusterSnapshot,
+): MemoryGraphClusterSnapshot {
+	return {
+		...cluster,
+		ownerScope: { ...cluster.ownerScope },
+		nodeIds: [...cluster.nodeIds],
+		reasonCodes: [...cluster.reasonCodes],
+		applicability: cluster.applicability
+			? { ...cluster.applicability }
+			: undefined,
+		metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
+	};
+}
+
+function operationId(planId: string, kind: string, id: string): string {
+	return `${planId}:${kind}:${stablePart(id)}`;
+}
+
+function buildPlanId(ownerScope: OwnerScope, evidenceIds: string[]): string {
+	return `evolution:${ownerScopeKey(ownerScope)}:${evidenceIds
+		.sort()
+		.map(stablePart)
+		.join("+")}`;
+}
+
+function errorInfo(error: unknown): { name: string; message: string } {
+	if (error instanceof Error) {
+		return { name: error.name, message: error.message };
+	}
+	return { name: "Error", message: String(error) };
+}
+
+export function buildMemoryGraphEvolutionPlan(
+	input: BuildMemoryGraphEvolutionPlanInput,
+): MemoryGraphUpdatePlan {
+	const existingNodeIds = new Set(input.snapshot.nodes.map((node) => node.id));
+	const existingSourceIdentities = new Set(
+		input.snapshot.nodes.map((node) => node.sourceId ?? node.id),
+	);
+	const batchSourceIdentities = new Set<string>();
+	const effectiveNewEvidence = input.newEvidence.filter((evidence) => {
+		const sourceIdentity = evidence.sourceIdentity ?? evidence.id;
+		if (!sameOwnerScope(evidence.ownerScope, input.ownerScope)) return false;
+		if (existingNodeIds.has(evidence.id)) return false;
+		if (existingSourceIdentities.has(sourceIdentity)) return false;
+		if (batchSourceIdentities.has(sourceIdentity)) return false;
+		batchSourceIdentities.add(sourceIdentity);
+		return true;
+	});
+	const allEvidenceById = new Map<string, MemoryGraphEvolutionEvidence>();
+	for (const evidence of input.candidateEvidence) {
+		if (sameOwnerScope(evidence.ownerScope, input.ownerScope)) {
+			allEvidenceById.set(evidence.id, evidence);
+		}
+	}
+	for (const evidence of effectiveNewEvidence) {
+		allEvidenceById.set(evidence.id, evidence);
+	}
+
+	const planId = buildPlanId(
+		input.ownerScope,
+		input.newEvidence.map((evidence) => evidence.sourceIdentity ?? evidence.id),
+	);
+	const newIds = new Set(effectiveNewEvidence.map((evidence) => evidence.id));
+	const records = [...allEvidenceById.values()].map(evidenceToRecord);
+	const candidates = buildMemoryRelationCandidates({
+		records,
+		getCandidateKeys: candidateKeys,
+	}).filter(
+		(candidate) =>
+			newIds.has(candidate.fromRecordId) || newIds.has(candidate.toRecordId),
+	);
+	const evidenceById = allEvidenceById;
+	const judgments = judgeMemoryRelationCandidates({
+		records,
+		candidates,
+		now: input.now,
+		judgeCandidate(candidate, context) {
+			const left = evidenceById.get(candidate.fromRecordId);
+			const right = evidenceById.get(candidate.toRecordId);
+			if (!left || !right) {
+				return {
+					relation: "uncertain",
+					weight: 0,
+					reasonCodes: ["uncertain_candidate"],
+				};
+			}
+			if (
+				!applicabilityOverlaps(
+					left.applicability,
+					right.applicability,
+					input.now,
+				)
+			) {
+				return {
+					relation: "uncertain",
+					weight: 0,
+					reasonCodes: ["uncertain_candidate"],
+				};
+			}
+			if (
+				context.defaultDecision.relation === "support" &&
+				!applicabilityEquivalent(left.applicability, right.applicability)
+			) {
+				return {
+					relation: "related",
+					weight: 0.45,
+					reasonCodes: ["candidate_related"],
+				};
+			}
+			return context.defaultDecision;
+		},
+	}).judgments.filter((judgment) => judgment.relation !== "uncertain");
+
+	const relevantEvidenceIds = new Set(
+		effectiveNewEvidence.map((item) => item.id),
+	);
+	for (const judgment of judgments) {
+		relevantEvidenceIds.add(judgment.candidate.fromRecordId);
+		relevantEvidenceIds.add(judgment.candidate.toRecordId);
+	}
+	const candidateNodes = [...relevantEvidenceIds]
+		.filter((id) => !existingNodeIds.has(id))
+		.flatMap((id) => {
+			const evidence = evidenceById.get(id);
+			return evidence ? [graphNode(evidence)] : [];
+		});
+	const nodesById = new Map(
+		input.snapshot.nodes.map((node) => [node.id, node]),
+	);
+	for (const node of candidateNodes) nodesById.set(node.id, node);
+
+	const operations: MemoryGraphOperation[] = candidateNodes.map((node) => ({
+		operationId: operationId(planId, "create-node", node.id),
+		ownerScope: input.ownerScope,
+		kind: "create-node",
+		nodeIds: [node.id],
+		reasonCodes: ["new_evidence_node"],
+	}));
+	const existingEdges = new Map(
+		input.snapshot.edges.map((edge) => [edge.id, edge]),
+	);
+	const candidateEdges: MemoryGraphEdge[] = [];
+
+	for (const judgment of judgments) {
+		const kind = judgment.relation as "support" | "compete" | "related";
+		const id = edgeId(
+			kind,
+			judgment.candidate.fromRecordId,
+			judgment.candidate.toRecordId,
+		);
+		const previous = existingEdges.get(id);
+		const evidenceNodeIds = unique([
+			...(previous?.evidenceNodeIds ?? []),
+			...[
+				judgment.candidate.fromRecordId,
+				judgment.candidate.toRecordId,
+			].filter((nodeId) => newIds.has(nodeId)),
+		]);
+		const left = evidenceById.get(judgment.candidate.fromRecordId);
+		const right = evidenceById.get(judgment.candidate.toRecordId);
+		if (!left || !right) continue;
+		const edge: MemoryGraphEdge = {
+			id,
+			ownerScope: input.ownerScope,
+			fromNodeId: judgment.candidate.fromRecordId,
+			toNodeId: judgment.candidate.toRecordId,
+			kind,
+			weight: previous
+				? Math.min(1, previous.weight + judgment.weight * 0.25)
+				: judgment.weight,
+			confidence: judgment.candidate.score,
+			evidenceNodeIds,
+			reasonCodes: unique([
+				...(previous?.reasonCodes ?? []),
+				...judgment.reasonCodes,
+			]),
+			createdAt: previous?.createdAt ?? input.now,
+			updatedAt: input.now,
+			applicability: applicabilityEquivalent(
+				left.applicability,
+				right.applicability,
+			)
+				? (left.applicability ?? right.applicability)
+				: undefined,
+			metadata: {
+				candidateKeys: judgment.candidate.candidateKeys,
+			},
+		};
+		candidateEdges.push(edge);
+		operations.push({
+			operationId: operationId(
+				planId,
+				previous ? "reinforce-edge" : "create-edge",
+				id,
+			),
+			ownerScope: input.ownerScope,
+			kind: previous ? "reinforce-edge" : "create-edge",
+			nodeIds: [edge.fromNodeId, edge.toNodeId],
+			edgeIds: [id],
+			reasonCodes: edge.reasonCodes,
+		});
+	}
+
+	const clusters = new Map(
+		input.snapshot.clusters.map((cluster) => [
+			cluster.clusterId,
+			cloneCluster(cluster),
+		]),
+	);
+	const clusterByNode = new Map<string, string>();
+	for (const cluster of clusters.values()) {
+		for (const nodeId of cluster.nodeIds)
+			clusterByNode.set(nodeId, cluster.clusterId);
+	}
+	const touchedClusterIds = new Set<string>();
+	for (const node of candidateNodes) {
+		if (!clusterByNode.has(node.id)) {
+			const cluster = singletonCluster(node, input.now);
+			clusters.set(cluster.clusterId, cluster);
+			clusterByNode.set(node.id, cluster.clusterId);
+			touchedClusterIds.add(cluster.clusterId);
+		}
+	}
+
+	for (const edge of candidateEdges.filter((item) => item.kind === "support")) {
+		const leftClusterId = clusterByNode.get(edge.fromNodeId);
+		const rightClusterId = clusterByNode.get(edge.toNodeId);
+		if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId) {
+			if (leftClusterId) touchedClusterIds.add(leftClusterId);
+			continue;
+		}
+		const leftCluster = clusters.get(leftClusterId);
+		const rightCluster = clusters.get(rightClusterId);
+		if (!leftCluster || !rightCluster) continue;
+		if (
+			!applicabilityEquivalent(
+				leftCluster.applicability,
+				rightCluster.applicability,
+			)
+		) {
+			continue;
+		}
+		const target = input.snapshot.clusters.some(
+			(cluster) => cluster.clusterId === rightClusterId,
+		)
+			? rightCluster
+			: leftCluster;
+		const source =
+			target.clusterId === leftClusterId ? rightCluster : leftCluster;
+		target.nodeIds = unique([...target.nodeIds, ...source.nodeIds]);
+		target.updatedAt = input.now;
+		target.reasonCodes = unique([
+			...target.reasonCodes,
+			"support_cluster_join",
+		]);
+		for (const nodeId of source.nodeIds)
+			clusterByNode.set(nodeId, target.clusterId);
+		clusters.delete(source.clusterId);
+		touchedClusterIds.delete(source.clusterId);
+		touchedClusterIds.add(target.clusterId);
+	}
+
+	for (const edge of candidateEdges.filter((item) => item.kind === "compete")) {
+		const leftClusterId = clusterByNode.get(edge.fromNodeId);
+		const rightClusterId = clusterByNode.get(edge.toNodeId);
+		if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId)
+			continue;
+		const competitionKey = `competition:${[leftClusterId, rightClusterId]
+			.sort()
+			.map(stablePart)
+			.join(":")}`;
+		for (const clusterId of [leftClusterId, rightClusterId]) {
+			const cluster = clusters.get(clusterId);
+			if (!cluster) continue;
+			cluster.competitionKey = competitionKey;
+			cluster.updatedAt = input.now;
+			cluster.reasonCodes = unique([
+				...cluster.reasonCodes,
+				"competition_preserved_before_supersession",
+			]);
+			touchedClusterIds.add(clusterId);
+		}
+	}
+
+	const allEdges = [...input.snapshot.edges, ...candidateEdges].reduce(
+		(map, edge) => map.set(edge.id, edge),
+		new Map<string, MemoryGraphEdge>(),
+	);
+	for (const clusterId of touchedClusterIds) {
+		const cluster = clusters.get(clusterId);
+		if (!cluster) continue;
+		const nodeIds = new Set(cluster.nodeIds);
+		const supportEdges = [...allEdges.values()].filter(
+			(edge) =>
+				edge.kind === "support" &&
+				nodeIds.has(edge.fromNodeId) &&
+				nodeIds.has(edge.toNodeId),
+		);
+		cluster.supportScore = supportEdges.length
+			? supportEdges.reduce((sum, edge) => sum + edge.weight, 0) /
+				supportEdges.length
+			: (cluster.supportScore ?? 0);
+	}
+
+	const candidateClusters = [...touchedClusterIds]
+		.map((clusterId) => clusters.get(clusterId))
+		.filter((cluster): cluster is MemoryGraphClusterSnapshot =>
+			Boolean(cluster),
+		);
+	for (const cluster of candidateClusters) {
+		operations.push({
+			operationId: operationId(planId, "upsert-cluster", cluster.clusterId),
+			ownerScope: input.ownerScope,
+			kind: "upsert-cluster",
+			nodeIds: [...cluster.nodeIds],
+			clusterId: cluster.clusterId,
+			reasonCodes: cluster.reasonCodes,
+		});
+	}
+
+	return {
+		planId,
+		ownerScope: input.ownerScope,
+		candidateNodes,
+		candidateEdges,
+		candidateClusters,
+		operations,
+		expectedVersion: input.snapshot.version ?? "0",
+		persistence: input.persistence,
+		reasonCodes: unique([
+			"incremental_graph_evolution",
+			...(candidateEdges.some((edge) => edge.kind === "support")
+				? ["support_evidence_applied"]
+				: []),
+			...(candidateEdges.some((edge) => edge.kind === "compete")
+				? ["competition_preserved_before_supersession"]
+				: []),
+			...(operations.length === 0 ? ["no_new_graph_operations"] : []),
+		]),
+		metadata: {
+			consideredCandidateIds: unique(
+				judgments.flatMap((judgment) => [
+					judgment.candidate.fromRecordId,
+					judgment.candidate.toRecordId,
+				]),
+			),
+			newEvidenceIds: input.newEvidence.map((evidence) => evidence.id),
+		},
+	};
+}
+
+export async function runMemoryGraphEvolution(
+	input: RunMemoryGraphEvolutionInput,
+): Promise<MemoryGraphEvolutionRunResult> {
+	if (input.enabled !== true) {
+		return {
+			status: "disabled",
+			ownerScope: input.ownerScope,
+			consideredCandidateIds: [],
+			reasonCodes: ["memory_graph_evolution_disabled"],
+		};
+	}
+
+	try {
+		const now = input.now ?? Date.now();
+		const snapshot = await input.store.readSnapshot({
+			ownerScope: input.ownerScope,
+			includeAuditOnly: true,
+		});
+		const plan = buildMemoryGraphEvolutionPlan({
+			ownerScope: input.ownerScope,
+			newEvidence: input.newEvidence,
+			candidateEvidence: input.candidateEvidence,
+			snapshot,
+			now,
+			persistence: {
+				mode: input.dryRun ? "dry-run" : "write",
+				enabled: !input.dryRun,
+			},
+		});
+		const consideredCandidateIds = Array.isArray(
+			plan.metadata?.consideredCandidateIds,
+		)
+			? plan.metadata.consideredCandidateIds.filter(
+					(value): value is string => typeof value === "string",
+				)
+			: [];
+
+		if (input.dryRun) {
+			return {
+				status: "planned",
+				ownerScope: input.ownerScope,
+				plan,
+				consideredCandidateIds,
+				reasonCodes: unique([...plan.reasonCodes, "memory_graph_dry_run"]),
+			};
+		}
+
+		const persistenceResult = await input.store.persistPlan(plan);
+		const status: MemoryGraphEvolutionRunStatus = persistenceResult.conflict
+			? "conflict"
+			: persistenceResult.mutatesGraph
+				? "applied"
+				: "no-op";
+		return {
+			status,
+			ownerScope: input.ownerScope,
+			plan,
+			persistenceResult,
+			consideredCandidateIds,
+			reasonCodes: unique([
+				...plan.reasonCodes,
+				...persistenceResult.diagnostics,
+			]),
+		};
+	} catch (error) {
+		return {
+			status: "failed",
+			ownerScope: input.ownerScope,
+			consideredCandidateIds: [],
+			reasonCodes: ["memory_graph_evolution_failed"],
+			error: errorInfo(error),
+		};
+	}
+}

--- a/packages/ai/memory-consolidation/src/graph-evolution.ts
+++ b/packages/ai/memory-consolidation/src/graph-evolution.ts
@@ -1,631 +1,645 @@
 import type { MemoryEvidenceRecord } from "./evidence-cluster";
 import type {
-	MemoryApplicabilityContext,
-	MemoryGraphClusterSnapshot,
-	MemoryGraphEdge,
-	MemoryGraphNode,
-	MemoryGraphOperation,
-	MemoryGraphSnapshot,
-	MemoryGraphStore,
-	MemoryGraphUpdatePlan,
-	MemoryGraphUpdateResult,
-	OwnerScope,
+  MemoryApplicabilityContext,
+  MemoryGraphClusterSnapshot,
+  MemoryGraphEdge,
+  MemoryGraphNode,
+  MemoryGraphOperation,
+  MemoryGraphSnapshot,
+  MemoryGraphStore,
+  MemoryGraphUpdatePlan,
+  MemoryGraphUpdateResult,
+  OwnerScope,
 } from "./graph-contracts";
 import {
-	buildMemoryRelationCandidates,
-	judgeMemoryRelationCandidates,
+  buildMemoryRelationCandidates,
+  judgeMemoryRelationCandidates,
 } from "./pipeline";
 
 export interface MemoryGraphEvolutionEvidence {
-	id: string;
-	ownerScope: OwnerScope;
-	timestamp: number;
-	text?: string;
-	relationGroup?: string;
-	relationValue?: string;
-	topicKeys?: string[];
-	applicability?: MemoryApplicabilityContext;
-	sourceIdentity?: string;
-	accessCount?: number;
-	importanceScore?: number;
-	metadata?: Record<string, unknown>;
+  id: string;
+  ownerScope: OwnerScope;
+  timestamp: number;
+  text?: string;
+  relationGroup?: string;
+  relationValue?: string;
+  topicKeys?: string[];
+  applicability?: MemoryApplicabilityContext;
+  sourceIdentity?: string;
+  accessCount?: number;
+  importanceScore?: number;
+  metadata?: Record<string, unknown>;
 }
 
 export interface BuildMemoryGraphEvolutionPlanInput {
-	ownerScope: OwnerScope;
-	newEvidence: MemoryGraphEvolutionEvidence[];
-	candidateEvidence: MemoryGraphEvolutionEvidence[];
-	snapshot: MemoryGraphSnapshot;
-	now: number;
-	persistence: { mode: "dry-run" | "write"; enabled: boolean };
+  ownerScope: OwnerScope;
+  newEvidence: MemoryGraphEvolutionEvidence[];
+  candidateEvidence: MemoryGraphEvolutionEvidence[];
+  snapshot: MemoryGraphSnapshot;
+  now: number;
+  persistence: { mode: "dry-run" | "write"; enabled: boolean };
 }
 
 export type MemoryGraphEvolutionRunStatus =
-	| "disabled"
-	| "planned"
-	| "applied"
-	| "no-op"
-	| "conflict"
-	| "failed";
+  | "disabled"
+  | "planned"
+  | "applied"
+  | "no-op"
+  | "conflict"
+  | "failed";
 
 export interface MemoryGraphEvolutionRunResult {
-	status: MemoryGraphEvolutionRunStatus;
-	ownerScope: OwnerScope;
-	plan?: MemoryGraphUpdatePlan;
-	persistenceResult?: MemoryGraphUpdateResult;
-	consideredCandidateIds: string[];
-	reasonCodes: string[];
-	error?: { name: string; message: string };
+  status: MemoryGraphEvolutionRunStatus;
+  ownerScope: OwnerScope;
+  plan?: MemoryGraphUpdatePlan;
+  persistenceResult?: MemoryGraphUpdateResult;
+  consideredCandidateIds: string[];
+  reasonCodes: string[];
+  error?: { name: string; message: string };
 }
 
 export interface RunMemoryGraphEvolutionInput {
-	ownerScope: OwnerScope;
-	newEvidence: MemoryGraphEvolutionEvidence[];
-	candidateEvidence: MemoryGraphEvolutionEvidence[];
-	store: MemoryGraphStore;
-	enabled?: boolean;
-	dryRun?: boolean;
-	now?: number;
+  ownerScope: OwnerScope;
+  newEvidence: MemoryGraphEvolutionEvidence[];
+  candidateEvidence: MemoryGraphEvolutionEvidence[];
+  store: MemoryGraphStore;
+  enabled?: boolean;
+  dryRun?: boolean;
+  now?: number;
 }
 
 function unique(values: string[]): string[] {
-	return [...new Set(values)].sort();
+  return [...new Set(values)].sort();
 }
 
 function stablePart(value: string): string {
-	return encodeURIComponent(value).replaceAll("%", "_");
+  return encodeURIComponent(value).replaceAll("%", "_");
 }
 
 export function ownerScopeKey(scope: OwnerScope): string {
-	return [scope.tenantId ?? "", scope.workspaceId ?? "", scope.userId]
-		.map(stablePart)
-		.join(":");
+  return [scope.tenantId ?? "", scope.workspaceId ?? "", scope.userId]
+    .map(stablePart)
+    .join(":");
 }
 
 export function sameOwnerScope(left: OwnerScope, right: OwnerScope): boolean {
-	return ownerScopeKey(left) === ownerScopeKey(right);
+  return ownerScopeKey(left) === ownerScopeKey(right);
 }
 
 function applicabilityKey(
-	applicability: MemoryApplicabilityContext | undefined,
+  applicability: MemoryApplicabilityContext | undefined,
 ): string {
-	if (!applicability || applicability.scope === "global") return "global";
-	return `${applicability.scope}:${applicability.key ?? ""}`;
+  if (!applicability || applicability.scope === "global") return "global";
+  return `${applicability.scope}:${applicability.key ?? ""}`;
 }
 
 function applicabilityActive(
-	applicability: MemoryApplicabilityContext | undefined,
-	now: number,
+  applicability: MemoryApplicabilityContext | undefined,
+  now: number,
 ): boolean {
-	if (!applicability) return true;
-	if (applicability.validFrom !== undefined && now < applicability.validFrom) {
-		return false;
-	}
-	if (
-		applicability.validUntil !== undefined &&
-		now > applicability.validUntil
-	) {
-		return false;
-	}
-	return true;
+  if (!applicability) return true;
+  if (applicability.validFrom !== undefined && now < applicability.validFrom) {
+    return false;
+  }
+  if (
+    applicability.validUntil !== undefined &&
+    now > applicability.validUntil
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function applicabilityOverlaps(
-	left: MemoryApplicabilityContext | undefined,
-	right: MemoryApplicabilityContext | undefined,
-	now: number,
+  left: MemoryApplicabilityContext | undefined,
+  right: MemoryApplicabilityContext | undefined,
+  now: number,
 ): boolean {
-	if (!applicabilityActive(left, now) || !applicabilityActive(right, now)) {
-		return false;
-	}
-	const leftKey = applicabilityKey(left);
-	const rightKey = applicabilityKey(right);
-	return leftKey === "global" || rightKey === "global" || leftKey === rightKey;
+  if (!applicabilityActive(left, now) || !applicabilityActive(right, now)) {
+    return false;
+  }
+  const leftKey = applicabilityKey(left);
+  const rightKey = applicabilityKey(right);
+  return leftKey === "global" || rightKey === "global" || leftKey === rightKey;
 }
 
 export function applicabilityEquivalent(
-	left: MemoryApplicabilityContext | undefined,
-	right: MemoryApplicabilityContext | undefined,
+  left: MemoryApplicabilityContext | undefined,
+  right: MemoryApplicabilityContext | undefined,
 ): boolean {
-	return applicabilityKey(left) === applicabilityKey(right);
+  return applicabilityKey(left) === applicabilityKey(right);
 }
 
 function evidenceToRecord(
-	evidence: MemoryGraphEvolutionEvidence,
+  evidence: MemoryGraphEvolutionEvidence,
 ): MemoryEvidenceRecord {
-	return {
-		id: evidence.id,
-		userId: evidence.ownerScope.userId,
-		timestamp: evidence.timestamp,
-		text: evidence.text,
-		tier: "short",
-		accessCount: evidence.accessCount,
-		importanceScore: evidence.importanceScore,
-		metadata: {
-			...evidence.metadata,
-			relationGroup: evidence.relationGroup,
-			relationValue: evidence.relationValue,
-			topicKeys: evidence.topicKeys,
-		},
-	};
+  return {
+    id: evidence.id,
+    userId: evidence.ownerScope.userId,
+    timestamp: evidence.timestamp,
+    text: evidence.text,
+    tier: "short",
+    accessCount: evidence.accessCount,
+    importanceScore: evidence.importanceScore,
+    metadata: {
+      ...evidence.metadata,
+      relationGroup: evidence.relationGroup,
+      relationValue: evidence.relationValue,
+      topicKeys: evidence.topicKeys,
+    },
+  };
 }
 
 function candidateKeys(record: MemoryEvidenceRecord): string[] {
-	const relationGroup = record.metadata?.relationGroup;
-	const topicKeys = Array.isArray(record.metadata?.topicKeys)
-		? record.metadata.topicKeys.filter(
-				(value): value is string => typeof value === "string",
-			)
-		: [];
-	return unique([
-		...(typeof relationGroup === "string" ? [`relation:${relationGroup}`] : []),
-		...topicKeys.map((key) => `topic:${key}`),
-	]);
+  const relationGroup = record.metadata?.relationGroup;
+  const topicKeys = Array.isArray(record.metadata?.topicKeys)
+    ? record.metadata.topicKeys.filter(
+        (value): value is string => typeof value === "string",
+      )
+    : [];
+  return unique([
+    ...(typeof relationGroup === "string" ? [`relation:${relationGroup}`] : []),
+    ...topicKeys.map((key) => `topic:${key}`),
+  ]);
 }
 
 function graphNode(evidence: MemoryGraphEvolutionEvidence): MemoryGraphNode {
-	return {
-		id: evidence.id,
-		ownerScope: evidence.ownerScope,
-		type: "raw",
-		sourceId: evidence.sourceIdentity ?? evidence.id,
-		createdAt: evidence.timestamp,
-		visibility: "default",
-		applicability: evidence.applicability,
-		metadata: {
-			...evidence.metadata,
-			relationGroup: evidence.relationGroup,
-			relationValue: evidence.relationValue,
-			topicKeys: evidence.topicKeys,
-			sourceIdentity: evidence.sourceIdentity ?? evidence.id,
-		},
-	};
+  return {
+    id: evidence.id,
+    ownerScope: evidence.ownerScope,
+    type: "raw",
+    sourceId: evidence.sourceIdentity ?? evidence.id,
+    createdAt: evidence.timestamp,
+    visibility: "default",
+    applicability: evidence.applicability,
+    metadata: {
+      ...evidence.metadata,
+      relationGroup: evidence.relationGroup,
+      relationValue: evidence.relationValue,
+      topicKeys: evidence.topicKeys,
+      sourceIdentity: evidence.sourceIdentity ?? evidence.id,
+    },
+  };
 }
 
 function edgeId(kind: string, left: string, right: string): string {
-	return `edge:${kind}:${[left, right].sort().map(stablePart).join(":")}`;
+  return `edge:${kind}:${[left, right].sort().map(stablePart).join(":")}`;
 }
 
 function singletonCluster(
-	node: MemoryGraphNode,
-	now: number,
+  node: MemoryGraphNode,
+  now: number,
 ): MemoryGraphClusterSnapshot {
-	return {
-		clusterId: `cluster:${stablePart(node.id)}`,
-		ownerScope: node.ownerScope,
-		nodeIds: [node.id],
-		lifecycleStatus: "forming",
-		supportScore: 0,
-		updatedAt: now,
-		reasonCodes: ["new_evidence_cluster"],
-		applicability: node.applicability,
-	};
+  return {
+    clusterId: `cluster:${stablePart(node.id)}`,
+    ownerScope: node.ownerScope,
+    nodeIds: [node.id],
+    lifecycleStatus: "forming",
+    supportScore: 0,
+    updatedAt: now,
+    reasonCodes: ["new_evidence_cluster"],
+    applicability: node.applicability,
+  };
 }
 
 function cloneCluster(
-	cluster: MemoryGraphClusterSnapshot,
+  cluster: MemoryGraphClusterSnapshot,
 ): MemoryGraphClusterSnapshot {
-	return {
-		...cluster,
-		ownerScope: { ...cluster.ownerScope },
-		nodeIds: [...cluster.nodeIds],
-		reasonCodes: [...cluster.reasonCodes],
-		applicability: cluster.applicability
-			? { ...cluster.applicability }
-			: undefined,
-		metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
-	};
+  return {
+    ...cluster,
+    ownerScope: { ...cluster.ownerScope },
+    nodeIds: [...cluster.nodeIds],
+    reasonCodes: [...cluster.reasonCodes],
+    applicability: cluster.applicability
+      ? { ...cluster.applicability }
+      : undefined,
+    metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
+  };
 }
 
 function operationId(planId: string, kind: string, id: string): string {
-	return `${planId}:${kind}:${stablePart(id)}`;
+  return `${planId}:${kind}:${stablePart(id)}`;
 }
 
 function buildPlanId(ownerScope: OwnerScope, evidenceIds: string[]): string {
-	return `evolution:${ownerScopeKey(ownerScope)}:${evidenceIds
-		.sort()
-		.map(stablePart)
-		.join("+")}`;
+  return `evolution:${ownerScopeKey(ownerScope)}:${evidenceIds
+    .sort()
+    .map(stablePart)
+    .join("+")}`;
 }
 
 function errorInfo(error: unknown): { name: string; message: string } {
-	if (error instanceof Error) {
-		return { name: error.name, message: error.message };
-	}
-	return { name: "Error", message: String(error) };
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { name: "Error", message: String(error) };
 }
 
 export function buildMemoryGraphEvolutionPlan(
-	input: BuildMemoryGraphEvolutionPlanInput,
+  input: BuildMemoryGraphEvolutionPlanInput,
 ): MemoryGraphUpdatePlan {
-	const existingNodeIds = new Set(input.snapshot.nodes.map((node) => node.id));
-	const existingSourceIdentities = new Set(
-		input.snapshot.nodes.map((node) => node.sourceId ?? node.id),
-	);
-	const batchSourceIdentities = new Set<string>();
-	const effectiveNewEvidence = input.newEvidence.filter((evidence) => {
-		const sourceIdentity = evidence.sourceIdentity ?? evidence.id;
-		if (!sameOwnerScope(evidence.ownerScope, input.ownerScope)) return false;
-		if (existingNodeIds.has(evidence.id)) return false;
-		if (existingSourceIdentities.has(sourceIdentity)) return false;
-		if (batchSourceIdentities.has(sourceIdentity)) return false;
-		batchSourceIdentities.add(sourceIdentity);
-		return true;
-	});
-	const allEvidenceById = new Map<string, MemoryGraphEvolutionEvidence>();
-	for (const evidence of input.candidateEvidence) {
-		if (sameOwnerScope(evidence.ownerScope, input.ownerScope)) {
-			allEvidenceById.set(evidence.id, evidence);
-		}
-	}
-	for (const evidence of effectiveNewEvidence) {
-		allEvidenceById.set(evidence.id, evidence);
-	}
+  const existingNodeIds = new Set(input.snapshot.nodes.map((node) => node.id));
+  const existingSourceIdentities = new Set(
+    input.snapshot.nodes.map((node) => node.sourceId ?? node.id),
+  );
+  const candidateBySourceIdentity = new Map<
+    string,
+    MemoryGraphEvolutionEvidence
+  >();
+  for (const evidence of input.candidateEvidence) {
+    if (!sameOwnerScope(evidence.ownerScope, input.ownerScope)) continue;
+    const sourceIdentity = evidence.sourceIdentity ?? evidence.id;
+    if (!candidateBySourceIdentity.has(sourceIdentity)) {
+      candidateBySourceIdentity.set(sourceIdentity, evidence);
+    }
+  }
+  const batchSourceIdentities = new Set<string>();
+  const effectiveNewEvidence: MemoryGraphEvolutionEvidence[] = [];
+  for (const evidence of input.newEvidence) {
+    const sourceIdentity = evidence.sourceIdentity ?? evidence.id;
+    if (!sameOwnerScope(evidence.ownerScope, input.ownerScope)) continue;
+    if (existingSourceIdentities.has(sourceIdentity)) continue;
+    if (batchSourceIdentities.has(sourceIdentity)) continue;
+    batchSourceIdentities.add(sourceIdentity);
+    const existingCandidate = candidateBySourceIdentity.get(sourceIdentity);
+    const selectedEvidence = existingCandidate ?? evidence;
+    if (existingNodeIds.has(selectedEvidence.id)) continue;
+    effectiveNewEvidence.push(selectedEvidence);
+  }
+  const allEvidenceById = new Map<string, MemoryGraphEvolutionEvidence>();
+  for (const evidence of input.candidateEvidence) {
+    if (sameOwnerScope(evidence.ownerScope, input.ownerScope)) {
+      allEvidenceById.set(evidence.id, evidence);
+    }
+  }
+  for (const evidence of effectiveNewEvidence) {
+    allEvidenceById.set(evidence.id, evidence);
+  }
 
-	const planId = buildPlanId(
-		input.ownerScope,
-		input.newEvidence.map((evidence) => evidence.sourceIdentity ?? evidence.id),
-	);
-	const newIds = new Set(effectiveNewEvidence.map((evidence) => evidence.id));
-	const records = [...allEvidenceById.values()].map(evidenceToRecord);
-	const candidates = buildMemoryRelationCandidates({
-		records,
-		getCandidateKeys: candidateKeys,
-	}).filter(
-		(candidate) =>
-			newIds.has(candidate.fromRecordId) || newIds.has(candidate.toRecordId),
-	);
-	const evidenceById = allEvidenceById;
-	const judgments = judgeMemoryRelationCandidates({
-		records,
-		candidates,
-		now: input.now,
-		judgeCandidate(candidate, context) {
-			const left = evidenceById.get(candidate.fromRecordId);
-			const right = evidenceById.get(candidate.toRecordId);
-			if (!left || !right) {
-				return {
-					relation: "uncertain",
-					weight: 0,
-					reasonCodes: ["uncertain_candidate"],
-				};
-			}
-			if (
-				!applicabilityOverlaps(
-					left.applicability,
-					right.applicability,
-					input.now,
-				)
-			) {
-				return {
-					relation: "uncertain",
-					weight: 0,
-					reasonCodes: ["uncertain_candidate"],
-				};
-			}
-			if (
-				context.defaultDecision.relation === "support" &&
-				!applicabilityEquivalent(left.applicability, right.applicability)
-			) {
-				return {
-					relation: "related",
-					weight: 0.45,
-					reasonCodes: ["candidate_related"],
-				};
-			}
-			return context.defaultDecision;
-		},
-	}).judgments.filter((judgment) => judgment.relation !== "uncertain");
+  const planId = buildPlanId(
+    input.ownerScope,
+    input.newEvidence.map((evidence) => evidence.sourceIdentity ?? evidence.id),
+  );
+  const newIds = new Set(effectiveNewEvidence.map((evidence) => evidence.id));
+  const records = [...allEvidenceById.values()].map(evidenceToRecord);
+  const candidates = buildMemoryRelationCandidates({
+    records,
+    getCandidateKeys: candidateKeys,
+  }).filter(
+    (candidate) =>
+      newIds.has(candidate.fromRecordId) || newIds.has(candidate.toRecordId),
+  );
+  const evidenceById = allEvidenceById;
+  const judgments = judgeMemoryRelationCandidates({
+    records,
+    candidates,
+    now: input.now,
+    judgeCandidate(candidate, context) {
+      const left = evidenceById.get(candidate.fromRecordId);
+      const right = evidenceById.get(candidate.toRecordId);
+      if (!left || !right) {
+        return {
+          relation: "uncertain",
+          weight: 0,
+          reasonCodes: ["uncertain_candidate"],
+        };
+      }
+      if (
+        !applicabilityOverlaps(
+          left.applicability,
+          right.applicability,
+          input.now,
+        )
+      ) {
+        return {
+          relation: "uncertain",
+          weight: 0,
+          reasonCodes: ["uncertain_candidate"],
+        };
+      }
+      if (
+        context.defaultDecision.relation === "support" &&
+        !applicabilityEquivalent(left.applicability, right.applicability)
+      ) {
+        return {
+          relation: "related",
+          weight: 0.45,
+          reasonCodes: ["candidate_related"],
+        };
+      }
+      return context.defaultDecision;
+    },
+  }).judgments.filter((judgment) => judgment.relation !== "uncertain");
 
-	const relevantEvidenceIds = new Set(
-		effectiveNewEvidence.map((item) => item.id),
-	);
-	for (const judgment of judgments) {
-		relevantEvidenceIds.add(judgment.candidate.fromRecordId);
-		relevantEvidenceIds.add(judgment.candidate.toRecordId);
-	}
-	const candidateNodes = [...relevantEvidenceIds]
-		.filter((id) => !existingNodeIds.has(id))
-		.flatMap((id) => {
-			const evidence = evidenceById.get(id);
-			return evidence ? [graphNode(evidence)] : [];
-		});
-	const nodesById = new Map(
-		input.snapshot.nodes.map((node) => [node.id, node]),
-	);
-	for (const node of candidateNodes) nodesById.set(node.id, node);
+  const relevantEvidenceIds = new Set(
+    effectiveNewEvidence.map((item) => item.id),
+  );
+  for (const judgment of judgments) {
+    relevantEvidenceIds.add(judgment.candidate.fromRecordId);
+    relevantEvidenceIds.add(judgment.candidate.toRecordId);
+  }
+  const candidateNodes = [...relevantEvidenceIds]
+    .filter((id) => !existingNodeIds.has(id))
+    .flatMap((id) => {
+      const evidence = evidenceById.get(id);
+      return evidence ? [graphNode(evidence)] : [];
+    });
+  const nodesById = new Map(
+    input.snapshot.nodes.map((node) => [node.id, node]),
+  );
+  for (const node of candidateNodes) nodesById.set(node.id, node);
 
-	const operations: MemoryGraphOperation[] = candidateNodes.map((node) => ({
-		operationId: operationId(planId, "create-node", node.id),
-		ownerScope: input.ownerScope,
-		kind: "create-node",
-		nodeIds: [node.id],
-		reasonCodes: ["new_evidence_node"],
-	}));
-	const existingEdges = new Map(
-		input.snapshot.edges.map((edge) => [edge.id, edge]),
-	);
-	const candidateEdges: MemoryGraphEdge[] = [];
+  const operations: MemoryGraphOperation[] = candidateNodes.map((node) => ({
+    operationId: operationId(planId, "create-node", node.id),
+    ownerScope: input.ownerScope,
+    kind: "create-node",
+    nodeIds: [node.id],
+    reasonCodes: ["new_evidence_node"],
+  }));
+  const existingEdges = new Map(
+    input.snapshot.edges.map((edge) => [edge.id, edge]),
+  );
+  const candidateEdges: MemoryGraphEdge[] = [];
 
-	for (const judgment of judgments) {
-		const kind = judgment.relation as "support" | "compete" | "related";
-		const id = edgeId(
-			kind,
-			judgment.candidate.fromRecordId,
-			judgment.candidate.toRecordId,
-		);
-		const previous = existingEdges.get(id);
-		const evidenceNodeIds = unique([
-			...(previous?.evidenceNodeIds ?? []),
-			...[
-				judgment.candidate.fromRecordId,
-				judgment.candidate.toRecordId,
-			].filter((nodeId) => newIds.has(nodeId)),
-		]);
-		const left = evidenceById.get(judgment.candidate.fromRecordId);
-		const right = evidenceById.get(judgment.candidate.toRecordId);
-		if (!left || !right) continue;
-		const edge: MemoryGraphEdge = {
-			id,
-			ownerScope: input.ownerScope,
-			fromNodeId: judgment.candidate.fromRecordId,
-			toNodeId: judgment.candidate.toRecordId,
-			kind,
-			weight: previous
-				? Math.min(1, previous.weight + judgment.weight * 0.25)
-				: judgment.weight,
-			confidence: judgment.candidate.score,
-			evidenceNodeIds,
-			reasonCodes: unique([
-				...(previous?.reasonCodes ?? []),
-				...judgment.reasonCodes,
-			]),
-			createdAt: previous?.createdAt ?? input.now,
-			updatedAt: input.now,
-			applicability: applicabilityEquivalent(
-				left.applicability,
-				right.applicability,
-			)
-				? (left.applicability ?? right.applicability)
-				: undefined,
-			metadata: {
-				candidateKeys: judgment.candidate.candidateKeys,
-			},
-		};
-		candidateEdges.push(edge);
-		operations.push({
-			operationId: operationId(
-				planId,
-				previous ? "reinforce-edge" : "create-edge",
-				id,
-			),
-			ownerScope: input.ownerScope,
-			kind: previous ? "reinforce-edge" : "create-edge",
-			nodeIds: [edge.fromNodeId, edge.toNodeId],
-			edgeIds: [id],
-			reasonCodes: edge.reasonCodes,
-		});
-	}
+  for (const judgment of judgments) {
+    const kind = judgment.relation as "support" | "compete" | "related";
+    const id = edgeId(
+      kind,
+      judgment.candidate.fromRecordId,
+      judgment.candidate.toRecordId,
+    );
+    const previous = existingEdges.get(id);
+    const evidenceNodeIds = unique([
+      ...(previous?.evidenceNodeIds ?? []),
+      ...[
+        judgment.candidate.fromRecordId,
+        judgment.candidate.toRecordId,
+      ].filter((nodeId) => newIds.has(nodeId)),
+    ]);
+    const left = evidenceById.get(judgment.candidate.fromRecordId);
+    const right = evidenceById.get(judgment.candidate.toRecordId);
+    if (!left || !right) continue;
+    const edge: MemoryGraphEdge = {
+      id,
+      ownerScope: input.ownerScope,
+      fromNodeId: judgment.candidate.fromRecordId,
+      toNodeId: judgment.candidate.toRecordId,
+      kind,
+      weight: previous
+        ? Math.min(1, previous.weight + judgment.weight * 0.25)
+        : judgment.weight,
+      confidence: judgment.candidate.score,
+      evidenceNodeIds,
+      reasonCodes: unique([
+        ...(previous?.reasonCodes ?? []),
+        ...judgment.reasonCodes,
+      ]),
+      createdAt: previous?.createdAt ?? input.now,
+      updatedAt: input.now,
+      applicability: applicabilityEquivalent(
+        left.applicability,
+        right.applicability,
+      )
+        ? (left.applicability ?? right.applicability)
+        : undefined,
+      metadata: {
+        candidateKeys: judgment.candidate.candidateKeys,
+      },
+    };
+    candidateEdges.push(edge);
+    operations.push({
+      operationId: operationId(
+        planId,
+        previous ? "reinforce-edge" : "create-edge",
+        id,
+      ),
+      ownerScope: input.ownerScope,
+      kind: previous ? "reinforce-edge" : "create-edge",
+      nodeIds: [edge.fromNodeId, edge.toNodeId],
+      edgeIds: [id],
+      reasonCodes: edge.reasonCodes,
+    });
+  }
 
-	const clusters = new Map(
-		input.snapshot.clusters.map((cluster) => [
-			cluster.clusterId,
-			cloneCluster(cluster),
-		]),
-	);
-	const clusterByNode = new Map<string, string>();
-	for (const cluster of clusters.values()) {
-		for (const nodeId of cluster.nodeIds)
-			clusterByNode.set(nodeId, cluster.clusterId);
-	}
-	const touchedClusterIds = new Set<string>();
-	for (const node of candidateNodes) {
-		if (!clusterByNode.has(node.id)) {
-			const cluster = singletonCluster(node, input.now);
-			clusters.set(cluster.clusterId, cluster);
-			clusterByNode.set(node.id, cluster.clusterId);
-			touchedClusterIds.add(cluster.clusterId);
-		}
-	}
+  const clusters = new Map(
+    input.snapshot.clusters.map((cluster) => [
+      cluster.clusterId,
+      cloneCluster(cluster),
+    ]),
+  );
+  const clusterByNode = new Map<string, string>();
+  for (const cluster of clusters.values()) {
+    for (const nodeId of cluster.nodeIds)
+      clusterByNode.set(nodeId, cluster.clusterId);
+  }
+  const touchedClusterIds = new Set<string>();
+  for (const node of candidateNodes) {
+    if (!clusterByNode.has(node.id)) {
+      const cluster = singletonCluster(node, input.now);
+      clusters.set(cluster.clusterId, cluster);
+      clusterByNode.set(node.id, cluster.clusterId);
+      touchedClusterIds.add(cluster.clusterId);
+    }
+  }
 
-	for (const edge of candidateEdges.filter((item) => item.kind === "support")) {
-		const leftClusterId = clusterByNode.get(edge.fromNodeId);
-		const rightClusterId = clusterByNode.get(edge.toNodeId);
-		if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId) {
-			if (leftClusterId) touchedClusterIds.add(leftClusterId);
-			continue;
-		}
-		const leftCluster = clusters.get(leftClusterId);
-		const rightCluster = clusters.get(rightClusterId);
-		if (!leftCluster || !rightCluster) continue;
-		if (
-			!applicabilityEquivalent(
-				leftCluster.applicability,
-				rightCluster.applicability,
-			)
-		) {
-			continue;
-		}
-		const target = input.snapshot.clusters.some(
-			(cluster) => cluster.clusterId === rightClusterId,
-		)
-			? rightCluster
-			: leftCluster;
-		const source =
-			target.clusterId === leftClusterId ? rightCluster : leftCluster;
-		target.nodeIds = unique([...target.nodeIds, ...source.nodeIds]);
-		target.updatedAt = input.now;
-		target.reasonCodes = unique([
-			...target.reasonCodes,
-			"support_cluster_join",
-		]);
-		for (const nodeId of source.nodeIds)
-			clusterByNode.set(nodeId, target.clusterId);
-		clusters.delete(source.clusterId);
-		touchedClusterIds.delete(source.clusterId);
-		touchedClusterIds.add(target.clusterId);
-	}
+  for (const edge of candidateEdges.filter((item) => item.kind === "support")) {
+    const leftClusterId = clusterByNode.get(edge.fromNodeId);
+    const rightClusterId = clusterByNode.get(edge.toNodeId);
+    if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId) {
+      if (leftClusterId) touchedClusterIds.add(leftClusterId);
+      continue;
+    }
+    const leftCluster = clusters.get(leftClusterId);
+    const rightCluster = clusters.get(rightClusterId);
+    if (!leftCluster || !rightCluster) continue;
+    if (
+      !applicabilityEquivalent(
+        leftCluster.applicability,
+        rightCluster.applicability,
+      )
+    ) {
+      continue;
+    }
+    const target = input.snapshot.clusters.some(
+      (cluster) => cluster.clusterId === rightClusterId,
+    )
+      ? rightCluster
+      : leftCluster;
+    const source =
+      target.clusterId === leftClusterId ? rightCluster : leftCluster;
+    target.nodeIds = unique([...target.nodeIds, ...source.nodeIds]);
+    target.updatedAt = input.now;
+    target.reasonCodes = unique([
+      ...target.reasonCodes,
+      "support_cluster_join",
+    ]);
+    for (const nodeId of source.nodeIds)
+      clusterByNode.set(nodeId, target.clusterId);
+    clusters.delete(source.clusterId);
+    touchedClusterIds.delete(source.clusterId);
+    touchedClusterIds.add(target.clusterId);
+  }
 
-	for (const edge of candidateEdges.filter((item) => item.kind === "compete")) {
-		const leftClusterId = clusterByNode.get(edge.fromNodeId);
-		const rightClusterId = clusterByNode.get(edge.toNodeId);
-		if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId)
-			continue;
-		const competitionKey = `competition:${[leftClusterId, rightClusterId]
-			.sort()
-			.map(stablePart)
-			.join(":")}`;
-		for (const clusterId of [leftClusterId, rightClusterId]) {
-			const cluster = clusters.get(clusterId);
-			if (!cluster) continue;
-			cluster.competitionKey = competitionKey;
-			cluster.updatedAt = input.now;
-			cluster.reasonCodes = unique([
-				...cluster.reasonCodes,
-				"competition_preserved_before_supersession",
-			]);
-			touchedClusterIds.add(clusterId);
-		}
-	}
+  for (const edge of candidateEdges.filter((item) => item.kind === "compete")) {
+    const leftClusterId = clusterByNode.get(edge.fromNodeId);
+    const rightClusterId = clusterByNode.get(edge.toNodeId);
+    if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId)
+      continue;
+    const competitionKey = `competition:${[leftClusterId, rightClusterId]
+      .sort()
+      .map(stablePart)
+      .join(":")}`;
+    for (const clusterId of [leftClusterId, rightClusterId]) {
+      const cluster = clusters.get(clusterId);
+      if (!cluster) continue;
+      cluster.competitionKey = competitionKey;
+      cluster.updatedAt = input.now;
+      cluster.reasonCodes = unique([
+        ...cluster.reasonCodes,
+        "competition_preserved_before_supersession",
+      ]);
+      touchedClusterIds.add(clusterId);
+    }
+  }
 
-	const allEdges = [...input.snapshot.edges, ...candidateEdges].reduce(
-		(map, edge) => map.set(edge.id, edge),
-		new Map<string, MemoryGraphEdge>(),
-	);
-	for (const clusterId of touchedClusterIds) {
-		const cluster = clusters.get(clusterId);
-		if (!cluster) continue;
-		const nodeIds = new Set(cluster.nodeIds);
-		const supportEdges = [...allEdges.values()].filter(
-			(edge) =>
-				edge.kind === "support" &&
-				nodeIds.has(edge.fromNodeId) &&
-				nodeIds.has(edge.toNodeId),
-		);
-		cluster.supportScore = supportEdges.length
-			? supportEdges.reduce((sum, edge) => sum + edge.weight, 0) /
-				supportEdges.length
-			: (cluster.supportScore ?? 0);
-	}
+  const allEdges = [...input.snapshot.edges, ...candidateEdges].reduce(
+    (map, edge) => map.set(edge.id, edge),
+    new Map<string, MemoryGraphEdge>(),
+  );
+  for (const clusterId of touchedClusterIds) {
+    const cluster = clusters.get(clusterId);
+    if (!cluster) continue;
+    const nodeIds = new Set(cluster.nodeIds);
+    const supportEdges = [...allEdges.values()].filter(
+      (edge) =>
+        edge.kind === "support" &&
+        nodeIds.has(edge.fromNodeId) &&
+        nodeIds.has(edge.toNodeId),
+    );
+    cluster.supportScore = supportEdges.length
+      ? supportEdges.reduce((sum, edge) => sum + edge.weight, 0) /
+        supportEdges.length
+      : (cluster.supportScore ?? 0);
+  }
 
-	const candidateClusters = [...touchedClusterIds]
-		.map((clusterId) => clusters.get(clusterId))
-		.filter((cluster): cluster is MemoryGraphClusterSnapshot =>
-			Boolean(cluster),
-		);
-	for (const cluster of candidateClusters) {
-		operations.push({
-			operationId: operationId(planId, "upsert-cluster", cluster.clusterId),
-			ownerScope: input.ownerScope,
-			kind: "upsert-cluster",
-			nodeIds: [...cluster.nodeIds],
-			clusterId: cluster.clusterId,
-			reasonCodes: cluster.reasonCodes,
-		});
-	}
+  const candidateClusters = [...touchedClusterIds]
+    .map((clusterId) => clusters.get(clusterId))
+    .filter((cluster): cluster is MemoryGraphClusterSnapshot =>
+      Boolean(cluster),
+    );
+  for (const cluster of candidateClusters) {
+    operations.push({
+      operationId: operationId(planId, "upsert-cluster", cluster.clusterId),
+      ownerScope: input.ownerScope,
+      kind: "upsert-cluster",
+      nodeIds: [...cluster.nodeIds],
+      clusterId: cluster.clusterId,
+      reasonCodes: cluster.reasonCodes,
+    });
+  }
 
-	return {
-		planId,
-		ownerScope: input.ownerScope,
-		candidateNodes,
-		candidateEdges,
-		candidateClusters,
-		operations,
-		expectedVersion: input.snapshot.version ?? "0",
-		persistence: input.persistence,
-		reasonCodes: unique([
-			"incremental_graph_evolution",
-			...(candidateEdges.some((edge) => edge.kind === "support")
-				? ["support_evidence_applied"]
-				: []),
-			...(candidateEdges.some((edge) => edge.kind === "compete")
-				? ["competition_preserved_before_supersession"]
-				: []),
-			...(operations.length === 0 ? ["no_new_graph_operations"] : []),
-		]),
-		metadata: {
-			consideredCandidateIds: unique(
-				judgments.flatMap((judgment) => [
-					judgment.candidate.fromRecordId,
-					judgment.candidate.toRecordId,
-				]),
-			),
-			newEvidenceIds: input.newEvidence.map((evidence) => evidence.id),
-		},
-	};
+  return {
+    planId,
+    ownerScope: input.ownerScope,
+    candidateNodes,
+    candidateEdges,
+    candidateClusters,
+    operations,
+    expectedVersion: input.snapshot.version ?? "0",
+    persistence: input.persistence,
+    reasonCodes: unique([
+      "incremental_graph_evolution",
+      ...(candidateEdges.some((edge) => edge.kind === "support")
+        ? ["support_evidence_applied"]
+        : []),
+      ...(candidateEdges.some((edge) => edge.kind === "compete")
+        ? ["competition_preserved_before_supersession"]
+        : []),
+      ...(operations.length === 0 ? ["no_new_graph_operations"] : []),
+    ]),
+    metadata: {
+      consideredCandidateIds: unique(
+        judgments.flatMap((judgment) => [
+          judgment.candidate.fromRecordId,
+          judgment.candidate.toRecordId,
+        ]),
+      ),
+      newEvidenceIds: input.newEvidence.map((evidence) => evidence.id),
+    },
+  };
 }
 
 export async function runMemoryGraphEvolution(
-	input: RunMemoryGraphEvolutionInput,
+  input: RunMemoryGraphEvolutionInput,
 ): Promise<MemoryGraphEvolutionRunResult> {
-	if (input.enabled !== true) {
-		return {
-			status: "disabled",
-			ownerScope: input.ownerScope,
-			consideredCandidateIds: [],
-			reasonCodes: ["memory_graph_evolution_disabled"],
-		};
-	}
+  if (input.enabled !== true) {
+    return {
+      status: "disabled",
+      ownerScope: input.ownerScope,
+      consideredCandidateIds: [],
+      reasonCodes: ["memory_graph_evolution_disabled"],
+    };
+  }
 
-	try {
-		const now = input.now ?? Date.now();
-		const snapshot = await input.store.readSnapshot({
-			ownerScope: input.ownerScope,
-			includeAuditOnly: true,
-		});
-		const plan = buildMemoryGraphEvolutionPlan({
-			ownerScope: input.ownerScope,
-			newEvidence: input.newEvidence,
-			candidateEvidence: input.candidateEvidence,
-			snapshot,
-			now,
-			persistence: {
-				mode: input.dryRun ? "dry-run" : "write",
-				enabled: !input.dryRun,
-			},
-		});
-		const consideredCandidateIds = Array.isArray(
-			plan.metadata?.consideredCandidateIds,
-		)
-			? plan.metadata.consideredCandidateIds.filter(
-					(value): value is string => typeof value === "string",
-				)
-			: [];
+  try {
+    const now = input.now ?? Date.now();
+    const snapshot = await input.store.readSnapshot({
+      ownerScope: input.ownerScope,
+      includeAuditOnly: true,
+    });
+    const plan = buildMemoryGraphEvolutionPlan({
+      ownerScope: input.ownerScope,
+      newEvidence: input.newEvidence,
+      candidateEvidence: input.candidateEvidence,
+      snapshot,
+      now,
+      persistence: {
+        mode: input.dryRun ? "dry-run" : "write",
+        enabled: !input.dryRun,
+      },
+    });
+    const consideredCandidateIds = Array.isArray(
+      plan.metadata?.consideredCandidateIds,
+    )
+      ? plan.metadata.consideredCandidateIds.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
 
-		if (input.dryRun) {
-			return {
-				status: "planned",
-				ownerScope: input.ownerScope,
-				plan,
-				consideredCandidateIds,
-				reasonCodes: unique([...plan.reasonCodes, "memory_graph_dry_run"]),
-			};
-		}
+    if (input.dryRun) {
+      return {
+        status: "planned",
+        ownerScope: input.ownerScope,
+        plan,
+        consideredCandidateIds,
+        reasonCodes: unique([...plan.reasonCodes, "memory_graph_dry_run"]),
+      };
+    }
 
-		const persistenceResult = await input.store.persistPlan(plan);
-		const status: MemoryGraphEvolutionRunStatus = persistenceResult.conflict
-			? "conflict"
-			: persistenceResult.mutatesGraph
-				? "applied"
-				: "no-op";
-		return {
-			status,
-			ownerScope: input.ownerScope,
-			plan,
-			persistenceResult,
-			consideredCandidateIds,
-			reasonCodes: unique([
-				...plan.reasonCodes,
-				...persistenceResult.diagnostics,
-			]),
-		};
-	} catch (error) {
-		return {
-			status: "failed",
-			ownerScope: input.ownerScope,
-			consideredCandidateIds: [],
-			reasonCodes: ["memory_graph_evolution_failed"],
-			error: errorInfo(error),
-		};
-	}
+    const persistenceResult = await input.store.persistPlan(plan);
+    const status: MemoryGraphEvolutionRunStatus = persistenceResult.conflict
+      ? "conflict"
+      : persistenceResult.mutatesGraph
+        ? "applied"
+        : "no-op";
+    return {
+      status,
+      ownerScope: input.ownerScope,
+      plan,
+      persistenceResult,
+      consideredCandidateIds,
+      reasonCodes: unique([
+        ...plan.reasonCodes,
+        ...persistenceResult.diagnostics,
+      ]),
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      ownerScope: input.ownerScope,
+      consideredCandidateIds: [],
+      reasonCodes: ["memory_graph_evolution_failed"],
+      error: errorInfo(error),
+    };
+  }
 }

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -3,6 +3,7 @@ export * from "./diagnostics-bundle";
 export * from "./evaluation";
 export * from "./evidence-cluster";
 export * from "./graph-contracts";
+export * from "./graph-evolution";
 export * from "./graph-retrieval";
 export * from "./governance";
 export * from "./plan";

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -14,6 +14,11 @@ import type {
   RawMessageQuery,
 } from "./manager";
 import {
+  type MemoryGraphEvolutionRunResult,
+  type RawMessageGraphEvolutionOptions,
+  storeRawMessagesWithGraphEvolution,
+} from "./memory-graph-evolution";
+import {
   ensureRawMessagesSQLiteMigration,
   migrateIndexedDBRawMessagesToSQLite,
   shouldUseRawMessageApiStorage,
@@ -134,10 +139,20 @@ export async function storeRawMessagesFromInsight(
     embeddingUpdatedAt?: number;
     metadata?: Record<string, any>;
   }>,
-): Promise<{ success: boolean; stored: number; errors: number }> {
+  graphEvolution?: RawMessageGraphEvolutionOptions,
+): Promise<{
+  success: boolean;
+  stored: number;
+  errors: number;
+  graphEvolution?: MemoryGraphEvolutionRunResult;
+}> {
   if (shouldUseRawMessageApiStorage()) {
     try {
-      return await sqliteStoreRawMessagesFromInsight(userId, messages);
+      return await sqliteStoreRawMessagesFromInsight(
+        userId,
+        messages,
+        graphEvolution,
+      );
     } catch (error) {
       console.warn(
         "[Client Raw Messages API] Failed to store messages, falling back to IndexedDB:",
@@ -156,11 +171,16 @@ export async function storeRawMessagesFromInsight(
       createdAt: Date.now() / 1000,
     }));
 
-    const results = await manager.storeMessages(messagesWithUserId);
+    const stored = await storeRawMessagesWithGraphEvolution({
+      storage: manager,
+      messages: messagesWithUserId,
+      graphEvolution,
+    });
     return {
       success: true,
-      stored: results.length,
+      stored: stored.ids.length,
       errors: 0,
+      graphEvolution: stored.graphEvolution,
     };
   } catch (error) {
     console.error("[Client IndexedDB] Failed to store messages:", error);

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -3,5 +3,6 @@ export * from "./embedding";
 export * from "./extractor";
 export * from "./forgetting";
 export * from "./manager";
+export * from "./memory-graph-evolution";
 export * from "./sqlite-client";
 export * from "./storage";

--- a/packages/indexeddb/src/memory-graph-evolution.ts
+++ b/packages/indexeddb/src/memory-graph-evolution.ts
@@ -1,608 +1,652 @@
 import {
-	type MemoryApplicabilityContext,
-	type MemoryGraphAuditTrail,
-	type MemoryGraphEvolutionEvidence,
-	type MemoryGraphEvolutionRunResult,
-	type MemoryGraphOperation,
-	type MemoryGraphSnapshot,
-	type MemoryGraphStore,
-	type MemoryGraphUpdatePlan,
-	type MemoryGraphUpdateResult,
-	type OwnerScope,
-	ownerScopeKey,
-	runMemoryGraphEvolution,
-	sameOwnerScope,
+  type MemoryApplicabilityContext,
+  type MemoryGraphAuditTrail,
+  type MemoryGraphEvolutionEvidence,
+  type MemoryGraphEvolutionRunResult,
+  type MemoryGraphOperation,
+  type MemoryGraphSnapshot,
+  type MemoryGraphStore,
+  type MemoryGraphUpdatePlan,
+  type MemoryGraphUpdateResult,
+  type OwnerScope,
+  ownerScopeKey,
+  runMemoryGraphEvolution,
+  sameOwnerScope,
 } from "../../ai/memory-consolidation/src";
 export type { MemoryGraphEvolutionRunResult } from "../../ai/memory-consolidation/src";
 import type { RawMessage, RawMessageQuery } from "./storage";
 
 const LEDGER_METADATA_KEY = "memoryGraphLedger";
+const LEDGER_MESSAGE_PREFIX = "__openloomi_memory_graph__";
 const LEDGER_PLATFORM = "openloomi-internal";
 const LEDGER_BOT_ID = "memory-graph";
 
 export interface RawMessageGraphEvolutionStorage {
-	storeMessage(message: RawMessage): Promise<number>;
-	storeMessages(messages: RawMessage[]): Promise<number[]>;
-	getMessageById(messageId: string): Promise<RawMessage | null>;
-	queryMessages(query: RawMessageQuery): Promise<RawMessage[]>;
+  storeMessage(message: RawMessage): Promise<number>;
+  storeMessages(messages: RawMessage[]): Promise<number[]>;
+  getMessageById(messageId: string): Promise<RawMessage | null>;
+  queryMessages(query: RawMessageQuery): Promise<RawMessage[]>;
 }
 
 export interface RawMessageGraphEvolutionOptions {
-	enabled?: boolean;
-	dryRun?: boolean;
-	workspaceId?: string;
-	tenantId?: string;
-	candidateLimit?: number;
+  enabled?: boolean;
+  dryRun?: boolean;
+  workspaceId?: string;
+  tenantId?: string;
+  candidateLimit?: number;
 }
 
 export interface StoreRawMessagesWithGraphEvolutionInput {
-	storage: RawMessageGraphEvolutionStorage;
-	messages: RawMessage[];
-	graphEvolution?: RawMessageGraphEvolutionOptions;
-	now?: number;
+  storage: RawMessageGraphEvolutionStorage;
+  messages: RawMessage[];
+  graphEvolution?: RawMessageGraphEvolutionOptions;
+  now?: number;
 }
 
 export interface StoreRawMessagesWithGraphEvolutionResult {
-	ids: number[];
-	graphEvolution: MemoryGraphEvolutionRunResult;
+  ids: number[];
+  graphEvolution: MemoryGraphEvolutionRunResult;
 }
 
 interface MemoryGraphLedgerPayload {
-	schemaVersion: 1;
-	ownerScope: OwnerScope;
-	snapshot: MemoryGraphSnapshot;
-	appliedOperations: MemoryGraphOperation[];
+  schemaVersion: 1;
+  ownerScope: OwnerScope;
+  snapshot: MemoryGraphSnapshot;
+  appliedOperations: MemoryGraphOperation[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function optionalString(value: unknown): string | undefined {
-	return typeof value === "string" && value.length > 0 ? value : undefined;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isOwnerScopeValue(value: unknown): value is OwnerScope {
+  return (
+    isRecord(value) &&
+    typeof value.userId === "string" &&
+    (value.workspaceId === undefined ||
+      typeof value.workspaceId === "string") &&
+    (value.tenantId === undefined || typeof value.tenantId === "string")
+  );
 }
 
 export function parseRawMessageGraphEvolutionOptions(
-	value: unknown,
+  value: unknown,
 ): RawMessageGraphEvolutionOptions {
-	if (!isRecord(value)) return {};
-	const candidateLimit =
-		typeof value.candidateLimit === "number" &&
-		Number.isFinite(value.candidateLimit)
-			? Math.max(1, Math.min(500, Math.floor(value.candidateLimit)))
-			: undefined;
-	return {
-		enabled: value.enabled === true,
-		dryRun: value.dryRun === true,
-		workspaceId: optionalString(value.workspaceId),
-		tenantId: optionalString(value.tenantId),
-		candidateLimit,
-	};
+  if (!isRecord(value)) return {};
+  const candidateLimit =
+    typeof value.candidateLimit === "number" &&
+    Number.isFinite(value.candidateLimit)
+      ? Math.max(1, Math.min(500, Math.floor(value.candidateLimit)))
+      : undefined;
+  return {
+    enabled: value.enabled === true,
+    dryRun: value.dryRun === true,
+    workspaceId: optionalString(value.workspaceId),
+    tenantId: optionalString(value.tenantId),
+    candidateLimit,
+  };
 }
 
 export function memoryGraphLedgerMessageId(ownerScope: OwnerScope): string {
-	return `__openloomi_memory_graph__:${ownerScopeKey(ownerScope)}`;
+  return `${LEDGER_MESSAGE_PREFIX}:${ownerScopeKey(ownerScope)}`;
+}
+
+function assertNoReservedGraphPayload(messages: RawMessage[]): void {
+  const reserved = messages.some(
+    (message) =>
+      message.messageId.startsWith(`${LEDGER_MESSAGE_PREFIX}:`) ||
+      message.metadata?.[LEDGER_METADATA_KEY] !== undefined,
+  );
+  if (reserved) {
+    throw new Error(
+      "Raw messages cannot use the internal memory graph namespace",
+    );
+  }
 }
 
 function emptySnapshot(
-	ownerScope: OwnerScope,
-	now: number,
+  ownerScope: OwnerScope,
+  now: number,
 ): MemoryGraphSnapshot {
-	return {
-		ownerScope: { ...ownerScope },
-		nodes: [],
-		edges: [],
-		clusters: [],
-		version: "0",
-		capturedAt: now,
-	};
+  return {
+    ownerScope: { ...ownerScope },
+    nodes: [],
+    edges: [],
+    clusters: [],
+    version: "0",
+    capturedAt: now,
+  };
 }
 
 function cloneSnapshot(snapshot: MemoryGraphSnapshot): MemoryGraphSnapshot {
-	return {
-		...snapshot,
-		ownerScope: { ...snapshot.ownerScope },
-		nodes: snapshot.nodes.map((node) => ({
-			...node,
-			ownerScope: { ...node.ownerScope },
-			applicability: node.applicability ? { ...node.applicability } : undefined,
-			metadata: node.metadata ? { ...node.metadata } : undefined,
-		})),
-		edges: snapshot.edges.map((edge) => ({
-			...edge,
-			ownerScope: { ...edge.ownerScope },
-			evidenceNodeIds: [...edge.evidenceNodeIds],
-			reasonCodes: [...edge.reasonCodes],
-			applicability: edge.applicability ? { ...edge.applicability } : undefined,
-			metadata: edge.metadata ? { ...edge.metadata } : undefined,
-		})),
-		clusters: snapshot.clusters.map((cluster) => ({
-			...cluster,
-			ownerScope: { ...cluster.ownerScope },
-			nodeIds: [...cluster.nodeIds],
-			reasonCodes: [...cluster.reasonCodes],
-			applicability: cluster.applicability
-				? { ...cluster.applicability }
-				: undefined,
-			metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
-		})),
-	};
+  return {
+    ...snapshot,
+    ownerScope: { ...snapshot.ownerScope },
+    nodes: snapshot.nodes.map((node) => ({
+      ...node,
+      ownerScope: { ...node.ownerScope },
+      applicability: node.applicability ? { ...node.applicability } : undefined,
+      metadata: node.metadata ? { ...node.metadata } : undefined,
+    })),
+    edges: snapshot.edges.map((edge) => ({
+      ...edge,
+      ownerScope: { ...edge.ownerScope },
+      evidenceNodeIds: [...edge.evidenceNodeIds],
+      reasonCodes: [...edge.reasonCodes],
+      applicability: edge.applicability ? { ...edge.applicability } : undefined,
+      metadata: edge.metadata ? { ...edge.metadata } : undefined,
+    })),
+    clusters: snapshot.clusters.map((cluster) => ({
+      ...cluster,
+      ownerScope: { ...cluster.ownerScope },
+      nodeIds: [...cluster.nodeIds],
+      reasonCodes: [...cluster.reasonCodes],
+      applicability: cluster.applicability
+        ? { ...cluster.applicability }
+        : undefined,
+      metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
+    })),
+  };
 }
 
 function parseLedger(
-	message: RawMessage | null,
-	ownerScope: OwnerScope,
-	now: number,
+  message: RawMessage | null,
+  ownerScope: OwnerScope,
+  now: number,
 ): MemoryGraphLedgerPayload {
-	const value = message?.metadata?.[LEDGER_METADATA_KEY];
-	if (!isRecord(value) || value.schemaVersion !== 1) {
-		return {
-			schemaVersion: 1,
-			ownerScope: { ...ownerScope },
-			snapshot: emptySnapshot(ownerScope, now),
-			appliedOperations: [],
-		};
-	}
-	const storedScope = value.ownerScope;
-	const snapshot = value.snapshot;
-	const appliedOperations = value.appliedOperations;
-	if (
-		!isRecord(storedScope) ||
-		typeof storedScope.userId !== "string" ||
-		!sameOwnerScope(storedScope as unknown as OwnerScope, ownerScope) ||
-		!isRecord(snapshot) ||
-		!Array.isArray(snapshot.nodes) ||
-		!Array.isArray(snapshot.edges) ||
-		!Array.isArray(snapshot.clusters) ||
-		!Array.isArray(appliedOperations)
-	) {
-		throw new Error("Invalid owner-scoped memory graph ledger payload");
-	}
-	return {
-		schemaVersion: 1,
-		ownerScope: { ...ownerScope },
-		snapshot: cloneSnapshot(snapshot as unknown as MemoryGraphSnapshot),
-		appliedOperations: appliedOperations as MemoryGraphOperation[],
-	};
+  const value = message?.metadata?.[LEDGER_METADATA_KEY];
+  if (!isRecord(value) || value.schemaVersion !== 1) {
+    return {
+      schemaVersion: 1,
+      ownerScope: { ...ownerScope },
+      snapshot: emptySnapshot(ownerScope, now),
+      appliedOperations: [],
+    };
+  }
+  const storedScope = value.ownerScope;
+  const snapshot = value.snapshot;
+  const appliedOperations = value.appliedOperations;
+  if (
+    !isOwnerScopeValue(storedScope) ||
+    !sameOwnerScope(storedScope, ownerScope) ||
+    !isRecord(snapshot) ||
+    !Array.isArray(snapshot.nodes) ||
+    !Array.isArray(snapshot.edges) ||
+    !Array.isArray(snapshot.clusters) ||
+    !Array.isArray(appliedOperations)
+  ) {
+    throw new Error("Invalid owner-scoped memory graph ledger payload");
+  }
+  const graphObjects = [
+    ...snapshot.nodes,
+    ...snapshot.edges,
+    ...snapshot.clusters,
+    ...appliedOperations,
+  ];
+  if (
+    !isOwnerScopeValue(snapshot.ownerScope) ||
+    !sameOwnerScope(snapshot.ownerScope, ownerScope) ||
+    graphObjects.some(
+      (item) =>
+        !isRecord(item) ||
+        !isOwnerScopeValue(item.ownerScope) ||
+        !sameOwnerScope(item.ownerScope, ownerScope),
+    )
+  ) {
+    throw new Error("Invalid owner-scoped memory graph ledger payload");
+  }
+  const storedSnapshot = snapshot as unknown as MemoryGraphSnapshot;
+  const storedOperations = appliedOperations as MemoryGraphOperation[];
+  return {
+    schemaVersion: 1,
+    ownerScope: { ...ownerScope },
+    snapshot: cloneSnapshot(storedSnapshot),
+    appliedOperations: storedOperations,
+  };
 }
 
 function nextVersion(version: string | undefined): string {
-	const parsed = Number.parseInt(version ?? "0", 10);
-	return String(Number.isFinite(parsed) ? parsed + 1 : 1);
+  const parsed = Number.parseInt(version ?? "0", 10);
+  return String(Number.isFinite(parsed) ? parsed + 1 : 1);
 }
 
 function scopeErrors(plan: MemoryGraphUpdatePlan): string[] {
-	const scopes = [
-		...plan.candidateNodes.map((node) => node.ownerScope),
-		...plan.candidateEdges.map((edge) => edge.ownerScope),
-		...(plan.candidateClusters ?? []).map((cluster) => cluster.ownerScope),
-		...plan.operations.map((operation) => operation.ownerScope),
-	];
-	return scopes.some((scope) => !sameOwnerScope(scope, plan.ownerScope))
-		? ["memory_graph_scope_mismatch"]
-		: [];
+  const scopes = [
+    ...plan.candidateNodes.map((node) => node.ownerScope),
+    ...plan.candidateEdges.map((edge) => edge.ownerScope),
+    ...(plan.candidateClusters ?? []).map((cluster) => cluster.ownerScope),
+    ...plan.operations.map((operation) => operation.ownerScope),
+  ];
+  return scopes.some((scope) => !sameOwnerScope(scope, plan.ownerScope))
+    ? ["memory_graph_scope_mismatch"]
+    : [];
 }
 
 function noMutationResult(
-	plan: MemoryGraphUpdatePlan,
-	diagnostics: string[],
-	options: { conflict?: boolean; replayed?: boolean; version?: string } = {},
+  plan: MemoryGraphUpdatePlan,
+  diagnostics: string[],
+  options: { conflict?: boolean; replayed?: boolean; version?: string } = {},
 ): MemoryGraphUpdateResult {
-	return {
-		ownerScope: { ...plan.ownerScope },
-		appliedOperations: [],
-		skippedOperations: plan.operations.map((operation) => ({
-			operation,
-			reasonCodes: diagnostics,
-		})),
-		mutatesGraph: false,
-		diagnostics,
-		conflict: options.conflict,
-		replayed: options.replayed,
-		version: options.version,
-	};
+  return {
+    ownerScope: { ...plan.ownerScope },
+    appliedOperations: [],
+    skippedOperations: plan.operations.map((operation) => ({
+      operation,
+      reasonCodes: diagnostics,
+    })),
+    mutatesGraph: false,
+    diagnostics,
+    conflict: options.conflict,
+    replayed: options.replayed,
+    version: options.version,
+  };
 }
 
 function filterSnapshot(
-	snapshot: MemoryGraphSnapshot,
-	query: Parameters<MemoryGraphStore["readSnapshot"]>[0],
+  snapshot: MemoryGraphSnapshot,
+  query: Parameters<MemoryGraphStore["readSnapshot"]>[0],
 ): MemoryGraphSnapshot {
-	const nodeIds = query.nodeIds ? new Set(query.nodeIds) : undefined;
-	const clusterIds = query.clusterIds ? new Set(query.clusterIds) : undefined;
-	return {
-		...cloneSnapshot(snapshot),
-		nodes: snapshot.nodes.filter(
-			(node) =>
-				sameOwnerScope(node.ownerScope, query.ownerScope) &&
-				(!nodeIds || nodeIds.has(node.id)) &&
-				(query.includeAuditOnly || node.visibility !== "audit-only"),
-		),
-		edges: snapshot.edges.filter(
-			(edge) =>
-				sameOwnerScope(edge.ownerScope, query.ownerScope) &&
-				(!nodeIds ||
-					nodeIds.has(edge.fromNodeId) ||
-					nodeIds.has(edge.toNodeId)),
-		),
-		clusters: snapshot.clusters.filter(
-			(cluster) =>
-				sameOwnerScope(cluster.ownerScope, query.ownerScope) &&
-				(!clusterIds || clusterIds.has(cluster.clusterId)),
-		),
-	};
+  const nodeIds = query.nodeIds ? new Set(query.nodeIds) : undefined;
+  const clusterIds = query.clusterIds ? new Set(query.clusterIds) : undefined;
+  return {
+    ...cloneSnapshot(snapshot),
+    nodes: snapshot.nodes.filter(
+      (node) =>
+        sameOwnerScope(node.ownerScope, query.ownerScope) &&
+        (!nodeIds || nodeIds.has(node.id)) &&
+        (query.includeAuditOnly || node.visibility !== "audit-only"),
+    ),
+    edges: snapshot.edges.filter(
+      (edge) =>
+        sameOwnerScope(edge.ownerScope, query.ownerScope) &&
+        (!nodeIds ||
+          nodeIds.has(edge.fromNodeId) ||
+          nodeIds.has(edge.toNodeId)),
+    ),
+    clusters: snapshot.clusters.filter(
+      (cluster) =>
+        sameOwnerScope(cluster.ownerScope, query.ownerScope) &&
+        (!clusterIds || clusterIds.has(cluster.clusterId)),
+    ),
+  };
 }
 
 const ownerGraphLocks = new Map<string, Promise<void>>();
 
 async function withOwnerGraphLock<T>(
-	key: string,
-	operation: () => Promise<T>,
+  key: string,
+  operation: () => Promise<T>,
 ): Promise<T> {
-	const previous = ownerGraphLocks.get(key) ?? Promise.resolve();
-	let release = () => {};
-	const current = new Promise<void>((resolve) => {
-		release = resolve;
-	});
-	const queued = previous.then(() => current);
-	ownerGraphLocks.set(key, queued);
-	await previous;
-	try {
-		return await operation();
-	} finally {
-		release();
-		if (ownerGraphLocks.get(key) === queued) ownerGraphLocks.delete(key);
-	}
+  const previous = ownerGraphLocks.get(key) ?? Promise.resolve();
+  let release = () => {};
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  ownerGraphLocks.set(key, queued);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (ownerGraphLocks.get(key) === queued) ownerGraphLocks.delete(key);
+  }
 }
 
 export function createRawMessageMemoryGraphStore(input: {
-	storage: RawMessageGraphEvolutionStorage;
-	ownerScope: OwnerScope;
-	now?: () => number;
+  storage: RawMessageGraphEvolutionStorage;
+  ownerScope: OwnerScope;
+  now?: () => number;
 }): MemoryGraphStore {
-	const clock = input.now ?? Date.now;
-	const readLedger = async () =>
-		parseLedger(
-			await input.storage.getMessageById(
-				memoryGraphLedgerMessageId(input.ownerScope),
-			),
-			input.ownerScope,
-			clock(),
-		);
+  const clock = input.now ?? Date.now;
+  const readLedger = async () =>
+    parseLedger(
+      await input.storage.getMessageById(
+        memoryGraphLedgerMessageId(input.ownerScope),
+      ),
+      input.ownerScope,
+      clock(),
+    );
 
-	return {
-		async readSnapshot(query) {
-			if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
-				return emptySnapshot(query.ownerScope, clock());
-			}
-			return filterSnapshot((await readLedger()).snapshot, query);
-		},
+  return {
+    async readSnapshot(query) {
+      if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
+        return emptySnapshot(query.ownerScope, clock());
+      }
+      return filterSnapshot((await readLedger()).snapshot, query);
+    },
 
-		async persistPlan(plan) {
-			return withOwnerGraphLock(ownerScopeKey(input.ownerScope), async () => {
-				if (!sameOwnerScope(plan.ownerScope, input.ownerScope)) {
-					return noMutationResult(plan, ["memory_graph_scope_mismatch"]);
-				}
-				const invalidScopes = scopeErrors(plan);
-				if (invalidScopes.length > 0) {
-					return noMutationResult(plan, invalidScopes);
-				}
-				if (!plan.persistence.enabled || plan.persistence.mode !== "write") {
-					return noMutationResult(plan, ["memory_graph_persistence_disabled"]);
-				}
+    async persistPlan(plan) {
+      return withOwnerGraphLock(ownerScopeKey(input.ownerScope), async () => {
+        if (!sameOwnerScope(plan.ownerScope, input.ownerScope)) {
+          return noMutationResult(plan, ["memory_graph_scope_mismatch"]);
+        }
+        const invalidScopes = scopeErrors(plan);
+        if (invalidScopes.length > 0) {
+          return noMutationResult(plan, invalidScopes);
+        }
+        if (!plan.persistence.enabled || plan.persistence.mode !== "write") {
+          return noMutationResult(plan, ["memory_graph_persistence_disabled"]);
+        }
 
-				const ledger = await readLedger();
-				const currentVersion = ledger.snapshot.version ?? "0";
-				const appliedIds = new Set(
-					ledger.appliedOperations.map((operation) => operation.operationId),
-				);
-				const pendingOperations = plan.operations.filter(
-					(operation) => !appliedIds.has(operation.operationId),
-				);
-				if (pendingOperations.length === 0) {
-					return noMutationResult(plan, ["memory_graph_operation_replayed"], {
-						replayed: true,
-						version: currentVersion,
-					});
-				}
-				if (
-					plan.expectedVersion !== undefined &&
-					plan.expectedVersion !== currentVersion
-				) {
-					return noMutationResult(plan, ["memory_graph_version_conflict"], {
-						conflict: true,
-						version: currentVersion,
-					});
-				}
+        const ledger = await readLedger();
+        const currentVersion = ledger.snapshot.version ?? "0";
+        const appliedIds = new Set(
+          ledger.appliedOperations.map((operation) => operation.operationId),
+        );
+        const pendingOperations = plan.operations.filter(
+          (operation) => !appliedIds.has(operation.operationId),
+        );
+        if (pendingOperations.length === 0) {
+          return noMutationResult(plan, ["memory_graph_operation_replayed"], {
+            replayed: true,
+            version: currentVersion,
+          });
+        }
+        if (
+          plan.expectedVersion !== undefined &&
+          plan.expectedVersion !== currentVersion
+        ) {
+          return noMutationResult(plan, ["memory_graph_version_conflict"], {
+            conflict: true,
+            version: currentVersion,
+          });
+        }
 
-				const snapshot = cloneSnapshot(ledger.snapshot);
-				const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
-				const edges = new Map(snapshot.edges.map((edge) => [edge.id, edge]));
-				const clusters = new Map(
-					snapshot.clusters.map((cluster) => [cluster.clusterId, cluster]),
-				);
-				for (const node of plan.candidateNodes) nodes.set(node.id, node);
-				for (const edge of plan.candidateEdges) edges.set(edge.id, edge);
-				for (const candidate of plan.candidateClusters ?? []) {
-					const candidateNodes = new Set(candidate.nodeIds);
-					for (const [clusterId, cluster] of clusters) {
-						if (clusterId === candidate.clusterId) continue;
-						const remainingNodeIds = cluster.nodeIds.filter(
-							(nodeId) => !candidateNodes.has(nodeId),
-						);
-						if (remainingNodeIds.length === 0) clusters.delete(clusterId);
-						else if (remainingNodeIds.length !== cluster.nodeIds.length) {
-							clusters.set(clusterId, {
-								...cluster,
-								nodeIds: remainingNodeIds,
-							});
-						}
-					}
-					clusters.set(candidate.clusterId, candidate);
-				}
+        const snapshot = cloneSnapshot(ledger.snapshot);
+        const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+        const edges = new Map(snapshot.edges.map((edge) => [edge.id, edge]));
+        const clusters = new Map(
+          snapshot.clusters.map((cluster) => [cluster.clusterId, cluster]),
+        );
+        for (const node of plan.candidateNodes) nodes.set(node.id, node);
+        for (const edge of plan.candidateEdges) edges.set(edge.id, edge);
+        for (const candidate of plan.candidateClusters ?? []) {
+          const candidateNodes = new Set(candidate.nodeIds);
+          for (const [clusterId, cluster] of clusters) {
+            if (clusterId === candidate.clusterId) continue;
+            const remainingNodeIds = cluster.nodeIds.filter(
+              (nodeId) => !candidateNodes.has(nodeId),
+            );
+            if (remainingNodeIds.length === 0) clusters.delete(clusterId);
+            else if (remainingNodeIds.length !== cluster.nodeIds.length) {
+              clusters.set(clusterId, {
+                ...cluster,
+                nodeIds: remainingNodeIds,
+              });
+            }
+          }
+          clusters.set(candidate.clusterId, candidate);
+        }
 
-				const now = clock();
-				const version = nextVersion(currentVersion);
-				const updatedSnapshot: MemoryGraphSnapshot = {
-					ownerScope: { ...input.ownerScope },
-					nodes: [...nodes.values()],
-					edges: [...edges.values()],
-					clusters: [...clusters.values()],
-					version,
-					capturedAt: now,
-				};
-				const payload: MemoryGraphLedgerPayload = {
-					schemaVersion: 1,
-					ownerScope: { ...input.ownerScope },
-					snapshot: updatedSnapshot,
-					appliedOperations: [
-						...ledger.appliedOperations,
-						...pendingOperations,
-					],
-				};
-				await input.storage.storeMessage({
-					messageId: memoryGraphLedgerMessageId(input.ownerScope),
-					platform: LEDGER_PLATFORM,
-					botId: LEDGER_BOT_ID,
-					userId: input.ownerScope.userId,
-					channel: input.ownerScope.workspaceId,
-					timestamp: Math.floor(now / 1000),
-					content: "OpenLoomi internal memory graph ledger",
-					attachments: [],
-					metadata: { [LEDGER_METADATA_KEY]: payload },
-					createdAt: Math.floor(now / 1000),
-					memoryStage: "long",
-					archivedAt: Math.floor(now / 1000),
-					isPinned: true,
-				});
+        const now = clock();
+        const version = nextVersion(currentVersion);
+        const updatedSnapshot: MemoryGraphSnapshot = {
+          ownerScope: { ...input.ownerScope },
+          nodes: [...nodes.values()],
+          edges: [...edges.values()],
+          clusters: [...clusters.values()],
+          version,
+          capturedAt: now,
+        };
+        const payload: MemoryGraphLedgerPayload = {
+          schemaVersion: 1,
+          ownerScope: { ...input.ownerScope },
+          snapshot: updatedSnapshot,
+          appliedOperations: [
+            ...ledger.appliedOperations,
+            ...pendingOperations,
+          ],
+        };
+        await input.storage.storeMessage({
+          messageId: memoryGraphLedgerMessageId(input.ownerScope),
+          platform: LEDGER_PLATFORM,
+          botId: LEDGER_BOT_ID,
+          userId: input.ownerScope.userId,
+          channel: input.ownerScope.workspaceId,
+          timestamp: Math.floor(now / 1000),
+          content: "OpenLoomi internal memory graph ledger",
+          attachments: [],
+          metadata: { [LEDGER_METADATA_KEY]: payload },
+          createdAt: Math.floor(now / 1000),
+          memoryStage: "long",
+          archivedAt: Math.floor(now / 1000),
+          isPinned: true,
+        });
 
-				return {
-					ownerScope: { ...input.ownerScope },
-					appliedOperations: pendingOperations,
-					skippedOperations: plan.operations
-						.filter((operation) => appliedIds.has(operation.operationId))
-						.map((operation) => ({
-							operation,
-							reasonCodes: ["memory_graph_operation_replayed"],
-						})),
-					mutatesGraph: true,
-					diagnostics: ["memory_graph_plan_persisted"],
-					version,
-				};
-			});
-		},
+        return {
+          ownerScope: { ...input.ownerScope },
+          appliedOperations: pendingOperations,
+          skippedOperations: plan.operations
+            .filter((operation) => appliedIds.has(operation.operationId))
+            .map((operation) => ({
+              operation,
+              reasonCodes: ["memory_graph_operation_replayed"],
+            })),
+          mutatesGraph: true,
+          diagnostics: ["memory_graph_plan_persisted"],
+          version,
+        };
+      });
+    },
 
-		async readAuditTrail(query): Promise<MemoryGraphAuditTrail> {
-			const ledger = await readLedger();
-			if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
-				return {
-					ownerScope: { ...query.ownerScope },
-					nodeId: query.nodeId,
-					sourceNodeIds: [],
-					edgeIds: [],
-					operationIds: [],
-					reasonCodes: ["memory_graph_scope_mismatch"],
-				};
-			}
-			const node = ledger.snapshot.nodes.find(
-				(item) => item.id === query.nodeId,
-			);
-			const edges = ledger.snapshot.edges.filter(
-				(edge) =>
-					edge.fromNodeId === query.nodeId || edge.toNodeId === query.nodeId,
-			);
-			const operations = ledger.appliedOperations.filter((operation) =>
-				operation.nodeIds.includes(query.nodeId),
-			);
-			return {
-				ownerScope: { ...input.ownerScope },
-				nodeId: query.nodeId,
-				sourceNodeIds: [
-					...(node?.sourceId ? [node.sourceId] : []),
-					...edges.flatMap((edge) => edge.evidenceNodeIds),
-				].filter((value, index, values) => values.indexOf(value) === index),
-				edgeIds: edges.map((edge) => edge.id),
-				operationIds: operations.map((operation) => operation.operationId),
-				reasonCodes: node
-					? ["memory_graph_audit_trail_available"]
-					: ["memory_graph_node_not_found"],
-			};
-		},
-	};
+    async readAuditTrail(query): Promise<MemoryGraphAuditTrail> {
+      const ledger = await readLedger();
+      if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
+        return {
+          ownerScope: { ...query.ownerScope },
+          nodeId: query.nodeId,
+          sourceNodeIds: [],
+          edgeIds: [],
+          operationIds: [],
+          reasonCodes: ["memory_graph_scope_mismatch"],
+        };
+      }
+      const node = ledger.snapshot.nodes.find(
+        (item) => item.id === query.nodeId,
+      );
+      const edges = ledger.snapshot.edges.filter(
+        (edge) =>
+          edge.fromNodeId === query.nodeId || edge.toNodeId === query.nodeId,
+      );
+      const operations = ledger.appliedOperations.filter((operation) =>
+        operation.nodeIds.includes(query.nodeId),
+      );
+      return {
+        ownerScope: { ...input.ownerScope },
+        nodeId: query.nodeId,
+        sourceNodeIds: [
+          ...(node?.sourceId ? [node.sourceId] : []),
+          ...edges.flatMap((edge) => edge.evidenceNodeIds),
+        ].filter((value, index, values) => values.indexOf(value) === index),
+        edgeIds: edges.map((edge) => edge.id),
+        operationIds: operations.map((operation) => operation.operationId),
+        reasonCodes: node
+          ? ["memory_graph_audit_trail_available"]
+          : ["memory_graph_node_not_found"],
+      };
+    },
+  };
 }
 
 function ownerScopeFromMessage(message: RawMessage): OwnerScope {
-	const stored = message.metadata?.memoryOwnerScope;
-	if (isRecord(stored) && typeof stored.userId === "string") {
-		return {
-			userId: stored.userId,
-			workspaceId: optionalString(stored.workspaceId),
-			tenantId: optionalString(stored.tenantId),
-		};
-	}
-	return { userId: message.userId };
+  const stored = message.metadata?.memoryOwnerScope;
+  if (isRecord(stored) && typeof stored.userId === "string") {
+    return {
+      userId: stored.userId,
+      workspaceId: optionalString(stored.workspaceId),
+      tenantId: optionalString(stored.tenantId),
+    };
+  }
+  return { userId: message.userId };
 }
 
 function applicabilityFromMessage(
-	message: RawMessage,
+  message: RawMessage,
 ): MemoryApplicabilityContext {
-	const stored = message.metadata?.memoryApplicability;
-	if (isRecord(stored) && typeof stored.scope === "string") {
-		const scope = stored.scope;
-		if (
-			[
-				"global",
-				"task",
-				"conversation",
-				"channel",
-				"project",
-				"custom",
-			].includes(scope)
-		) {
-			return {
-				scope: scope as MemoryApplicabilityContext["scope"],
-				key: optionalString(stored.key),
-				validFrom:
-					typeof stored.validFrom === "number" ? stored.validFrom : undefined,
-				validUntil:
-					typeof stored.validUntil === "number" ? stored.validUntil : undefined,
-			};
-		}
-	}
-	return message.channel
-		? { scope: "channel", key: `${message.platform}:${message.channel}` }
-		: { scope: "global" };
+  const stored = message.metadata?.memoryApplicability;
+  if (isRecord(stored) && typeof stored.scope === "string") {
+    const scope = stored.scope;
+    if (
+      [
+        "global",
+        "task",
+        "conversation",
+        "channel",
+        "project",
+        "custom",
+      ].includes(scope)
+    ) {
+      return {
+        scope: scope as MemoryApplicabilityContext["scope"],
+        key: optionalString(stored.key),
+        validFrom:
+          typeof stored.validFrom === "number" ? stored.validFrom : undefined,
+        validUntil:
+          typeof stored.validUntil === "number" ? stored.validUntil : undefined,
+      };
+    }
+  }
+  return message.channel
+    ? { scope: "channel", key: `${message.platform}:${message.channel}` }
+    : { scope: "global" };
 }
 
 function stringArray(value: unknown): string[] {
-	return Array.isArray(value)
-		? value.filter((item): item is string => typeof item === "string")
-		: [];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
 }
 
 function messageToEvidence(message: RawMessage): MemoryGraphEvolutionEvidence {
-	const relation = message.metadata?.memoryRelation;
-	return {
-		id: message.messageId,
-		ownerScope: ownerScopeFromMessage(message),
-		timestamp:
-			message.timestamp < 1e11 ? message.timestamp * 1000 : message.timestamp,
-		text: message.content,
-		relationGroup:
-			optionalString(message.metadata?.relationGroup) ??
-			(isRecord(relation) ? optionalString(relation.group) : undefined),
-		relationValue:
-			optionalString(message.metadata?.relationValue) ??
-			(isRecord(relation) ? optionalString(relation.value) : undefined),
-		topicKeys: stringArray(
-			message.metadata?.memoryTopicKeys ?? message.metadata?.topicKeys,
-		),
-		applicability: applicabilityFromMessage(message),
-		sourceIdentity:
-			optionalString(message.metadata?.sourceIdentity) ?? message.messageId,
-		accessCount: message.accessCount,
-		importanceScore: message.importanceScore,
-		metadata: message.metadata,
-	};
+  const relation = message.metadata?.memoryRelation;
+  return {
+    id: message.messageId,
+    ownerScope: ownerScopeFromMessage(message),
+    timestamp:
+      message.timestamp < 1e11 ? message.timestamp * 1000 : message.timestamp,
+    text: message.content,
+    relationGroup:
+      optionalString(message.metadata?.relationGroup) ??
+      (isRecord(relation) ? optionalString(relation.group) : undefined),
+    relationValue:
+      optionalString(message.metadata?.relationValue) ??
+      (isRecord(relation) ? optionalString(relation.value) : undefined),
+    topicKeys: stringArray(
+      message.metadata?.memoryTopicKeys ?? message.metadata?.topicKeys,
+    ),
+    applicability: applicabilityFromMessage(message),
+    sourceIdentity:
+      optionalString(message.metadata?.sourceIdentity) ?? message.messageId,
+    accessCount: message.accessCount,
+    importanceScore: message.importanceScore,
+    metadata: message.metadata,
+  };
 }
 
 function withGraphMetadata(
-	message: RawMessage,
-	ownerScope: OwnerScope,
+  message: RawMessage,
+  ownerScope: OwnerScope,
 ): RawMessage {
-	const applicability = applicabilityFromMessage(message);
-	return {
-		...message,
-		metadata: {
-			...message.metadata,
-			memoryOwnerScope: ownerScope,
-			memoryApplicability: applicability,
-		},
-	};
+  const applicability = applicabilityFromMessage(message);
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      memoryOwnerScope: ownerScope,
+      memoryApplicability: applicability,
+    },
+  };
 }
 
 function disabledResult(ownerScope: OwnerScope): MemoryGraphEvolutionRunResult {
-	return {
-		status: "disabled",
-		ownerScope,
-		consideredCandidateIds: [],
-		reasonCodes: ["memory_graph_evolution_disabled"],
-	};
+  return {
+    status: "disabled",
+    ownerScope,
+    consideredCandidateIds: [],
+    reasonCodes: ["memory_graph_evolution_disabled"],
+  };
 }
 
 export async function storeRawMessagesWithGraphEvolution(
-	input: StoreRawMessagesWithGraphEvolutionInput,
+  input: StoreRawMessagesWithGraphEvolutionInput,
 ): Promise<StoreRawMessagesWithGraphEvolutionResult> {
-	if (input.messages.length === 0) {
-		const ownerScope = { userId: "" };
-		return { ids: [], graphEvolution: disabledResult(ownerScope) };
-	}
-	const options = input.graphEvolution ?? {};
-	const ownerScope: OwnerScope = {
-		userId: input.messages[0].userId,
-		workspaceId: options.workspaceId,
-		tenantId: options.tenantId,
-	};
-	const mixedOwnerBatch = input.messages.some(
-		(message) => message.userId !== ownerScope.userId,
-	);
-	const scopedMessages = input.messages.map((message) =>
-		withGraphMetadata(message, {
-			userId: message.userId,
-			workspaceId: options.workspaceId,
-			tenantId: options.tenantId,
-		}),
-	);
-	const ids = await input.storage.storeMessages(scopedMessages);
-	if (options.enabled !== true) {
-		return { ids, graphEvolution: disabledResult(ownerScope) };
-	}
+  if (input.messages.length === 0) {
+    const ownerScope = { userId: "" };
+    return { ids: [], graphEvolution: disabledResult(ownerScope) };
+  }
+  assertNoReservedGraphPayload(input.messages);
+  const options = input.graphEvolution ?? {};
+  const ownerScope: OwnerScope = {
+    userId: input.messages[0].userId,
+    workspaceId: options.workspaceId,
+    tenantId: options.tenantId,
+  };
+  const mixedOwnerBatch = input.messages.some(
+    (message) => message.userId !== ownerScope.userId,
+  );
+  const scopedMessages = input.messages.map((message) =>
+    withGraphMetadata(message, {
+      userId: message.userId,
+      workspaceId: options.workspaceId,
+      tenantId: options.tenantId,
+    }),
+  );
+  const ids = await input.storage.storeMessages(scopedMessages);
+  if (options.enabled !== true) {
+    return { ids, graphEvolution: disabledResult(ownerScope) };
+  }
 
-	if (
-		mixedOwnerBatch ||
-		scopedMessages.some(
-			(message) => !sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
-		)
-	) {
-		return {
-			ids,
-			graphEvolution: {
-				status: "failed",
-				ownerScope,
-				consideredCandidateIds: [],
-				reasonCodes: ["memory_graph_scope_mismatch"],
-			},
-		};
-	}
+  if (
+    mixedOwnerBatch ||
+    scopedMessages.some(
+      (message) => !sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
+    )
+  ) {
+    return {
+      ids,
+      graphEvolution: {
+        status: "failed",
+        ownerScope,
+        consideredCandidateIds: [],
+        reasonCodes: ["memory_graph_scope_mismatch"],
+      },
+    };
+  }
 
-	const candidateLimit = options.candidateLimit ?? 200;
-	const newIds = new Set(scopedMessages.map((message) => message.messageId));
-	const candidates = (
-		await input.storage.queryMessages({
-			userId: ownerScope.userId,
-			includeArchived: false,
-			includeDeprecated: true,
-			reverse: true,
-			limit: candidateLimit + scopedMessages.length,
-		})
-	).filter(
-		(message) =>
-			!newIds.has(message.messageId) &&
-			!message.metadata?.[LEDGER_METADATA_KEY] &&
-			sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
-	);
-	const store = createRawMessageMemoryGraphStore({
-		storage: input.storage,
-		ownerScope,
-		now: () => input.now ?? Date.now(),
-	});
-	const graphEvolution = await runMemoryGraphEvolution({
-		ownerScope,
-		newEvidence: scopedMessages.map(messageToEvidence),
-		candidateEvidence: candidates.map(messageToEvidence),
-		store,
-		enabled: true,
-		dryRun: options.dryRun,
-		now: input.now,
-	});
-	return { ids, graphEvolution };
+  const candidateLimit = options.candidateLimit ?? 200;
+  const newIds = new Set(scopedMessages.map((message) => message.messageId));
+  const candidates = (
+    await input.storage.queryMessages({
+      userId: ownerScope.userId,
+      includeArchived: false,
+      includeDeprecated: true,
+      reverse: true,
+      limit: candidateLimit + scopedMessages.length,
+    })
+  ).filter(
+    (message) =>
+      !newIds.has(message.messageId) &&
+      !message.metadata?.[LEDGER_METADATA_KEY] &&
+      sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
+  );
+  const store = createRawMessageMemoryGraphStore({
+    storage: input.storage,
+    ownerScope,
+    now: () => input.now ?? Date.now(),
+  });
+  const graphEvolution = await runMemoryGraphEvolution({
+    ownerScope,
+    newEvidence: scopedMessages.map(messageToEvidence),
+    candidateEvidence: candidates.map(messageToEvidence),
+    store,
+    enabled: true,
+    dryRun: options.dryRun,
+    now: input.now,
+  });
+  return { ids, graphEvolution };
 }

--- a/packages/indexeddb/src/memory-graph-evolution.ts
+++ b/packages/indexeddb/src/memory-graph-evolution.ts
@@ -1,0 +1,608 @@
+import {
+	type MemoryApplicabilityContext,
+	type MemoryGraphAuditTrail,
+	type MemoryGraphEvolutionEvidence,
+	type MemoryGraphEvolutionRunResult,
+	type MemoryGraphOperation,
+	type MemoryGraphSnapshot,
+	type MemoryGraphStore,
+	type MemoryGraphUpdatePlan,
+	type MemoryGraphUpdateResult,
+	type OwnerScope,
+	ownerScopeKey,
+	runMemoryGraphEvolution,
+	sameOwnerScope,
+} from "../../ai/memory-consolidation/src";
+export type { MemoryGraphEvolutionRunResult } from "../../ai/memory-consolidation/src";
+import type { RawMessage, RawMessageQuery } from "./storage";
+
+const LEDGER_METADATA_KEY = "memoryGraphLedger";
+const LEDGER_PLATFORM = "openloomi-internal";
+const LEDGER_BOT_ID = "memory-graph";
+
+export interface RawMessageGraphEvolutionStorage {
+	storeMessage(message: RawMessage): Promise<number>;
+	storeMessages(messages: RawMessage[]): Promise<number[]>;
+	getMessageById(messageId: string): Promise<RawMessage | null>;
+	queryMessages(query: RawMessageQuery): Promise<RawMessage[]>;
+}
+
+export interface RawMessageGraphEvolutionOptions {
+	enabled?: boolean;
+	dryRun?: boolean;
+	workspaceId?: string;
+	tenantId?: string;
+	candidateLimit?: number;
+}
+
+export interface StoreRawMessagesWithGraphEvolutionInput {
+	storage: RawMessageGraphEvolutionStorage;
+	messages: RawMessage[];
+	graphEvolution?: RawMessageGraphEvolutionOptions;
+	now?: number;
+}
+
+export interface StoreRawMessagesWithGraphEvolutionResult {
+	ids: number[];
+	graphEvolution: MemoryGraphEvolutionRunResult;
+}
+
+interface MemoryGraphLedgerPayload {
+	schemaVersion: 1;
+	ownerScope: OwnerScope;
+	snapshot: MemoryGraphSnapshot;
+	appliedOperations: MemoryGraphOperation[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function parseRawMessageGraphEvolutionOptions(
+	value: unknown,
+): RawMessageGraphEvolutionOptions {
+	if (!isRecord(value)) return {};
+	const candidateLimit =
+		typeof value.candidateLimit === "number" &&
+		Number.isFinite(value.candidateLimit)
+			? Math.max(1, Math.min(500, Math.floor(value.candidateLimit)))
+			: undefined;
+	return {
+		enabled: value.enabled === true,
+		dryRun: value.dryRun === true,
+		workspaceId: optionalString(value.workspaceId),
+		tenantId: optionalString(value.tenantId),
+		candidateLimit,
+	};
+}
+
+export function memoryGraphLedgerMessageId(ownerScope: OwnerScope): string {
+	return `__openloomi_memory_graph__:${ownerScopeKey(ownerScope)}`;
+}
+
+function emptySnapshot(
+	ownerScope: OwnerScope,
+	now: number,
+): MemoryGraphSnapshot {
+	return {
+		ownerScope: { ...ownerScope },
+		nodes: [],
+		edges: [],
+		clusters: [],
+		version: "0",
+		capturedAt: now,
+	};
+}
+
+function cloneSnapshot(snapshot: MemoryGraphSnapshot): MemoryGraphSnapshot {
+	return {
+		...snapshot,
+		ownerScope: { ...snapshot.ownerScope },
+		nodes: snapshot.nodes.map((node) => ({
+			...node,
+			ownerScope: { ...node.ownerScope },
+			applicability: node.applicability ? { ...node.applicability } : undefined,
+			metadata: node.metadata ? { ...node.metadata } : undefined,
+		})),
+		edges: snapshot.edges.map((edge) => ({
+			...edge,
+			ownerScope: { ...edge.ownerScope },
+			evidenceNodeIds: [...edge.evidenceNodeIds],
+			reasonCodes: [...edge.reasonCodes],
+			applicability: edge.applicability ? { ...edge.applicability } : undefined,
+			metadata: edge.metadata ? { ...edge.metadata } : undefined,
+		})),
+		clusters: snapshot.clusters.map((cluster) => ({
+			...cluster,
+			ownerScope: { ...cluster.ownerScope },
+			nodeIds: [...cluster.nodeIds],
+			reasonCodes: [...cluster.reasonCodes],
+			applicability: cluster.applicability
+				? { ...cluster.applicability }
+				: undefined,
+			metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
+		})),
+	};
+}
+
+function parseLedger(
+	message: RawMessage | null,
+	ownerScope: OwnerScope,
+	now: number,
+): MemoryGraphLedgerPayload {
+	const value = message?.metadata?.[LEDGER_METADATA_KEY];
+	if (!isRecord(value) || value.schemaVersion !== 1) {
+		return {
+			schemaVersion: 1,
+			ownerScope: { ...ownerScope },
+			snapshot: emptySnapshot(ownerScope, now),
+			appliedOperations: [],
+		};
+	}
+	const storedScope = value.ownerScope;
+	const snapshot = value.snapshot;
+	const appliedOperations = value.appliedOperations;
+	if (
+		!isRecord(storedScope) ||
+		typeof storedScope.userId !== "string" ||
+		!sameOwnerScope(storedScope as unknown as OwnerScope, ownerScope) ||
+		!isRecord(snapshot) ||
+		!Array.isArray(snapshot.nodes) ||
+		!Array.isArray(snapshot.edges) ||
+		!Array.isArray(snapshot.clusters) ||
+		!Array.isArray(appliedOperations)
+	) {
+		throw new Error("Invalid owner-scoped memory graph ledger payload");
+	}
+	return {
+		schemaVersion: 1,
+		ownerScope: { ...ownerScope },
+		snapshot: cloneSnapshot(snapshot as unknown as MemoryGraphSnapshot),
+		appliedOperations: appliedOperations as MemoryGraphOperation[],
+	};
+}
+
+function nextVersion(version: string | undefined): string {
+	const parsed = Number.parseInt(version ?? "0", 10);
+	return String(Number.isFinite(parsed) ? parsed + 1 : 1);
+}
+
+function scopeErrors(plan: MemoryGraphUpdatePlan): string[] {
+	const scopes = [
+		...plan.candidateNodes.map((node) => node.ownerScope),
+		...plan.candidateEdges.map((edge) => edge.ownerScope),
+		...(plan.candidateClusters ?? []).map((cluster) => cluster.ownerScope),
+		...plan.operations.map((operation) => operation.ownerScope),
+	];
+	return scopes.some((scope) => !sameOwnerScope(scope, plan.ownerScope))
+		? ["memory_graph_scope_mismatch"]
+		: [];
+}
+
+function noMutationResult(
+	plan: MemoryGraphUpdatePlan,
+	diagnostics: string[],
+	options: { conflict?: boolean; replayed?: boolean; version?: string } = {},
+): MemoryGraphUpdateResult {
+	return {
+		ownerScope: { ...plan.ownerScope },
+		appliedOperations: [],
+		skippedOperations: plan.operations.map((operation) => ({
+			operation,
+			reasonCodes: diagnostics,
+		})),
+		mutatesGraph: false,
+		diagnostics,
+		conflict: options.conflict,
+		replayed: options.replayed,
+		version: options.version,
+	};
+}
+
+function filterSnapshot(
+	snapshot: MemoryGraphSnapshot,
+	query: Parameters<MemoryGraphStore["readSnapshot"]>[0],
+): MemoryGraphSnapshot {
+	const nodeIds = query.nodeIds ? new Set(query.nodeIds) : undefined;
+	const clusterIds = query.clusterIds ? new Set(query.clusterIds) : undefined;
+	return {
+		...cloneSnapshot(snapshot),
+		nodes: snapshot.nodes.filter(
+			(node) =>
+				sameOwnerScope(node.ownerScope, query.ownerScope) &&
+				(!nodeIds || nodeIds.has(node.id)) &&
+				(query.includeAuditOnly || node.visibility !== "audit-only"),
+		),
+		edges: snapshot.edges.filter(
+			(edge) =>
+				sameOwnerScope(edge.ownerScope, query.ownerScope) &&
+				(!nodeIds ||
+					nodeIds.has(edge.fromNodeId) ||
+					nodeIds.has(edge.toNodeId)),
+		),
+		clusters: snapshot.clusters.filter(
+			(cluster) =>
+				sameOwnerScope(cluster.ownerScope, query.ownerScope) &&
+				(!clusterIds || clusterIds.has(cluster.clusterId)),
+		),
+	};
+}
+
+const ownerGraphLocks = new Map<string, Promise<void>>();
+
+async function withOwnerGraphLock<T>(
+	key: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const previous = ownerGraphLocks.get(key) ?? Promise.resolve();
+	let release = () => {};
+	const current = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const queued = previous.then(() => current);
+	ownerGraphLocks.set(key, queued);
+	await previous;
+	try {
+		return await operation();
+	} finally {
+		release();
+		if (ownerGraphLocks.get(key) === queued) ownerGraphLocks.delete(key);
+	}
+}
+
+export function createRawMessageMemoryGraphStore(input: {
+	storage: RawMessageGraphEvolutionStorage;
+	ownerScope: OwnerScope;
+	now?: () => number;
+}): MemoryGraphStore {
+	const clock = input.now ?? Date.now;
+	const readLedger = async () =>
+		parseLedger(
+			await input.storage.getMessageById(
+				memoryGraphLedgerMessageId(input.ownerScope),
+			),
+			input.ownerScope,
+			clock(),
+		);
+
+	return {
+		async readSnapshot(query) {
+			if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
+				return emptySnapshot(query.ownerScope, clock());
+			}
+			return filterSnapshot((await readLedger()).snapshot, query);
+		},
+
+		async persistPlan(plan) {
+			return withOwnerGraphLock(ownerScopeKey(input.ownerScope), async () => {
+				if (!sameOwnerScope(plan.ownerScope, input.ownerScope)) {
+					return noMutationResult(plan, ["memory_graph_scope_mismatch"]);
+				}
+				const invalidScopes = scopeErrors(plan);
+				if (invalidScopes.length > 0) {
+					return noMutationResult(plan, invalidScopes);
+				}
+				if (!plan.persistence.enabled || plan.persistence.mode !== "write") {
+					return noMutationResult(plan, ["memory_graph_persistence_disabled"]);
+				}
+
+				const ledger = await readLedger();
+				const currentVersion = ledger.snapshot.version ?? "0";
+				const appliedIds = new Set(
+					ledger.appliedOperations.map((operation) => operation.operationId),
+				);
+				const pendingOperations = plan.operations.filter(
+					(operation) => !appliedIds.has(operation.operationId),
+				);
+				if (pendingOperations.length === 0) {
+					return noMutationResult(plan, ["memory_graph_operation_replayed"], {
+						replayed: true,
+						version: currentVersion,
+					});
+				}
+				if (
+					plan.expectedVersion !== undefined &&
+					plan.expectedVersion !== currentVersion
+				) {
+					return noMutationResult(plan, ["memory_graph_version_conflict"], {
+						conflict: true,
+						version: currentVersion,
+					});
+				}
+
+				const snapshot = cloneSnapshot(ledger.snapshot);
+				const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+				const edges = new Map(snapshot.edges.map((edge) => [edge.id, edge]));
+				const clusters = new Map(
+					snapshot.clusters.map((cluster) => [cluster.clusterId, cluster]),
+				);
+				for (const node of plan.candidateNodes) nodes.set(node.id, node);
+				for (const edge of plan.candidateEdges) edges.set(edge.id, edge);
+				for (const candidate of plan.candidateClusters ?? []) {
+					const candidateNodes = new Set(candidate.nodeIds);
+					for (const [clusterId, cluster] of clusters) {
+						if (clusterId === candidate.clusterId) continue;
+						const remainingNodeIds = cluster.nodeIds.filter(
+							(nodeId) => !candidateNodes.has(nodeId),
+						);
+						if (remainingNodeIds.length === 0) clusters.delete(clusterId);
+						else if (remainingNodeIds.length !== cluster.nodeIds.length) {
+							clusters.set(clusterId, {
+								...cluster,
+								nodeIds: remainingNodeIds,
+							});
+						}
+					}
+					clusters.set(candidate.clusterId, candidate);
+				}
+
+				const now = clock();
+				const version = nextVersion(currentVersion);
+				const updatedSnapshot: MemoryGraphSnapshot = {
+					ownerScope: { ...input.ownerScope },
+					nodes: [...nodes.values()],
+					edges: [...edges.values()],
+					clusters: [...clusters.values()],
+					version,
+					capturedAt: now,
+				};
+				const payload: MemoryGraphLedgerPayload = {
+					schemaVersion: 1,
+					ownerScope: { ...input.ownerScope },
+					snapshot: updatedSnapshot,
+					appliedOperations: [
+						...ledger.appliedOperations,
+						...pendingOperations,
+					],
+				};
+				await input.storage.storeMessage({
+					messageId: memoryGraphLedgerMessageId(input.ownerScope),
+					platform: LEDGER_PLATFORM,
+					botId: LEDGER_BOT_ID,
+					userId: input.ownerScope.userId,
+					channel: input.ownerScope.workspaceId,
+					timestamp: Math.floor(now / 1000),
+					content: "OpenLoomi internal memory graph ledger",
+					attachments: [],
+					metadata: { [LEDGER_METADATA_KEY]: payload },
+					createdAt: Math.floor(now / 1000),
+					memoryStage: "long",
+					archivedAt: Math.floor(now / 1000),
+					isPinned: true,
+				});
+
+				return {
+					ownerScope: { ...input.ownerScope },
+					appliedOperations: pendingOperations,
+					skippedOperations: plan.operations
+						.filter((operation) => appliedIds.has(operation.operationId))
+						.map((operation) => ({
+							operation,
+							reasonCodes: ["memory_graph_operation_replayed"],
+						})),
+					mutatesGraph: true,
+					diagnostics: ["memory_graph_plan_persisted"],
+					version,
+				};
+			});
+		},
+
+		async readAuditTrail(query): Promise<MemoryGraphAuditTrail> {
+			const ledger = await readLedger();
+			if (!sameOwnerScope(query.ownerScope, input.ownerScope)) {
+				return {
+					ownerScope: { ...query.ownerScope },
+					nodeId: query.nodeId,
+					sourceNodeIds: [],
+					edgeIds: [],
+					operationIds: [],
+					reasonCodes: ["memory_graph_scope_mismatch"],
+				};
+			}
+			const node = ledger.snapshot.nodes.find(
+				(item) => item.id === query.nodeId,
+			);
+			const edges = ledger.snapshot.edges.filter(
+				(edge) =>
+					edge.fromNodeId === query.nodeId || edge.toNodeId === query.nodeId,
+			);
+			const operations = ledger.appliedOperations.filter((operation) =>
+				operation.nodeIds.includes(query.nodeId),
+			);
+			return {
+				ownerScope: { ...input.ownerScope },
+				nodeId: query.nodeId,
+				sourceNodeIds: [
+					...(node?.sourceId ? [node.sourceId] : []),
+					...edges.flatMap((edge) => edge.evidenceNodeIds),
+				].filter((value, index, values) => values.indexOf(value) === index),
+				edgeIds: edges.map((edge) => edge.id),
+				operationIds: operations.map((operation) => operation.operationId),
+				reasonCodes: node
+					? ["memory_graph_audit_trail_available"]
+					: ["memory_graph_node_not_found"],
+			};
+		},
+	};
+}
+
+function ownerScopeFromMessage(message: RawMessage): OwnerScope {
+	const stored = message.metadata?.memoryOwnerScope;
+	if (isRecord(stored) && typeof stored.userId === "string") {
+		return {
+			userId: stored.userId,
+			workspaceId: optionalString(stored.workspaceId),
+			tenantId: optionalString(stored.tenantId),
+		};
+	}
+	return { userId: message.userId };
+}
+
+function applicabilityFromMessage(
+	message: RawMessage,
+): MemoryApplicabilityContext {
+	const stored = message.metadata?.memoryApplicability;
+	if (isRecord(stored) && typeof stored.scope === "string") {
+		const scope = stored.scope;
+		if (
+			[
+				"global",
+				"task",
+				"conversation",
+				"channel",
+				"project",
+				"custom",
+			].includes(scope)
+		) {
+			return {
+				scope: scope as MemoryApplicabilityContext["scope"],
+				key: optionalString(stored.key),
+				validFrom:
+					typeof stored.validFrom === "number" ? stored.validFrom : undefined,
+				validUntil:
+					typeof stored.validUntil === "number" ? stored.validUntil : undefined,
+			};
+		}
+	}
+	return message.channel
+		? { scope: "channel", key: `${message.platform}:${message.channel}` }
+		: { scope: "global" };
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function messageToEvidence(message: RawMessage): MemoryGraphEvolutionEvidence {
+	const relation = message.metadata?.memoryRelation;
+	return {
+		id: message.messageId,
+		ownerScope: ownerScopeFromMessage(message),
+		timestamp:
+			message.timestamp < 1e11 ? message.timestamp * 1000 : message.timestamp,
+		text: message.content,
+		relationGroup:
+			optionalString(message.metadata?.relationGroup) ??
+			(isRecord(relation) ? optionalString(relation.group) : undefined),
+		relationValue:
+			optionalString(message.metadata?.relationValue) ??
+			(isRecord(relation) ? optionalString(relation.value) : undefined),
+		topicKeys: stringArray(
+			message.metadata?.memoryTopicKeys ?? message.metadata?.topicKeys,
+		),
+		applicability: applicabilityFromMessage(message),
+		sourceIdentity:
+			optionalString(message.metadata?.sourceIdentity) ?? message.messageId,
+		accessCount: message.accessCount,
+		importanceScore: message.importanceScore,
+		metadata: message.metadata,
+	};
+}
+
+function withGraphMetadata(
+	message: RawMessage,
+	ownerScope: OwnerScope,
+): RawMessage {
+	const applicability = applicabilityFromMessage(message);
+	return {
+		...message,
+		metadata: {
+			...message.metadata,
+			memoryOwnerScope: ownerScope,
+			memoryApplicability: applicability,
+		},
+	};
+}
+
+function disabledResult(ownerScope: OwnerScope): MemoryGraphEvolutionRunResult {
+	return {
+		status: "disabled",
+		ownerScope,
+		consideredCandidateIds: [],
+		reasonCodes: ["memory_graph_evolution_disabled"],
+	};
+}
+
+export async function storeRawMessagesWithGraphEvolution(
+	input: StoreRawMessagesWithGraphEvolutionInput,
+): Promise<StoreRawMessagesWithGraphEvolutionResult> {
+	if (input.messages.length === 0) {
+		const ownerScope = { userId: "" };
+		return { ids: [], graphEvolution: disabledResult(ownerScope) };
+	}
+	const options = input.graphEvolution ?? {};
+	const ownerScope: OwnerScope = {
+		userId: input.messages[0].userId,
+		workspaceId: options.workspaceId,
+		tenantId: options.tenantId,
+	};
+	const mixedOwnerBatch = input.messages.some(
+		(message) => message.userId !== ownerScope.userId,
+	);
+	const scopedMessages = input.messages.map((message) =>
+		withGraphMetadata(message, {
+			userId: message.userId,
+			workspaceId: options.workspaceId,
+			tenantId: options.tenantId,
+		}),
+	);
+	const ids = await input.storage.storeMessages(scopedMessages);
+	if (options.enabled !== true) {
+		return { ids, graphEvolution: disabledResult(ownerScope) };
+	}
+
+	if (
+		mixedOwnerBatch ||
+		scopedMessages.some(
+			(message) => !sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
+		)
+	) {
+		return {
+			ids,
+			graphEvolution: {
+				status: "failed",
+				ownerScope,
+				consideredCandidateIds: [],
+				reasonCodes: ["memory_graph_scope_mismatch"],
+			},
+		};
+	}
+
+	const candidateLimit = options.candidateLimit ?? 200;
+	const newIds = new Set(scopedMessages.map((message) => message.messageId));
+	const candidates = (
+		await input.storage.queryMessages({
+			userId: ownerScope.userId,
+			includeArchived: false,
+			includeDeprecated: true,
+			reverse: true,
+			limit: candidateLimit + scopedMessages.length,
+		})
+	).filter(
+		(message) =>
+			!newIds.has(message.messageId) &&
+			!message.metadata?.[LEDGER_METADATA_KEY] &&
+			sameOwnerScope(ownerScopeFromMessage(message), ownerScope),
+	);
+	const store = createRawMessageMemoryGraphStore({
+		storage: input.storage,
+		ownerScope,
+		now: () => input.now ?? Date.now(),
+	});
+	const graphEvolution = await runMemoryGraphEvolution({
+		ownerScope,
+		newEvidence: scopedMessages.map(messageToEvidence),
+		candidateEvidence: candidates.map(messageToEvidence),
+		store,
+		enabled: true,
+		dryRun: options.dryRun,
+		now: input.now,
+	});
+	return { ids, graphEvolution };
+}

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -1,17 +1,21 @@
 import type {
+  RawMessageSemanticSearchInput,
+  RunRawMessageEmbeddingDreamInput,
+} from "./embedding";
+import type {
+  RunMemoryForgettingCycleResult,
+  RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions,
+} from "./forgetting";
+import type {
   MemorySummaryRecord,
   RawMessage,
   RawMessageEmbeddingUpdate,
   RawMessageQuery,
 } from "./manager";
 import type {
-  RunRawMessageEmbeddingDreamInput,
-  RawMessageSemanticSearchInput,
-} from "./embedding";
-import type {
-  RunMemoryForgettingCycleResult,
-  RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions,
-} from "./forgetting";
+  MemoryGraphEvolutionRunResult,
+  RawMessageGraphEvolutionOptions,
+} from "./memory-graph-evolution";
 
 export type SQLiteRawMessageQueryResultItem =
   | (RawMessage & { sourceType: "raw" })
@@ -259,17 +263,25 @@ export async function sqliteStoreRawMessagesFromInsight(
     embeddingUpdatedAt?: number;
     metadata?: Record<string, any>;
   }>,
-): Promise<{ success: boolean; stored: number; errors: number }> {
+  graphEvolution?: RawMessageGraphEvolutionOptions,
+): Promise<{
+  success: boolean;
+  stored: number;
+  errors: number;
+  graphEvolution?: MemoryGraphEvolutionRunResult;
+}> {
   const response = await requestSQLiteRawMessages<{
     success: boolean;
     stored: number;
     errors: number;
+    graphEvolution?: MemoryGraphEvolutionRunResult;
   }>("store", {
     messages: messages.map((message) => ({
       ...message,
       userId,
       createdAt: currentUnixSeconds(),
     })),
+    graphEvolution,
   });
   return response;
 }


### PR DESCRIPTION
## Summary
- Evolves the durable memory graph immediately after real raw-message writes when explicitly enabled.
- Discovers same-owner candidates, preserves applicability, and persists support, competition, related, cluster, and operation history in one versioned plan.
- Keeps baseline raw writes available when graph evolution is disabled or graph persistence fails.

## Contract
- Requirements: MR-1, MR-2, MR-3, MR-4, MR-9, MR-10.
- ADRs: ADR-0001, ADR-0002, ADR-0003, ADR-0005.
- Architecture: Candidate Discovery, Graph Interaction Engine, Memory Graph Store, New Evidence Interaction.
- Authoritative details: `packages/ai/memory-consolidation/docs/memory-graph-evolution-requirements.md`, architecture document, ADR index, and execution plan.

## Runtime path
`raw-message POST / IndexedDB insight fallback -> store raw evidence -> same-scope candidate query -> runMemoryGraphEvolution -> buildMemoryGraphEvolutionPlan -> owner-scoped archived graph ledger`

## Behavior and failure handling
- Repeated compatible evidence reinforces a cluster; duplicate source identities do not inflate support, including duplicates first stored while graph evolution was disabled.
- Contradictions create competition without immediate supersession; unrelated and applicability-mismatched evidence remains separate.
- Plan and operation identities are stable, completed replays are no-op, stale plans return version conflict, and same-process writes are serialized per owner scope.
- Ledger failure does not roll back a successful raw write; retry converges without duplicate reinforcement.
- Reserved internal ledger IDs/metadata are rejected, and every persisted nested graph object is owner-scope validated.
- No DB migration, UI, scheduler, or real LLM dependency.

## Verification
- Focused Vitest: 5 files, 65 tests passed.
- `tsc --noEmit --project packages/ai/memory-consolidation/tsconfig.json`: passed.
- apps/web `tsc --noEmit`: passed.
- Prettier check for all touched files: passed.
- Biome import-only check for touched TypeScript files: passed.
- `git diff --check origin/main...HEAD`: passed.