### PR TITLE
fix(codex): treat active native runtime as setup ready

### DIFF
--- a/apps/marketing/content/plugins/codex.mdx
+++ b/apps/marketing/content/plugins/codex.mdx
@@ -325,12 +325,12 @@ The valid states are: `happy`, `idle`, `juggling`, `needsinput`, `presenting`, `
 | `version`                  | detected OpenLoomi version                                                            |
 | `tokenPresent`             | a local auth token exists                                                             |
 | `session`                  | `tokenPresent`, `guestBootstrapSupported`, `guestBootstrapMode`                       |
-| `aiProviderConfigured`     | a direct OpenAI-compatible or Anthropic-compatible AI provider is configured           |
+| `aiProviderConfigured`     | a direct OpenAI-compatible or Anthropic-compatible AI provider is configured          |
 | `aiProviderStatus`         | `runtime_configured` \| `unavailable`                                                 |
-| `executionProviderReady`   | direct AI provider or native Codex runtime can execute tasks                           |
+| `executionProviderReady`   | direct AI provider or native Codex runtime can execute tasks                          |
 | `executionProviderSource`  | `ai_provider` \| `native_codex_runtime` \| `null`                                     |
-| `nativeRuntimeActive`      | `/api/native/providers` reports Codex as the active default native runtime             |
-| `nativeRuntime`            | summarized `/api/native/providers` probe result                                        |
+| `nativeRuntimeActive`      | `/api/native/providers` reports Codex as the active default native runtime            |
+| `nativeRuntime`            | summarized `/api/native/providers` probe result                                       |
 | `connectorStatusAvailable` | whether the local API can report connector status                                     |
 | `apiReachable`             | local HTTP API responded                                                              |
 | `ready`                    | everything needed is in place                                                         |

--- a/apps/marketing/content/plugins/codex.mdx
+++ b/apps/marketing/content/plugins/codex.mdx
@@ -325,13 +325,24 @@ The valid states are: `happy`, `idle`, `juggling`, `needsinput`, `presenting`, `
 | `version`                  | detected OpenLoomi version                                                            |
 | `tokenPresent`             | a local auth token exists                                                             |
 | `session`                  | `tokenPresent`, `guestBootstrapSupported`, `guestBootstrapMode`                       |
-| `aiProviderConfigured`     | an AI provider is configured                                                          |
+| `aiProviderConfigured`     | a direct OpenAI-compatible or Anthropic-compatible AI provider is configured           |
 | `aiProviderStatus`         | `runtime_configured` \| `unavailable`                                                 |
+| `executionProviderReady`   | direct AI provider or native Codex runtime can execute tasks                           |
+| `executionProviderSource`  | `ai_provider` \| `native_codex_runtime` \| `null`                                     |
+| `nativeRuntimeActive`      | `/api/native/providers` reports Codex as the active default native runtime             |
+| `nativeRuntime`            | summarized `/api/native/providers` probe result                                        |
 | `connectorStatusAvailable` | whether the local API can report connector status                                     |
 | `apiReachable`             | local HTTP API responded                                                              |
 | `ready`                    | everything needed is in place                                                         |
 | `nextAction`               | what to do next (see below)                                                           |
 | `checks`                   | detailed provider / connector / runtime checks (e.g. `aiProviderRuntime.providers[]`) |
+
+`aiProviderConfigured: false` does not necessarily block native Codex CLI
+execution. When `/api/native/providers` reports `defaultAgent: "codex"` and the
+Codex agent metadata is present, `setup-status` may still be `ready: true` with
+`executionProviderSource: "native_codex_runtime"`. Direct AI provider settings
+remain relevant for features that explicitly use OpenLoomi-owned model-provider
+configuration.
 
 ### `nextAction` values
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -628,6 +628,24 @@ For source checkouts, check project markers and likely CLI locations:
   },
   "aiProviderConfigured": true,
   "aiProviderStatus": "runtime_configured",
