### PR TITLE
fix: restore Windows Claude shell tooling

### DIFF
--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -9,7 +9,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { arch, homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   createSdkMcpServer,
   query,
@@ -249,9 +249,14 @@ function spawnClaudeCodeProcess(options: {
   }
 
   // Direct spawn for executables
+  const isBundledNativeClaude =
+    options.command.includes("cli-bundle") &&
+    ["claude", "claude.exe"].includes(basename(options.command).toLowerCase());
   const childProcess = spawn(options.command, options.args, {
     cwd: resolvedCwd,
-    env: asProcessEnv(options.env),
+    env: isBundledNativeClaude
+      ? { ...options.env, CLAUDECODE: "" }
+      : asProcessEnv(options.env),
     stdio: ["pipe", "pipe", "pipe"],
     signal: options.signal,
     windowsHide: true,
@@ -544,7 +549,19 @@ function getSidecarClaudeCodePath(): string | undefined {
   for (const bundleDir of bundleLocations) {
     if (!existsSync(bundleDir)) continue;
 
-    // New bundle structure: files are directly in bundle directory (cli.js, vendor/, node)
+    // Current bundle structure: a platform-native Claude Code executable.
+    const nativeClaudePath = join(
+      bundleDir,
+      os === "win32" ? "claude.exe" : "claude",
+    );
+    if (existsSync(nativeClaudePath)) {
+      console.log(
+        `[Claude] Using bundled native Claude Code: ${nativeClaudePath}`,
+      );
+      return nativeClaudePath;
+    }
+
+    // Legacy bundle structure: cli.js plus vendor assets and a wrapper.
     const claudeCliPath = join(bundleDir, "cli.js");
     const nodeBinPath = join(bundleDir, os === "win32" ? "node.exe" : "node");
     const vendorDir = join(bundleDir, "vendor");

--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -255,7 +255,7 @@ function spawnClaudeCodeProcess(options: {
   const childProcess = spawn(options.command, options.args, {
     cwd: resolvedCwd,
     env: isBundledNativeClaude
-      ? { ...options.env, CLAUDECODE: "" }
+      ? asProcessEnv({ ...options.env, CLAUDECODE: "" })
       : asProcessEnv(options.env),
     stdio: ["pipe", "pipe", "pipe"],
     signal: options.signal,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,7 @@
     "@openloomi/sqlite": "workspace:*",
     "@openloomi/voice-kokoro": "workspace:*",
     "@openloomi/voice-whisper": "workspace:*",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.71",
+    "@anthropic-ai/claude-agent-sdk": "0.2.141",
     "@anthropic-ai/sandbox-runtime": "^0.0.32",
     "@anthropic-ai/sdk": "^0.72.1",
     "@aws-sdk/client-secrets-manager": "^3.901.0",

--- a/apps/web/scripts/bundle-runtime.js
+++ b/apps/web/scripts/bundle-runtime.js
@@ -1,219 +1,228 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import https from "node:https";
 import http from "node:http";
-import { execSync } from "node:child_process";
+import https from "node:https";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
 import * as tar from "tar";
 
+const require = createRequire(import.meta.url);
 const TARGET_DIR = process.argv[2] || "./cli-bundle";
 const CACHE_DIR =
-  process.env.openloomi_BUNDLE_CACHE ||
+  process.env.OPENLOOMI_BUNDLE_CACHE ||
   path.join(os.homedir(), ".cache/openloomi-bundle");
 const CACHE_EXPIRE_DAYS = 0;
-const CLAUDE_VERSION = "2.1.71";
 
-const arch = os.arch();
+const sdkEntryPath = require.resolve("@anthropic-ai/claude-agent-sdk");
+const sdkPackagePath = path.join(path.dirname(sdkEntryPath), "package.json");
+const sdkManifestPath = path.join(path.dirname(sdkEntryPath), "manifest.json");
+const sdkPackage = JSON.parse(fs.readFileSync(sdkPackagePath, "utf8"));
+const sdkManifest = JSON.parse(fs.readFileSync(sdkManifestPath, "utf8"));
+const SDK_VERSION = sdkPackage.version;
+const CLAUDE_VERSION = sdkManifest.version;
+
 const rawPlatform = os.platform();
-const isAarch64 = arch === "arm64";
-const isDarwin = rawPlatform === "darwin";
-const isLinux = rawPlatform === "linux";
-const isWindows = rawPlatform === "win32";
+const rawArch = os.arch();
+const isMusl =
+  rawPlatform === "linux" &&
+  typeof process.report?.getReport === "function" &&
+  process.report.getReport().header.glibcVersionRuntime === undefined;
+const platformKey = `${rawPlatform}-${rawArch}${isMusl ? "-musl" : ""}`;
+const platformManifest = sdkManifest.platforms?.[platformKey];
 
-const platform = isDarwin
-  ? "darwin"
-  : isLinux
-    ? "linux"
-    : isWindows
-      ? "windows"
-      : "unknown";
+if (!platformManifest) {
+  console.error(
+    `Unsupported Claude Code runtime platform: ${platformKey}. Supported: ${Object.keys(sdkManifest.platforms ?? {}).join(", ")}`,
+  );
+  process.exit(1);
+}
 
-const ARCH_SUFFIX = isAarch64 ? "aarch64" : "x86_64";
-
-console.log("========================================");
-console.log("  Bundling Claude Code + Node.js");
-console.log("  for Tauri Distribution (with Cache)");
-console.log("========================================");
-console.log("");
-console.log("Platform:", platform);
-console.log("Architecture:", ARCH_SUFFIX);
-console.log("Cache directory:", CACHE_DIR);
-console.log("");
-
-fs.mkdirSync(TARGET_DIR, { recursive: true });
-fs.mkdirSync(`${CACHE_DIR}/claude-code`, { recursive: true });
-
+const packageName = `claude-agent-sdk-${platformKey}`;
+const binaryName = platformManifest.binary;
+const cacheFile = path.join(
+  CACHE_DIR,
+  "claude-code",
+  `${packageName}-${SDK_VERSION}.tgz`,
+);
+const archiveFile = path.join(
+  os.tmpdir(),
+  `${packageName}-${SDK_VERSION}-${process.pid}.tgz`,
+);
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openloomi-bundle-"));
 
 function cleanup() {
   try {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(archiveFile, { force: true });
   } catch {}
 }
 process.on("exit", cleanup);
 
-const CLAUDE_CACHE_FILE = `${CACHE_DIR}/claude-code/claude-code-${CLAUDE_VERSION}.tgz`;
-
 function checkCacheValid(file) {
   if (!fs.existsSync(file)) return false;
   if (CACHE_EXPIRE_DAYS === 0) return true;
-  const mtime = fs.statSync(file).mtime;
-  const age = (Date.now() - mtime.getTime()) / 1000;
-  return age < CACHE_EXPIRE_DAYS * 86400;
+  const ageSeconds = (Date.now() - fs.statSync(file).mtimeMs) / 1000;
+  return ageSeconds < CACHE_EXPIRE_DAYS * 86_400;
 }
 
-function downloadFile(url, dest) {
+function writeCacheAtomically(source, destination) {
+  const temporaryCacheFile = `${destination}.${process.pid}.tmp`;
+  try {
+    fs.copyFileSync(source, temporaryCacheFile);
+    try {
+      fs.renameSync(temporaryCacheFile, destination);
+    } catch (error) {
+      // A concurrent build may have populated the same immutable version.
+      if (!fs.existsSync(destination)) throw error;
+    }
+  } finally {
+    fs.rmSync(temporaryCacheFile, { force: true });
+  }
+}
+
+function downloadFile(url, destination, redirectsRemaining = 5) {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest);
     const protocol = url.startsWith("https") ? https : http;
-    protocol
-      .get(url, (response) => {
-        if (response.statusCode === 301 || response.statusCode === 302) {
-          file.close();
-          downloadFile(response.headers.location, dest)
-            .then(resolve)
-            .catch(reject);
-          return;
-        }
-        response.pipe(file);
-        file.on("finish", () => {
-          file.close();
-          resolve();
-        });
-      })
-      .on("error", (err) => {
-        fs.unlink(dest, () => {});
-        reject(err);
-      });
+    const request = protocol.get(url, (response) => {
+      const statusCode = response.statusCode ?? 0;
+      if (
+        statusCode >= 300 &&
+        statusCode < 400 &&
+        response.headers.location &&
+        redirectsRemaining > 0
+      ) {
+        response.resume();
+        downloadFile(
+          new URL(response.headers.location, url).toString(),
+          destination,
+          redirectsRemaining - 1,
+        )
+          .then(resolve)
+          .catch(reject);
+        return;
+      }
+      if (statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Download failed with HTTP ${statusCode}: ${url}`));
+        return;
+      }
+
+      const file = fs.createWriteStream(destination, { mode: 0o600 });
+      response.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+    request.on("error", reject);
   });
 }
 
-console.log("[1/3] Processing Claude Code...");
-console.log("  Version:", CLAUDE_VERSION);
+function hashFile(file) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = fs.createReadStream(file);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
 
-if (checkCacheValid(CLAUDE_CACHE_FILE)) {
-  console.log("  Using cached Claude Code:", CLAUDE_CACHE_FILE);
-  fs.copyFileSync(CLAUDE_CACHE_FILE, `${tmpDir}/claude-code.tgz`);
+function formatSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+console.log("========================================");
+console.log("  Bundling native Claude Code runtime");
+console.log("  for Tauri Distribution (with Cache)");
+console.log("========================================");
+console.log("");
+console.log("SDK version:", SDK_VERSION);
+console.log("Claude Code version:", CLAUDE_VERSION);
+console.log("Platform:", platformKey);
+console.log("Cache directory:", CACHE_DIR);
+console.log("");
+
+fs.mkdirSync(TARGET_DIR, { recursive: true });
+fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+
+const archiveFromCache = checkCacheValid(cacheFile);
+if (archiveFromCache) {
+  console.log("Using cached Claude Code:", cacheFile);
+  fs.copyFileSync(cacheFile, archiveFile);
 } else {
-  console.log("  Downloading Claude Code (no valid cache)...");
-  const url = `https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${CLAUDE_VERSION}.tgz`;
-  try {
-    execSync(`curl -sL "${url}" -o "${tmpDir}/claude-code.tgz"`, {
-      stdio: "pipe",
-    });
-  } catch {
-    console.log("  Downloading via Node.js fallback...");
-    await downloadFile(url, `${tmpDir}/claude-code.tgz`);
-  }
-  console.log("  Saving to cache:", CLAUDE_CACHE_FILE);
-  fs.copyFileSync(`${tmpDir}/claude-code.tgz`, CLAUDE_CACHE_FILE);
+  const url = `https://registry.npmjs.org/@anthropic-ai/${packageName}/-/${packageName}-${SDK_VERSION}.tgz`;
+  console.log("Downloading Claude Code:", url);
+  await downloadFile(url, archiveFile);
 }
 
-console.log("  Extracting...");
-await tar.extract({ file: `${tmpDir}/claude-code.tgz`, cwd: tmpDir });
-
-const rm = (p) => {
-  try {
-    fs.rmSync(p, { recursive: true, force: true });
-  } catch {}
-};
-rm(`${TARGET_DIR}/cli.js`);
-rm(`${TARGET_DIR}/package.json`);
-rm(`${TARGET_DIR}/vendor`);
-
-for (const f of fs.readdirSync(TARGET_DIR)) {
-  if (/\.wasm$|\.d\.ts$|bun\.lock$/.test(f)) {
-    try {
-      fs.unlinkSync(`${TARGET_DIR}/${f}`);
-    } catch {}
-  }
+console.log("Extracting native runtime...");
+try {
+  await tar.extract({ file: archiveFile, cwd: tmpDir });
+} catch (error) {
+  if (archiveFromCache) fs.rmSync(cacheFile, { force: true });
+  throw error;
 }
 
-fs.copyFileSync(`${tmpDir}/package/cli.js`, `${TARGET_DIR}/cli.js`);
-fs.copyFileSync(`${tmpDir}/package/package.json`, `${TARGET_DIR}/package.json`);
-
-const copyDirRec = (src, dest) => {
-  if (!fs.existsSync(src)) return;
-  fs.mkdirSync(dest, { recursive: true });
-  for (const item of fs.readdirSync(src)) {
-    const s = path.join(src, item);
-    const d = path.join(dest, item);
-    fs.statSync(s).isDirectory() ? copyDirRec(s, d) : fs.copyFileSync(s, d);
-  }
-};
-copyDirRec(`${tmpDir}/package/vendor`, `${TARGET_DIR}/vendor`);
-
-for (const item of fs.readdirSync(`${tmpDir}/package`)) {
-  if (/\.wasm$|\.d\.ts$|bun\.lock$/.test(item)) {
-    try {
-      fs.copyFileSync(`${tmpDir}/package/${item}`, `${TARGET_DIR}/${item}`);
-    } catch {}
-  }
-}
-
-console.log("  Done");
-
-console.log("");
-console.log("[Cleanup] Removing unnecessary platform files from vendor...");
-if (fs.existsSync(`${TARGET_DIR}/vendor/ripgrep`)) {
-  const ripgrepDir = `${TARGET_DIR}/vendor/ripgrep`;
-  let keepDir = "";
-  if (platform === "darwin")
-    keepDir = isAarch64 ? "arm64-darwin" : "x64-darwin";
-  else if (platform === "linux")
-    keepDir = isAarch64 ? "arm64-linux" : "x64-linux";
-  else if (platform === "windows") keepDir = "x64-win32";
-
-  if (keepDir) {
-    console.log("  Keeping platform:", keepDir);
-    for (const item of fs.readdirSync(ripgrepDir)) {
-      if (item !== keepDir && item !== "COPYING") {
-        console.log("  Removing:", item);
-        rm(`${ripgrepDir}/${item}`);
-      }
-    }
-    console.log("  Vendor cleanup complete");
-  }
-}
-
-console.log("");
-console.log("[2/3] Using system Node.js (not bundled)...");
-console.log("  Skipping Node.js bundle - will use system Node.js at runtime");
-
-console.log("");
-console.log("[3/3] Verifying bundle...");
-
-if (fs.existsSync(`${TARGET_DIR}/cli.js`)) {
-  const stat = fs.statSync(`${TARGET_DIR}/cli.js`);
-  const size =
-    stat.size < 1024
-      ? `${stat.size} B`
-      : stat.size < 1024 * 1024
-        ? `${(stat.size / 1024).toFixed(1)} KB`
-        : `${(stat.size / (1024 * 1024)).toFixed(1)} MB`;
-  console.log("  Claude Code CLI:", size);
-} else {
-  console.error("Error: cli.js not found!");
+const sourceBinary = path.join(tmpDir, "package", binaryName);
+if (!fs.existsSync(sourceBinary)) {
+  if (archiveFromCache) fs.rmSync(cacheFile, { force: true });
+  console.error(`Claude Code package did not contain ${binaryName}`);
   process.exit(1);
 }
 
-console.log("  Node.js: (using system Node.js)");
+for (const legacyName of [
+  "cli.js",
+  "claude",
+  "claude.exe",
+  "claude.cmd",
+  "claude.sh",
+  "node",
+  "node.exe",
+  "package.json",
+  "vendor",
+]) {
+  fs.rmSync(path.join(TARGET_DIR, legacyName), {
+    recursive: true,
+    force: true,
+  });
+}
+for (const file of fs.readdirSync(TARGET_DIR)) {
+  if (/\.wasm$|\.d\.ts$|bun\.lock$/.test(file)) {
+    fs.rmSync(path.join(TARGET_DIR, file), { force: true });
+  }
+}
 
-if (fs.existsSync(`${TARGET_DIR}/vendor`)) {
-  let count = 0;
-  const countFiles = (dir) => {
-    for (const item of fs.readdirSync(dir)) {
-      const p = path.join(dir, item);
-      fs.statSync(p).isDirectory() ? countFiles(p) : count++;
-    }
-  };
-  countFiles(`${TARGET_DIR}/vendor`);
-  console.log("  Vendor files:", count);
-} else {
-  console.error("Error: vendor directory not found!");
+const targetBinary = path.join(TARGET_DIR, binaryName);
+fs.copyFileSync(sourceBinary, targetBinary);
+if (rawPlatform !== "win32") fs.chmodSync(targetBinary, 0o755);
+
+for (const metadataFile of ["package.json", "LICENSE.md", "README.md"]) {
+  const source = path.join(tmpDir, "package", metadataFile);
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, path.join(TARGET_DIR, metadataFile));
+  }
+}
+
+const actualChecksum = await hashFile(targetBinary);
+if (actualChecksum !== platformManifest.checksum) {
+  if (archiveFromCache) fs.rmSync(cacheFile, { force: true });
+  console.error(
+    `Claude Code checksum mismatch: expected ${platformManifest.checksum}, received ${actualChecksum}`,
+  );
   process.exit(1);
 }
 
+if (!archiveFromCache) {
+  writeCacheAtomically(archiveFile, cacheFile);
+  console.log("Cached verified Claude Code:", cacheFile);
+}
+
+const binarySize = fs.statSync(targetBinary).size;
+console.log("Claude Code CLI:", targetBinary);
+console.log("Size:", formatSize(binarySize));
+console.log("SHA-256: verified");
 console.log("");
 console.log("========================================");
 console.log("  Bundle complete! (with Cache)");

--- a/apps/web/scripts/tauri-build.js
+++ b/apps/web/scripts/tauri-build.js
@@ -70,7 +70,7 @@ fs.writeFileSync(".next/standalone/package.json", "{}");
 fs.writeFileSync(".next/standalone/apps/web/package.json", "{}");
 fs.writeFileSync(".next/standalone/node_modules/package.json", "{}");
 
-console.log("Bundling Claude and Node.js runtime...");
+console.log("Bundling native Claude Code runtime...");
 execSync("pnpm bundle:runtime", { stdio: "inherit" });
 
 console.log("Bundling native-agent CLI runner...");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,7 @@ importers:
     dependencies:
       '@agentclientprotocol/sdk':
         specifier: ^0.22.1
-        version: 0.22.1(zod@4.4.3)
+        version: 0.22.1(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^1.0.0
         version: 1.0.36(zod@4.3.6)
@@ -162,8 +162,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.181(react@19.2.5)(zod@4.3.6)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.71
-        version: 0.2.117(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: 0.2.141
+        version: 0.2.141(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@anthropic-ai/sandbox-runtime':
         specifier: ^0.0.32
         version: 0.0.32
@@ -1070,7 +1070,7 @@ importers:
         version: 3.10.1
       langchain:
         specifier: ^1.2.3
-        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
@@ -1523,7 +1523,7 @@ importers:
         version: 3.10.1
       langchain:
         specifier: ^1.2.3
-        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
@@ -1808,52 +1808,52 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.117':
-    resolution: {integrity: sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
+    resolution: {integrity: sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.117':
-    resolution: {integrity: sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
+    resolution: {integrity: sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.117':
-    resolution: {integrity: sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
+    resolution: {integrity: sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.117':
-    resolution: {integrity: sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
+    resolution: {integrity: sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.117':
-    resolution: {integrity: sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
+    resolution: {integrity: sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.117':
-    resolution: {integrity: sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
+    resolution: {integrity: sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.117':
-    resolution: {integrity: sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
+    resolution: {integrity: sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.117':
-    resolution: {integrity: sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
+    resolution: {integrity: sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.117':
-    resolution: {integrity: sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA==}
+  '@anthropic-ai/claude-agent-sdk@0.2.141':
+    resolution: {integrity: sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -1875,8 +1875,8 @@ packages:
       zod:
         optional: true
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1884,8 +1884,8 @@ packages:
       zod:
         optional: true
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.93.0':
+    resolution: {integrity: sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -13348,6 +13348,10 @@ snapshots:
 
   '@acemir/cssom@0.9.31': {}
 
+  '@agentclientprotocol/sdk@0.22.1(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+
   '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
@@ -13518,44 +13522,44 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.117':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.117(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.141(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.93.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.117
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.117
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.141
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.141
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -13587,17 +13591,17 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
-
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@anthropic-ai/sdk@0.93.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -15900,7 +15904,7 @@ snapshots:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))':
+  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -15908,8 +15912,6 @@ snapshots:
       uuid: 13.0.0
     optionalDependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
       svelte: 5.56.1(@typescript-eslint/types@8.59.3)
       vue: 3.5.35(typescript@5.9.3)
 
@@ -15926,11 +15928,11 @@ snapshots:
       svelte: 5.56.1(@typescript-eslint/types@8.59.3)
       vue: 3.5.35(typescript@5.9.3)
 
-  '@langchain/langgraph@1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)':
+  '@langchain/langgraph@1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.4.3
@@ -21954,7 +21956,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.0)
+      retry-axios: 2.6.0(axios@1.15.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -22474,10 +22476,10 @@ snapshots:
 
   kysely@0.29.2: {}
 
-  langchain@1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6)):
+  langchain@1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)
+      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
       langsmith: 0.5.21(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       uuid: 11.1.0
@@ -24913,7 +24915,7 @@ snapshots:
 
   resumable-stream@2.2.12: {}
 
-  retry-axios@2.6.0(axios@1.15.0):
+  retry-axios@2.6.0(axios@1.15.0(debug@4.4.3)):
     dependencies:
       axios: 1.15.0(debug@4.4.3)
 


### PR DESCRIPTION
## Summary

Mirrors alloomi [#3070](https://github.com/melandlabs/alloomi/pull/3070) — pull the platform-native `claude` / `claude.exe` binary from `@anthropic-ai/claude-agent-sdk` instead of downloading the legacy `@anthropic-ai/claude-code` npm tarball and emitting a `cli.js` + `vendor/` + `node` directory that needed a `.cmd` / `.sh` wrapper script to launch.

After this PR, Tauri bundles ship the native Claude Code binary directly into `cli-bundle/`, so Windows users no longer depend on Node.js being on `PATH` (or a fallback to a system `node` call inside the `.cmd` wrapper) to start Claude.

## What changed

- **`apps/web/scripts/bundle-runtime.js`** — full rewrite:
  - Resolves the SDK via `createRequire(import.meta.url)`, reads its `package.json` + `manifest.json` to discover `SDK_VERSION`, `CLAUDE_VERSION`, per-platform `binary` filename, and the SHA-256 `checksum`.
  - Builds `platformKey = "${rawPlatform}-${rawArch}${isMusl ? '-musl' : ''}"` (musl detected via `process.report.getReport().header.glibcVersionRuntime`).
  - Downloads `claude-agent-sdk-${platformKey}-${SDK_VERSION}.tgz` from the npm registry, extracts, copies the native binary out.
  - Verifies SHA-256 against `platformManifest.checksum`; invalidates cache on mismatch.
  - Caches the verified tarball under `~/.cache/openloomi-bundle/` (env-overridable via `OPENLOOMI_BUNDLE_CACHE`), with atomic temp-file rename to be safe under concurrent builds.
  - Replaces the legacy `execSync('curl ...')` branch with a Node-native `https` follow-redirect implementation that has a redirect-count guard and proper error handling.
  - Before emitting, purges legacy artifacts from any pre-existing `cli-bundle/`: `cli.js`, `claude`, `claude.exe`, `claude.cmd`, `claude.sh`, `node`, `node.exe`, `package.json`, `vendor`, plus `.wasm` / `.d.ts` / `bun.lock` strays.
- **`apps/web/lib/ai/extensions/agent/claude/index.ts`** — three surgical edits:
  - Add `basename` to the `node:path` import.
  - Add a native-binary short-circuit at the top of each iteration in `getSidecarClaudeCodePath`. When `cli-bundle/claude` (or `claude.exe`) exists, return it directly. Otherwise fall through to the existing `cli.js` + wrapper generation path so legacy bundles keep working.
  - In the "Direct spawn for executables" branch of `spawnClaudeCodeProcess`, detect `isBundledNativeClaude` (command path includes `cli-bundle` and basename is `claude` / `claude.exe`) and inject `CLAUDECODE: ""` so the spawned binary doesn't think it's nested.
- **`apps/web/scripts/tauri-build.js`** — log line rename: "Bundling Claude and Node.js runtime..." → "Bundling native Claude Code runtime..." since Node.js is no longer bundled.
- **`apps/web/package.json`** — `@anthropic-ai/claude-agent-sdk` pinned from `^0.2.71` to `0.2.141` to match alloomi and pull the platform-binary distribution format.
- **`pnpm-lock.yaml`** — regenerated via `pnpm install --filter web`. The eight platform-specific packages (`claude-agent-sdk-darwin-arm64`, `-linux-arm64-musl`, `-win32-x64`, etc.) all move to `0.2.141`.

## What deliberately did NOT change (and why)

- **No `mcp/tools/bash.ts` / `persistent-shell.ts` / `shell-tool-config.ts` work** — openloomi has no custom Bash MCP server and no PowerShell tool integration, so the `createBashMcpServer({ shellPath })`, `resolveBashExecutable`, `configureWindowsPowerShellTool`, `setQueryEnvironmentVariable`, and `CLAUDE_CODE_GIT_BASH_PATH` plumbing from alloomi don't apply.
- **No `ALLOWED_TOOLS += "PowerShell"`** — same reason.
- **No `getBusinessToolsInstruction` Windows/PowerShell branch** — same reason.
- **No Bash-MCP graceful-degradation branch** — same reason.
- **No error classifier rewrite** — openloomi's classifier (in `claude/index.ts` around the `isApiCompatibilityError` / `isProcessCrash` / `isTimeoutError` chain) is already structured differently from alloomi's, so it doesn't suffer from the same "exit-1 misrouted into `custom_api_incompatible`" bug that alloomi's PR fixes.

## Test plan

- [x] `cd apps/web && node scripts/bundle-runtime.js` completes end-to-end on darwin-arm64, emits `cli-bundle/claude` (197 MB, `0o755`), SHA-256 verified, legacy `cli.js` / `vendor/` / `node` / `claude.sh` / `bun.lock` artifacts purged.
- [x] `pnpm install --filter web` resolves cleanly (pre-existing peer-dep warnings untouched).
- [x] `git diff --stat` shows the expected five-file change set under `apps/web/...` and `pnpm-lock.yaml`.
- [ ] Windows Tauri build (`pnpm -F web tauri:build` on win32) — needs Windows runner. Verify the resulting bundle contains `cli-bundle/claude.exe`, that the runtime picks it up via the new branch in `getSidecarClaudeCodePath`, and that `spawnClaudeCodeProcess` injects `CLAUDECODE=""`.
- [ ] macOS Tauri build (`pnpm -F web tauri:build` on darwin) — verify the runtime path picks the native `claude` binary, and that legacy-format bundles still resolve through the wrapper fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)