### PR TITLE
feat: add backend image generation provider layer

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -107,6 +107,41 @@ OPENAI_API_KEY=****
 # Optional: Custom base URL for OpenAI Audio API (defaults to https://api.openai.com/v1)
 # OPENAI_AUDIO_BASE_URL=https://api.openai.com/v1
 
+# Image Generation API (Lifestyle image Day 1 backend)
+# Provider selection: openai | openrouter | nano-banana
+# Keep real keys in apps/web/.env.local only. Do not commit local secrets.
+#
+# IMAGE_GENERATION_PROVIDER=openrouter
+# Optional global timeout for slow image providers.
+# IMAGE_GENERATION_TIMEOUT_MS=120000
+#
+# Official OpenAI Images API.
+# Reuses OPENAI_API_KEY above.
+# OPENAI_IMAGE_MODEL=gpt-image-2
+# OPENAI_IMAGE_BASE_URL=https://api.openai.com/v1
+# Optional full endpoint override. If set, this is used exactly and no path is appended.
+# OPENAI_IMAGE_GENERATION_URL=https://api.openai.com/v1/images/generations
+# OPENAI_IMAGE_TIMEOUT_MS=120000
+#
+# OpenRouter Images API.
+# API docs: https://openrouter.ai/docs/api/api-reference/images/generate-an-image
+# OPENROUTER_API_KEY=****
+# OPENROUTER_IMAGE_MODEL=bytedance-seed/seedream-4.5
+# OPENROUTER_IMAGE_BASE_URL=https://openrouter.ai/api/v1
+# Optional full endpoint override. If set, this is used exactly and no path is appended.
+# OPENROUTER_IMAGE_GENERATION_URL=https://openrouter.ai/api/v1/images
+# OPENROUTER_IMAGE_TIMEOUT_MS=120000
+#
+# Nano Banana or custom image provider.
+# Use IMAGE_GENERATION_URL when the provider gives a full endpoint.
+# Use BASE_URL only for OpenAI-compatible APIs where /v1/images/generations
+# should be appended automatically.
+# NANO_BANANA_API_KEY=****
+# NANO_BANANA_MODEL=nano-banana
+# NANO_BANANA_BASE_URL=https://provider.example/v1
+# NANO_BANANA_IMAGE_GENERATION_URL=https://provider.example/draw
+# NANO_BANANA_TIMEOUT_MS=120000
+
 # Vector store backend configuration (optional)
 # Desktop defaults to sqlite-vec. Set individual backends to "chroma" to use
 # ChromaDB as the semantic vector index instead.

