### PR TITLE
fix(codex): surface connector readiness status

### DIFF
--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -628,7 +628,19 @@ For source checkouts, check project markers and likely CLI locations:
   },
   "aiProviderConfigured": true,
   "aiProviderStatus": "runtime_configured",
-  "connectorStatusAvailable": false,
+  "connectorStatusAvailable": true,
+  "connectors": [
+    {
+      "id": "gmail",
+      "label": "Gmail",
+      "connected": false,
+      "accountCount": 0
+    }
+  ],
+  "connectorSetupRecommended": true,
+  "recommendedNextAction": "configure_connectors",
+  "recommendedReason": "CONNECTOR_SETUP_REQUIRED",
+  "connectorSetupUrl": "http://localhost:3515/connectors",
   "apiReachable": false,
   "ready": true,
   "nextAction": "run",
@@ -646,10 +658,30 @@ For source checkouts, check project markers and likely CLI locations:
           "modelPresent": true
         }
       ]
+    },
+    "connectors": {
+      "checked": true,
+      "available": true,
+      "reason": "CONNECTOR_STATUS_LOADED",
+      "setupRecommended": true
     }
   }
 }
 ```
+
+Connector readiness is a status-only advisory. Missing Gmail, Slack, GitHub,
+Calendar, or Linear connections should not block memory-only or local runtime
+workflows, so `ready` can remain `true` while `connectorSetupRecommended`
+points the user to the OpenLoomi-owned `/connectors` setup surface. Connector
+tokens, account identifiers, OAuth secrets, passwords, and Composio secrets
+must never be printed by the Codex bridge.
+
+The bridge first reads the Loop connector status endpoint and then, when a local
+session token is available, merges OpenLoomi-owned native integration accounts
+from `/api/integrations` as status-only rows. This lets Codex show native
+connections such as Gmail or QQbot as connected even when the Loop/Composio
+probe is unavailable or slow, while still keeping all credentials inside
+OpenLoomi-owned surfaces.
 
 Common `nextAction` values:
 

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -30,9 +30,46 @@ const SESSION_BOOTSTRAP_TIMEOUT_MS = 30000;
 const SESSION_BOOTSTRAP_POLL_MS = 2000;
 const SESSION_API_TIMEOUT_MS = 5000;
 const API_PROBE_TIMEOUT_MS = 1000;
+const CONNECTOR_STATUS_TIMEOUT_MS = 2500;
 const MAX_COMMAND_OUTPUT = 4096;
 const RUN_LOCK_TTL_MS = RUN_TIMEOUT_MS + 60_000;
 const DEBUG_DISCOVERY = process.env.OPENLOOMI_DEBUG_DISCOVERY === "1";
+const MONITORING_CONNECTOR_IDS = new Set([
+  "gmail",
+  "google_calendar",
+  "github",
+  "slack",
+  "linear",
+]);
+const NATIVE_CONNECTOR_LABELS = {
+  asana: "Asana",
+  dingtalk: "DingTalk",
+  discord: "Discord",
+  facebook_messenger: "Messenger",
+  feishu: "Feishu",
+  github: "GitHub",
+  gmail: "Gmail",
+  google_calendar: "Google Calendar",
+  google_docs: "Google Docs",
+  google_drive: "Google Drive",
+  google_meet: "Google Meet",
+  hubspot: "HubSpot",
+  imessage: "iMessage",
+  instagram: "Instagram",
+  jira: "Jira",
+  linear: "Linear",
+  linkedin: "LinkedIn",
+  notion: "Notion",
+  outlook: "Outlook",
+  outlook_calendar: "Outlook Calendar",
+  qqbot: "QQ",
+  slack: "Slack",
+  teams: "Teams",
+  telegram: "Telegram",
+  twitter: "X",
+  weixin: "Weixin",
+  whatsapp: "WhatsApp",
+};
 const OFFICIAL_RELEASE_SOURCE = {
   owner: "melandlabs",
   repo: "openloomi",
@@ -267,6 +304,11 @@ async function buildSetupStatus() {
     apiProbe.source = "aiProviderRuntime";
   }
 
+  const connectorStatus = await getConnectorStatus(
+    apiProbe.reachableUrl,
+    token,
+  );
+
   const baseStatus = {
     mode: discovery.mode,
     installed: discovery.installed,
@@ -275,7 +317,22 @@ async function buildSetupStatus() {
     tokenPresent: token.present,
     aiProviderConfigured: aiProvider.configured,
     aiProviderStatus: aiProvider.status,
-    connectorStatusAvailable: false,
+    connectorStatusAvailable: connectorStatus.available,
+    connectors: connectorStatus.connectors,
+    connectorSetupRecommended: connectorStatus.setupRecommended,
+    recommendedNextAction: connectorStatus.recommendedNextAction,
+    recommendedReason: connectorStatus.recommendedReason,
+    connectorSetupUrl: connectorStatus.setupUrl,
+    connectorStatus: {
+      checked: connectorStatus.checked,
+      available: connectorStatus.available,
+      reason: connectorStatus.reason,
+      baseUrl: connectorStatus.baseUrl,
+      endpoint: connectorStatus.endpoint,
+      connectedCount: connectorStatus.connectedCount,
+      monitoringConnected: connectorStatus.monitoringConnected,
+      monitoringConnectorIds: [...MONITORING_CONNECTOR_IDS],
+    },
     apiReachable: Boolean(apiProbe.reachableUrl),
     apiBaseUrl: apiProbe.reachableUrl,
     apiProbe: {
@@ -308,6 +365,7 @@ async function buildSetupStatus() {
       aiProvider: aiProvider.checked,
       aiProviderRuntime: aiProvider.runtime,
       apiProbe: apiProbe.attempts,
+      connectors: connectorStatus.check,
       discovery: discovery.checked,
       codexRuntimeEnv: {
         key: codexRuntimeEnv.key,
@@ -328,6 +386,481 @@ async function buildSetupStatus() {
       apiProbe,
     ),
   };
+}
+
+async function getConnectorStatus(baseUrl, tokenStatus) {
+  const normalizedBaseUrl = normalizeLocalApiUrl(baseUrl);
+  const endpoint = "/api/loop/connectors";
+  const setupUrl = normalizedBaseUrl ? `${normalizedBaseUrl}/connectors` : null;
+
+  if (!normalizedBaseUrl) {
+    return buildConnectorStatus({
+      checked: false,
+      available: false,
+      reason: "OPENLOOMI_API_UNREACHABLE",
+      baseUrl: null,
+      endpoint,
+      setupUrl,
+    });
+  }
+
+  if (typeof fetch !== "function") {
+    return buildConnectorStatus({
+      checked: true,
+      available: false,
+      reason: "FETCH_UNAVAILABLE",
+      baseUrl: normalizedBaseUrl,
+      endpoint,
+      setupUrl,
+    });
+  }
+
+  const nativeStatus = await getNativeIntegrationConnectorStatus(
+    normalizedBaseUrl,
+    tokenStatus,
+  );
+
+  try {
+    const response = await fetchWithTimeout(
+      `${normalizedBaseUrl}${endpoint}`,
+      {
+        headers: {
+          Accept: "application/json",
+        },
+        redirect: "manual",
+      },
+      CONNECTOR_STATUS_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      return buildConnectorStatusWithNativeFallback(
+        {
+          checked: true,
+          available: false,
+          reason: `CONNECTOR_STATUS_HTTP_${response.status}`,
+          status: response.status,
+          baseUrl: normalizedBaseUrl,
+          endpoint,
+          setupUrl,
+        },
+        nativeStatus,
+      );
+    }
+
+    let payload;
+    try {
+      payload = await response.json();
+    } catch {
+      return buildConnectorStatusWithNativeFallback(
+        {
+          checked: true,
+          available: false,
+          reason: "CONNECTOR_STATUS_MALFORMED_RESPONSE",
+          status: response.status,
+          baseUrl: normalizedBaseUrl,
+          endpoint,
+          setupUrl,
+        },
+        nativeStatus,
+      );
+    }
+
+    const rawConnectors = extractConnectorList(payload);
+
+    if (!rawConnectors) {
+      return buildConnectorStatusWithNativeFallback(
+        {
+          checked: true,
+          available: false,
+          reason: "CONNECTOR_STATUS_MISSING_ITEMS",
+          status: response.status,
+          baseUrl: normalizedBaseUrl,
+          endpoint,
+          setupUrl,
+        },
+        nativeStatus,
+      );
+    }
+
+    const connectors = mergeConnectorEntries(
+      rawConnectors.map(summarizeConnectorEntry).filter(Boolean),
+      nativeStatus.connectors,
+    );
+
+    return buildConnectorStatus({
+      checked: true,
+      available: true,
+      reason: nativeStatus.available
+        ? "CONNECTOR_STATUS_LOADED_WITH_NATIVE_INTEGRATIONS"
+        : "CONNECTOR_STATUS_LOADED",
+      status: response.status,
+      baseUrl: normalizedBaseUrl,
+      endpoint,
+      setupUrl,
+      connectors,
+      sources: nativeStatus.available
+        ? ["loop-connectors", "native-integrations"]
+        : ["loop-connectors"],
+      nativeReason: nativeStatus.reason,
+    });
+  } catch (error) {
+    return buildConnectorStatusWithNativeFallback(
+      {
+        checked: true,
+        available: false,
+        reason:
+          error && error.name === "AbortError"
+            ? "CONNECTOR_STATUS_TIMEOUT"
+            : "CONNECTOR_STATUS_UNREACHABLE",
+        baseUrl: normalizedBaseUrl,
+        endpoint,
+        setupUrl,
+      },
+      nativeStatus,
+    );
+  }
+}
+
+function buildConnectorStatusWithNativeFallback(baseStatus, nativeStatus) {
+  if (nativeStatus.available) {
+    return buildConnectorStatus({
+      ...baseStatus,
+      available: true,
+      reason: `${baseStatus.reason}_WITH_NATIVE_INTEGRATIONS`,
+      connectors: nativeStatus.connectors,
+      sources: ["native-integrations"],
+      nativeReason: nativeStatus.reason,
+    });
+  }
+
+  return buildConnectorStatus({
+    ...baseStatus,
+    sources: [],
+    nativeReason: nativeStatus.reason,
+  });
+}
+
+async function getNativeIntegrationConnectorStatus(baseUrl, tokenStatus) {
+  const endpoint = "/api/integrations";
+
+  if (!tokenStatus?.present) {
+    return {
+      available: false,
+      reason: "NATIVE_INTEGRATIONS_TOKEN_MISSING",
+      connectors: [],
+    };
+  }
+
+  const token = readOpenLoomiAuthToken(tokenStatus);
+
+  if (!hasValue(token)) {
+    return {
+      available: false,
+      reason: "NATIVE_INTEGRATIONS_TOKEN_UNREADABLE",
+      connectors: [],
+    };
+  }
+
+  try {
+    const sessionResponse = await fetchWithTimeout(
+      `${baseUrl}/api/auth/set-token?token=${encodeURIComponent(token)}`,
+      {
+        method: "GET",
+        redirect: "manual",
+      },
+      SESSION_API_TIMEOUT_MS,
+    );
+    const cookieHeader = toCookieHeader(
+      getSetCookieHeaders(sessionResponse.headers),
+    );
+
+    if (!cookieHeader) {
+      return {
+        available: false,
+        reason: "NATIVE_INTEGRATIONS_SESSION_COOKIE_MISSING",
+        connectors: [],
+      };
+    }
+
+    const response = await fetchWithTimeout(
+      `${baseUrl}${endpoint}`,
+      {
+        headers: {
+          Accept: "application/json",
+          Cookie: cookieHeader,
+        },
+        redirect: "manual",
+      },
+      CONNECTOR_STATUS_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      return {
+        available: false,
+        reason: `NATIVE_INTEGRATIONS_HTTP_${response.status}`,
+        connectors: [],
+      };
+    }
+
+    let payload;
+    try {
+      payload = await response.json();
+    } catch {
+      return {
+        available: false,
+        reason: "NATIVE_INTEGRATIONS_MALFORMED_RESPONSE",
+        connectors: [],
+      };
+    }
+
+    const accounts = Array.isArray(payload?.accounts) ? payload.accounts : null;
+
+    if (!accounts) {
+      return {
+        available: false,
+        reason: "NATIVE_INTEGRATIONS_MISSING_ACCOUNTS",
+        connectors: [],
+      };
+    }
+
+    return {
+      available: true,
+      reason: "NATIVE_INTEGRATIONS_LOADED",
+      connectors: summarizeNativeIntegrationAccounts(accounts),
+    };
+  } catch (error) {
+    return {
+      available: false,
+      reason:
+        error && error.name === "AbortError"
+          ? "NATIVE_INTEGRATIONS_TIMEOUT"
+          : "NATIVE_INTEGRATIONS_UNREACHABLE",
+      connectors: [],
+    };
+  }
+}
+
+function summarizeNativeIntegrationAccounts(accounts) {
+  const counts = new Map();
+
+  for (const account of accounts) {
+    if (!account || typeof account !== "object") {
+      continue;
+    }
+
+    const id = normalizeConnectorId(account.platform);
+
+    if (!id || !isNativeIntegrationConnected(account)) {
+      continue;
+    }
+
+    counts.set(id, (counts.get(id) || 0) + 1);
+  }
+
+  return [...counts.entries()].map(([id, accountCount]) => ({
+    id,
+    label: NATIVE_CONNECTOR_LABELS[id] || formatConnectorLabel(id),
+    connected: true,
+    accountCount,
+  }));
+}
+
+function isNativeIntegrationConnected(account) {
+  const status =
+    typeof account.status === "string" ? account.status.toLowerCase() : "";
+
+  return !["disabled", "disconnected", "revoked", "error"].includes(status);
+}
+
+function mergeConnectorEntries(primary, secondary) {
+  const byId = new Map();
+
+  for (const connector of [...primary, ...secondary]) {
+    if (!connector?.id) {
+      continue;
+    }
+
+    const existing = byId.get(connector.id);
+
+    if (!existing) {
+      byId.set(connector.id, connector);
+      continue;
+    }
+
+    byId.set(connector.id, {
+      ...existing,
+      ...connector,
+      connected: Boolean(existing.connected || connector.connected),
+      accountCount: Math.max(
+        existing.accountCount || 0,
+        connector.accountCount || 0,
+      ),
+      lastError: connector.connected
+        ? undefined
+        : existing.lastError || connector.lastError,
+    });
+  }
+
+  return [...byId.values()].map((connector) => {
+    if (connector.lastError === undefined) {
+      const { lastError, ...rest } = connector;
+      return rest;
+    }
+
+    return connector;
+  });
+}
+
+function buildConnectorStatus({
+  checked,
+  available,
+  reason,
+  status = null,
+  baseUrl,
+  endpoint,
+  setupUrl,
+  connectors = [],
+  sources = [],
+  nativeReason = null,
+}) {
+  const connectedCount = connectors.filter(
+    (connector) => connector.connected,
+  ).length;
+  const monitoringConnectors = connectors.filter((connector) =>
+    MONITORING_CONNECTOR_IDS.has(connector.id),
+  );
+  const monitoringConnected = monitoringConnectors.some(
+    (connector) => connector.connected,
+  );
+  const setupRecommended = Boolean(
+    (!available && checked && setupUrl) || (available && connectedCount === 0),
+  );
+
+  return {
+    checked,
+    available,
+    reason,
+    status,
+    baseUrl,
+    endpoint,
+    setupUrl,
+    connectors,
+    connectedCount,
+    monitoringConnected,
+    sources,
+    nativeReason,
+    setupRecommended,
+    recommendedNextAction: setupRecommended ? "configure_connectors" : null,
+    recommendedReason: setupRecommended ? "CONNECTOR_SETUP_REQUIRED" : null,
+    check: {
+      checked,
+      available,
+      reason,
+      status,
+      baseUrl,
+      endpoint,
+      connectedCount,
+      monitoringConnected,
+      sources,
+      nativeReason,
+      setupRecommended,
+    },
+  };
+}
+
+function extractConnectorList(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+
+  if (Array.isArray(payload?.connectors)) {
+    return payload.connectors;
+  }
+
+  return null;
+}
+
+function normalizeConnectorId(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function formatConnectorLabel(id) {
+  return id
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function summarizeConnectorEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const id = normalizeConnectorId(entry.id);
+
+  if (!id) {
+    return null;
+  }
+
+  const label =
+    typeof entry.label === "string" && entry.label.trim()
+      ? entry.label.trim()
+      : id;
+  const accountCount = normalizeConnectorAccountCount(entry.accountCount);
+  const connector = {
+    id,
+    label,
+    connected: Boolean(entry.connected),
+    accountCount,
+  };
+  const lastError = sanitizeConnectorLastError(entry.lastError);
+
+  if (lastError) {
+    connector.lastError = lastError;
+  }
+
+  if (typeof entry.probed === "boolean") {
+    connector.probed = entry.probed;
+  }
+
+  if (typeof entry.fetchedAt === "string" && entry.fetchedAt.trim()) {
+    connector.fetchedAt = entry.fetchedAt.trim();
+  }
+
+  return connector;
+}
+
+function normalizeConnectorAccountCount(value) {
+  const count = Number(value);
+
+  if (!Number.isFinite(count) || count < 0) {
+    return 0;
+  }
+
+  return Math.floor(count);
+}
+
+function sanitizeConnectorLastError(value) {
+  if (!hasValue(value)) {
+    return null;
+  }
+
+  const text = String(value).replace(/\s+/g, " ").trim();
+
+  if (!text) {
+    return null;
+  }
+
+  if (/token|secret|password|authorization|bearer|api[_-]?key/i.test(text)) {
+    return "redacted";
+  }
+
+  return text.slice(0, 160);
 }
 
 function installInstructions() {

--- a/plugins/codex/skills/openloomi-connectors/SKILL.md
+++ b/plugins/codex/skills/openloomi-connectors/SKILL.md
@@ -35,3 +35,15 @@ printf "%s" "<user connector request>" | node "$SKILL_DIR/../../scripts/loomi-br
 
 Keep connector authentication, sync, message access, and platform-specific
 actions inside OpenLoomi runtime.
+
+When `setup-status` includes `connectorStatusAvailable: true`, report only the
+status-only connector fields such as `id`, `connected`, and `accountCount`. When
+it includes `connectorSetupRecommended: true`, treat
+`recommendedNextAction: "configure_connectors"` as a non-blocking setup
+recommendation and hand the user to the reported OpenLoomi `/connectors` URL.
+Do not treat this as core runtime failure when `ready: true`.
+
+`setup-status` may merge Loop connector rows with OpenLoomi native integration
+accounts (for example Gmail or QQbot) as status-only connector rows. Report that
+connected state when present, but keep all authentication, sync, and account
+management inside OpenLoomi.

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -211,7 +211,7 @@ function writeRunLock(home, { startedAt = Date.now(), pid = 99999 } = {}) {
   return lockPath;
 }
 
-async function withPetApiServer(handler, fn) {
+async function withLocalApiServer(handler, fn) {
   const requests = [];
   const server = createServer((req, res) => {
     let raw = "";
@@ -244,6 +244,10 @@ async function withPetApiServer(handler, fn) {
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+}
+
+async function withPetApiServer(handler, fn) {
+  return withLocalApiServer(handler, fn);
 }
 
 function writeFakeCtl(home) {
@@ -285,6 +289,70 @@ function writeFakeCtl(home) {
   );
   chmodSync(shim, 0o755);
   return shim;
+}
+
+function writeJsonResponse(res, status, payload, headers = {}) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    ...headers,
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function createReadySetupApiHandler({
+  connectorStatus = 200,
+  connectorPayload = { items: [] },
+  integrationStatus = 200,
+  integrationPayload = { accounts: [] },
+} = {}) {
+  return (req, res) => {
+    const url = req.url || "/";
+
+    if (url === "/" || url === "") {
+      writeJsonResponse(res, 200, { ok: true });
+      return;
+    }
+
+    if (url.startsWith("/api/auth/set-token")) {
+      writeJsonResponse(
+        res,
+        200,
+        { ok: true },
+        {
+          "Set-Cookie": "authjs.session-token=fake-session; Path=/; HttpOnly",
+        },
+      );
+      return;
+    }
+
+    if (url.startsWith("/api/preferences/ai")) {
+      writeJsonResponse(res, 200, {
+        settings: [
+          {
+            providerType: "anthropic_compatible",
+            enabled: true,
+            hasApiKey: true,
+            baseUrl: "https://api.example.invalid",
+            model: "claude-test",
+          },
+        ],
+        systemDefaults: {},
+      });
+      return;
+    }
+
+    if (url.startsWith("/api/loop/connectors")) {
+      writeJsonResponse(res, connectorStatus, connectorPayload);
+      return;
+    }
+
+    if (url.startsWith("/api/integrations")) {
+      writeJsonResponse(res, integrationStatus, integrationPayload);
+      return;
+    }
+
+    writeJsonResponse(res, 404, { error: "not found" });
+  };
 }
 
 // -----------------------------------------------------------------------------
@@ -393,6 +461,216 @@ test("setup-status exposes the protocol contract fields", () => {
   }
 });
 
+test("setup-status recommends connector setup when monitored connectors are disconnected", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        connectorPayload: {
+          items: [
+            {
+              id: "gmail",
+              label: "Gmail",
+              connected: false,
+              accountCount: 0,
+              probed: true,
+              fetchedAt: "2026-07-14T00:00:00.000Z",
+            },
+            {
+              id: "slack",
+              label: "Slack",
+              connected: false,
+              accountCount: 0,
+              probed: true,
+            },
+            {
+              id: "obsidian",
+              label: "Obsidian",
+              connected: false,
+              accountCount: 0,
+              lastError: "local-only",
+            },
+          ],
+        },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+        });
+
+        assert.equal(j.ready, true);
+        assert.equal(j.nextAction, "run");
+        assert.equal(j.reason, "READY");
+        assert.equal(j.connectorStatusAvailable, true);
+        assert.equal(j.connectorSetupRecommended, true);
+        assert.equal(j.recommendedNextAction, "configure_connectors");
+        assert.equal(j.recommendedReason, "CONNECTOR_SETUP_REQUIRED");
+        assert.equal(j.connectorSetupUrl, `${baseUrl}/connectors`);
+        assert.equal(j.checks.connectors.available, true);
+        assert.equal(j.checks.connectors.setupRecommended, true);
+        assert.ok(Array.isArray(j.connectors));
+        assert.equal(j.connectors[0].id, "gmail");
+        assert.equal(j.connectors[0].connected, false);
+        assert.equal(j.connectors[0].accountCount, 0);
+      },
+    );
+  });
+});
+
+test("setup-status does not recommend connector setup when a monitored connector is connected", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        connectorPayload: {
+          items: [
+            {
+              id: "gmail",
+              label: "Gmail",
+              connected: true,
+              accountCount: 1,
+              word_id: "must-not-leak",
+              oauthToken: "must-not-leak",
+              lastError: "bearer must-not-leak",
+            },
+          ],
+        },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+        });
+
+        assert.equal(j.ready, true);
+        assert.equal(j.connectorStatusAvailable, true);
+        assert.equal(j.connectorSetupRecommended, false);
+        assert.equal(j.recommendedNextAction, null);
+        assert.equal(j.recommendedReason, null);
+        assert.equal(j.connectors.length, 1);
+        assert.deepEqual(j.connectors[0], {
+          id: "gmail",
+          label: "Gmail",
+          connected: true,
+          accountCount: 1,
+          lastError: "redacted",
+        });
+        const serialized = JSON.stringify(j.connectors);
+        assert.equal(serialized.includes("must-not-leak"), false);
+        assert.equal(serialized.includes("word_id"), false);
+        assert.equal(serialized.includes("oauthToken"), false);
+      },
+    );
+  });
+});
+
+test("setup-status keeps core readiness when connector status endpoint fails", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        connectorStatus: 500,
+        connectorPayload: { error: "connectors failed" },
+        integrationStatus: 500,
+        integrationPayload: { error: "integrations failed" },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+        });
+
+        assert.equal(j.ready, true);
+        assert.equal(j.nextAction, "run");
+        assert.equal(j.reason, "READY");
+        assert.equal(j.connectorStatusAvailable, false);
+        assert.equal(j.connectorSetupRecommended, true);
+        assert.equal(j.recommendedNextAction, "configure_connectors");
+        assert.equal(j.recommendedReason, "CONNECTOR_SETUP_REQUIRED");
+        assert.deepEqual(j.connectors, []);
+        assert.equal(j.checks.connectors.available, false);
+        assert.equal(j.checks.connectors.reason, "CONNECTOR_STATUS_HTTP_500");
+        assert.equal(
+          j.checks.connectors.nativeReason,
+          "NATIVE_INTEGRATIONS_HTTP_500",
+        );
+      },
+    );
+  });
+});
+
+test("setup-status falls back to native integrations when loop connector status fails", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        connectorStatus: 500,
+        connectorPayload: { error: "connectors failed" },
+        integrationPayload: {
+          accounts: [
+            {
+              id: "native-gmail-account",
+              platform: "gmail",
+              externalId: "must-not-leak",
+              displayName: "Gmail",
+              status: "connected",
+            },
+            {
+              id: "native-qq-account",
+              platform: "qqbot",
+              externalId: "must-not-leak",
+              displayName: "QQ",
+              status: "connected",
+            },
+          ],
+        },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+        });
+
+        assert.equal(j.ready, true);
+        assert.equal(j.connectorStatusAvailable, true);
+        assert.equal(j.connectorSetupRecommended, false);
+        assert.equal(j.recommendedNextAction, null);
+        assert.equal(j.recommendedReason, null);
+        assert.equal(
+          j.connectorStatus.reason,
+          "CONNECTOR_STATUS_HTTP_500_WITH_NATIVE_INTEGRATIONS",
+        );
+        assert.deepEqual(
+          j.connectors.map((connector) => ({
+            id: connector.id,
+            connected: connector.connected,
+            accountCount: connector.accountCount,
+          })),
+          [
+            { id: "gmail", connected: true, accountCount: 1 },
+            { id: "qqbot", connected: true, accountCount: 1 },
+          ],
+        );
+        const serialized = JSON.stringify(j.connectors);
+        assert.equal(serialized.includes("must-not-leak"), false);
+      },
+    );
+  });
+});
+
 test("setup-status aiProvider checks only report presence, never values", () => {
   withFakeHome((env) => {
     const j = runJson(["setup-status"], env);
@@ -415,7 +693,7 @@ test("setup-status aiProvider checks only report presence, never values", () => 
   });
 });
 
-test('run preserves the direct runner by not synthesizing OPENLOOMI_API_URL', () => {
+test("run preserves the direct runner by not synthesizing OPENLOOMI_API_URL", () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
@@ -433,34 +711,34 @@ test('run preserves the direct runner by not synthesizing OPENLOOMI_API_URL', ()
     assert.equal(r.code, 0, r.stderr || r.stdout);
     const j = JSON.parse(r.stdout);
     assert.equal(j.ready, true);
-    assert.equal(j.reason, 'RUN_COMPLETE');
+    assert.equal(j.reason, "RUN_COMPLETE");
     assert.equal(j.result.env.OPENLOOMI_API_URL, null);
-    assert.equal(j.result.prompt, 'Reply with exactly: OpenLoomi ready.');
-    assert.ok(!r.stdout.includes('sk-test-never-print'));
+    assert.equal(j.result.prompt, "Reply with exactly: OpenLoomi ready.");
+    assert.ok(!r.stdout.includes("sk-test-never-print"));
   });
 });
 
-test('run preserves an explicitly configured OPENLOOMI_API_URL', () => {
+test("run preserves an explicitly configured OPENLOOMI_API_URL", () => {
   withFakeHome((env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
     const r = runOutcomeWithInput(
-      ['run'],
+      ["run"],
       {
         ...env,
         OPENLOOMI_CTL: ctl,
-        OPENLOOMI_BASE_URL: 'http://localhost:3414',
-        OPENLOOMI_API_URL: 'http://localhost:3515',
-        ANTHROPIC_API_KEY: 'sk-test-never-print',
+        OPENLOOMI_BASE_URL: "http://localhost:3414",
+        OPENLOOMI_API_URL: "http://localhost:3515",
+        ANTHROPIC_API_KEY: "sk-test-never-print",
       },
-      'Reply with exactly: OpenLoomi ready.',
+      "Reply with exactly: OpenLoomi ready.",
     );
     assert.equal(r.code, 0, r.stderr || r.stdout);
     const j = JSON.parse(r.stdout);
     assert.equal(j.ready, true);
-    assert.equal(j.reason, 'RUN_COMPLETE');
-    assert.equal(j.result.env.OPENLOOMI_API_URL, 'http://localhost:3515');
-    assert.ok(!r.stdout.includes('sk-test-never-print'));
+    assert.equal(j.reason, "RUN_COMPLETE");
+    assert.equal(j.result.env.OPENLOOMI_API_URL, "http://localhost:3515");
+    assert.ok(!r.stdout.includes("sk-test-never-print"));
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/melandlabs/openloomi/issues/328

## Summary

This PR updates the Codex plugin setup-status flow so connector readiness is reported separately from core OpenLoomi runtime readiness.

The bridge now:
- keeps `ready: true` for core runtime readiness when OpenLoomi is installed, authenticated, and AI provider setup is available;
- queries `/api/loop/connectors` for status-only connector rows;
- falls back to OpenLoomi native integrations from `/api/integrations` when Loop connector status is unavailable or slow;
- reports connected native accounts such as Gmail and QQbot as status-only connector rows;
- recommends `configure_connectors` only when connector status cannot be confirmed or no connector is connected;
- avoids printing OAuth tokens, passwords, account identifiers, cookies, Composio secrets, or other connector credentials.

## Testing

```powershell
pnpm exec prettier --check "plugins/codex/scripts/loomi-bridge.mjs" "plugins/codex/tests/bridge.test.mjs" "plugins/codex/README.md" "plugins/codex/skills/openloomi-connectors/SKILL.md"

node --test plugins/codex/tests/bridge.test.mjs