### PR TITLE
fix(web): auto-bootstrap guest session for loop and usage routes

### DIFF
--- a/apps/web/app/api/llm/usage/summary/route.ts
+++ b/apps/web/app/api/llm/usage/summary/route.ts
@@ -6,19 +6,29 @@
  * LOOMI Online card.
  *
  * Status semantics:
- * - 401 when no authenticated user (mirrors `/api/native/agent`).
+ * - 401 when no authenticated user AND auto-guest bootstrap fails
+ *   (mirrors `/api/native/agent`).
  * - 200 with `configured: false` when the user has no enabled provider.
  * - 200 with `configured: true` and zero totals when the user has a
  *   provider but no usage has been recorded yet.
  * - 200 with `error: "usage_unavailable"` when the usage file could not
  *   be read; the card renders its error state without breaking other
  *   functionality.
+ *
+ * First-hit auto-guest: a fresh `pnpm tauri:dev` install has no
+ * NextAuth session cookie yet but the home view fetches usage right
+ * after the pet opens the main webview. The route falls through to
+ * `ensureGuestSession()` (see `lib/auth/auto-guest.ts`) — same
+ * plumbing the plugins use via `/api/remote-auth/guest`, just
+ * in-process so we don't redirect each parallel call to /guest-login
+ * and race-create one guest account per request.
  */
 
 import { NextResponse } from "next/server";
 
 import { auth } from "@/app/(auth)/auth";
 import { getAuthUser } from "@/lib/auth/dual-auth";
+import { ensureGuestSession } from "@/lib/auth/auto-guest";
 import { getUserLlmProviderEarliestEnabledSince } from "@/lib/db/queries";
 import { getConfiguredDefaultAgentProvider } from "@/lib/ai/native-agent/provider-env";
 import { getUserUsageSummary } from "@/lib/llm-usage/summary";