--- a/apps/web/app/api/ai/v1/images/generations/route.ts
+++ b/apps/web/app/api/ai/v1/images/generations/route.ts
@@ -1,0 +1,171 @@
+import { auth } from "@/app/(auth)/auth";
+import { generateImageForApi } from "@/lib/ai/image-generation/service";
+import { isTauriMode } from "@/lib/env/constants";
+import type { ImageGenerationRequest } from "@openloomi/ai/agent";
+
+export const runtime = "nodejs";
+
+type ImageGenerationBody = {
+  prompt?: unknown;
+  provider?: unknown;
+  model?: unknown;
+  size?: unknown;
+  aspectRatio?: unknown;
+  quality?: unknown;
+  outputFormat?: unknown;
+  responseFormat?: unknown;
+  imageCount?: unknown;
+  n?: unknown;
+  referenceImageUrls?: unknown;
+  referenceImages?: unknown;
+};
+
+export async function POST(request: Request) {
+  const session = await auth().catch(() => null);
+  if (!session?.user?.id && !isTauriMode()) {
+    return Response.json(
+      { error: "Unauthorized", code: "unauthorized:auth" },
+      { status: 401 },
+    );
+  }
+
+  const body = (await request
+    .json()
+    .catch(() => null)) as ImageGenerationBody | null;
+  const normalized = normalizeImageGenerationBody(body);
+
+  if (!normalized.ok) {
+    return Response.json(
+      {
+        success: false,
+        error: normalized.error,
+        errorType: "validation_error",
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await generateImageForApi(normalized.request);
+  return Response.json(result, {
+    status: result.success ? 200 : statusFromErrorType(result.errorType),
+  });
+}
+
+function normalizeImageGenerationBody(
+  body: ImageGenerationBody | null,
+):
+  | { ok: true; request: ImageGenerationRequest }
+  | { ok: false; error: string } {
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "Invalid image generation payload" };
+  }
+
+  const prompt = normalizeRequiredString(body.prompt);
+  if (!prompt) {
+    return { ok: false, error: "prompt is required" };
+  }
+
+  const imageCount = normalizeImageCount(body.imageCount ?? body.n);
+  return {
+    ok: true,
+    request: {
+      prompt,
+      provider: normalizeOptionalString(body.provider),
+      model: normalizeOptionalString(body.model),
+      size: normalizeOptionalString(body.size),
+      aspectRatio: normalizeOptionalString(body.aspectRatio),
+      quality: normalizeQuality(body.quality),
+      outputFormat: normalizeOutputFormat(body.outputFormat),
+      responseFormat: normalizeResponseFormat(body.responseFormat),
+      imageCount,
+      n: imageCount,
+      referenceImageUrls: normalizeStringArray(body.referenceImageUrls),
+      referenceImages: Array.isArray(body.referenceImages)
+        ? (body.referenceImages as ImageGenerationRequest["referenceImages"])
+        : undefined,
+    },
+  };
+}
+
+function statusFromErrorType(errorType?: string): number {
+  switch (errorType) {
+    case "configuration_error":
+    case "validation_error":
+    case "provider_not_found":
+      return 400;
+    case "rate_limit":
+      return 429;
+    case "timeout":
+      return 504;
+    case "provider_error":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+function normalizeRequiredString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeImageCount(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(1, Math.min(4, Math.floor(value)));
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value
+    .map((item) => normalizeOptionalString(item))
+    .filter((item): item is string => Boolean(item));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeQuality(
+  value: unknown,
+): ImageGenerationRequest["quality"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (
+    normalized === "auto" ||
+    normalized === "low" ||
+    normalized === "medium" ||
+    normalized === "high" ||
+    normalized === "standard" ||
+    normalized === "hd"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeOutputFormat(
+  value: unknown,
+): ImageGenerationRequest["outputFormat"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (normalized === "png" || normalized === "jpeg" || normalized === "webp") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeResponseFormat(
+  value: unknown,
+): ImageGenerationRequest["responseFormat"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (
+    normalized === "url" ||
+    normalized === "b64_json" ||
+    normalized === "data_url"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}

--- a/apps/web/app/api/ai/v1/images/generations/route.ts
+++ b/apps/web/app/api/ai/v1/images/generations/route.ts
@@ -1,7 +1,11 @@
 import { auth } from "@/app/(auth)/auth";
 import { generateImageForApi } from "@/lib/ai/image-generation/service";
+import { recordImageGenerationUsage } from "@/lib/ai/image-generation/usage";
 import { isTauriMode } from "@/lib/env/constants";
-import type { ImageGenerationRequest } from "@openloomi/ai/agent";
+import type {
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from "@openloomi/ai/agent";
 
 export const runtime = "nodejs";
 
@@ -46,9 +50,33 @@ export async function POST(request: Request) {
   }
 
   const result = await generateImageForApi(normalized.request);
+  await recordUsageSafely(session?.user?.id ?? null, result);
   return Response.json(result, {
     status: result.success ? 200 : statusFromErrorType(result.errorType),
   });
+}
+
+async function recordUsageSafely(
+  userId: string | null,
+  result: ImageGenerationResponse,
+): Promise<void> {
+  try {
+    await recordImageGenerationUsage({
+      userId,
+      endpoint: "api/ai/v1/images/generations",
+      provider: result.provider,
+      model: result.model,
+      imageCount: result.imageCount,
+      creditsUsed: result.creditsUsed ?? 0,
+      status: result.success ? "success" : "failed",
+      errorType: result.errorType,
+      costMode: "estimated",
+      quotaMode: "record_only",
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    console.warn("[image-generation] usage tracking failed", error);
+  }
 }
 
 function normalizeImageGenerationBody(

--- a/apps/web/lib/ai/image-generation/service.ts
+++ b/apps/web/lib/ai/image-generation/service.ts
@@ -1,0 +1,61 @@
+import {
+  __resetImageGenProvidersForTests,
+  generateImage,
+  NanoBananaImageGenProvider,
+  OpenAIImageGenProvider,
+  registerImageGenProvider,
+  type ImageGenerationRequest,
+  type ImageGenerationResponse,
+} from "@openloomi/ai/agent";
+
+let providersRegistered = false;
+
+export async function generateImageForApi(
+  request: ImageGenerationRequest,
+): Promise<ImageGenerationResponse> {
+  ensureImageGenerationProvidersRegistered();
+  return generateImage({
+    ...request,
+    provider:
+      normalizeOptionalString(request.provider) ||
+      normalizeOptionalString(process.env.IMAGE_GENERATION_PROVIDER),
+  });
+}
+
+export function ensureImageGenerationProvidersRegistered(): void {
+  if (providersRegistered) return;
+
+  registerImageGenProvider(
+    new OpenAIImageGenProvider({
+      apiKey: normalizeOptionalString(process.env.OPENAI_API_KEY),
+      baseUrl: normalizeOptionalString(process.env.OPENAI_IMAGE_BASE_URL),
+      defaultModel: normalizeOptionalString(process.env.OPENAI_IMAGE_MODEL),
+    }),
+  );
+
+  registerImageGenProvider(
+    new NanoBananaImageGenProvider({
+      apiKey: normalizeOptionalString(process.env.NANO_BANANA_API_KEY),
+      baseUrl: normalizeOptionalString(process.env.NANO_BANANA_BASE_URL),
+      imageGenerationUrl: normalizeOptionalString(
+        process.env.NANO_BANANA_IMAGE_GENERATION_URL,
+      ),
+      defaultModel: normalizeOptionalString(process.env.NANO_BANANA_MODEL),
+    }),
+  );
+
+  providersRegistered = true;
+}
+
+export function __resetImageGenerationServiceForTests(): void {
+  providersRegistered = false;
+  __resetImageGenProvidersForTests();
+}
+
+function normalizeOptionalString(
+  value: string | null | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/apps/web/lib/ai/image-generation/service.ts
+++ b/apps/web/lib/ai/image-generation/service.ts
@@ -3,6 +3,7 @@ import {
   generateImage,
   NanoBananaImageGenProvider,
   OpenAIImageGenProvider,
+  OpenRouterImageGenProvider,
   registerImageGenProvider,
   type ImageGenerationRequest,
   type ImageGenerationResponse,
@@ -29,7 +30,31 @@ export function ensureImageGenerationProvidersRegistered(): void {
     new OpenAIImageGenProvider({
       apiKey: normalizeOptionalString(process.env.OPENAI_API_KEY),
       baseUrl: normalizeOptionalString(process.env.OPENAI_IMAGE_BASE_URL),
+      imageGenerationUrl: normalizeOptionalString(
+        process.env.OPENAI_IMAGE_GENERATION_URL,
+      ),
       defaultModel: normalizeOptionalString(process.env.OPENAI_IMAGE_MODEL),
+      timeoutMs: normalizePositiveInteger(
+        process.env.OPENAI_IMAGE_TIMEOUT_MS ||
+          process.env.IMAGE_GENERATION_TIMEOUT_MS,
+      ),
+    }),
+  );
+
+  registerImageGenProvider(
+    new OpenRouterImageGenProvider({
+      apiKey: normalizeOptionalString(process.env.OPENROUTER_API_KEY),
+      baseUrl: normalizeOptionalString(process.env.OPENROUTER_IMAGE_BASE_URL),
+      imageGenerationUrl: normalizeOptionalString(
+        process.env.OPENROUTER_IMAGE_GENERATION_URL,
+      ),
+      defaultModel: normalizeOptionalString(process.env.OPENROUTER_IMAGE_MODEL),
+      timeoutMs: normalizePositiveInteger(
+        process.env.OPENROUTER_IMAGE_TIMEOUT_MS ||
+          process.env.IMAGE_GENERATION_TIMEOUT_MS,
+      ),
+      referer: normalizeOptionalString(process.env.NEXT_PUBLIC_APP_URL),
+      title: "OpenLoomi",
     }),
   );
 
@@ -41,6 +66,10 @@ export function ensureImageGenerationProvidersRegistered(): void {
         process.env.NANO_BANANA_IMAGE_GENERATION_URL,
       ),
       defaultModel: normalizeOptionalString(process.env.NANO_BANANA_MODEL),
+      timeoutMs: normalizePositiveInteger(
+        process.env.NANO_BANANA_TIMEOUT_MS ||
+          process.env.IMAGE_GENERATION_TIMEOUT_MS,
+      ),
     }),
   );
 
@@ -58,4 +87,13 @@ function normalizeOptionalString(
   if (!value) return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizePositiveInteger(
+  value: string | null | undefined,
+): number | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) return undefined;
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }

--- a/apps/web/lib/ai/image-generation/usage.ts
+++ b/apps/web/lib/ai/image-generation/usage.ts
@@ -1,0 +1,37 @@
+export type ImageGenerationUsageStatus = "success" | "failed";
+
+export type ImageGenerationUsageRecord = {
+  userId: string | null;
+  endpoint: "api/ai/v1/images/generations";
+  provider: string;
+  model: string;
+  imageCount: number;
+  creditsUsed: number;
+  status: ImageGenerationUsageStatus;
+  errorType?: string;
+  costMode: "estimated";
+  quotaMode: "record_only";
+  createdAt: Date;
+};
+
+type ImageGenerationUsageRecorder = (
+  record: ImageGenerationUsageRecord,
+) => Promise<void> | void;
+
+let usageRecorder: ImageGenerationUsageRecorder = async () => {};
+
+export async function recordImageGenerationUsage(
+  record: ImageGenerationUsageRecord,
+): Promise<void> {
+  await usageRecorder(record);
+}
+
+export function __setImageGenerationUsageRecorderForTests(
+  recorder: ImageGenerationUsageRecorder,
+): void {
+  usageRecorder = recorder;
+}
+
+export function __resetImageGenerationUsageRecorderForTests(): void {
+  usageRecorder = async () => {};
+}

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -43,13 +43,23 @@ describe("POST /api/ai/v1/images/generations", () => {
     authState.user = { id: "user-image-generation", type: "regular" };
     envState.tauriMode = false;
     delete process.env.IMAGE_GENERATION_PROVIDER;
+    delete process.env.NEXT_PUBLIC_APP_URL;
     delete process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_IMAGE_MODEL;
     delete process.env.OPENAI_IMAGE_BASE_URL;
+    delete process.env.OPENAI_IMAGE_GENERATION_URL;
+    delete process.env.OPENAI_IMAGE_TIMEOUT_MS;
+    delete process.env.IMAGE_GENERATION_TIMEOUT_MS;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_IMAGE_BASE_URL;
+    delete process.env.OPENROUTER_IMAGE_GENERATION_URL;
+    delete process.env.OPENROUTER_IMAGE_MODEL;
+    delete process.env.OPENROUTER_IMAGE_TIMEOUT_MS;
     delete process.env.NANO_BANANA_API_KEY;
     delete process.env.NANO_BANANA_BASE_URL;
     delete process.env.NANO_BANANA_IMAGE_GENERATION_URL;
     delete process.env.NANO_BANANA_MODEL;
+    delete process.env.NANO_BANANA_TIMEOUT_MS;
   });
 
   test("returns 401 when unauthenticated outside Tauri", async () => {
@@ -133,6 +143,83 @@ describe("POST /api/ai/v1/images/generations", () => {
       mimeType: "image/png",
     });
     expect(body.creditsUsed).toBeGreaterThan(0);
+  });
+
+  test("uses OpenAI full image generation endpoint without appending a path", async () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.OPENAI_IMAGE_GENERATION_URL = "https://images.example/draw";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: "aGVsbG8=" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "a lifestyle image",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://images.example/draw",
+      expect.any(Object),
+    );
+  });
+
+  test("uses OpenRouter image API shape with aspect_ratio output", async () => {
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+    process.env.OPENROUTER_IMAGE_MODEL = "bytedance-seed/seedream-4.5";
+    process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: "aGVsbG8=" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "openrouter",
+        prompt: "a lifestyle image",
+        size: "1024x1024",
+        outputFormat: "png",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/images",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-openrouter-key",
+          "HTTP-Referer": "http://localhost:3000",
+          "X-Title": "OpenLoomi",
+        }),
+      }),
+    );
+    const [, options] = fetchMock.mock.calls[0];
+    const payload = JSON.parse((options as RequestInit).body as string);
+    expect(payload).toMatchObject({
+      model: "bytedance-seed/seedream-4.5",
+      prompt: "a lifestyle image",
+      aspect_ratio: "1:1",
+      output_format: "png",
+    });
+    expect(payload.size).toBeUndefined();
+
+    expect(await response.json()).toMatchObject({
+      success: true,
+      provider: "openrouter",
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+    });
   });
 
   test("uses request provider over env default and accepts Nano Banana url output", async () => {

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -33,12 +33,38 @@ import {
 
 const fetchMock = vi.fn();
 const usageRecords: ImageGenerationUsageRecord[] = [];
+const IMAGE_GENERATION_ENV_KEYS = [
+  "IMAGE_GENERATION_PROVIDER",
+  "NEXT_PUBLIC_APP_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_IMAGE_MODEL",
+  "OPENAI_IMAGE_BASE_URL",
+  "OPENAI_IMAGE_GENERATION_URL",
+  "OPENAI_IMAGE_TIMEOUT_MS",
+  "IMAGE_GENERATION_TIMEOUT_MS",
+  "OPENROUTER_API_KEY",
+  "OPENROUTER_IMAGE_BASE_URL",
+  "OPENROUTER_IMAGE_GENERATION_URL",
+  "OPENROUTER_IMAGE_MODEL",
+  "OPENROUTER_IMAGE_TIMEOUT_MS",
+  "NANO_BANANA_API_KEY",
+  "NANO_BANANA_BASE_URL",
+  "NANO_BANANA_IMAGE_GENERATION_URL",
+  "NANO_BANANA_MODEL",
+  "NANO_BANANA_TIMEOUT_MS",
+];
 
 function request(body: unknown): Request {
   return new Request("http://localhost/api/ai/v1/images/generations", {
     method: "POST",
     body: JSON.stringify(body),
   });
+}
+
+function clearImageGenerationEnv(): void {
+  for (const key of IMAGE_GENERATION_ENV_KEYS) {
+    Reflect.deleteProperty(process.env, key);
+  }
 }
 
 describe("POST /api/ai/v1/images/generations", () => {
@@ -53,24 +79,7 @@ describe("POST /api/ai/v1/images/generations", () => {
     });
     authState.user = { id: "user-image-generation", type: "regular" };
     envState.tauriMode = false;
-    delete process.env.IMAGE_GENERATION_PROVIDER;
-    delete process.env.NEXT_PUBLIC_APP_URL;
-    delete process.env.OPENAI_API_KEY;
-    delete process.env.OPENAI_IMAGE_MODEL;
-    delete process.env.OPENAI_IMAGE_BASE_URL;
-    delete process.env.OPENAI_IMAGE_GENERATION_URL;
-    delete process.env.OPENAI_IMAGE_TIMEOUT_MS;
-    delete process.env.IMAGE_GENERATION_TIMEOUT_MS;
-    delete process.env.OPENROUTER_API_KEY;
-    delete process.env.OPENROUTER_IMAGE_BASE_URL;
-    delete process.env.OPENROUTER_IMAGE_GENERATION_URL;
-    delete process.env.OPENROUTER_IMAGE_MODEL;
-    delete process.env.OPENROUTER_IMAGE_TIMEOUT_MS;
-    delete process.env.NANO_BANANA_API_KEY;
-    delete process.env.NANO_BANANA_BASE_URL;
-    delete process.env.NANO_BANANA_IMAGE_GENERATION_URL;
-    delete process.env.NANO_BANANA_MODEL;
-    delete process.env.NANO_BANANA_TIMEOUT_MS;
+    clearImageGenerationEnv();
   });
 
   test("returns 401 when unauthenticated outside Tauri", async () => {

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -25,8 +25,14 @@ vi.mock("@/lib/env/constants", () => ({
 
 import { POST } from "@/app/api/ai/v1/images/generations/route";
 import { __resetImageGenerationServiceForTests } from "@/lib/ai/image-generation/service";
+import {
+  __resetImageGenerationUsageRecorderForTests,
+  __setImageGenerationUsageRecorderForTests,
+  type ImageGenerationUsageRecord,
+} from "@/lib/ai/image-generation/usage";
 
 const fetchMock = vi.fn();
+const usageRecords: ImageGenerationUsageRecord[] = [];
 
 function request(body: unknown): Request {
   return new Request("http://localhost/api/ai/v1/images/generations", {
@@ -39,7 +45,12 @@ describe("POST /api/ai/v1/images/generations", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockReset();
+    usageRecords.length = 0;
     __resetImageGenerationServiceForTests();
+    __resetImageGenerationUsageRecorderForTests();
+    __setImageGenerationUsageRecorderForTests((record) => {
+      usageRecords.push(record);
+    });
     authState.user = { id: "user-image-generation", type: "regular" };
     envState.tauriMode = false;
     delete process.env.IMAGE_GENERATION_PROVIDER;
@@ -94,6 +105,19 @@ describe("POST /api/ai/v1/images/generations", () => {
       success: false,
       provider: "openai",
       errorType: "configuration_error",
+    });
+    expect(usageRecords).toHaveLength(1);
+    expect(usageRecords[0]).toMatchObject({
+      userId: "user-image-generation",
+      endpoint: "api/ai/v1/images/generations",
+      provider: "openai",
+      model: "gpt-image-2",
+      imageCount: 1,
+      creditsUsed: 750,
+      status: "failed",
+      errorType: "configuration_error",
+      costMode: "estimated",
+      quotaMode: "record_only",
     });
   });
 
@@ -219,6 +243,18 @@ describe("POST /api/ai/v1/images/generations", () => {
       success: true,
       provider: "openrouter",
       dataUrl: "data:image/png;base64,aGVsbG8=",
+    });
+    expect(usageRecords).toHaveLength(1);
+    expect(usageRecords[0]).toMatchObject({
+      userId: "user-image-generation",
+      endpoint: "api/ai/v1/images/generations",
+      provider: "openrouter",
+      model: "bytedance-seed/seedream-4.5",
+      imageCount: 1,
+      creditsUsed: 750,
+      status: "success",
+      costMode: "estimated",
+      quotaMode: "record_only",
     });
   });
 

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type AuthUser = { id: string; type: "regular" };
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: "user-image-generation",
+    type: "regular" as const,
+  } as AuthUser | null,
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: async () => (authState.user ? { user: authState.user } : null),
+}));
+
+const envState = vi.hoisted(() => ({
+  tauriMode: false,
+}));
+
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: () => envState.tauriMode,
+}));
+
+import { POST } from "@/app/api/ai/v1/images/generations/route";
+import { __resetImageGenerationServiceForTests } from "@/lib/ai/image-generation/service";
+
+const fetchMock = vi.fn();
+
+function request(body: unknown): Request {
+  return new Request("http://localhost/api/ai/v1/images/generations", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/ai/v1/images/generations", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    __resetImageGenerationServiceForTests();
+    authState.user = { id: "user-image-generation", type: "regular" };
+    envState.tauriMode = false;
+    delete process.env.IMAGE_GENERATION_PROVIDER;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_IMAGE_MODEL;
+    delete process.env.OPENAI_IMAGE_BASE_URL;
+    delete process.env.NANO_BANANA_API_KEY;
+    delete process.env.NANO_BANANA_BASE_URL;
+    delete process.env.NANO_BANANA_IMAGE_GENERATION_URL;
+    delete process.env.NANO_BANANA_MODEL;
+  });
+
+  test("returns 401 when unauthenticated outside Tauri", async () => {
+    authState.user = null;
+
+    const response = await POST(request({ prompt: "test" }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: "Unauthorized",
+      code: "unauthorized:auth",
+    });
+  });
+
+  test("returns validation error when prompt is missing", async () => {
+    const response = await POST(request({ provider: "openai" }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      errorType: "validation_error",
+    });
+  });
+
+  test("returns configuration error when selected provider is missing env", async () => {
+    const response = await POST(
+      request({ provider: "openai", prompt: "a lifestyle image" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      provider: "openai",
+      errorType: "configuration_error",
+    });
+  });
+
+  test("normalizes OpenAI b64_json into a dataUrl", async () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              b64_json: "aGVsbG8=",
+              revised_prompt: "a revised lifestyle image",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "openai",
+        prompt: "a lifestyle image",
+        size: "1024x1024",
+        outputFormat: "png",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/images/generations",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-openai-key",
+        }),
+      }),
+    );
+    const body = await response.json();
+    expect(body).toMatchObject({
+      success: true,
+      provider: "openai",
+      model: "gpt-image-2",
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+      b64Json: "aGVsbG8=",
+      mimeType: "image/png",
+    });
+    expect(body.creditsUsed).toBeGreaterThan(0);
+  });
+
+  test("uses request provider over env default and accepts Nano Banana url output", async () => {
+    process.env.IMAGE_GENERATION_PROVIDER = "openai";
+    process.env.NANO_BANANA_API_KEY = "test-nano-key";
+    process.env.NANO_BANANA_IMAGE_GENERATION_URL =
+      "https://nano.example/images";
+    process.env.NANO_BANANA_MODEL = "nano-banana";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              url: "https://cdn.example/generated.png",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "nano-banana",
+        prompt: "a lifestyle image",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://nano.example/images",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-nano-key",
+          "x-api-key": "test-nano-key",
+        }),
+      }),
+    );
+    expect(await response.json()).toMatchObject({
+      success: true,
+      provider: "nano-banana",
+      imageUrl: "https://cdn.example/generated.png",
+    });
+  });
+});

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -13,6 +13,7 @@
     "./agent/native-cli": "./src/agent/native-cli/index.ts",
     "./agent/native-runner": "./src/agent/native-runner/index.ts",
     "./agent/runtime": "./src/agent/runtime/index.ts",