+  "executionProviderReady": true,
+  "executionProviderSource": "ai_provider | native_codex_runtime",
+  "nativeRuntimeActive": false,
+  "nativeRuntimeProvider": "claude | codex | null",
+  "nativeRuntime": {
+    "checked": true,
+    "available": true,
+    "active": false,
+    "reason": "CODEX_RUNTIME_INACTIVE",
+    "defaultAgent": "claude",
+    "codexAgentAvailable": true,
+    "agents": [
+      {
+        "type": "codex",
+        "name": "Codex CLI"
+      }
+    ]
+  },
   "connectorStatusAvailable": true,
   "connectors": [
     {
@@ -659,6 +677,12 @@ For source checkouts, check project markers and likely CLI locations:
         }
       ]
     },
+    "nativeProvider": {
+      "checked": true,
+      "available": true,
+      "active": false,
+      "reason": "CODEX_RUNTIME_INACTIVE"
+    },
     "connectors": {
       "checked": true,
       "available": true,
@@ -668,6 +692,15 @@ For source checkouts, check project markers and likely CLI locations:
   }
 }
 ```
+
+`aiProviderConfigured` only describes OpenLoomi-owned direct
+OpenAI-compatible or Anthropic-compatible provider settings. Native Codex CLI
+execution is tracked separately through `nativeRuntime*` and
+`executionProvider*` fields. When `/api/native/providers` reports
+`defaultAgent: "codex"` and the Codex agent metadata is present,
+`setup-status` may return `ready: true` with
+`executionProviderSource: "native_codex_runtime"` even while
+`aiProviderConfigured` remains `false`.
 
 Connector readiness is a status-only advisory. Missing Gmail, Slack, GitHub,
 Calendar, or Linear connections should not block memory-only or local runtime

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -308,6 +308,13 @@ async function buildSetupStatus() {
     apiProbe.reachableUrl,
     token,
   );
+  const nativeProviderStatus = await getNativeProviderStatus(
+    apiProbe.reachableUrl,
+  );
+  const executionProvider = getExecutionProviderStatus(
+    aiProvider,
+    nativeProviderStatus,
+  );
 
   const baseStatus = {
     mode: discovery.mode,
@@ -317,6 +324,22 @@ async function buildSetupStatus() {
     tokenPresent: token.present,
     aiProviderConfigured: aiProvider.configured,
     aiProviderStatus: aiProvider.status,
+    executionProviderReady: executionProvider.ready,
+    executionProviderSource: executionProvider.source,
+    nativeRuntimeActive: nativeProviderStatus.active,
+    nativeRuntimeProvider: nativeProviderStatus.defaultAgent,
+    nativeRuntimeStatus: nativeProviderStatus.reason,
+    nativeRuntime: {
+      checked: nativeProviderStatus.checked,
+      available: nativeProviderStatus.available,
+      active: nativeProviderStatus.active,
+      reason: nativeProviderStatus.reason,
+      baseUrl: nativeProviderStatus.baseUrl,
+      endpoint: nativeProviderStatus.endpoint,
+      defaultAgent: nativeProviderStatus.defaultAgent,
+      codexAgentAvailable: nativeProviderStatus.codexAgentAvailable,
+      agents: nativeProviderStatus.agents,
+    },
     connectorStatusAvailable: connectorStatus.available,
     connectors: connectorStatus.connectors,
     connectorSetupRecommended: connectorStatus.setupRecommended,
@@ -364,6 +387,7 @@ async function buildSetupStatus() {
       auth: token.checked,
       aiProvider: aiProvider.checked,
       aiProviderRuntime: aiProvider.runtime,
+      nativeProvider: nativeProviderStatus,
       apiProbe: apiProbe.attempts,
       connectors: connectorStatus.check,
       discovery: discovery.checked,
@@ -384,7 +408,147 @@ async function buildSetupStatus() {
       aiProvider,
       codexRuntimeEnv,
       apiProbe,
+      nativeProviderStatus,
     ),
+  };
+}
+
+async function getNativeProviderStatus(baseUrl) {
+  const normalizedBaseUrl = normalizeLocalApiUrl(baseUrl);
+  const endpoint = "/api/native/providers";
+
+  if (!normalizedBaseUrl) {
+    return buildNativeProviderStatus({
+      checked: false,
+      available: false,
+      reason: "OPENLOOMI_API_UNREACHABLE",
+      baseUrl: null,
+      endpoint,
+    });
+  }
+
+  if (typeof fetch !== "function") {
+    return buildNativeProviderStatus({
+      checked: true,
+      available: false,
+      reason: "FETCH_UNAVAILABLE",
+      baseUrl: normalizedBaseUrl,
+      endpoint,
+    });
+  }
+
+  try {
+    const response = await fetchWithTimeout(
+      `${normalizedBaseUrl}${endpoint}`,
+      {
+        headers: {
+          Accept: "application/json",
+        },
+        redirect: "manual",
+      },
+      API_PROBE_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      return buildNativeProviderStatus({
+        checked: true,
+        available: false,
+        reason: `NATIVE_PROVIDERS_HTTP_${response.status}`,
+        baseUrl: normalizedBaseUrl,
+        endpoint,
+        status: response.status,
+      });
+    }
+
+    const payload = await response.json().catch(() => null);
+    const agents = Array.isArray(payload?.agents)
+      ? payload.agents.map(summarizeNativeAgent)
+      : [];
+    const defaultAgent =
+      typeof payload?.defaultAgent === "string" ? payload.defaultAgent : null;
+    const codexAgentAvailable = agents.some(
+      (agent) => agent.type === CODEX_RUNTIME_PROVIDER,
+    );
+    const active =
+      defaultAgent === CODEX_RUNTIME_PROVIDER && codexAgentAvailable;
+
+    return buildNativeProviderStatus({
+      checked: true,
+      available: true,
+      active,
+      reason: active ? "CODEX_RUNTIME_ACTIVE" : "CODEX_RUNTIME_INACTIVE",
+      baseUrl: normalizedBaseUrl,
+      endpoint,
+      status: response.status,
+      defaultAgent,
+      codexAgentAvailable,
+      agents,
+    });
+  } catch (error) {
+    return buildNativeProviderStatus({
+      checked: true,
+      available: false,
+      reason: error?.name === "AbortError" ? "API_TIMEOUT" : "API_UNREACHABLE",
+      baseUrl: normalizedBaseUrl,
+      endpoint,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function buildNativeProviderStatus({
+  checked,
+  available,
+  active = false,
+  reason,
+  baseUrl,
+  endpoint,
+  status = null,
+  defaultAgent = null,
+  codexAgentAvailable = false,
+  agents = [],
+  error = null,
+}) {
+  return {
+    checked,
+    available,
+    active,
+    reason,
+    baseUrl,
+    endpoint,
+    status,
+    defaultAgent,
+    codexAgentAvailable,
+    agents,
+    error,
+  };
+}
+
+function summarizeNativeAgent(agent) {
+  return {
+    type: typeof agent?.type === "string" ? agent.type : null,
+    name: typeof agent?.name === "string" ? agent.name : null,
+  };
+}
+
+function getExecutionProviderStatus(aiProvider, nativeProvider) {
+  if (aiProvider.configured) {
+    return {
+      ready: true,
+      source: "ai_provider",
+    };
+  }
+
+  if (nativeProvider.active) {
+    return {
+      ready: true,
+      source: "native_codex_runtime",
+    };
+  }
+
+  return {
+    ready: false,
+    source: null,
   };
 }
 
@@ -4479,12 +4643,14 @@ function getReadinessDecision(
   aiProvider,
   codexRuntimeEnv,
   apiProbe,
+  nativeProviderStatus,
 ) {
   // codexRuntimeEnv is intentionally NOT a gate here: a missing
   // OPENLOOMI_AGENT_PROVIDER only blocks the OpenLoomi GUI desktop from
   // routing through Codex; the bridge itself can still drive openloomi-ctl.
   // The setup state machine handles that branch separately.
   void codexRuntimeEnv;
+  const nativeCodexRuntimeReady = Boolean(nativeProviderStatus?.active);
 
   if (discovery.status === "invalid") {
     return {
@@ -4532,7 +4698,20 @@ function getReadinessDecision(
       reason: "READY_SESSION_BOOTSTRAP_PENDING",
       sessionInitializationRequired: true,
       message:
-        "OpenLoomi is installed. The bridge will initialize a local guest/session token on run, then re-check OpenLoomi AI provider settings.",
+        nativeCodexRuntimeReady
+          ? "OpenLoomi is installed and the native Codex runtime is active. The bridge will initialize a local guest/session token on run before execution."
+          : "OpenLoomi is installed. The bridge will initialize a local guest/session token on run, then re-check OpenLoomi AI provider settings.",
+    };
+  }
+
+  if (!aiProvider.configured && nativeCodexRuntimeReady) {
+    return {
+      ready: true,
+      nextAction: "run",
+      reason: "READY",
+      readinessSource: "native_codex_runtime",
+      message:
+        "OpenLoomi is ready through the native Codex runtime. A separate OpenLoomi AI provider is not required for native Codex execution.",
     };
   }
 

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -4697,10 +4697,9 @@ function getReadinessDecision(
       nextAction: "run",
       reason: "READY_SESSION_BOOTSTRAP_PENDING",
       sessionInitializationRequired: true,
-      message:
-        nativeCodexRuntimeReady
-          ? "OpenLoomi is installed and the native Codex runtime is active. The bridge will initialize a local guest/session token on run before execution."
-          : "OpenLoomi is installed. The bridge will initialize a local guest/session token on run, then re-check OpenLoomi AI provider settings.",
+      message: nativeCodexRuntimeReady
+        ? "OpenLoomi is installed and the native Codex runtime is active. The bridge will initialize a local guest/session token on run before execution."
+        : "OpenLoomi is installed. The bridge will initialize a local guest/session token on run, then re-check OpenLoomi AI provider settings.",
     };
   }
 

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -300,10 +300,27 @@ function writeJsonResponse(res, status, payload, headers = {}) {
 }
 
 function createReadySetupApiHandler({
+  aiPreferencePayload = {
+    settings: [
+      {
+        providerType: "anthropic_compatible",
+        enabled: true,
+        hasApiKey: true,
+        baseUrl: "https://api.example.invalid",
+        model: "claude-test",
+      },
+    ],
+    systemDefaults: {},
+  },
   connectorStatus = 200,
   connectorPayload = { items: [] },
   integrationStatus = 200,
   integrationPayload = { accounts: [] },
+  nativeProviderStatus = 200,
+  nativeProviderPayload = {
+    defaultAgent: "claude",
+    agents: [{ type: "claude", name: "Claude" }],
+  },
 } = {}) {
   return (req, res) => {
     const url = req.url || "/";
@@ -326,18 +343,12 @@ function createReadySetupApiHandler({
     }
 
     if (url.startsWith("/api/preferences/ai")) {
-      writeJsonResponse(res, 200, {
-        settings: [
-          {
-            providerType: "anthropic_compatible",
-            enabled: true,
-            hasApiKey: true,
-            baseUrl: "https://api.example.invalid",
-            model: "claude-test",
-          },
-        ],
-        systemDefaults: {},
-      });
+      writeJsonResponse(res, 200, aiPreferencePayload);
+      return;
+    }
+
+    if (url.startsWith("/api/native/providers")) {
+      writeJsonResponse(res, nativeProviderStatus, nativeProviderPayload);
       return;
     }
 
@@ -459,6 +470,86 @@ test("setup-status exposes the protocol contract fields", () => {
       `unexpected nextAction when not installed: ${j.nextAction}`,
     );
   }
+});
+
+test("setup-status treats active native Codex runtime as execution-ready without an AI provider", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        aiPreferencePayload: {
+          settings: [],
+          systemDefaults: {},
+        },
+        nativeProviderPayload: {
+          defaultAgent: "codex",
+          agents: [{ type: "codex", name: "Codex CLI" }],
+        },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+          OPENLOOMI_AGENT_PROVIDER: "codex",
+        });
+
+        assert.equal(j.aiProviderConfigured, false);
+        assert.equal(j.executionProviderReady, true);
+        assert.equal(j.executionProviderSource, "native_codex_runtime");
+        assert.equal(j.nativeRuntimeActive, true);
+        assert.equal(j.nativeRuntimeProvider, "codex");
+        assert.equal(j.nativeRuntime.codexAgentAvailable, true);
+        assert.equal(j.ready, true);
+        assert.equal(j.nextAction, "run");
+        assert.equal(j.reason, "READY");
+        assert.equal(j.readinessSource, "native_codex_runtime");
+        assert.equal(j.checks.nativeProvider.active, true);
+      },
+    );
+  });
+});
+
+test("setup-status still requires an AI provider when the native Codex runtime is inactive", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
+    await withLocalApiServer(
+      createReadySetupApiHandler({
+        aiPreferencePayload: {
+          settings: [],
+          systemDefaults: {},
+        },
+        nativeProviderPayload: {
+          defaultAgent: "claude",
+          agents: [
+            { type: "claude", name: "Claude" },
+            { type: "codex", name: "Codex CLI" },
+          ],
+        },
+      }),
+      async ({ baseUrl }) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          OPENLOOMI_CTL: ctl,
+          OPENLOOMI_BASE_URL: baseUrl,
+        });
+
+        assert.equal(j.aiProviderConfigured, false);
+        assert.equal(j.executionProviderReady, false);
+        assert.equal(j.executionProviderSource, null);
+        assert.equal(j.nativeRuntimeActive, false);
+        assert.equal(j.nativeRuntimeProvider, "claude");
+        assert.equal(j.nativeRuntime.codexAgentAvailable, true);
+        assert.equal(j.ready, false);
+        assert.equal(j.nextAction, "configure_ai_provider");
+        assert.equal(j.reason, "AI_PROVIDER_REQUIRED");
+      },
+    );
+  });
 });
 
 test("setup-status recommends connector setup when monitored connectors are disconnected", async () => {


### PR DESCRIPTION
Fixes #343

## Summary

This updates the Codex plugin readiness check so an active OpenLoomi native Codex runtime can satisfy execution-provider readiness without requiring a separate OpenAI-compatible or Anthropic-compatible API provider.

When `/api/native/providers` reports `defaultAgent: "codex"` and includes the Codex agent metadata, `setup-status` can now return `ready: true` / `nextAction: "run"` even if `aiProviderConfigured` is `false`.

## Changes

- Add a `/api/native/providers` probe to the Codex bridge setup status.
- Expose native runtime readiness through new setup-status fields:
  - `executionProviderReady`
  - `executionProviderSource`
  - `nativeRuntimeActive`
  - `nativeRuntimeProvider`
  - `nativeRuntime`
  - `checks.nativeProvider`
- Update readiness logic so active native Codex runtime avoids the incorrect `AI_PROVIDER_REQUIRED` result.
- Preserve the existing meaning of `aiProviderConfigured`: it still only represents OpenLoomi-owned direct AI provider settings.
- Add regression coverage for:
  - active native Codex runtime + no AI provider -> ready
  - inactive native Codex runtime + no AI provider -> still requires provider
- Update Codex plugin readiness docs.

## Boundary

This does not make `aiProviderConfigured: false` mean every OpenLoomi AI feature is available. It only unblocks the native Codex execution path.

Direct OpenLoomi AI provider configuration may still be required for features that explicitly depend on OpenLoomi-owned model-provider settings, embeddings, image generation, audio, or other non-native-runtime providers.

## Test

```bash
node --test plugins/codex/tests/bridge.test.mjs
```