@@ -27,51 +37,77 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request) {
-  const authUser = await getAuthUser(req);
+  let authUser = await getAuthUser(req);
+  let attachSessionCookies: ((response: NextResponse) => void) | null = null;
+
   if (!authUser?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const guest = await ensureGuestSession();
+    if (guest.session?.user?.id) {
+      authUser = {
+        id: guest.session.user.id,
+        email: guest.session.user.email,
+        name: guest.session.user.name,
+        type: guest.session.user.type,
+      };
+    }
+    if (guest.minted) {
+      attachSessionCookies = guest.attachSessionCookies;
+    }
+    if (!authUser?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
   }
 
+  try {
+    const response = await renderSummaryResponse(authUser.id);
+    if (attachSessionCookies) {
+      attachSessionCookies(response);
+    }
+    return response;
+  } catch (error) {
+    console.error("[llm-usage/summary] unexpected error:", error);
+    const errorBody = {
+      error: "usage_unavailable",
+      message:
+        error instanceof Error ? error.message : "Unexpected server error",
+    };
+    const errorResp = NextResponse.json(errorBody, { status: 200 });
+    if (attachSessionCookies) {
+      attachSessionCookies(errorResp);
+    }
+    return errorResp;
+  }
+}
+
+async function renderSummaryResponse(userId: string): Promise<NextResponse> {
   // Mirror the `webSession` path used by `/api/native/agent` so the
   // summary endpoint reports the same identity as the SSE caller.
   await auth().catch(() => null);
 
-  try {
-    const providerContext = await getUserLlmProviderEarliestEnabledSince(
-      authUser.id,
-    );
+  const providerContext = await getUserLlmProviderEarliestEnabledSince(
+    userId,
+  );
 
-    // Non-claude runtimes (codex/opencode/hermes/openclaw) ship their own
-    // CLI auth and don't require a `user_llm_api_settings` row. When the
-    // env-resolved runtime is one of those and no DB row exists, the
-    // user is *still* configured from a runtime perspective — synthesize
-    // an epoch-0 baseline so the SQL filter counts every recorded
-    // native-agent row for this user (including prior claude calls), and
-    // surface the runtime as the current provider in the card tooltip.
-    // The pet card detects the epoch sentinel and suppresses the
-    // "since X" line because we don't actually know when the env var
-    // was first set.
-    const defaultAgent = getConfiguredDefaultAgentProvider();
-    if (!providerContext.providerSince && defaultAgent !== "claude") {
-      providerContext.providerSince = new Date(0);
-      providerContext.currentProvider = {
-        providerType: defaultAgent,
-        model: null,
-        enabledSince: new Date(0),
-      };
-    }
-
-    const summary = await getUserUsageSummary(authUser.id, providerContext);
-    return NextResponse.json(summary);
-  } catch (error) {
-    console.error("[llm-usage/summary] unexpected error:", error);
-    return NextResponse.json(
-      {
-        error: "usage_unavailable",
-        message:
-          error instanceof Error ? error.message : "Unexpected server error",
-      },
-      { status: 200 },
-    );
+  // Non-claude runtimes (codex/opencode/hermes/openclaw) ship their own
+  // CLI auth and don't require a `user_llm_api_settings` row. When the
+  // env-resolved runtime is one of those and no DB row exists, the
+  // user is *still* configured from a runtime perspective — synthesize
+  // an epoch-0 baseline so the SQL filter counts every recorded
+  // native-agent row for this user (including prior claude calls), and
+  // surface the runtime as the current provider in the card tooltip.
+  // The pet card detects the epoch sentinel and suppresses the
+  // "since X" line because we don't actually know when the env var
+  // was first set.
+  const defaultAgent = getConfiguredDefaultAgentProvider();
+  if (!providerContext.providerSince && defaultAgent !== "claude") {
+    providerContext.providerSince = new Date(0);
+    providerContext.currentProvider = {
+      providerType: defaultAgent,
+      model: null,
+      enabledSince: new Date(0),
+    };
   }
+
+  const summary = await getUserUsageSummary(userId, providerContext);
+  return NextResponse.json(summary);
 }

--- a/apps/web/app/api/llm/usage/summary/route.ts
+++ b/apps/web/app/api/llm/usage/summary/route.ts
@@ -84,9 +84,7 @@ async function renderSummaryResponse(userId: string): Promise<NextResponse> {
   // summary endpoint reports the same identity as the SSE caller.
   await auth().catch(() => null);
 
-  const providerContext = await getUserLlmProviderEarliestEnabledSince(
-    userId,
-  );
+  const providerContext = await getUserLlmProviderEarliestEnabledSince(userId);
 
   // Non-claude runtimes (codex/opencode/hermes/openclaw) ship their own
   // CLI auth and don't require a `user_llm_api_settings` row. When the

--- a/apps/web/app/api/loop/action/[id]/route.ts
+++ b/apps/web/app/api/loop/action/[id]/route.ts
@@ -18,6 +18,7 @@
 import { NextResponse } from "next/server";
 import { and, eq, isNull } from "drizzle-orm";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 import { deleteJob, getJob } from "@/lib/loop";
 import { db } from "@/lib/db";
 import { scheduledJobs } from "@/lib/db/schema";
@@ -29,7 +30,7 @@ interface RouteCtx {
   params: Promise<{ id: string }>;
 }
 
-export async function DELETE(_req: Request, ctx: RouteCtx) {
+export const DELETE = withAutoGuest<RouteCtx>(async (_req, ctx) => {
   try {
     const session = await auth();
     const userId = session?.user?.id;
@@ -93,4 +94,4 @@ export async function DELETE(_req: Request, ctx: RouteCtx) {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/app/api/loop/action/by-decision/[id]/route.ts
+++ b/apps/web/app/api/loop/action/by-decision/[id]/route.ts
@@ -31,6 +31,7 @@
 import { NextResponse } from "next/server";
 import { and, desc, eq } from "drizzle-orm";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 import { db } from "@/lib/db";
 import { scheduledJobs } from "@/lib/db/schema";
 
@@ -41,7 +42,7 @@ interface RouteCtx {
   params: Promise<{ id: string }>;
 }
 
-export async function GET(_req: Request, ctx: RouteCtx) {
+export const GET = withAutoGuest<RouteCtx>(async (_req, ctx) => {
   try {
     const session = await auth();
     const userId = session?.user?.id;
@@ -117,7 +118,7 @@ export async function GET(_req: Request, ctx: RouteCtx) {
       { status: 500 },
     );
   }
-}
+});
 
 function safeJsonParse(text: string): unknown {
   try {

--- a/apps/web/app/api/loop/action/schedule/route.ts
+++ b/apps/web/app/api/loop/action/schedule/route.ts
@@ -36,6 +36,7 @@
 
 import { NextResponse } from "next/server";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 import { createJob, decisions, registerLoopHandlers } from "@/lib/loop";
 
 export const dynamic = "force-dynamic";
@@ -52,7 +53,7 @@ const ACTION_VERB: Record<string, string> = {
   promote: "Promote",
 };
 
-export async function POST(req: Request) {
+export const POST = withAutoGuest(async (req: Request) => {
   try {
     const session = await auth();
     const userId = session?.user?.id;
@@ -124,4 +125,4 @@ export async function POST(req: Request) {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/app/api/loop/brief/content/route.ts
+++ b/apps/web/app/api/loop/brief/content/route.ts
@@ -22,15 +22,19 @@
 import { NextResponse } from "next/server";
 import { readBrief } from "@/lib/loop/brief";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
+export const GET = withAutoGuest(async () => {
   try {
     // Auth is required so a user can only read their own brief; on a
     // single-user local install the file is the only one present so
-    // this is largely a smoke check.
+    // this is largely a smoke check. withAutoGuest transparently
+    // mints a guest on first-hit so a fresh Tauri install doesn't
+    // bounce through /guest-login (which would race-create one
+    // guest row per parallel API call).
     const session = await auth();
     if (!session?.user?.id) {
       return NextResponse.json({ error: "auth required" }, { status: 401 });
@@ -43,4 +47,4 @@ export async function GET() {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/app/api/loop/decision/[id]/route.ts
+++ b/apps/web/app/api/loop/decision/[id]/route.ts
@@ -13,6 +13,7 @@
 
 import { NextResponse } from "next/server";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 import { applyDecisionAction, decisions, getDecision, log } from "@/lib/loop";
 import type { DecisionActionInput } from "@/lib/loop";
 
@@ -65,7 +66,7 @@ export async function POST(req: Request, ctx: RouteCtx) {
 const MAX_DRAFT_BODY = 50_000;
 const MAX_DRAFT_SUBJECT = 998;
 
-export async function PATCH(req: Request, ctx: RouteCtx) {
+export const PATCH = withAutoGuest<RouteCtx>(async (req, ctx) => {
   try {
     const session = await auth();
     const userId = session?.user?.id;
@@ -138,4 +139,4 @@ export async function PATCH(req: Request, ctx: RouteCtx) {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/app/api/loop/preferences/route.ts
+++ b/apps/web/app/api/loop/preferences/route.ts
@@ -8,6 +8,7 @@
 
 import { NextResponse } from "next/server";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 import { getPreferences, setPreferencesForUser } from "@/lib/loop";
 import type { LoopPreferences } from "@/lib/loop";
 
@@ -47,7 +48,7 @@ const TIME_RE = /^([01]?\d|2[0-3]):[0-5]\d$/;
  */
 const TIMEZONE_RE = /^[A-Za-z_]+(?:\/[A-Za-z_+\-]+){0,3}$/;
 
-export async function GET() {
+export const GET = withAutoGuest(async () => {
   try {
     const prefs = getPreferences();
     // Self-heal: even if the user never clicks Save, opening the Loop
@@ -72,9 +73,9 @@ export async function GET() {
       { status: 500 },
     );
   }
-}
+});
 
-export async function PUT(req: Request) {
+export const PUT = withAutoGuest(async (req: Request) => {
   try {
     let body: Partial<LoopPreferences> = {};
     try {
@@ -188,4 +189,4 @@ export async function PUT(req: Request) {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/app/api/loop/wrap/content/route.ts
+++ b/apps/web/app/api/loop/wrap/content/route.ts
@@ -13,12 +13,17 @@
 import { NextResponse } from "next/server";
 import { readWrap } from "@/lib/loop/wrap";
 import { auth } from "@/app/(auth)/auth";
+import { withAutoGuest } from "@/lib/auth/with-auto-guest";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
+export const GET = withAutoGuest(async () => {
   try {
+    // Mirror /api/loop/brief/content: a fresh Tauri install has no
+    // session yet, so the wrapper auto-mints a guest on the first
+    // call instead of bouncing to /guest-login (which races one
+    // guest row per parallel API call).
     const session = await auth();
     if (!session?.user?.id) {
       return NextResponse.json({ error: "auth required" }, { status: 401 });
@@ -31,4 +36,4 @@ export async function GET() {
       { status: 500 },
     );
   }
-}
+});

--- a/apps/web/lib/auth/auto-guest.ts
+++ b/apps/web/lib/auth/auto-guest.ts
@@ -1,0 +1,236 @@
+/**
+ * Auto-guest bootstrap for routes that should mint an anonymous guest
+ * the first time they're hit without a session.
+ *
+ * Mirrors the plugin-side `POST /api/remote-auth/guest` (see
+ * `apps/web/app/api/remote-auth/guest/route.ts`) but instead of returning
+ * a Bearer it sets the NextAuth session cookie on the in-flight response
+ * so the browser reuses the same identity for every subsequent call.
+ *
+ * The browser's cookie jar carries the identity, so once the first
+ * response lands, every later request hits `auth()` and exits early —
+ * we do NOT mint a new user each call. That fixes the original bug where
+ * 5 concurrent first-burst requests each spawned one guest row because
+ * the proxy redirected each to `/guest-login` and the page ran
+ * `POST /api/auth/guest` independently per mount.
+ *
+ * Stable ID source: an httpOnly `loomi-anon-id` cookie set on the very
+ * first request and reused for every subsequent request from the same
+ * browser. The guest email is `${anonId}@guest.local` so concurrent
+ * first-burst calls race on `getUser(...)` reuse (the row exists after
+ * the first insert) instead of each generating a unique timestamp.
+ *
+ * In Tauri mode the helper additionally writes the freshly minted
+ * bearer JWT to `~/.openloomi/token` (base64-encoded, mirroring
+ * `apps/web/src-tauri/src/storage.rs:save_token`). This is what
+ * the existing `guest-login/page.tsx` does via
+ * `invoke("save_token", ...)` after fetching `/api/auth/token` — we
+ * just inline the same shape server-side so plugins, Bridge CLI,
+ * and any other non-browser consumer can authenticate as the same
+ * identity the GUI just adopted. Web mode skips this step because
+ * `~/.openloomi/` is a Tauri-specific namespace and the file isn't
+ * consumed by anything in pure-web runs.
+ *
+ * Runtime: must run with `runtime = "nodejs"` — uses `signIn` (which
+ * touches NextAuth's adapter layer), `db` (better-sqlite3), and
+ * direct FS writes for the token file.
+ */
+
+import { cookies } from "next/headers";
+import type { NextResponse } from "next/server";
+import type { Session } from "next-auth";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { auth, signIn } from "@/app/(auth)/auth";
+import { getUser, createUser } from "@/lib/db/queries";
+import { DUMMY_PASSWORD } from "@/lib/env/constants";
+import { generateToken } from "@/lib/auth/remote-auth-utils";
+
+export const ANON_ID_COOKIE = "loomi-anon-id";
+const ANON_ID_MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 year
+const GUEST_EMAIL_DOMAIN = "@guest.local";
+
+function newAnonId(): string {
+  // Stable, no PII. UUID v4 in hex (strip dashes) keeps it URL-safe
+  // and trivially distinguishable from any other `email-prefix` we
+  // might use elsewhere. Prefixed with `anon-` so DB inspection can
+  // tell guest emails apart from regular users at a glance.
+  const hex = (globalThis.crypto?.randomUUID?.() ?? "")
+    .replace(/-/g, "");
+  if (hex.length === 32) return `anon-${hex}`;
+  // Fallback for runtimes without global crypto — extremely unlikely
+  // in practice (Node 19+ and the Edge runtime both have it) but we
+  // guard so a missing crypto doesn't break first-paint.
+  return `anon-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
+export interface AutoGuestResult {
+  /** The session after the bootstrap, or null if minting failed. */
+  session: Session | null;
+  /**
+   * Apply the cookies the bootstrap just minted (`loomi-anon-id`,
+   * `authjs.session-token`, csrf) onto a `NextResponse` before
+   * returning it. Mirrors the existing
+   * `app/(auth)/api/auth/guest/route.ts` post-`signIn` cookie-copy
+   * pattern so the browser persists the session across redirects.
+   *
+   * Safe to call on any NextResponse; no-op when `minted === false`.
+   */
+  attachSessionCookies: (response: NextResponse) => void;
+  /** True if this call actually minted or refreshed a guest. */
+  minted: boolean;
+  /** The guest email used (or that already exists) — handy for tests. */
+  guestEmail: string | null;
+}
+
+const NOOP_ATTACH = () => {};
+
+export async function ensureGuestSession(): Promise<AutoGuestResult> {
+  // 1. Already authenticated — nothing to do. The browser is reusing
+  // the cookies set on the previous response and `auth()` decodes the
+  // session JWT into a fully populated Session.
+  const existing = await auth();
+  if (existing?.user?.id) {
+    return {
+      session: existing,
+      attachSessionCookies: NOOP_ATTACH,
+      minted: false,
+      guestEmail: existing.user.email ?? null,
+    };
+  }
+
+  // 2. Resolve anon-id (read or mint + persist). One stable id per
+  // browser, persisted for the install lifetime, makes concurrent
+  // first-burst calls idempotent on `getUser(guestEmail)`.
+  const cookieStore = await cookies();
+  let anonId = cookieStore.get(ANON_ID_COOKIE)?.value ?? null;
+  let mintedAnon = false;
+  if (!anonId) {
+    anonId = newAnonId();
+    cookieStore.set({
+      name: ANON_ID_COOKIE,
+      value: anonId,
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: ANON_ID_MAX_AGE_SECONDS,
+    });
+    mintedAnon = true;
+  }
+  const guestEmail = `${anonId}${GUEST_EMAIL_DOMAIN}`;
+
+  // 3. Idempotent: get-or-create user. Because the anon-id is stable,
+  // parallel first-burst calls all hit this `getUser`, see the row on
+  // the second-or-later insert, and reuse the same id. No more than
+  // one guest row per install.
+  const existingUsers = await getUser(guestEmail);
+  let userId: string;
+  if (existingUsers.length > 0) {
+    userId = existingUsers[0].id;
+  } else {
+    const [created] = await createUser(guestEmail, DUMMY_PASSWORD);
+    if (!created) {
+      throw new Error("[auto-guest] Failed to create guest user");
+    }
+    userId = created.id;
+  }
+
+  // 4. Re-sign in so the response gets a fresh NextAuth session cookie.
+  // We do this even when the user row already existed, because the
+  // browser may have lost its session cookie (`/login` clears them per
+  // proxy.ts:91-103) while the anon-id persists — re-signing bridges
+  // that gap without forcing a new identity.
+  await signIn("credentials", {
+    email: guestEmail,
+    password: DUMMY_PASSWORD,
+    redirect: false,
+  });
+
+  // 5. In Tauri mode, write the same bearer JWT that the existing
+  // `guest-login/page.tsx` flow writes via `invoke("save_token", ...)`
+  // — but server-side so plugins / Bridge CLI / anything reading
+  // `~/.openloomi/token` outside the browser can authenticate as the
+  // same identity the GUI just adopted. Encoding matches
+  // `apps/web/src-tauri/src/storage.rs:save_token` (base64-STANDARD
+  // of the raw JWT, 0o600 on Unix). Skipped in pure-web mode where
+  // the file isn't consumed and `~/.openloomi/` is a Tauri-only
+  // namespace. Wrapped in try/catch so a transient FS hiccup never
+  // breaks the API response — plugins will simply see the old (or no)
+  // token until the next auto-guest run.
+  if (process.env.IS_TAURI === "true") {
+    await writeTauriTokenFile(userId, guestEmail);
+  }
+
+  const session = await auth();
+
+  // 6. Build the cookie-attach hook. We copy every cookie the store
+  // currently holds with the canonical NextAuth + anon-id attribute
+  // set. Same shape as the existing
+  // `app/(auth)/api/auth/guest/route.ts:67-77` post-`signIn` block.
+  const attachSessionCookies = (response: NextResponse) => {
+    for (const cookie of cookieStore.getAll()) {
+      response.cookies.set({
+        name: cookie.name,
+        value: cookie.value,
+        path: "/",
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+      });
+    }
+  };
+
+  return {
+    session,
+    attachSessionCookies,
+    minted: mintedAnon,
+    guestEmail,
+  };
+}
+
+/**
+ * Write `~/.openloomi/token` with a base64-STANDARD encoded JWT, mirroring
+ * `apps/web/src-tauri/src/storage.rs:save_token`. Used only by the Tauri
+ * auto-guest bootstrap so plugins / Bridge CLI / non-browser consumers
+ * can authenticate as the same identity the GUI just minted.
+ *
+ * Best-effort: a transient FS error logs a warning and returns without
+ * throwing so the calling API can still respond successfully. The plugin
+ * sees the old (or no) token until the next auto-guest run.
+ */
+async function writeTauriTokenFile(
+  userId: string,
+  guestEmail: string,
+): Promise<void> {
+  try {
+    const token = generateToken(userId, guestEmail);
+    const home = os.homedir();
+    if (!home) {
+      console.warn("[auto-guest] HOME is not set; skipping token write");
+      return;
+    }
+    const tokenPath = path.join(home, ".openloomi", "token");
+    const dir = path.dirname(tokenPath);
+    await fs.mkdir(dir, { recursive: true });
+    const encoded = Buffer.from(token, "utf8").toString("base64");
+    await fs.writeFile(tokenPath, encoded, { encoding: "utf8", mode: 0o600 });
+    // Best-effort chmod in case the FS ignored `mode` (some FUSE mounts
+    // drop POSIX bits). Mirrors storage.rs:113-119's `chmod 0o600`.
+    try {
+      await fs.chmod(tokenPath, 0o600);
+    } catch {
+      /* non-fatal */
+    }
+    console.log(`[auto-guest] wrote token file: ${tokenPath}`);
+  } catch (e) {
+    console.warn(
+      `[auto-guest] failed to write ~/.openloomi/token: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+}

--- a/apps/web/lib/auth/auto-guest.ts
+++ b/apps/web/lib/auth/auto-guest.ts
@@ -56,8 +56,7 @@ function newAnonId(): string {
   // and trivially distinguishable from any other `email-prefix` we
   // might use elsewhere. Prefixed with `anon-` so DB inspection can
   // tell guest emails apart from regular users at a glance.
-  const hex = (globalThis.crypto?.randomUUID?.() ?? "")
-    .replace(/-/g, "");
+  const hex = (globalThis.crypto?.randomUUID?.() ?? "").replace(/-/g, "");
   if (hex.length === 32) return `anon-${hex}`;
   // Fallback for runtimes without global crypto — extremely unlikely
   // in practice (Node 19+ and the Edge runtime both have it) but we

--- a/apps/web/lib/auth/with-auto-guest.ts
+++ b/apps/web/lib/auth/with-auto-guest.ts
@@ -1,0 +1,73 @@
+/**
+ * Higher-order wrapper for Next.js Route Handlers that should
+ * transparently bootstrap an anonymous guest when called without a
+ * session.
+ *
+ * Routes wrap their handler like:
+ *
+ *   export const GET = withAutoGuest(async (req) => {
+ *     const session = ...   // now guaranteed to exist
+ *     return NextResponse.json({...});
+ *   });
+ *
+ * The wrapper:
+ *  1. Calls `auth()`. If a session exists, falls through.
+ *  2. Otherwise calls `ensureGuestSession()` — same helper the plugins
+ *     use via `/api/remote-auth/guest`.
+ *  3. Re-runs the handler with a populated session.
+ *  4. After the handler returns, attaches any cookies the mint wrote
+ *     (NextAuth session, csrf, `loomi-anon-id`) onto the outgoing
+ *     NextResponse. This mirrors the manual cookie-copy block in
+ *     `app/(auth)/api/auth/guest/route.ts:62-77` so we keep parity
+ *     with the existing redirect handler.
+ *
+ * If everything is fine, the wrapper is essentially a no-op for the
+ * caller; the only observable change on a hot path is one extra
+ * `auth()` call we already pay for in the wrapped handler.
+ *
+ * Runtime: must run with `runtime = "nodejs"` — see `auto-guest.ts`.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { auth } from "@/app/(auth)/auth";
+import { ensureGuestSession } from "./auto-guest";
+
+type JsonHandler<TCtx> = (
+  request: NextRequest,
+  ctx: TCtx,
+) => Promise<NextResponse>;
+
+export function withAutoGuest<TCtx = unknown>(
+  handler: JsonHandler<TCtx>,
+): JsonHandler<TCtx> {
+  return async (request, ctx) => {
+    let session = await auth();
+    let attachSessionCookies: ((response: NextResponse) => void) | null = null;
+
+    if (!session?.user?.id) {
+      const guest = await ensureGuestSession();
+      session = guest.session;
+      if (guest.minted) {
+        attachSessionCookies = guest.attachSessionCookies;
+      }
+    }
+
+    if (!session?.user?.id) {
+      const errResp = NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+      if (attachSessionCookies) {
+        attachSessionCookies(errResp);
+      }
+      return errResp;
+    }
+
+    const response = await handler(request, ctx);
+    if (attachSessionCookies) {
+      attachSessionCookies(response);
+    }
+    return response;
+  };
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -64,6 +64,17 @@ export async function proxy(request: NextRequest) {
   if (pathname.startsWith("/api/ai")) return NextResponse.next();
   if (pathname.startsWith("/api/preferences")) return NextResponse.next();
   if (pathname.startsWith("/api/integrations")) return NextResponse.next();
+  // /api/loop/* and /api/llm/usage/* are guest-bootstrapping APIs: their
+  // route handlers fall back to `ensureGuestSession()` when the request
+  // has no session cookie, minting an anonymous guest and writing the
+  // NextAuth session cookie on the first response. Letting the request
+  // through here avoids the proxy redirecting the very first call to
+  // /guest-login (which spawns one browser page per parallel API request
+  // and races N concurrent `POST /api/auth/guest` calls into multiple
+  // orphan guest users). See `lib/auth/auto-guest.ts` for the mint path
+  // these routes share with the plugin-side `/api/remote-auth/guest`.
+  if (pathname.startsWith("/api/loop")) return NextResponse.next();
+  if (pathname.startsWith("/api/llm/usage")) return NextResponse.next();
   if (pathname.startsWith("/api/user") || pathname.startsWith("/api/quota"))
     return NextResponse.next();
   if (pathname.startsWith("/api/slack") || pathname.startsWith("/api/discord"))

--- a/apps/web/tests/api/llm-usage-summary.route.test.ts
+++ b/apps/web/tests/api/llm-usage-summary.route.test.ts
@@ -28,6 +28,25 @@ vi.mock("@/lib/auth/dual-auth", () => ({
   },
 }));
 
+// Auto-guest bootstrap is the new first-hit fallback when getAuthUser
+// rejects. Mirrored as a hoisted mock so individual tests can flip the
+// outcome — without it, ensureGuestSession would try to hit the real DB
+// and FS during unit runs. `null` simulates a failed bootstrap (the
+// route should then 401).
+const autoGuestState = vi.hoisted(() => ({
+  session: null as { user: { id: string; email: string | null } } | null,
+  minted: false,
+}));
+
+vi.mock("@/lib/auth/auto-guest", () => ({
+  ensureGuestSession: async () => ({
+    session: autoGuestState.session,
+    attachSessionCookies: () => {},
+    minted: autoGuestState.minted,
+    guestEmail: autoGuestState.session?.user?.email ?? null,
+  }),
+}));
+
 const dbState = vi.hoisted(() => ({
   providerSince: null as Date | null,
   currentProvider: undefined as
@@ -120,17 +139,46 @@ describe("GET /api/llm/usage/summary", () => {
     summaryState.error = undefined;
     dualAuthState.reject = false;
     dualAuthState.user = { id: "user-llm-usage", type: "regular" };
+    // Default: auto-guest succeeds with the same dual-auth user so the
+    // existing positive-path tests keep working unchanged.
+    autoGuestState.session = dualAuthState.user
+      ? { user: { id: dualAuthState.user.id, email: null } }
+      : null;
+    autoGuestState.minted = false;
     agentProviderState.currentDefaultProvider = "claude";
   });
 
   test("returns 401 when unauthenticated", async () => {
+    // Simulate the dual-auth reject path AND a failed auto-guest
+    // bootstrap — the route should still 401 because no user identity
+    // is recoverable.
     dualAuthState.reject = true;
+    autoGuestState.session = null;
     const res = await GET(
       new Request("http://localhost/api/llm/usage/summary"),
     );
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error).toBe("Unauthorized");
+  });
+
+  test("auto-mints guest and returns 200 when dual-auth rejects but bootstrap succeeds", async () => {
+    // This mirrors the fresh `pnpm tauri:dev` install path: the cookie
+    // jar is empty so `getAuthUser` rejects, but `ensureGuestSession`
+    // mints a stable anon-id and returns a session — the route must
+    // NOT bounce through /guest-login or 401 here.
+    dualAuthState.reject = true;
+    autoGuestState.session = {
+      user: { id: "guest-bootstrap-1", email: "anon-x@guest.local" },
+    };
+    autoGuestState.minted = true;
+    const res = await GET(
+      new Request("http://localhost/api/llm/usage/summary"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // The minted guest identity must be the one used downstream.
+    expect(body.configured).toBe(false);
   });
 
   test("returns configured=false with zero totals when no provider", async () => {


### PR DESCRIPTION
## Summary

Fresh `pnpm tauri:dev` installs hit `/api/loop/*` and `/api/llm/usage/*` with no NextAuth session cookie yet. Today the proxy redirects those calls to `/guest-login`, which spawns one browser page per parallel API request and races N concurrent `POST /api/auth/guest` calls into multiple orphan guest users — one row per concurrent first-burst request.

This PR adds a server-side auto-guest bootstrap shared with the plugin-side `/api/remote-auth/guest`, so a fresh install mints at most one guest row and never bounces through `/guest-login` for these routes.

## What's in it

- **`lib/auth/auto-guest.ts`** — `ensureGuestSession()`:
  - Reuses a stable httpOnly `loomi-anon-id` cookie (one per browser, 1y max-age) so parallel first-burst calls collide on `getUser(guestEmail)` and mint at most one guest row per install.
  - Re-signs in via NextAuth and copies the freshly minted session cookie onto the outgoing response (same shape as `app/(auth)/api/auth/guest/route.ts`).
  - In Tauri mode, also writes `~/.openloomi/token` (base64-encoded JWT, 0o600) so plugins / Bridge CLI authenticate as the same identity the GUI just adopted — same shape the existing `guest-login` page produces via `invoke("save_token", ...)`. Best-effort; a transient FS error logs a warning and never breaks the API response.
- **`lib/auth/with-auto-guest.ts`** — higher-order wrapper for Route Handlers. Calls `auth()`; if no session, bootstraps one and re-runs the handler with a populated session, then attaches the mint cookies onto the outgoing `NextResponse`. No-op on the hot path once a session exists.
- **`proxy.ts`** — let `/api/loop/*` and `/api/llm/usage/*` pass through so the in-process bootstrap can mint the guest instead of redirecting.
- **Seven `/api/loop` handlers wrapped with `withAutoGuest`**:
  - `action/[id]` (DELETE)
  - `action/by-decision/[id]` (GET)
  - `action/schedule` (POST)
  - `brief/content` (GET)
  - `decision/[id]` (PATCH)
  - `preferences` (GET, PUT)
  - `wrap/content` (GET)
- **`/api/llm/usage/summary`** now falls through to `ensureGuestSession()` on first hit so a fresh install renders the LOOMI Online card on the home view without redirecting. Extracted the success path into `renderSummaryResponse(userId)` and adds cookie-attachment to both success and error responses.

## Behavior

- **First hit, no session, no anon-id**: mint anon-id → get-or-create user → re-sign-in → attach session cookies → run handler → return response with cookies set. One guest row created.
- **First hit, no session, anon-id already set** (concurrent sibling request): `getUser(guestEmail)` returns the row created by the sibling, so `createUser` is skipped. Re-signs in, attaches cookies, runs handler.
- **Subsequent hits** (session cookie present): `auth()` returns the session, wrapper is a no-op, the extra `auth()` call is the only overhead.
- **Tauri mode**: identical to web, plus `~/.openloomi/token` is refreshed so non-browser consumers stay in sync with the GUI identity.

## Why not just keep redirecting to `/guest-login`?

That path is fine for browser-initiated sign-in but breaks under first-paint parallel API fan-out: every concurrent request from a fresh install races through `/guest-login` and independently hits `POST /api/auth/guest`, each spawning a row with a unique timestamp-based email. The user's own bug report described seeing 5 guest rows from one install. The server-side bootstrap shares one anon-id across all first-burst calls, so the row is created once and reused.

## Test plan

- [ ] Fresh `pnpm tauri:dev` install (or wipe `~/.openloomi/` + clear browser cookies), open the app, confirm one and only one guest row is created even with the loop / usage endpoints firing in parallel on first paint.
- [ ] Reload — should reuse the same guest user (no new rows).
- [ ] Visit `/login` (clears the session cookie per `proxy.ts`), confirm a subsequent API call re-signs the same guest instead of minting a new identity.
- [ ] In Tauri builds, confirm `~/.openloomi/token` is written with base64-encoded JWT (0o600) after the first auto-guest run, and that Bridge CLI / plugins authenticate as the same identity.
- [ ] Smoke-check each wrapped `/api/loop/*` route — they should return data, not 401, on a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)