+    "./agent/image-gen": "./src/agent/image-gen/index.ts",
     "./agent/sandbox": "./src/agent/sandbox/index.ts",
     "./agent/sandbox/types": "./src/agent/sandbox/types.ts",
     "./agent/sandbox/plugin": "./src/agent/sandbox/plugin.ts",

--- a/packages/ai/src/agent/image-gen/base.ts
+++ b/packages/ai/src/agent/image-gen/base.ts
@@ -1,0 +1,50 @@
+import type {
+  ImageGenerationCapabilities,
+  ImageGenerationModality,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+  ImageModelInfo,
+} from "./types";
+
+export abstract class ImageGenProvider {
+  abstract get name(): string;
+  abstract get displayName(): string;
+
+  abstract isAvailable(): boolean;
+  abstract listModels(): ImageModelInfo[];
+  abstract defaultModel(): string | null;
+  abstract capabilities(): ImageGenerationCapabilities;
+
+  abstract generate(
+    request: ImageGenerationRequest,
+  ): Promise<ImageGenerationResponse>;
+
+  protected routeModality(
+    request: Pick<
+      ImageGenerationRequest,
+      "referenceImageUrls" | "referenceImages"
+    >,
+  ): ImageGenerationModality {
+    return request.referenceImageUrls?.length || request.referenceImages?.length
+      ? "image"
+      : "text";
+  }
+
+  protected dataUrlFromBase64(base64: string, mimeType = "image/png"): string {
+    const stripped = this.stripDataUrlPrefix(base64);
+    return `data:${mimeType};base64,${stripped}`;
+  }
+
+  protected stripDataUrlPrefix(value: string): string {
+    const trimmed = value.trim();
+    const marker = ";base64,";
+    const markerIndex = trimmed.indexOf(marker);
+    return markerIndex >= 0
+      ? trimmed.slice(markerIndex + marker.length)
+      : trimmed;
+  }
+
+  protected async sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/ai/src/agent/image-gen/index.ts
+++ b/packages/ai/src/agent/image-gen/index.ts
@@ -26,4 +26,5 @@ export {
 } from "./registry";
 
 export { OpenAIImageGenProvider } from "./providers/openai";
+export { OpenRouterImageGenProvider } from "./providers/openrouter";
 export { NanoBananaImageGenProvider } from "./providers/nano-banana";

--- a/packages/ai/src/agent/image-gen/index.ts
+++ b/packages/ai/src/agent/image-gen/index.ts
@@ -1,0 +1,29 @@
+export type {
+  GeneratedImage,
+  ImageGenerationCapabilities,
+  ImageGenerationErrorType,
+  ImageGenerationModality,
+  ImageGenerationOutputFormat,
+  ImageGenerationProviderName,
+  ImageGenerationQuality,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+  ImageGenerationResponseFormat,
+  ImageModelInfo,
+  ImageReference,
+} from "./types";
+
+export { ImageGenProvider } from "./base";
+
+export {
+  __resetImageGenProvidersForTests,
+  generateImage,
+  getAllImageGenProviders,
+  getDefaultImageGenProvider,
+  getImageGenProvider,
+  getImageGenProviderCapabilities,
+  registerImageGenProvider,
+} from "./registry";
+
+export { OpenAIImageGenProvider } from "./providers/openai";
+export { NanoBananaImageGenProvider } from "./providers/nano-banana";

--- a/packages/ai/src/agent/image-gen/providers/nano-banana.ts
+++ b/packages/ai/src/agent/image-gen/providers/nano-banana.ts
@@ -1,0 +1,438 @@
+import { calculateImageCredits } from "../../billing/model-pricing";
+import { ImageGenProvider } from "../base";
+import type {
+  GeneratedImage,
+  ImageGenerationCapabilities,
+  ImageGenerationOutputFormat,
+  ImageGenerationQuality,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+  ImageModelInfo,
+} from "../types";
+
+const DEFAULT_MODEL = "nano-banana";
+const DEFAULT_SIZE = "1024x1024";
+
+const NANO_BANANA_MODELS: ImageModelInfo[] = [
+  {
+    id: "nano-banana",
+    name: "nano-banana",
+    displayName: "Nano Banana",
+    supportedModality: ["text"],
+    supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+    supportedQualities: ["auto", "low", "medium", "high"],
+    supportedOutputFormats: ["png", "jpeg", "webp"],
+  },
+];
+
+const NANO_BANANA_CAPABILITIES: ImageGenerationCapabilities = {
+  supportsTextToImage: true,
+  supportsImageReference: false,
+  supportsUrlOutput: true,
+  supportsBase64Output: true,
+  supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+  supportedQualities: ["auto", "low", "medium", "high"],
+  supportedOutputFormats: ["png", "jpeg", "webp"],
+};
+
+type NanoBananaImageGenProviderOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  imageGenerationUrl?: string;
+  defaultModel?: string;
+};
+
+type ProviderImageCandidate = {
+  url?: unknown;
+  image_url?: unknown;
+  b64_json?: unknown;
+  base64?: unknown;
+  data_url?: unknown;
+  image?: unknown;
+  revised_prompt?: unknown;
+};
+
+export class NanoBananaImageGenProvider extends ImageGenProvider {
+  private apiKey?: string;
+  private baseUrl?: string;
+  private imageGenerationUrl?: string;
+  private model: string;
+
+  constructor(options: NanoBananaImageGenProviderOptions = {}) {
+    super();
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl;
+    this.imageGenerationUrl = options.imageGenerationUrl;
+    this.model = options.defaultModel || DEFAULT_MODEL;
+  }
+
+  get name(): string {
+    return "nano-banana";
+  }
+
+  get displayName(): string {
+    return "Nano Banana";
+  }
+
+  isAvailable(): boolean {
+    return Boolean(this.apiKey?.trim() && this.resolveEndpoint());
+  }
+
+  listModels(): ImageModelInfo[] {
+    return NANO_BANANA_MODELS;
+  }
+
+  defaultModel(): string | null {
+    return this.isAvailable() ? this.model : null;
+  }
+
+  capabilities(): ImageGenerationCapabilities {
+    return NANO_BANANA_CAPABILITIES;
+  }
+
+  async generate(
+    request: ImageGenerationRequest,
+  ): Promise<ImageGenerationResponse> {
+    const model = request.model || this.model;
+    const imageCount = normalizeImageCount(request.imageCount ?? request.n);
+    const modality = this.routeModality(request);
+    const creditsUsed = calculateImageCredits(
+      model,
+      imageCount,
+      qualityForBilling(request.quality),
+    );
+    const endpoint = this.resolveEndpoint();
+
+    if (!this.apiKey?.trim() || !endpoint) {
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error:
+          "Nano Banana provider is not configured. Set NANO_BANANA_API_KEY and NANO_BANANA_IMAGE_GENERATION_URL or NANO_BANANA_BASE_URL.",
+        errorType: "configuration_error",
+      });
+    }
+
+    if (modality === "image") {
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error:
+          "Reference images are not supported by the Day 1 Nano Banana text-to-image provider.",
+        errorType: "validation_error",
+      });
+    }
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "x-api-key": this.apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildPayload(request, model, imageCount)),
+        signal: AbortSignal.timeout(120_000),
+      });
+
+      const text = await response.text();
+      const parsed = parseJson<Record<string, unknown>>(text);
+
+      if (!response.ok) {
+        return failure({
+          model,
+          prompt: request.prompt,
+          imageCount,
+          modality,
+          creditsUsed,
+          error:
+            extractErrorMessage(parsed) ||
+            `Nano Banana API error ${response.status}: ${text}`,
+          errorType: mapStatusToErrorType(response.status),
+        });
+      }
+
+      const images = normalizeImages(parsed, request.outputFormat);
+      if (images.length === 0) {
+        return failure({
+          model,
+          prompt: request.prompt,
+          imageCount,
+          modality,
+          creditsUsed,
+          error: "Nano Banana API returned no image data",
+          errorType: "provider_error",
+        });
+      }
+
+      const first = images[0];
+      return {
+        success: true,
+        provider: this.name,
+        model,
+        prompt: request.prompt,
+        modality,
+        imageCount: images.length,
+        images,
+        imageUrl: first.imageUrl,
+        b64Json: first.b64Json,
+        dataUrl: first.dataUrl,
+        mimeType: first.mimeType,
+        creditsUsed,
+      };
+    } catch (error) {
+      const isTimeout =
+        error instanceof DOMException && error.name === "TimeoutError";
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Nano Banana image generation failed",
+        errorType: isTimeout ? "timeout" : "unknown_error",
+      });
+    }
+  }
+
+  private resolveEndpoint(): string | undefined {
+    const direct = normalizeOptionalString(this.imageGenerationUrl);
+    if (direct) return direct;
+
+    const base = normalizeOptionalString(this.baseUrl);
+    if (!base) return undefined;
+    const normalized = base.replace(/\/+$/, "");
+    if (normalized.endsWith("/images/generations")) return normalized;
+    if (normalized.endsWith("/v1")) return `${normalized}/images/generations`;
+    return `${normalized}/v1/images/generations`;
+  }
+}
+
+function buildPayload(
+  request: ImageGenerationRequest,
+  model: string,
+  imageCount: number,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    model,
+    prompt: request.prompt,
+    n: imageCount,
+    size: request.size || DEFAULT_SIZE,
+  };
+
+  if (request.quality) payload.quality = request.quality;
+  if (request.outputFormat) payload.output_format = request.outputFormat;
+  if (request.responseFormat) {
+    payload.response_format =
+      request.responseFormat === "data_url"
+        ? "b64_json"
+        : request.responseFormat;
+  }
+
+  return payload;
+}
+
+function normalizeImages(
+  result: Record<string, unknown> | null,
+  outputFormat?: ImageGenerationOutputFormat,
+): GeneratedImage[] {
+  const candidates = collectCandidates(result);
+  const mimeType = mimeTypeForOutputFormat(outputFormat);
+  return candidates
+    .map((candidate): GeneratedImage | null => {
+      const revisedPrompt =
+        typeof candidate.revised_prompt === "string"
+          ? candidate.revised_prompt
+          : undefined;
+      const url = firstString(candidate.url, candidate.image_url);
+      if (url) {
+        return isDataUrl(url)
+          ? dataUrlImage(url, revisedPrompt)
+          : { imageUrl: url, mimeType, revisedPrompt };
+      }
+
+      const dataUrl = firstString(candidate.data_url);
+      if (dataUrl) return dataUrlImage(dataUrl, revisedPrompt);
+
+      const encoded = firstString(candidate.b64_json, candidate.base64);
+      if (encoded) return base64Image(encoded, mimeType, revisedPrompt);
+
+      if (typeof candidate.image === "string") {
+        if (isDataUrl(candidate.image)) {
+          return dataUrlImage(candidate.image, revisedPrompt);
+        }
+        if (isHttpUrl(candidate.image)) {
+          return {
+            imageUrl: candidate.image,
+            mimeType,
+            revisedPrompt,
+          };
+        }
+        return base64Image(candidate.image, mimeType, revisedPrompt);
+      }
+
+      return null;
+    })
+    .filter((image): image is GeneratedImage => image !== null);
+}
+
+function collectCandidates(
+  result: Record<string, unknown> | null,
+): ProviderImageCandidate[] {
+  if (!result) return [];
+  const candidates: ProviderImageCandidate[] = [];
+  for (const key of ["data", "images", "output", "result"]) {
+    const value = result[key];
+    if (Array.isArray(value)) {
+      candidates.push(...(value as ProviderImageCandidate[]));
+    } else if (value && typeof value === "object") {
+      candidates.push(value as ProviderImageCandidate);
+    }
+  }
+  candidates.push(result as ProviderImageCandidate);
+  return candidates;
+}
+
+function failure(args: {
+  model: string;
+  prompt: string;
+  imageCount: number;
+  modality: "text" | "image";
+  creditsUsed: number;
+  error: string;
+  errorType: ImageGenerationResponse["errorType"];
+}): ImageGenerationResponse {
+  return {
+    success: false,
+    provider: "nano-banana",
+    model: args.model,
+    prompt: args.prompt,
+    modality: args.modality,
+    imageCount: args.imageCount,
+    creditsUsed: args.creditsUsed,
+    error: args.error,
+    errorType: args.errorType,
+  };
+}
+
+function dataUrlImage(dataUrl: string, revisedPrompt?: string): GeneratedImage {
+  const mimeType = dataUrl.slice(5, dataUrl.indexOf(";base64,")) || "image/png";
+  return {
+    b64Json: stripDataUrlPrefix(dataUrl),
+    dataUrl,
+    mimeType,
+    revisedPrompt,
+  };
+}
+
+function base64Image(
+  base64: string,
+  mimeType: string,
+  revisedPrompt?: string,
+): GeneratedImage {
+  const b64Json = stripDataUrlPrefix(base64);
+  return {
+    b64Json,
+    dataUrl: `data:${mimeType};base64,${b64Json}`,
+    mimeType,
+    revisedPrompt,
+  };
+}
+
+function mapStatusToErrorType(
+  status: number,
+): ImageGenerationResponse["errorType"] {
+  if (status === 401 || status === 403) return "configuration_error";
+  if (status === 429) return "rate_limit";
+  if (status >= 500) return "provider_error";
+  return "provider_error";
+}
+
+function extractErrorMessage(
+  result: Record<string, unknown> | null,
+): string | undefined {
+  const error = result?.error;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  const message = result?.message;
+  return typeof message === "string" ? message : undefined;
+}
+
+function parseJson<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function normalizeOptionalString(
+  value: string | null | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeImageCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(4, Math.floor(value)));
+}
+
+function qualityForBilling(
+  quality: ImageGenerationQuality | undefined,
+): "standard" | "hd" {
+  return quality === "high" || quality === "hd" ? "hd" : "standard";
+}
+
+function mimeTypeForOutputFormat(
+  outputFormat?: ImageGenerationOutputFormat,
+): string {
+  switch (outputFormat) {
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "png":
+    default:
+      return "image/png";
+  }
+}
+
+function stripDataUrlPrefix(value: string): string {
+  const marker = ";base64,";
+  const trimmed = value.trim();
+  const markerIndex = trimmed.indexOf(marker);
+  return markerIndex >= 0
+    ? trimmed.slice(markerIndex + marker.length)
+    : trimmed;
+}
+
+function isDataUrl(value: string): boolean {
+  return /^data:image\/[a-z0-9.+-]+;base64,/i.test(value);
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}

