### PR TITLE
feat: Add lifestyle image generation trigger in chat

### DIFF
--- a/apps/web/app/api/ai/v1/images/lifestyle/generate/route.ts
+++ b/apps/web/app/api/ai/v1/images/lifestyle/generate/route.ts
@@ -1,0 +1,239 @@
+import {
+  composeLifestyleImagePrompt,
+  type LifestyleReferenceImageInput,
+} from "@/lib/ai/image-generation/lifestyle-composer";
+import { generateImageForApi } from "@/lib/ai/image-generation/service";
+import { recordImageGenerationUsage } from "@/lib/ai/image-generation/usage";
+import { getAuthUser } from "@/lib/auth/dual-auth";
+import type {
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from "@openloomi/ai/agent";
+
+export const runtime = "nodejs";
+
+type LifestyleGenerateBody = {
+  chatId?: unknown;
+  triggerPrompt?: unknown;
+  provider?: unknown;
+  model?: unknown;
+  size?: unknown;
+  aspectRatio?: unknown;
+  quality?: unknown;
+  outputFormat?: unknown;
+  responseFormat?: unknown;
+  imageCount?: unknown;
+  n?: unknown;
+  days?: unknown;
+  recentInsightLimit?: unknown;
+  chatMessageLimit?: unknown;
+  passReferenceImagesToProvider?: unknown;
+  referenceImages?: unknown;
+};
+
+export async function POST(request: Request) {
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user?.id) {
+    return Response.json(
+      { error: "Unauthorized", code: "unauthorized:auth" },
+      { status: 401 },
+    );
+  }
+
+  const body = (await request
+    .json()
+    .catch(() => ({}))) as LifestyleGenerateBody | null;
+  if (!body || typeof body !== "object") {
+    return Response.json(
+      {
+        success: false,
+        error: "Invalid lifestyle image generation payload",
+        errorType: "validation_error",
+      },
+      { status: 400 },
+    );
+  }
+
+  const imageCount = normalizeImageCount(body.imageCount ?? body.n);
+  const composed = await composeLifestyleImagePrompt({
+    userId: user.id,
+    chatId: normalizeOptionalString(body.chatId),
+    triggerPrompt: normalizeOptionalString(body.triggerPrompt),
+    referenceImages: normalizeReferenceImages(body.referenceImages),
+    days: normalizePositiveInteger(body.days),
+    recentInsightLimit: normalizePositiveInteger(body.recentInsightLimit),
+    chatMessageLimit: normalizePositiveInteger(body.chatMessageLimit),
+    passReferenceImagesToProvider: body.passReferenceImagesToProvider === true,
+    generation: {
+      provider: normalizeOptionalString(body.provider),
+      model: normalizeOptionalString(body.model),
+      size: normalizeOptionalString(body.size),
+      aspectRatio: normalizeOptionalString(body.aspectRatio),
+      quality: normalizeQuality(body.quality),
+      outputFormat: normalizeOutputFormat(body.outputFormat),
+      responseFormat: normalizeResponseFormat(body.responseFormat),
+      imageCount,
+      n: imageCount,
+    },
+  });
+
+  const imageResult = await generateImageForApi(
+    composed.imageGenerationRequest,
+  );
+  await recordUsageSafely(user.id, imageResult);
+
+  return Response.json(
+    {
+      success: imageResult.success,
+      prompt: composed.prompt,
+      sourceSummary: composed.sourceSummary,
+      warnings: composed.warnings,
+      imageGeneration: imageResult,
+      usage: {
+        provider: imageResult.provider,
+        model: imageResult.model,
+        imageCount: imageResult.imageCount,
+        creditsUsed: imageResult.creditsUsed ?? 0,
+        costMode: "estimated",
+        quotaMode: "record_only",
+      },
+      images: imageResult.images,
+      imageUrl: imageResult.imageUrl,
+      b64Json: imageResult.b64Json,
+      dataUrl: imageResult.dataUrl,
+      mimeType: imageResult.mimeType,
+      error: imageResult.error,
+      errorType: imageResult.errorType,
+    },
+    {
+      status: imageResult.success
+        ? 200
+        : statusFromErrorType(imageResult.errorType),
+    },
+  );
+}
+
+async function recordUsageSafely(
+  userId: string | null,
+  result: ImageGenerationResponse,
+): Promise<void> {
+  try {
+    await recordImageGenerationUsage({
+      userId,
+      endpoint: "api/ai/v1/images/lifestyle/generate",
+      provider: result.provider,
+      model: result.model,
+      imageCount: result.imageCount,
+      creditsUsed: result.creditsUsed ?? 0,
+      status: result.success ? "success" : "failed",
+      errorType: result.errorType,
+      costMode: "estimated",
+      quotaMode: "record_only",
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    console.warn("[lifestyle-image-generation] usage tracking failed", error);
+  }
+}
+
+function normalizeReferenceImages(
+  value: unknown,
+): LifestyleReferenceImageInput[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value
+    .filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === "object"),
+    )
+    .map((item) => ({
+      fileId: normalizeOptionalString(item.fileId),
+      url: normalizeOptionalString(item.url),
+      dataUrl: normalizeOptionalString(item.dataUrl),
+      b64Json: normalizeOptionalString(item.b64Json),
+      mimeType: normalizeOptionalString(item.mimeType),
+      role: normalizeReferenceRole(item.role),
+      note: normalizeOptionalString(item.note),
+    }));
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeReferenceRole(
+  value: unknown,
+): LifestyleReferenceImageInput["role"] | undefined {
+  return value === "style" || value === "subject" ? value : undefined;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function normalizeImageCount(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(1, Math.min(4, Math.floor(value)));
+}
+
+function normalizeQuality(
+  value: unknown,
+): ImageGenerationRequest["quality"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (
+    normalized === "auto" ||
+    normalized === "low" ||
+    normalized === "medium" ||
+    normalized === "high" ||
+    normalized === "standard" ||
+    normalized === "hd"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeOutputFormat(
+  value: unknown,
+): ImageGenerationRequest["outputFormat"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (normalized === "png" || normalized === "jpeg" || normalized === "webp") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeResponseFormat(
+  value: unknown,
+): ImageGenerationRequest["responseFormat"] | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (
+    normalized === "url" ||
+    normalized === "b64_json" ||
+    normalized === "data_url"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function statusFromErrorType(errorType?: string): number {
+  switch (errorType) {
+    case "configuration_error":
+    case "validation_error":
+    case "provider_not_found":
+      return 400;
+    case "rate_limit":
+      return 429;
+    case "timeout":
+      return 504;
+    case "provider_error":
+      return 502;
+    default:
+      return 500;
+  }
+}

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -39,9 +39,56 @@ import {
   pickPreferredArtifactPath,
 } from "@/lib/files/extract-artifact-paths";
 import { formatAgentStreamErrorForUser } from "@/lib/ai/runtime/format-error";
+import { detectLifestyleImageTrigger } from "@/lib/ai/image-generation/lifestyle-trigger";
 
 // Max retry attempts for stream errors
 const MAX_STREAM_RETRY_ATTEMPTS = 3;
+const LIFESTYLE_IMAGE_CONSENT_STORAGE_KEY =
+  "openloomi:lifestyle-image-consent:v1";
+
+type LifestyleImageGenerationApiResponse = {
+  success: boolean;
+  prompt?: string;
+  sourceSummary?: unknown;
+  warnings?: unknown[];
+  usage?: {
+    provider?: string;
+    model?: string;
+    imageCount?: number;
+    creditsUsed?: number;
+    costMode?: string;
+    quotaMode?: string;
+  };
+  images?: Array<{
+    imageUrl?: string;
+    dataUrl?: string;
+    b64Json?: string;
+    mimeType?: string;
+    revisedPrompt?: string;
+  }>;
+  imageUrl?: string;
+  dataUrl?: string;
+  b64Json?: string;
+  mimeType?: string;
+  error?: string;
+  errorType?: string;
+  imageGeneration?: {
+    provider?: string;
+    model?: string;
+    imageCount?: number;
+    creditsUsed?: number;
+  };
+};
+
+type ChatHistoryCache = {
+  chats?: Array<{
+    id: string;
+    title?: string;
+    createdAt?: Date | string;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
 
 // Independent state per chat
 type ChatSessionState = {
@@ -63,6 +110,15 @@ export interface ChatContextValue {
   ) => void;
   sendMessage: (content: any, options?: any) => Promise<void>;
   setSendMessage: (fn: (content: any, options?: any) => Promise<void>) => void;
+  confirmLifestyleImageGeneration: (input: {
+    chatId: string;
+    assistantMessageId: string;
+    prompt: string;
+  }) => Promise<void>;
+  declineLifestyleImageGeneration: (input: {
+    chatId: string;
+    assistantMessageId: string;
+  }) => void;
   stop: () => void;
 
   // Per-chat session states
@@ -127,6 +183,35 @@ export function useChatContext() {
 export function useChatContextOptional(): ChatContextValue | null {
   const context = useContext(ChatContext);
   return context || null;
+}
+
+function hasAcceptedLifestyleImageConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.localStorage.getItem(LIFESTYLE_IMAGE_CONSENT_STORAGE_KEY) ===
+    "accepted"
+  );
+}
+
+function acceptLifestyleImageConsent(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(LIFESTYLE_IMAGE_CONSENT_STORAGE_KEY, "accepted");
+}
+
+function getLifestyleImageUrl(
+  response: LifestyleImageGenerationApiResponse,
+): { url: string; mediaType: string } | null {
+  const image = response.images?.[0];
+  const mimeType = image?.mimeType || response.mimeType || "image/png";
+  const url =
+    image?.dataUrl ||
+    image?.imageUrl ||
+    response.dataUrl ||
+    response.imageUrl ||
+    (image?.b64Json ? `data:${mimeType};base64,${image.b64Json}` : null) ||
+    (response.b64Json ? `data:${mimeType};base64,${response.b64Json}` : null);
+
+  return url ? { url, mediaType: mimeType } : null;
 }
 
 export function ChatContextProvider({ children }: { children: ReactNode }) {
@@ -277,6 +362,310 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const saveChatMessageImmediately = useCallback(
+    (message: ChatMessage, chatId: string) => {
+      saveMessagesToDatabase([message], chatId, {
+        immediate: true,
+        skipSync: false,
+      });
+      mutate(
+        (key) => typeof key === "string" && key.startsWith("/api/history"),
+        undefined,
+        { revalidate: true },
+      );
+    },
+    [],
+  );
+
+  const saveUserMessageAndUpdateHistory = useCallback(
+    async (message: ChatMessage, chatId: string) => {
+      const result = await saveMessagesToDatabase([message], chatId);
+      if (!result?.chat) return;
+
+      const chat = result.chat;
+      mutate(
+        (key) => typeof key === "string" && key.startsWith("/api/history"),
+        (data: ChatHistoryCache | undefined) => {
+          if (!data || !data.chats) return data;
+          const existingIndex = data.chats.findIndex(
+            (item) => item.id === chat.id,
+          );
+          if (existingIndex >= 0) {
+            const newChats = [...data.chats];
+            newChats[existingIndex] = {
+              ...newChats[existingIndex],
+              title: chat.title,
+            };
+            return { ...data, chats: newChats };
+          }
+          return {
+            ...data,
+            chats: [
+              ...data.chats,
+              {
+                id: chat.id,
+                title: chat.title,
+                createdAt: chat.createdAt,
+                latestMessageContent: null,
+                latestMessageTime: chat.createdAt,
+                messageCount: 1,
+              },
+            ],
+          };
+        },
+        false,
+      );
+    },
+    [],
+  );
+
+  const generateLifestyleImageReply = useCallback(
+    async ({
+      chatId,
+      prompt,
+      assistantMessageId,
+      sourceUserMessageId,
+    }: {
+      chatId: string;
+      prompt: string;
+      assistantMessageId?: string;
+      sourceUserMessageId?: string;
+    }) => {
+      const replyId = assistantMessageId || generateUUID();
+      const loadingText = "Creating your lifestyle image...";
+      const loadingMessage = {
+        role: "assistant" as const,
+        content: loadingText,
+        id: replyId,
+        parts: [
+          { type: "text" as const, text: loadingText },
+          {
+            type: "data-lifestyleImageStatus" as const,
+            data: {
+              id: replyId,
+              status: "loading" as const,
+            },
+          },
+        ],
+        metadata: {
+          lifestyleImage: {
+            status: "loading",
+            sourceUserMessageId,
+          },
+        },
+      } as ChatMessage;
+
+      setIsSending(true);
+      setIsAgentRunningForChatFn(chatId, true);
+      setMessages((prev) => {
+        const index = prev.findIndex((message) => message.id === replyId);
+        if (index === -1) return [...prev, loadingMessage];
+        const next = [...prev];
+        next[index] = loadingMessage;
+        return next;
+      }, chatId);
+
+      try {
+        const headers: HeadersInit = {
+          "Content-Type": "application/json",
+        };
+        let cloudAuthToken: string | null = null;
+        try {
+          cloudAuthToken = getAuthToken();
+        } catch (error) {
+          console.error("[LifestyleImage] Failed to read auth token:", error);
+        }
+        if (cloudAuthToken) {
+          headers.Authorization = `Bearer ${cloudAuthToken}`;
+        }
+
+        const response = await fetch("/api/ai/v1/images/lifestyle/generate", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            chatId,
+            triggerPrompt: prompt,
+            outputFormat: "png",
+            responseFormat: "data_url",
+            imageCount: 1,
+          }),
+        });
+        const data = (await response
+          .json()
+          .catch(() => null)) as LifestyleImageGenerationApiResponse | null;
+
+        if (!response.ok || !data?.success) {
+          throw new Error(
+            data?.error ||
+              `Lifestyle image generation failed (${response.status})`,
+          );
+        }
+
+        const image = getLifestyleImageUrl(data);
+        if (!image) {
+          throw new Error("Image provider returned no displayable image");
+        }
+
+        const successText = "Here is your lifestyle image.";
+        const provider =
+          data.usage?.provider || data.imageGeneration?.provider || "unknown";
+        const model =
+          data.usage?.model || data.imageGeneration?.model || "unknown";
+        const imageCount =
+          data.usage?.imageCount || data.imageGeneration?.imageCount || 1;
+        const creditsUsed =
+          data.usage?.creditsUsed ?? data.imageGeneration?.creditsUsed ?? 0;
+        const successMessage = {
+          role: "assistant" as const,
+          content: successText,
+          id: replyId,
+          parts: [
+            { type: "text" as const, text: successText },
+            {
+              type: "file" as const,
+              url: image.url,
+              name: "lifestyle-image.png",
+              mediaType: image.mediaType,
+            },
+            {
+              type: "data-lifestyleImageStatus" as const,
+              data: {
+                id: replyId,
+                status: "success" as const,
+                provider,
+                model,
+                imageCount,
+                creditsUsed,
+              },
+            },
+          ],
+          metadata: {
+            lifestyleImage: {
+              status: "success",
+              provider,
+              model,
+              imageCount,
+              creditsUsed,
+              costMode: data.usage?.costMode ?? "estimated",
+              quotaMode: data.usage?.quotaMode ?? "record_only",
+              prompt: data.prompt,
+              sourceSummary: data.sourceSummary,
+              warnings: data.warnings,
+              sourceUserMessageId,
+            },
+          },
+        } as ChatMessage;
+
+        setMessages((prev) => {
+          const index = prev.findIndex((message) => message.id === replyId);
+          if (index === -1) return [...prev, successMessage];
+          const next = [...prev];
+          next[index] = successMessage;
+          return next;
+        }, chatId);
+        saveChatMessageImmediately(successMessage, chatId);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : "Lifestyle image generation failed";
+        const failedMessage = {
+          role: "assistant" as const,
+          content: errorMessage,
+          id: replyId,
+          parts: [
+            {
+              type: "error" as const,
+              content: errorMessage,
+            },
+            {
+              type: "data-lifestyleImageStatus" as const,
+              data: {
+                id: replyId,
+                status: "error" as const,
+                error: errorMessage,
+              },
+            },
+          ],
+          metadata: {
+            lifestyleImage: {
+              status: "error",
+              error: errorMessage,
+              sourceUserMessageId,
+            },
+          },
+        } as ChatMessage;
+
+        setMessages((prev) => {
+          const index = prev.findIndex((message) => message.id === replyId);
+          if (index === -1) return [...prev, failedMessage];
+          const next = [...prev];
+          next[index] = failedMessage;
+          return next;
+        }, chatId);
+        saveChatMessageImmediately(failedMessage, chatId);
+        toast({
+          type: "error",
+          description: errorMessage,
+        });
+      } finally {
+        setIsSending(false);
+        setIsAgentRunningForChatFn(chatId, false);
+      }
+    },
+    [
+      saveChatMessageImmediately,
+      setIsAgentRunningForChatFn,
+      setMessages,
+      setIsSending,
+    ],
+  );
+
+  const confirmLifestyleImageGeneration = useCallback<
+    ChatContextValue["confirmLifestyleImageGeneration"]
+  >(
+    async ({ chatId, assistantMessageId, prompt }) => {
+      acceptLifestyleImageConsent();
+      await generateLifestyleImageReply({
+        chatId,
+        prompt,
+        assistantMessageId,
+      });
+    },
+    [generateLifestyleImageReply],
+  );
+
+  const declineLifestyleImageGeneration = useCallback<
+    ChatContextValue["declineLifestyleImageGeneration"]
+  >(
+    ({ chatId, assistantMessageId }) => {
+      const declinedText = "Lifestyle image generation canceled.";
+      const declinedMessage = {
+        role: "assistant" as const,
+        content: declinedText,
+        id: assistantMessageId,
+        parts: [{ type: "text" as const, text: declinedText }],
+        metadata: {
+          lifestyleImage: {
+            status: "declined",
+          },
+        },
+      } as ChatMessage;
+
+      setMessages((prev) => {
+        const index = prev.findIndex(
+          (message) => message.id === assistantMessageId,
+        );
+        if (index === -1) return prev;
+        const next = [...prev];
+        next[index] = declinedMessage;
+        return next;
+      }, chatId);
+      saveChatMessageImmediately(declinedMessage, chatId);
+    },
+    [saveChatMessageImmediately, setMessages],
+  );
+
   // Create safe sendMessage wrapper, integrating intelligent routing
   const sendMessage: ChatContextValue["sendMessage"] = useCallback(
     async (message, options) => {
@@ -352,6 +741,75 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       // Ensure messageContent is not empty
       if (!messageContent || messageContent.trim() === "") {
         messageContent = t("auth.errors.streamError.analyzeContent");
+      }
+
+      const triggerMessageObject =
+        message && typeof message === "object"
+          ? (message as {
+              parts?: ChatMessage["parts"];
+              metadata?: Record<string, unknown>;
+            })
+          : null;
+      const lifestyleTrigger = detectLifestyleImageTrigger(messageContent);
+      if (
+        lifestyleTrigger.matched &&
+        lifestyleTrigger.confidence === "high" &&
+        triggerMessageObject?.metadata?.skipLifestyleImageTrigger !== true
+      ) {
+        const userMessage = {
+          role: "user" as const,
+          content: messageContent,
+          parts: triggerMessageObject?.parts || [
+            { type: "text" as const, text: messageContent },
+          ],
+          metadata: {
+            ...triggerMessageObject?.metadata,
+            lifestyleImageTrigger: {
+              kind: lifestyleTrigger.kind,
+              reason: lifestyleTrigger.reason,
+            },
+          },
+          id: generateUUID(),
+        } as ChatMessage;
+        setMessages((prev) => [...prev, userMessage], chatIdForMessages);
+        await saveUserMessageAndUpdateHistory(userMessage, chatIdForMessages);
+
+        if (!hasAcceptedLifestyleImageConsent()) {
+          const consentMessageId = generateUUID();
+          const consentMessage = {
+            role: "assistant" as const,
+            content: "",
+            id: consentMessageId,
+            parts: [
+              {
+                type: "data-lifestyleImageConsent" as const,
+                data: {
+                  id: consentMessageId,
+                  prompt: messageContent,
+                  reason: lifestyleTrigger.reason,
+                  createdAt: new Date().toISOString(),
+                },
+              },
+            ],
+            metadata: {
+              lifestyleImage: {
+                status: "consent_required",
+                sourceUserMessageId: userMessage.id,
+              },
+            },
+          } as ChatMessage;
+          setMessages((prev) => [...prev, consentMessage], chatIdForMessages);
+          saveChatMessageImmediately(consentMessage, chatIdForMessages);
+          setIsSending(false);
+          return Promise.resolve();
+        }
+
+        await generateLifestyleImageReply({
+          chatId: chatIdForMessages,
+          prompt: messageContent,
+          sourceUserMessageId: userMessage.id,
+        });
+        return Promise.resolve();
       }
 
       // Extract image attachments, file attachments, RAG documents and focused insights from message
@@ -1655,7 +2113,16 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
         return Promise.reject(error);
       }
     },
-    [activeChatId, messages, setMessages, t, setIsAgentRunningForChatFn],
+    [
+      activeChatId,
+      messages,
+      setMessages,
+      t,
+      setIsAgentRunningForChatFn,
+      saveUserMessageAndUpdateHistory,
+      saveChatMessageImmediately,
+      generateLifestyleImageReply,
+    ],
   );
 
   // setSendMessage - no longer needed because sendMessage is implemented in context
@@ -2080,6 +2547,8 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       setMessages,
       sendMessage,
       setSendMessage,
+      confirmLifestyleImageGeneration,
+      declineLifestyleImageGeneration,
       stop,
       // Per-chat states
       isAgentRunning: currentSessionState.isAgentRunning,
@@ -2132,6 +2601,8 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
     switchChatId,
     isSending,
     getIsAgentRunningByChatId,
+    confirmLifestyleImageGeneration,
+    declineLifestyleImageGeneration,
   ]);
 
   return (

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -379,7 +379,10 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
 
   const saveUserMessageAndUpdateHistory = useCallback(
     async (message: ChatMessage, chatId: string) => {
-      const result = await saveMessagesToDatabase([message], chatId);
+      const result = await saveMessagesToDatabase([message], chatId, {
+        immediate: true,
+        skipSync: false,
+      });
       if (!result?.chat) return;
 
       const chat = result.chat;
@@ -432,11 +435,13 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       sourceUserMessageId?: string;
     }) => {
       const replyId = assistantMessageId || generateUUID();
+      const replyCreatedAt = new Date();
       const loadingText = "Creating your lifestyle image...";
       const loadingMessage = {
         role: "assistant" as const,
         content: loadingText,
         id: replyId,
+        createdAt: replyCreatedAt,
         parts: [
           { type: "text" as const, text: loadingText },
           {
@@ -448,6 +453,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           },
         ],
         metadata: {
+          createdAt: replyCreatedAt.toISOString(),
           lifestyleImage: {
             status: "loading",
             sourceUserMessageId,
@@ -519,6 +525,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           role: "assistant" as const,
           content: successText,
           id: replyId,
+          createdAt: replyCreatedAt,
           parts: [
             { type: "text" as const, text: successText },
             {
@@ -526,6 +533,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               url: image.url,
               name: "lifestyle-image.png",
               mediaType: image.mediaType,
+              source: "lifestyle-image-generation",
             },
             {
               type: "data-lifestyleImageStatus" as const,
@@ -540,6 +548,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             },
           ],
           metadata: {
+            createdAt: replyCreatedAt.toISOString(),
             lifestyleImage: {
               status: "success",
               provider,
@@ -573,6 +582,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           role: "assistant" as const,
           content: errorMessage,
           id: replyId,
+          createdAt: replyCreatedAt,
           parts: [
             {
               type: "error" as const,
@@ -588,6 +598,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             },
           ],
           metadata: {
+            createdAt: replyCreatedAt.toISOString(),
             lifestyleImage: {
               status: "error",
               error: errorMessage,
@@ -640,12 +651,15 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   >(
     ({ chatId, assistantMessageId }) => {
       const declinedText = "Lifestyle image generation canceled.";
+      const declinedCreatedAt = new Date();
       const declinedMessage = {
         role: "assistant" as const,
         content: declinedText,
         id: assistantMessageId,
+        createdAt: declinedCreatedAt,
         parts: [{ type: "text" as const, text: declinedText }],
         metadata: {
+          createdAt: declinedCreatedAt.toISOString(),
           lifestyleImage: {
             status: "declined",
           },
@@ -756,14 +770,17 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
         lifestyleTrigger.confidence === "high" &&
         triggerMessageObject?.metadata?.skipLifestyleImageTrigger !== true
       ) {
+        const userMessageCreatedAt = new Date();
         const userMessage = {
           role: "user" as const,
           content: messageContent,
+          createdAt: userMessageCreatedAt,
           parts: triggerMessageObject?.parts || [
             { type: "text" as const, text: messageContent },
           ],
           metadata: {
             ...triggerMessageObject?.metadata,
+            createdAt: userMessageCreatedAt.toISOString(),
             lifestyleImageTrigger: {
               kind: lifestyleTrigger.kind,
               reason: lifestyleTrigger.reason,
@@ -776,10 +793,12 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
 
         if (!hasAcceptedLifestyleImageConsent()) {
           const consentMessageId = generateUUID();
+          const consentCreatedAt = new Date(userMessageCreatedAt.getTime() + 1);
           const consentMessage = {
             role: "assistant" as const,
             content: "",
             id: consentMessageId,
+            createdAt: consentCreatedAt,
             parts: [
               {
                 type: "data-lifestyleImageConsent" as const,
@@ -792,6 +811,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               },
             ],
             metadata: {
+              createdAt: consentCreatedAt.toISOString(),
               lifestyleImage: {
                 status: "consent_required",
                 sourceUserMessageId: userMessage.id,

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -42,6 +42,7 @@ import { InlineRefBadge } from "../inline-ref-badge";
 import { ErrorMessageDisplay } from "./error-message-display";
 import { NativeToolCall } from "./native-tool-call";
 import { RawMessagesResult } from "./raw-messages-result";
+import { LifestyleImageConsent } from "./lifestyle-image-consent";
 import { ToolCallAccordion, type ToolCallPart } from "./tool-call-accordion";
 import {
   LibraryItemRow,
@@ -133,6 +134,8 @@ const PurePreviewMessage = ({
     openFilePreviewPanel,
     messages: contextMessages,
     setMessages: contextSetMessages,
+    confirmLifestyleImageGeneration,
+    declineLifestyleImageGeneration,
   } = useChatContext();
   const [, copyToClipboard] = useCopyToClipboard();
 
@@ -1016,6 +1019,35 @@ const PurePreviewMessage = ({
                             maxHeight="400px"
                           />
                         </div>
+                      );
+                    }
+
+                    if (type === "data-lifestyleImageConsent") {
+                      const consentPart = part as {
+                        data?: {
+                          prompt?: string;
+                        };
+                      };
+                      const prompt = consentPart.data?.prompt?.trim();
+                      if (!prompt) return null;
+
+                      return (
+                        <LifestyleImageConsent
+                          key={key}
+                          onConfirm={() =>
+                            confirmLifestyleImageGeneration({
+                              chatId,
+                              assistantMessageId: message.id,
+                              prompt,
+                            })
+                          }
+                          onDecline={() =>
+                            declineLifestyleImageGeneration({
+                              chatId,
+                              assistantMessageId: message.id,
+                            })
+                          }
+                        />
                       );
                     }
 

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -687,6 +687,13 @@ const PurePreviewMessage = ({
             )}
           >
             {(() => {
+              const isLifestyleImageMessage = Boolean(
+                (message.metadata as any)?.lifestyleImage,
+              );
+              const isLifestyleImagePart = (part: any) =>
+                part.source === "lifestyle-image-generation" ||
+                isLifestyleImageMessage;
+
               // Collect image parts for separate rendering
               const imageParts: Array<{
                 part: any;
@@ -965,6 +972,13 @@ const PurePreviewMessage = ({
                       const { mediaType, name, url, blobPath } = filePart;
 
                       if (mediaType?.startsWith("image/")) {
+                        if (
+                          message.role === "assistant" &&
+                          isLifestyleImagePart(filePart)
+                        ) {
+                          return null;
+                        }
+
                         // Image rendering - convert mediaType to contentType
                         const attachment = {
                           ...filePart,
@@ -1298,11 +1312,19 @@ const PurePreviewMessage = ({
                   {message.role === "assistant" && imageParts.length > 0 && (
                     <div className="flex flex-wrap gap-2 items-center">
                       {imageParts.map(({ part, key }) => {
-                        const { url, name, mediaType } = part;
+                        const { url, name, mediaType, source } = part;
+                        const shouldEnableImageLightbox =
+                          isLifestyleImagePart(part);
                         return (
                           <PreviewAttachment
                             key={key}
-                            attachment={{ url, name, contentType: mediaType }}
+                            attachment={{
+                              url,
+                              name,
+                              contentType: mediaType,
+                              source,
+                            }}
+                            enableImageLightbox={shouldEnableImageLightbox}
                           />
                         );
                       })}

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -994,6 +994,8 @@ const PurePreviewMessage = ({
                         // Image rendering - convert mediaType to contentType
                         const attachment = {
                           ...filePart,
+                          name: name ?? "image",
+                          url: url ?? blobPath ?? "",
                           contentType: mediaType, // Convert field name
                         };
                         return (
@@ -1324,16 +1326,16 @@ const PurePreviewMessage = ({
                   {message.role === "assistant" && imageParts.length > 0 && (
                     <div className="flex flex-wrap gap-2 items-center">
                       {imageParts.map(({ part, key }) => {
-                        const { url, name, mediaType, source } = part;
+                        const { url, name, mediaType, source, blobPath } = part;
                         const shouldEnableImageLightbox =
                           isLifestyleImagePart(part);
                         return (
                           <PreviewAttachment
                             key={key}
                             attachment={{
-                              url,
-                              name,
-                              contentType: mediaType,
+                              url: url ?? blobPath ?? "",
+                              name: name ?? "image",
+                              contentType: mediaType ?? "image/png",
                               source,
                             }}
                             enableImageLightbox={shouldEnableImageLightbox}

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -687,16 +687,28 @@ const PurePreviewMessage = ({
             )}
           >
             {(() => {
+              type LifestyleImageMetadata = {
+                lifestyleImage?: unknown;
+              };
+              type ImageFilePart = {
+                mediaType?: string;
+                name?: string;
+                source?: string;
+                url?: string;
+                blobPath?: string;
+              };
+
               const isLifestyleImageMessage = Boolean(
-                (message.metadata as any)?.lifestyleImage,
+                (message.metadata as LifestyleImageMetadata | undefined)
+                  ?.lifestyleImage,
               );
-              const isLifestyleImagePart = (part: any) =>
+              const isLifestyleImagePart = (part: ImageFilePart) =>
                 part.source === "lifestyle-image-generation" ||
                 isLifestyleImageMessage;
 
               // Collect image parts for separate rendering
               const imageParts: Array<{
-                part: any;
+                part: ImageFilePart;
                 index: number;
                 key: string;
               }> = [];
@@ -704,7 +716,7 @@ const PurePreviewMessage = ({
               filteredParts?.forEach((part, index) => {
                 const { type } = part;
                 if (type === "file") {
-                  const filePart = part as any;
+                  const filePart = part as ImageFilePart;
                   const { mediaType } = filePart;
                   if (mediaType?.startsWith("image/")) {
                     const key = `message-${message.id}-part-${index}`;
@@ -968,7 +980,7 @@ const PurePreviewMessage = ({
 
                     // Handle file type (images rendered uniformly in imageParts later, skip here)
                     if (type === "file") {
-                      const filePart = part as any;
+                      const filePart = part as ImageFilePart;
                       const { mediaType, name, url, blobPath } = filePart;
 
                       if (mediaType?.startsWith("image/")) {

--- a/apps/web/components/message/lifestyle-image-consent.tsx
+++ b/apps/web/components/message/lifestyle-image-consent.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface LifestyleImageConsentProps {
+  onConfirm: () => Promise<void>;
+  onDecline: () => void;
+}
+
+export function LifestyleImageConsent({
+  onConfirm,
+  onDecline,
+}: LifestyleImageConsentProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  return (
+    <div className="mt-2 w-full max-w-xl rounded-[8px] border border-border bg-card p-3 text-sm shadow-sm">
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">Generate lifestyle image?</p>
+        <p className="text-muted-foreground">
+          OpenLoomi will use bounded profile, recent chat, insight, and memory
+          summaries to create one image prompt.
+        </p>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          disabled={isSubmitting}
+          onClick={async () => {
+            setIsSubmitting(true);
+            try {
+              await onConfirm();
+            } finally {
+              setIsSubmitting(false);
+            }
+          }}
+        >
+          Generate
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={isSubmitting}
+          onClick={onDecline}
+        >
+          Not now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/preview-attachment.tsx
+++ b/apps/web/components/preview-attachment.tsx
@@ -146,31 +146,32 @@ export const PreviewAttachment = ({
         </div>
       )}
       {imagePreview && enableImageLightbox && isPreviewOpen ? (
-        <div
-          className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/80 p-4"
-          role="dialog"
+        <dialog
+          open
+          className="fixed inset-0 z-[1000] m-0 flex size-full max-h-none max-w-none items-center justify-center border-0 bg-transparent p-4"
           aria-modal="true"
           aria-label={name ?? t("common.imagePreview", "Image preview")}
-          onClick={() => setIsPreviewOpen(false)}
         >
           <button
             type="button"
-            className="absolute right-4 top-4 z-10 flex size-9 items-center justify-center rounded-full bg-white/95 text-slate-900 shadow-md hover:bg-white"
+            className="absolute inset-0 bg-black/80"
             aria-label={t("common.close", "Close")}
-            onClick={(event) => {
-              event.stopPropagation();
-              setIsPreviewOpen(false);
-            }}
+            onClick={() => setIsPreviewOpen(false)}
+          />
+          <button
+            type="button"
+            className="absolute right-4 top-4 z-20 flex size-9 items-center justify-center rounded-full bg-white/95 text-slate-900 shadow-md hover:bg-white"
+            aria-label={t("common.close", "Close")}
+            onClick={() => setIsPreviewOpen(false)}
           >
             <RemixIcon name="close" size="size-5" />
           </button>
           <img
             src={displayUrl}
             alt={name ?? "Attachment"}
-            className="max-h-full max-w-full rounded-[8px] object-contain shadow-2xl"
-            onClick={(event) => event.stopPropagation()}
+            className="relative z-10 max-h-full max-w-full rounded-[8px] object-contain shadow-2xl"
           />
-        </div>
+        </dialog>
       ) : null}
     </div>
   );

--- a/apps/web/components/preview-attachment.tsx
+++ b/apps/web/components/preview-attachment.tsx
@@ -30,12 +30,14 @@ export const PreviewAttachment = ({
   isUploading = false,
   className,
   showMetadata = true,
+  enableImageLightbox = false,
   status,
 }: {
   attachment: Attachment;
   isUploading?: boolean;
   className?: string;
   showMetadata?: boolean;
+  enableImageLightbox?: boolean;
   status?: "expired";
 }) => {
   const { name, contentType, sizeBytes } = attachment;
@@ -44,6 +46,7 @@ export const PreviewAttachment = ({
   const iconName = getAttachmentIconName(contentType);
   const { t } = useTranslation();
   const [imageLoadError, setImageLoadError] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const fallbackSourceLabel = attachment.source
     ? SOURCE_LABEL[attachment.source]
     : undefined;
@@ -63,6 +66,20 @@ export const PreviewAttachment = ({
     status === "expired"
       ? t("chat.attachments.expiredOverlay", "Expired")
       : null;
+  const imagePreview =
+    isImage && displayUrl && !imageLoadError ? (
+      // NOTE: it is recommended to use next/image for images
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        key={displayUrl}
+        src={displayUrl}
+        alt={name ?? "Attachment"}
+        className="size-full object-cover"
+        onError={() => {
+          setImageLoadError(true);
+        }}
+      />
+    ) : null;
 
   return (
     <div
@@ -77,18 +94,17 @@ export const PreviewAttachment = ({
       )}
     >
       <div className="relative flex h-16 w-full items-center justify-center overflow-hidden bg-white">
-        {isImage && displayUrl && !imageLoadError ? (
-          // NOTE: it is recommended to use next/image for images
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            key={displayUrl}
-            src={displayUrl}
-            alt={name ?? "Attachment"}
-            className="size-full object-cover"
-            onError={() => {
-              setImageLoadError(true);
-            }}
-          />
+        {imagePreview && enableImageLightbox ? (
+          <button
+            type="button"
+            className="block size-full cursor-zoom-in"
+            title={t("common.open", "Open")}
+            onClick={() => setIsPreviewOpen(true)}
+          >
+            {imagePreview}
+          </button>
+        ) : imagePreview ? (
+          imagePreview
         ) : (
           <RemixIcon name={iconName} size="size-6" className="text-slate-500" />
         )}
@@ -129,6 +145,33 @@ export const PreviewAttachment = ({
           </div>
         </div>
       )}
+      {imagePreview && enableImageLightbox && isPreviewOpen ? (
+        <div
+          className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/80 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={name ?? t("common.imagePreview", "Image preview")}
+          onClick={() => setIsPreviewOpen(false)}
+        >
+          <button
+            type="button"
+            className="absolute right-4 top-4 z-10 flex size-9 items-center justify-center rounded-full bg-white/95 text-slate-900 shadow-md hover:bg-white"
+            aria-label={t("common.close", "Close")}
+            onClick={(event) => {
+              event.stopPropagation();
+              setIsPreviewOpen(false);
+            }}
+          >
+            <RemixIcon name="close" size="size-5" />
+          </button>
+          <img
+            src={displayUrl}
+            alt={name ?? "Attachment"}
+            className="max-h-full max-w-full rounded-[8px] object-contain shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/apps/web/lib/ai/image-generation/lifestyle-composer.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-composer.ts
@@ -75,6 +75,7 @@ export interface LifestylePromptSourceSummary {
 export interface ComposeLifestyleImagePromptInput {
   userId: string;
   chatId?: string;
+  triggerPrompt?: string;
   referenceImages?: LifestyleReferenceImageInput[];
   generation?: Partial<ImageGenerationRequest>;
   days?: number;
@@ -144,6 +145,7 @@ export async function composeLifestyleImagePrompt(
     topics: normalizeStringList(settings?.focusTopics, 8, 100),
   };
   const recentInterests = dedupeStrings([
+    ...normalizeOptionalListItem(input.triggerPrompt),
     ...extractMessageSnippets(chatContext.messages),
     ...extractInsightLabels(chatContext.insights),
   ]).slice(0, 8);
@@ -742,6 +744,12 @@ function dedupeInsights(insights: Insight[]): Insight[] {
     seen.add(item.id);
     return true;
   });
+}
+
+function normalizeOptionalListItem(value: unknown, itemLimit = 180): string[] {
+  if (typeof value !== "string") return [];
+  const clipped = clipText(value, itemLimit);
+  return clipped ? [clipped] : [];
 }
 
 function normalizeStringList(

--- a/apps/web/lib/ai/image-generation/lifestyle-trigger.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-trigger.ts
@@ -1,0 +1,86 @@
+export type LifestyleImageTriggerConfidence = "high" | "medium" | "low";
+
+export type LifestyleImageTriggerKind = "explicit_lifestyle_image_request";
+
+export interface LifestyleImageTriggerDecision {
+  matched: boolean;
+  confidence: LifestyleImageTriggerConfidence;
+  kind?: LifestyleImageTriggerKind;
+  reason?: string;
+}
+
+const IMAGE_ACTION_PATTERNS = [
+  /\b(generate|create|make|draw|render|design)\b/i,
+  /生成|创建|做一?张|画一?张|出一?张|生图|制作/,
+];
+
+const LIFESTYLE_IMAGE_PATTERNS = [
+  /\blifestyle\s+(image|picture|photo|portrait|visual|scene)\b/i,
+  /\b(image|picture|photo|portrait|visual|scene)\s+.*\blifestyle\b/i,
+  /生活方式(图片|照片|图像|视觉|场景|形象图|配图)/,
+  /生活(照|照片|图片|场景|方式图)/,
+  /个人(形象图|生活图|生活照)/,
+];
+
+const NEGATED_IMAGE_ACTION_PATTERNS = [
+  /\b(do not|don't|dont|no need to|without)\s+(generate|create|make|draw|render|design)\b/i,
+  /不要(生成|创建|做|画|出|制作)/,
+  /不用(生成|创建|做|画|出|制作)/,
+  /无需(生成|创建|做|画|出|制作)/,
+  /别(生成|创建|做|画|出|制作)/,
+];
+
+const PROMPT_ONLY_PATTERNS = [
+  /\blifestyle\s+(image|picture|photo|portrait|visual|scene)\s+prompt\b/i,
+  /\bprompt\s+for\s+(a\s+)?lifestyle\s+(image|picture|photo|portrait|visual|scene)\b/i,
+];
+
+export function detectLifestyleImageTrigger(
+  text: string | null | undefined,
+): LifestyleImageTriggerDecision {
+  const normalized = normalizeTriggerText(text);
+  if (!normalized) {
+    return { matched: false, confidence: "low" };
+  }
+
+  if (
+    NEGATED_IMAGE_ACTION_PATTERNS.some((pattern) => pattern.test(normalized))
+  ) {
+    return {
+      matched: false,
+      confidence: "low",
+      reason: "negated_image_generation_request",
+    };
+  }
+
+  if (PROMPT_ONLY_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return {
+      matched: false,
+      confidence: "low",
+      reason: "prompt_only_request",
+    };
+  }
+
+  const hasImageAction = IMAGE_ACTION_PATTERNS.some((pattern) =>
+    pattern.test(normalized),
+  );
+  const hasLifestyleImageTarget = LIFESTYLE_IMAGE_PATTERNS.some((pattern) =>
+    pattern.test(normalized),
+  );
+
+  if (hasImageAction && hasLifestyleImageTarget) {
+    return {
+      matched: true,
+      confidence: "high",
+      kind: "explicit_lifestyle_image_request",
+      reason: "explicit_image_action_and_lifestyle_target",
+    };
+  }
+
+  return { matched: false, confidence: "low" };
+}
+
+function normalizeTriggerText(text: string | null | undefined): string {
+  if (!text) return "";
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/apps/web/lib/ai/image-generation/usage.ts
+++ b/apps/web/lib/ai/image-generation/usage.ts
@@ -2,7 +2,9 @@ export type ImageGenerationUsageStatus = "success" | "failed";
 
 export type ImageGenerationUsageRecord = {
   userId: string | null;
-  endpoint: "api/ai/v1/images/generations";
+  endpoint:
+    | "api/ai/v1/images/generations"
+    | "api/ai/v1/images/lifestyle/generate";
   provider: string;
   model: string;
   imageCount: number;

--- a/apps/web/tests/api/lifestyle-generate.route.test.ts
+++ b/apps/web/tests/api/lifestyle-generate.route.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  user: { id: "user-lifestyle", email: "user@example.com" } as {
+    id: string;
+    email?: string;
+  } | null,
+}));
+
+vi.mock("@/lib/auth/dual-auth", () => ({
+  getAuthUser: async () => authState.user,
+}));
+
+const dbMocks = vi.hoisted(() => ({
+  getBotsByUserId: vi.fn(),
+  getChatById: vi.fn(),
+  getChatInsights: vi.fn(),
+  getMessagesByChatId: vi.fn(),
+  getStoredInsightsByBotIds: vi.fn(),
+  getUserInsightSettings: vi.fn(),
+  getUserProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => dbMocks);
+
+const storageMocks = vi.hoisted(() => ({
+  getUserFileById: vi.fn(),
+}));
+
+vi.mock("@/lib/db/storageService", () => storageMocks);
+
+const fsMocks = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => fsMocks);
+
+vi.mock("@/lib/utils/path", () => ({
+  getUserMemoryPath: (userId: string) => `/mock-memory/${userId}`,
+}));
+
+import { POST } from "@/app/api/ai/v1/images/lifestyle/generate/route";
+import { __resetImageGenerationServiceForTests } from "@/lib/ai/image-generation/service";
+import {
+  __resetImageGenerationUsageRecorderForTests,
+  __setImageGenerationUsageRecorderForTests,
+  type ImageGenerationUsageRecord,
+} from "@/lib/ai/image-generation/usage";
+
+const fetchMock = vi.fn();
+const usageRecords: ImageGenerationUsageRecord[] = [];
+
+function request(body: unknown): Request {
+  return new Request("http://localhost/api/ai/v1/images/lifestyle/generate", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function mockDefaultSources() {
+  dbMocks.getUserProfile.mockResolvedValue({
+    id: "user-lifestyle",
+    email: "user@example.com",
+    name: "Avery",
+  });
+  dbMocks.getUserInsightSettings.mockResolvedValue({
+    focusPeople: ["founder channel"],
+    focusTopics: ["AI agents", "product storytelling"],
+    identityIndustries: ["AI products"],
+    identityWorkDescription: "Building focused AI product workflows.",
+  });
+  dbMocks.getChatById.mockResolvedValue({
+    id: "chat-1",
+    userId: "user-lifestyle",
+  });
+  dbMocks.getMessagesByChatId.mockResolvedValue([]);
+  dbMocks.getChatInsights.mockResolvedValue([]);
+  dbMocks.getBotsByUserId.mockResolvedValue({
+    bots: [{ id: "bot-1" }],
+    hasMore: false,
+  });
+  dbMocks.getStoredInsightsByBotIds.mockResolvedValue({
+    insights: [],
+    hasMore: false,
+  });
+  fsMocks.readdir.mockRejectedValue(
+    Object.assign(new Error("missing"), {
+      code: "ENOENT",
+    }),
+  );
+}
+
+describe("POST /api/ai/v1/images/lifestyle/generate", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    usageRecords.length = 0;
+    authState.user = { id: "user-lifestyle", email: "user@example.com" };
+    __resetImageGenerationServiceForTests();
+    __resetImageGenerationUsageRecorderForTests();
+    __setImageGenerationUsageRecorderForTests((record) => {
+      usageRecords.push(record);
+    });
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    mockDefaultSources();
+  });
+
+  test("composes context, generates an image, and records usage", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: "aGVsbG8=" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        chatId: "chat-1",
+        triggerPrompt: "Generate a lifestyle image for my launch work.",
+        provider: "openai",
+        outputFormat: "png",
+        responseFormat: "data_url",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      success: true,
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+      usage: {
+        provider: "openai",
+        model: "gpt-image-2",
+        imageCount: 1,
+        quotaMode: "record_only",
+      },
+    });
+    expect(body.prompt).toContain("Generate a lifestyle image");
+    expect(usageRecords).toHaveLength(1);
+    expect(usageRecords[0]).toMatchObject({
+      userId: "user-lifestyle",
+      endpoint: "api/ai/v1/images/lifestyle/generate",
+      provider: "openai",
+      status: "success",
+      quotaMode: "record_only",
+    });
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    authState.user = null;
+
+    const response = await POST(request({ chatId: "chat-1" }));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/tests/unit/lifestyle-trigger.test.ts
+++ b/apps/web/tests/unit/lifestyle-trigger.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { detectLifestyleImageTrigger } from "@/lib/ai/image-generation/lifestyle-trigger";
+
+describe("detectLifestyleImageTrigger", () => {
+  test("matches explicit English lifestyle image generation requests", () => {
+    expect(
+      detectLifestyleImageTrigger(
+        "Please generate a lifestyle image for my current builder identity.",
+      ),
+    ).toMatchObject({
+      matched: true,
+      confidence: "high",
+      kind: "explicit_lifestyle_image_request",
+    });
+  });
+
+  test("matches explicit Chinese lifestyle image generation requests", () => {
+    expect(
+      detectLifestyleImageTrigger("帮我生成一张生活方式图片"),
+    ).toMatchObject({
+      matched: true,
+      confidence: "high",
+      kind: "explicit_lifestyle_image_request",
+    });
+  });
+
+  test("does not match ordinary lifestyle discussion", () => {
+    expect(
+      detectLifestyleImageTrigger("Let's talk about my lifestyle and focus."),
+    ).toMatchObject({
+      matched: false,
+    });
+  });
+
+  test("does not match prompt-only requests", () => {
+    expect(
+      detectLifestyleImageTrigger("Create a lifestyle image prompt for later."),
+    ).toMatchObject({
+      matched: false,
+      reason: "prompt_only_request",
+    });
+  });
+
+  test("does not match negated image generation requests", () => {
+    expect(
+      detectLifestyleImageTrigger("不要生成生活方式图片，只总结一下文字。"),
+    ).toMatchObject({
+      matched: false,
+      reason: "negated_image_generation_request",
+    });
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -108,6 +108,21 @@ export type CustomUIDataTypes = {
     content: string;
     id: string;
   };
+  lifestyleImageConsent: {
+    id: string;
+    prompt: string;
+    reason?: string;
+    createdAt: string;
+  };
+  lifestyleImageStatus: {
+    id: string;
+    status: "loading" | "success" | "error";
+    provider?: string;
+    model?: string;
+    creditsUsed?: number;
+    imageCount?: number;
+    error?: string;
+  };
   hideLoadingText: {
     id: string;
   };


### PR DESCRIPTION
## Summary

Adds the chat-side lifestyle image generation flow.

This PR introduces a lightweight trigger path that detects explicit lifestyle image requests in chat, asks for first-use consent, generates an image through the existing image generation API, and renders the result directly in the conversation.

## Functionality

- Detects explicit lifestyle image generation requests from user messages
- Shows a first-use consent prompt before generating lifestyle images
- Calls the lifestyle image generation endpoint using the existing image provider pipeline
- Displays loading, success, cancellation, and error states in the chat
- Renders generated lifestyle images as chat attachments
- Adds an in-page image preview modal for generated lifestyle images
- Preserves trigger metadata on generated messages for scoped rendering and future extension

## How To Use

1. Configure an image generation provider locally.
2. Start the app.
3. Send an explicit lifestyle image request in chat, for example:
   - `Generate a lifestyle image for me`
   - `帮我生成一张生活方式图片`
4. Accept the first-use consent prompt.
5. The generated image will appear in the assistant response.
6. Click the generated image to preview it in the current page and close the preview when finished.

## Design Boundaries

This PR intentionally keeps the trigger implementation conservative.

The current intent detection is rule-based and only targets explicit lifestyle image requests. It is not designed to be a complete natural-language intent engine, and it does not attempt broad semantic classification across all possible user phrasing.

The image preview and duplicate-rendering adjustments are scoped to generated lifestyle image messages through dedicated metadata/source markers, so normal chat attachments and general message rendering paths are not changed.

Generated images are displayed in the chat response. This PR does not introduce a full gallery, long-term asset management flow, or billing/quota enforcement.

## Follow-up Work

Planned follow-up areas include:

- Move lifestyle image intent detection into a dedicated skill-based trigger path
- Expand trigger coverage with provider/tool-call style intent routing instead of static rules
- Improve generated image persistence and retrieval for the lifestyle gallery experience
- Add richer user controls for regeneration, reference images, and prompt refinement
- Connect usage events to future quota or billing interfaces if needed

## Testing

- `pnpm exec prettier --check apps/web/components/chat-context.tsx apps/web/components/message/index.tsx apps/web/components/preview-attachment.tsx`
- `pnpm --filter web exec vitest run tests/unit/lifestyle-trigger.test.ts tests/api/lifestyle-composer.test.ts tests/api/lifestyle-generate.route.test.ts tests/api/image-generation.route.test.ts`