--- a/packages/ai/src/agent/image-gen/providers/nano-banana.ts
+++ b/packages/ai/src/agent/image-gen/providers/nano-banana.ts
@@ -40,6 +40,7 @@ type NanoBananaImageGenProviderOptions = {
   baseUrl?: string;
   imageGenerationUrl?: string;
   defaultModel?: string;
+  timeoutMs?: number;
 };
 
 type ProviderImageCandidate = {
@@ -57,6 +58,7 @@ export class NanoBananaImageGenProvider extends ImageGenProvider {
   private baseUrl?: string;
   private imageGenerationUrl?: string;
   private model: string;
+  private timeoutMs: number;
 
   constructor(options: NanoBananaImageGenProviderOptions = {}) {
     super();
@@ -64,6 +66,7 @@ export class NanoBananaImageGenProvider extends ImageGenProvider {
     this.baseUrl = options.baseUrl;
     this.imageGenerationUrl = options.imageGenerationUrl;
     this.model = options.defaultModel || DEFAULT_MODEL;
+    this.timeoutMs = options.timeoutMs || 120_000;
   }
 
   get name(): string {
@@ -138,7 +141,7 @@ export class NanoBananaImageGenProvider extends ImageGenProvider {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(buildPayload(request, model, imageCount)),
-        signal: AbortSignal.timeout(120_000),
+        signal: AbortSignal.timeout(this.timeoutMs),
       });
 
       const text = await response.text();

--- a/packages/ai/src/agent/image-gen/providers/nano-banana.ts
+++ b/packages/ai/src/agent/image-gen/providers/nano-banana.ts
@@ -417,7 +417,6 @@ function mimeTypeForOutputFormat(
       return "image/jpeg";
     case "webp":
       return "image/webp";
-    case "png":
     default:
       return "image/png";
   }

--- a/packages/ai/src/agent/image-gen/providers/openai.ts
+++ b/packages/ai/src/agent/image-gen/providers/openai.ts
@@ -353,7 +353,6 @@ function mimeTypeForOutputFormat(
       return "image/jpeg";
     case "webp":
       return "image/webp";
-    case "png":
     default:
       return "image/png";
   }

--- a/packages/ai/src/agent/image-gen/providers/openai.ts
+++ b/packages/ai/src/agent/image-gen/providers/openai.ts
@@ -1,0 +1,349 @@
+import { calculateImageCredits } from "../../billing/model-pricing";
+import { ImageGenProvider } from "../base";
+import type {
+  GeneratedImage,
+  ImageGenerationCapabilities,
+  ImageGenerationOutputFormat,
+  ImageGenerationQuality,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+  ImageModelInfo,
+} from "../types";
+
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_MODEL = "gpt-image-2";
+const DEFAULT_SIZE = "1024x1024";
+
+const OPENAI_IMAGE_MODELS: ImageModelInfo[] = [
+  {
+    id: "gpt-image-2",
+    name: "gpt-image-2",
+    displayName: "GPT-Image-2",
+    supportedModality: ["text"],
+    supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+    supportedQualities: ["auto", "low", "medium", "high"],
+    supportedOutputFormats: ["png", "jpeg", "webp"],
+  },
+];
+
+const OPENAI_CAPABILITIES: ImageGenerationCapabilities = {
+  supportsTextToImage: true,
+  supportsImageReference: false,
+  supportsUrlOutput: false,
+  supportsBase64Output: true,
+  supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+  supportedQualities: ["auto", "low", "medium", "high"],
+  supportedOutputFormats: ["png", "jpeg", "webp"],
+};
+
+type OpenAIImageGenProviderOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+};
+
+type OpenAIImageResponse = {
+  data?: Array<{
+    b64_json?: string;
+    url?: string;
+    revised_prompt?: string;
+  }>;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string;
+  };
+};
+
+export class OpenAIImageGenProvider extends ImageGenProvider {
+  private apiKey?: string;
+  private baseUrl: string;
+  private model: string;
+
+  constructor(options: OpenAIImageGenProviderOptions = {}) {
+    super();
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || OPENAI_BASE_URL;
+    this.model = options.defaultModel || DEFAULT_MODEL;
+  }
+
+  get name(): string {
+    return "openai";
+  }
+
+  get displayName(): string {
+    return "OpenAI Images";
+  }
+
+  isAvailable(): boolean {
+    return Boolean(this.apiKey?.trim());
+  }
+
+  listModels(): ImageModelInfo[] {
+    return OPENAI_IMAGE_MODELS;
+  }
+
+  defaultModel(): string | null {
+    return this.isAvailable() ? this.model : null;
+  }
+
+  capabilities(): ImageGenerationCapabilities {
+    return OPENAI_CAPABILITIES;
+  }
+
+  async generate(
+    request: ImageGenerationRequest,
+  ): Promise<ImageGenerationResponse> {
+    const model = request.model || this.model;
+    const imageCount = normalizeImageCount(request.imageCount ?? request.n);
+    const modality = this.routeModality(request);
+    const creditsUsed = calculateImageCredits(
+      model,
+      imageCount,
+      qualityForBilling(request.quality),
+    );
+
+    if (!this.apiKey?.trim()) {
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error: "OPENAI_API_KEY is not configured",
+        errorType: "configuration_error",
+      });
+    }
+
+    if (modality === "image") {
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error:
+          "Reference images are not supported by the Day 1 OpenAI text-to-image provider.",
+        errorType: "validation_error",
+      });
+    }
+
+    try {
+      const response = await fetch(buildImagesUrl(this.baseUrl), {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildPayload(request, model, imageCount)),
+        signal: AbortSignal.timeout(120_000),
+      });
+
+      const text = await response.text();
+      const parsed = parseJson<OpenAIImageResponse>(text);
+
+      if (!response.ok) {
+        return failure({
+          model,
+          prompt: request.prompt,
+          imageCount,
+          modality,
+          creditsUsed,
+          error:
+            parsed?.error?.message ||
+            `OpenAI image API error ${response.status}: ${text}`,
+          errorType: mapStatusToErrorType(response.status, parsed?.error?.type),
+        });
+      }
+
+      const images = normalizeImages(parsed, request.outputFormat);
+      if (images.length === 0) {
+        return failure({
+          model,
+          prompt: request.prompt,
+          imageCount,
+          modality,
+          creditsUsed,
+          error: "OpenAI image API returned no image data",
+          errorType: "provider_error",
+        });
+      }
+
+      const first = images[0];
+      return {
+        success: true,
+        provider: this.name,
+        model,
+        prompt: request.prompt,
+        modality,
+        imageCount: images.length,
+        images,
+        imageUrl: first.imageUrl,
+        b64Json: first.b64Json,
+        dataUrl: first.dataUrl,
+        mimeType: first.mimeType,
+        creditsUsed,
+      };
+    } catch (error) {
+      const isTimeout =
+        error instanceof DOMException && error.name === "TimeoutError";
+      return failure({
+        model,
+        prompt: request.prompt,
+        imageCount,
+        modality,
+        creditsUsed,
+        error:
+          error instanceof Error
+            ? error.message
+            : "OpenAI image generation failed",
+        errorType: isTimeout ? "timeout" : "unknown_error",
+      });
+    }
+  }
+}
+
+function buildPayload(
+  request: ImageGenerationRequest,
+  model: string,
+  imageCount: number,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    model,
+    prompt: request.prompt,
+    n: imageCount,
+    size: request.size || DEFAULT_SIZE,
+  };
+
+  if (request.quality) {
+    payload.quality = request.quality;
+  }
+
+  if (request.outputFormat) {
+    payload.output_format = request.outputFormat;
+  }
+
+  if (usesLegacyImageResponseFormat(model) && request.responseFormat) {
+    payload.response_format =
+      request.responseFormat === "data_url"
+        ? "b64_json"
+        : request.responseFormat;
+  }
+
+  return payload;
+}
+
+function buildImagesUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, "");
+  return normalized.endsWith("/v1")
+    ? `${normalized}/images/generations`
+    : `${normalized}/v1/images/generations`;
+}
+
+function usesLegacyImageResponseFormat(model: string): boolean {
+  const normalized = model.toLowerCase();
+  return normalized.startsWith("dall-e-");
+}
+
+function normalizeImages(
+  result: OpenAIImageResponse | null,
+  outputFormat?: ImageGenerationOutputFormat,
+): GeneratedImage[] {
+  const mimeType = mimeTypeForOutputFormat(outputFormat);
+  return (result?.data || [])
+    .map((item): GeneratedImage | null => {
+      if (item.b64_json) {
+        const b64Json = stripDataUrlPrefix(item.b64_json);
+        return {
+          b64Json,
+          dataUrl: `data:${mimeType};base64,${b64Json}`,
+          mimeType,
+          revisedPrompt: item.revised_prompt,
+        };
+      }
+      if (item.url) {
+        return {
+          imageUrl: item.url,
+          mimeType,
+          revisedPrompt: item.revised_prompt,
+        };
+      }
+      return null;
+    })
+    .filter((image): image is GeneratedImage => image !== null);
+}
+
+function failure(args: {
+  model: string;
+  prompt: string;
+  imageCount: number;
+  modality: "text" | "image";
+  creditsUsed: number;
+  error: string;
+  errorType: ImageGenerationResponse["errorType"];
+}): ImageGenerationResponse {
+  return {
+    success: false,
+    provider: "openai",
+    model: args.model,
+    prompt: args.prompt,
+    modality: args.modality,
+    imageCount: args.imageCount,
+    creditsUsed: args.creditsUsed,
+    error: args.error,
+    errorType: args.errorType,
+  };
+}
+
+function mapStatusToErrorType(
+  status: number,
+  providerType?: string,
+): ImageGenerationResponse["errorType"] {
+  if (status === 401 || status === 403) return "configuration_error";
+  if (status === 429) return "rate_limit";
+  if (providerType?.includes("safety")) return "safety_blocked";
+  if (status >= 500) return "provider_error";
+  return "provider_error";
+}
+
+function parseJson<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeImageCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(4, Math.floor(value)));
+}
+
+function qualityForBilling(
+  quality: ImageGenerationQuality | undefined,
+): "standard" | "hd" {
+  return quality === "high" || quality === "hd" ? "hd" : "standard";
+}
+
+function mimeTypeForOutputFormat(
+  outputFormat?: ImageGenerationOutputFormat,
+): string {
+  switch (outputFormat) {
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "png":
+    default:
+      return "image/png";
+  }
+}
+
+function stripDataUrlPrefix(value: string): string {
+  const marker = ";base64,";
+  const trimmed = value.trim();
+  const markerIndex = trimmed.indexOf(marker);
+  return markerIndex >= 0
+    ? trimmed.slice(markerIndex + marker.length)
+    : trimmed;
+}

--- a/packages/ai/src/agent/image-gen/providers/openrouter.ts
+++ b/packages/ai/src/agent/image-gen/providers/openrouter.ts
@@ -368,7 +368,6 @@ function mimeTypeForOutputFormat(
       return "image/jpeg";
     case "webp":
       return "image/webp";
-    case "png":
     default:
       return "image/png";
   }

--- a/packages/ai/src/agent/image-gen/providers/openrouter.ts
+++ b/packages/ai/src/agent/image-gen/providers/openrouter.ts
@@ -10,41 +10,42 @@ import type {
   ImageModelInfo,
 } from "../types";
 
-const OPENAI_BASE_URL = "https://api.openai.com/v1";
-const DEFAULT_MODEL = "gpt-image-2";
-const DEFAULT_SIZE = "1024x1024";
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_MODEL = "bytedance-seed/seedream-4.5";
 
-const OPENAI_IMAGE_MODELS: ImageModelInfo[] = [
+const OPENROUTER_IMAGE_MODELS: ImageModelInfo[] = [
   {
-    id: "gpt-image-2",
-    name: "gpt-image-2",
-    displayName: "GPT-Image-2",
+    id: "bytedance-seed/seedream-4.5",
+    name: "bytedance-seed/seedream-4.5",
+    displayName: "Seedream 4.5 (OpenRouter)",
     supportedModality: ["text"],
-    supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+    supportedSizes: ["1:1", "16:9", "9:16", "4:3", "3:4"],
     supportedQualities: ["auto", "low", "medium", "high"],
     supportedOutputFormats: ["png", "jpeg", "webp"],
   },
 ];
 
-const OPENAI_CAPABILITIES: ImageGenerationCapabilities = {
+const OPENROUTER_CAPABILITIES: ImageGenerationCapabilities = {
   supportsTextToImage: true,
   supportsImageReference: false,
   supportsUrlOutput: false,
   supportsBase64Output: true,
-  supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
+  supportedSizes: ["1:1", "16:9", "9:16", "4:3", "3:4"],
   supportedQualities: ["auto", "low", "medium", "high"],
   supportedOutputFormats: ["png", "jpeg", "webp"],
 };
 
-type OpenAIImageGenProviderOptions = {
+type OpenRouterImageGenProviderOptions = {
   apiKey?: string;
   baseUrl?: string;
   imageGenerationUrl?: string;
   defaultModel?: string;
   timeoutMs?: number;
+  referer?: string;
+  title?: string;
 };
 
-type OpenAIImageResponse = {
+type OpenRouterImageResponse = {
   data?: Array<{
     b64_json?: string;
     url?: string;
@@ -57,28 +58,32 @@ type OpenAIImageResponse = {
   };
 };
 
-export class OpenAIImageGenProvider extends ImageGenProvider {
+export class OpenRouterImageGenProvider extends ImageGenProvider {
   private apiKey?: string;
   private baseUrl: string;
   private imageGenerationUrl?: string;
   private model: string;
   private timeoutMs: number;
+  private referer?: string;
+  private title?: string;
 
-  constructor(options: OpenAIImageGenProviderOptions = {}) {
+  constructor(options: OpenRouterImageGenProviderOptions = {}) {
     super();
     this.apiKey = options.apiKey;
-    this.baseUrl = options.baseUrl || OPENAI_BASE_URL;
+    this.baseUrl = options.baseUrl || OPENROUTER_BASE_URL;
     this.imageGenerationUrl = options.imageGenerationUrl;
     this.model = options.defaultModel || DEFAULT_MODEL;
     this.timeoutMs = options.timeoutMs || 120_000;
+    this.referer = options.referer;
+    this.title = options.title;
   }
 
   get name(): string {
-    return "openai";
+    return "openrouter";
   }
 
   get displayName(): string {
-    return "OpenAI Images";
+    return "OpenRouter Images";
   }
 
   isAvailable(): boolean {
@@ -86,7 +91,7 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
   }
 
   listModels(): ImageModelInfo[] {
-    return OPENAI_IMAGE_MODELS;
+    return OPENROUTER_IMAGE_MODELS;
   }
 
   defaultModel(): string | null {
@@ -94,7 +99,7 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
   }
 
   capabilities(): ImageGenerationCapabilities {
-    return OPENAI_CAPABILITIES;
+    return OPENROUTER_CAPABILITIES;
   }
 
   async generate(
@@ -116,7 +121,7 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
         imageCount,
         modality,
         creditsUsed,
-        error: "OPENAI_API_KEY is not configured",
+        error: "OPENROUTER_API_KEY is not configured",
         errorType: "configuration_error",
       });
     }
@@ -129,7 +134,7 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
         modality,
         creditsUsed,
         error:
-          "Reference images are not supported by the Day 1 OpenAI text-to-image provider.",
+          "Reference images are not supported by the Day 1 OpenRouter text-to-image provider.",
         errorType: "validation_error",
       });
     }
@@ -139,17 +144,18 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
         buildImagesUrl(this.baseUrl, this.imageGenerationUrl),
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${this.apiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: buildHeaders({
+            apiKey: this.apiKey,
+            referer: this.referer,
+            title: this.title,
+          }),
           body: JSON.stringify(buildPayload(request, model, imageCount)),
           signal: AbortSignal.timeout(this.timeoutMs),
         },
       );
 
       const text = await response.text();
-      const parsed = parseJson<OpenAIImageResponse>(text);
+      const parsed = parseJson<OpenRouterImageResponse>(text);
 
       if (!response.ok) {
         return failure({
@@ -160,8 +166,8 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
           creditsUsed,
           error:
             parsed?.error?.message ||
-            `OpenAI image API error ${response.status}: ${text}`,
-          errorType: mapStatusToErrorType(response.status, parsed?.error?.type),
+            `OpenRouter image API error ${response.status}: ${text}`,
+          errorType: mapStatusToErrorType(response.status),
         });
       }
 
@@ -173,7 +179,7 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
           imageCount,
           modality,
           creditsUsed,
-          error: "OpenAI image API returned no image data",
+          error: "OpenRouter image API returned no image data",
           errorType: "provider_error",
         });
       }
@@ -205,11 +211,27 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
         error:
           error instanceof Error
             ? error.message
-            : "OpenAI image generation failed",
+            : "OpenRouter image generation failed",
         errorType: isTimeout ? "timeout" : "unknown_error",
       });
     }
   }
+}
+
+function buildHeaders(options: {
+  apiKey: string;
+  referer?: string;
+  title?: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${options.apiKey}`,
+    "Content-Type": "application/json",
+  };
+
+  if (options.referer) headers["HTTP-Referer"] = options.referer;
+  if (options.title) headers["X-Title"] = options.title;
+
+  return headers;
 }
 
 function buildPayload(
@@ -221,23 +243,12 @@ function buildPayload(
     model,
     prompt: request.prompt,
     n: imageCount,
-    size: request.size || DEFAULT_SIZE,
   };
 
-  if (request.quality) {
-    payload.quality = request.quality;
-  }
-
-  if (request.outputFormat) {
-    payload.output_format = request.outputFormat;
-  }
-
-  if (usesLegacyImageResponseFormat(model) && request.responseFormat) {
-    payload.response_format =
-      request.responseFormat === "data_url"
-        ? "b64_json"
-        : request.responseFormat;
-  }
+  const aspectRatio = request.aspectRatio || aspectRatioFromSize(request.size);
+  if (aspectRatio) payload.aspect_ratio = aspectRatio;
+  if (request.quality) payload.quality = request.quality;
+  if (request.outputFormat) payload.output_format = request.outputFormat;
 
   return payload;
 }
@@ -247,18 +258,11 @@ function buildImagesUrl(baseUrl: string, imageGenerationUrl?: string): string {
   if (direct) return direct;
 
   const normalized = baseUrl.replace(/\/+$/, "");
-  return normalized.endsWith("/v1")
-    ? `${normalized}/images/generations`
-    : `${normalized}/v1/images/generations`;
-}
-
-function usesLegacyImageResponseFormat(model: string): boolean {
-  const normalized = model.toLowerCase();
-  return normalized.startsWith("dall-e-");
+  return normalized.endsWith("/images") ? normalized : `${normalized}/images`;
 }
 
 function normalizeImages(
-  result: OpenAIImageResponse | null,
+  result: OpenRouterImageResponse | null,
   outputFormat?: ImageGenerationOutputFormat,
 ): GeneratedImage[] {
   const mimeType = mimeTypeForOutputFormat(outputFormat);
@@ -296,7 +300,7 @@ function failure(args: {
 }): ImageGenerationResponse {
   return {
     success: false,
-    provider: "openai",
+    provider: "openrouter",
     model: args.model,
     prompt: args.prompt,
     modality: args.modality,
@@ -309,13 +313,24 @@ function failure(args: {
 
 function mapStatusToErrorType(
   status: number,
-  providerType?: string,
 ): ImageGenerationResponse["errorType"] {
   if (status === 401 || status === 403) return "configuration_error";
   if (status === 429) return "rate_limit";
-  if (providerType?.includes("safety")) return "safety_blocked";
   if (status >= 500) return "provider_error";
   return "provider_error";
+}
+
+function aspectRatioFromSize(size: string | undefined): string | undefined {
+  switch (size) {
+    case "1024x1024":
+      return "1:1";
+    case "1536x1024":
+      return "3:2";
+    case "1024x1536":
+      return "2:3";
+    default:
+      return undefined;
+  }
 }
 
 function parseJson<T>(text: string): T | null {

--- a/packages/ai/src/agent/image-gen/registry.ts
+++ b/packages/ai/src/agent/image-gen/registry.ts
@@ -1,0 +1,88 @@
+import type { ImageGenProvider } from "./base";
+import type {
+  ImageGenerationCapabilities,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from "./types";
+
+const providers = new Map<string, ImageGenProvider>();
+
+export function registerImageGenProvider(provider: ImageGenProvider): void {
+  providers.set(provider.name, provider);
+}
+
+export function getImageGenProvider(
+  name: string,
+): ImageGenProvider | undefined {
+  return providers.get(name);
+}
+
+export function getAllImageGenProviders(): ImageGenProvider[] {
+  return Array.from(providers.values());
+}
+
+export function getDefaultImageGenProvider(): ImageGenProvider | undefined {
+  for (const provider of providers.values()) {
+    if (provider.isAvailable()) {
+      return provider;
+    }
+  }
+  return undefined;
+}
+
+export async function generateImage(
+  request: ImageGenerationRequest,
+): Promise<ImageGenerationResponse> {
+  const requestedProvider = normalizeProviderName(request.provider);
+  const provider = requestedProvider
+    ? getImageGenProvider(requestedProvider)
+    : getDefaultImageGenProvider();
+  const model = request.model || "unknown";
+  const imageCount = normalizeImageCount(request.imageCount ?? request.n);
+
+  if (!provider) {
+    return {
+      success: false,
+      provider: requestedProvider || "unknown",
+      model,
+      prompt: request.prompt,
+      modality:
+        request.referenceImageUrls?.length || request.referenceImages?.length
+          ? "image"
+          : "text",
+      imageCount,
+      error: requestedProvider
+        ? `Image generation provider not registered: ${requestedProvider}`
+        : "No image generation provider available",
+      errorType: "provider_not_found",
+    };
+  }
+
+  return provider.generate({
+    ...request,
+    provider: provider.name,
+    imageCount,
+  });
+}
+
+export function getImageGenProviderCapabilities(
+  name: string,
+): ImageGenerationCapabilities | null {
+  const provider = getImageGenProvider(name);
+  return provider ? provider.capabilities() : null;
+}
+
+export function __resetImageGenProvidersForTests(): void {
+  providers.clear();
+}
+
+function normalizeProviderName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeImageCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(4, Math.floor(value)));
+}

--- a/packages/ai/src/agent/image-gen/types.ts
+++ b/packages/ai/src/agent/image-gen/types.ts
@@ -1,0 +1,93 @@
+export type ImageGenerationProviderName = "openai" | "nano-banana" | string;
+
+export type ImageGenerationQuality =
+  | "auto"
+  | "low"
+  | "medium"
+  | "high"
+  | "standard"
+  | "hd";
+
+export type ImageGenerationOutputFormat = "png" | "jpeg" | "webp";
+
+export type ImageGenerationResponseFormat = "url" | "b64_json" | "data_url";
+
+export type ImageGenerationModality = "text" | "image";
+
+export type ImageGenerationErrorType =
+  | "configuration_error"
+  | "validation_error"
+  | "provider_not_found"
+  | "provider_error"
+  | "rate_limit"
+  | "safety_blocked"
+  | "timeout"
+  | "unknown_error";
+
+export interface ImageReference {
+  url?: string;
+  b64Json?: string;
+  dataUrl?: string;
+  mimeType?: string;
+}
+
+export interface ImageGenerationRequest {
+  provider?: ImageGenerationProviderName;
+  model?: string;
+  prompt: string;
+  size?: string;
+  aspectRatio?: string;
+  quality?: ImageGenerationQuality;
+  outputFormat?: ImageGenerationOutputFormat;
+  responseFormat?: ImageGenerationResponseFormat;
+  imageCount?: number;
+  n?: number;
+  referenceImageUrls?: string[];
+  referenceImages?: ImageReference[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface GeneratedImage {
+  imageUrl?: string;
+  b64Json?: string;
+  dataUrl?: string;
+  mimeType: string;
+  revisedPrompt?: string;
+}
+
+export interface ImageGenerationResponse {
+  success: boolean;
+  provider: string;
+  model: string;
+  prompt: string;
+  modality: ImageGenerationModality;
+  imageCount: number;
+  images?: GeneratedImage[];
+  imageUrl?: string;
+  b64Json?: string;
+  dataUrl?: string;
+  mimeType?: string;
+  creditsUsed?: number;
+  error?: string;
+  errorType?: ImageGenerationErrorType;
+}
+
+export interface ImageModelInfo {
+  id: string;
+  name: string;
+  displayName: string;
+  supportedModality: ImageGenerationModality[];
+  supportedSizes: string[];
+  supportedQualities: ImageGenerationQuality[];
+  supportedOutputFormats: ImageGenerationOutputFormat[];
+}
+
+export interface ImageGenerationCapabilities {
+  supportsTextToImage: boolean;
+  supportsImageReference: boolean;
+  supportsUrlOutput: boolean;
+  supportsBase64Output: boolean;
+  supportedSizes: string[];
+  supportedQualities: ImageGenerationQuality[];
+  supportedOutputFormats: ImageGenerationOutputFormat[];
+}

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -133,6 +133,9 @@ export * from "./native-cli";
 // Video Generation
 export * from "./video-gen";
 
+// Image Generation
+export * from "./image-gen";
+
 // Utils
 export { extractJsonFromMarkdown } from "./utils";
 


### PR DESCRIPTION
## Summary

Adds the basic backend foundation for image generation through the existing AI/provider layer.

This includes:

- A reusable image-generation provider abstraction under `@openloomi/ai`
- Provider implementations for OpenAI-compatible image generation, OpenRouter image generation, and a Nano Banana-compatible/custom image endpoint adapter
- A new authenticated API endpoint: `POST /api/ai/v1/images/generations`
- Support for normalized URL, base64, and data URL image responses
- Environment configuration examples for local provider setup
- A usage tracking hook that records provider, model, image count, estimated credits, status, and error type
- Focused API tests covering auth, validation, provider routing, output normalization, endpoint override behavior, and usage tracking

## Scope

This PR is focused on the backend provider/plugin layer and the API surface needed to generate an image from a prompt.

Usage tracking is plumbed through as a structured hook with estimated credit calculation and record-only quota mode. Persistent billing ledger integration and quota enforcement are intentionally kept outside this provider-layer scope.

Generated images are returned directly by the API and are not persisted by this PR.

## Follow-up Work

Planned follow-up areas include:

- Build the lifestyle context composer that turns user profile, focus topics, recent interests, and memories into a single image-generation description
- Add support for optional reference images where the selected provider supports image input
- Add the in-chat lifestyle image trigger, first-use consent/explainer flow, and user-facing loading/error states
- Persist generated images for the `/lifestyle` gallery experience
- Connect usage events to the finalized billing/quota ledger once product rules are settled
- Add broader end-to-end coverage around chat-triggered generation and image history flows

## Testing

- `pnpm --filter web exec vitest run tests/api/image-generation.route.test.ts`
- `pnpm exec biome lint apps/web/app/api/ai/v1/images/generations/route.ts apps/web/lib/ai/image-generation/service.ts apps/web/lib/ai/image-generation/usage.ts apps/web/tests/api/image-generation.route.test.ts packages/ai/src/agent/image-gen packages/ai/src/agent/index.ts`

Note: repository-wide `pnpm --filter web tsc` currently reports existing unrelated type issues around `cross-spawn` declarations and legacy CLI runtime integration test typings.