### PR TITLE
feat(memory): drive lifecycle consolidation from memory graph

### DIFF
--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -9,17 +9,15 @@ import type {
   MemorySummaryRecord,
   RawMessage,
   RawMessageQuery,
+  RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions,
 } from "@openloomi/indexeddb";
 import {
   parseRawMessageGraphEvolutionOptions,
   parseRawMessageGraphLifecycleOptions,
-  storeRawMessagesWithGraphEvolution,
-} from "@openloomi/indexeddb";
-import {
   queryMemoryWithFallback,
   runMemoryForgettingCycle,
-} from "@openloomi/indexeddb/forgetting";
-import type { RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions } from "@openloomi/indexeddb/forgetting";
+  storeRawMessagesWithGraphEvolution,
+} from "@openloomi/indexeddb";
 import { AppError } from "@openloomi/shared/errors";
 import type { NextRequest } from "next/server";
 

--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -162,7 +162,7 @@ async function queryRawMessagesWithFallback(
   const minRaw =
     query.minRawResultsWithoutFallback ?? query.pageSize ?? query.limit ?? 50;
 
-  const result = await queryMemoryWithFallback(manager as any, {
+  const result = await queryMemoryWithFallback(manager, {
     userId,
     keywords: query.keywords,
     startTime: normalizeTimestampToMs(query.startTime),
@@ -240,7 +240,7 @@ async function queryRawMessagesWithFallback(
         embeddingDimensions: item.record.embeddingDimensions,
         embeddingUpdatedAt: item.record.embeddingUpdatedAt,
         metadata:
-          (item.record.metadata as Record<string, any> | undefined) ??
+          (item.record.metadata as Record<string, unknown> | undefined) ??
           undefined,
         createdAt: item.record.timestamp,
         memoryStage: item.record.tier,
@@ -421,7 +421,7 @@ export async function POST(request: NextRequest) {
 
       case "forgettingCycle": {
         const result = await runMemoryForgettingCycle(
-          manager as any,
+          manager,
           userId,
           parseForgettingCycleOptions(body.options),
         );

--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -12,6 +12,7 @@ import type {
 } from "@openloomi/indexeddb";
 import {
   parseRawMessageGraphEvolutionOptions,
+  parseRawMessageGraphLifecycleOptions,
   storeRawMessagesWithGraphEvolution,
 } from "@openloomi/indexeddb";
 import {
@@ -121,6 +122,9 @@ function parseForgettingCycleOptions(value: unknown) {
         ? options.hardDeleteArchivedOlderThan
         : undefined,
     shadowDiagnostics: parseShadowDiagnosticsOptions(options.shadowDiagnostics),
+    graphLifecycle: parseRawMessageGraphLifecycleOptions(
+      options.graphLifecycle,
+    ),
   };
 }
 

--- a/apps/web/tests/unit/memory-graph-lifecycle-runtime.test.ts
+++ b/apps/web/tests/unit/memory-graph-lifecycle-runtime.test.ts
@@ -490,6 +490,57 @@ describe("memory graph lifecycle forgetting runtime", () => {
     );
   });
 
+  it("resolves all alternatives in a connected multi-way competition", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [
+      rawMessage("multi-zh", { relationValue: "zh" }),
+    ]);
+    await storeEvidence(
+      manager,
+      [rawMessage("multi-en", { relationValue: "en" })],
+      { now: NOW + 1000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("multi-ja-1", { relationValue: "ja" })],
+      { now: NOW + 2000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("multi-ja-2", { relationValue: "ja" })],
+      { now: NOW + 3000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("multi-ja-3", { relationValue: "ja" })],
+      { now: NOW + 4000 },
+    );
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 5000, graphLifecycle: { enabled: true } },
+    );
+    expect(result.graphLifecycle?.createdSummaries).toBe(1);
+    const graph = await snapshot(manager);
+    expect(
+      graph.clusters.find((cluster) => cluster.nodeIds.includes("multi-zh"))
+        ?.lifecycleStatus,
+    ).toBe("superseded");
+    expect(
+      graph.clusters.find((cluster) => cluster.nodeIds.includes("multi-en"))
+        ?.lifecycleStatus,
+    ).toBe("superseded");
+    expect(
+      graph.clusters.find((cluster) => cluster.nodeIds.includes("multi-ja-1")),
+    ).toEqual(
+      expect.objectContaining({
+        lifecycleStatus: "stable",
+        representativeNodeId: expect.any(String),
+      }),
+    );
+  });
+
   it("supports dry-run, owner-scope isolation, and stale singleton decay", async () => {
     const manager = new GraphLifecycleTestManager();
     await storeEvidence(manager, [rawMessage("workspace-a")], {
@@ -546,5 +597,67 @@ describe("memory graph lifecycle forgetting runtime", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("applies the same lifecycle transition again after an explicit reset", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("repeat-decay")], { now: NOW });
+
+    const firstDecay = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      {
+        now: NOW + 1000,
+        graphLifecycle: { enabled: true, decayAfterMs: 0 },
+      },
+    );
+    expect(firstDecay.graphLifecycle?.status).toBe("applied");
+
+    const graphStore = createRawMessageMemoryGraphStore({
+      storage: manager,
+      ownerScope: OWNER,
+      now: () => NOW + 2000,
+    });
+    const decayed = await graphStore.readSnapshot({
+      ownerScope: OWNER,
+      includeAuditOnly: true,
+    });
+    const cluster = decayed.clusters[0];
+    expect(cluster.lifecycleStatus).toBe("decaying");
+    await graphStore.persistPlan({
+      planId: "test-reset-lifecycle",
+      ownerScope: OWNER,
+      candidateNodes: [],
+      candidateEdges: [],
+      candidateClusters: [{ ...cluster, lifecycleStatus: "forming" }],
+      operations: [
+        {
+          operationId: "test-reset-lifecycle-operation",
+          ownerScope: OWNER,
+          kind: "set-cluster-lifecycle",
+          nodeIds: [...cluster.nodeIds],
+          clusterId: cluster.clusterId,
+          fromStatus: "decaying",
+          toStatus: "forming",
+          reasonCodes: ["test_explicit_reset"],
+        },
+      ],
+      expectedVersion: decayed.version,
+      persistence: { mode: "write", enabled: true },
+      reasonCodes: ["test_explicit_reset"],
+    });
+
+    const repeatedDecay = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      {
+        now: NOW + 3000,
+        graphLifecycle: { enabled: true, decayAfterMs: 0 },
+      },
+    );
+    expect(repeatedDecay.graphLifecycle?.status).toBe("applied");
+    expect((await snapshot(manager)).clusters[0].lifecycleStatus).toBe(
+      "decaying",
+    );
   });
 });

--- a/apps/web/tests/unit/memory-graph-lifecycle-runtime.test.ts
+++ b/apps/web/tests/unit/memory-graph-lifecycle-runtime.test.ts
@@ -1,0 +1,550 @@
+import {
+  type MemorySummaryRecord,
+  type RawMessage,
+  type RawMessageQuery,
+  createRawMessageMemoryGraphStore,
+  memoryGraphLedgerMessageId,
+  queryMemoryWithFallback,
+  runMemoryForgettingCycle,
+  storeRawMessagesWithGraphEvolution,
+} from "@openloomi/indexeddb";
+import type { OwnerScope } from "@openloomi/memory-consolidation";
+import { describe, expect, it } from "vitest";
+
+const NOW = 1_700_000_000_000;
+const OWNER = { userId: "user-1" } satisfies OwnerScope;
+
+class GraphLifecycleTestManager {
+  readonly messages = new Map<string, RawMessage>();
+  readonly summaries = new Map<string, MemorySummaryRecord>();
+  nextId = 1;
+  failSummaryWrites = 0;
+  failDeprecationWrites = 0;
+  ledgerWriteCount = 0;
+  readonly failLedgerWriteNumbers = new Set<number>();
+  hardDeleted = 0;
+  deprecateMessages?: (
+    messageIds: string[],
+    input?: {
+      userId?: string;
+      deprecatedAt?: number;
+      reason?: string;
+      supersededBySummaryId?: string;
+    },
+  ) => Promise<number>;
+
+  constructor(input: { supportsDeprecation?: boolean } = {}) {
+    if (input.supportsDeprecation !== false) {
+      this.deprecateMessages = async (messageIds, options = {}) => {
+        if (this.failDeprecationWrites > 0) {
+          this.failDeprecationWrites -= 1;
+          throw new Error("deprecation write failed");
+        }
+        let changed = 0;
+        for (const messageId of messageIds) {
+          const message = this.messages.get(messageId);
+          if (
+            !message ||
+            message.deprecatedAt !== undefined ||
+            (options.userId && message.userId !== options.userId)
+          ) {
+            continue;
+          }
+          this.messages.set(messageId, {
+            ...message,
+            deprecatedAt: options.deprecatedAt ?? Date.now(),
+            deprecationReason: options.reason,
+            supersededBySummaryId: options.supersededBySummaryId,
+          });
+          changed += 1;
+        }
+        return changed;
+      };
+    }
+  }
+
+  async storeMessage(message: RawMessage): Promise<number> {
+    if (message.messageId.startsWith("__openloomi_memory_graph__")) {
+      this.ledgerWriteCount += 1;
+      if (this.failLedgerWriteNumbers.has(this.ledgerWriteCount)) {
+        throw new Error("ledger write failed");
+      }
+    }
+    const existing = this.messages.get(message.messageId);
+    const id = existing?.id ?? this.nextId++;
+    this.messages.set(message.messageId, { ...message, id });
+    return id;
+  }
+
+  async storeMessages(messages: RawMessage[]): Promise<number[]> {
+    return Promise.all(messages.map((message) => this.storeMessage(message)));
+  }
+
+  async getMessageById(messageId: string): Promise<RawMessage | null> {
+    return this.messages.get(messageId) ?? null;
+  }
+
+  async queryMessages(query: RawMessageQuery): Promise<RawMessage[]> {
+    let messages = [...this.messages.values()];
+    if (query.userId) {
+      messages = messages.filter((message) => message.userId === query.userId);
+    }
+    if (!query.includeArchived) {
+      messages = messages.filter((message) => message.archivedAt === undefined);
+    }
+    if (!query.includeDeprecated) {
+      messages = messages.filter(
+        (message) => message.deprecatedAt === undefined,
+      );
+    }
+    if (query.memoryStages) {
+      messages = messages.filter(
+        (message) =>
+          message.memoryStage !== undefined &&
+          query.memoryStages?.includes(message.memoryStage),
+      );
+    }
+    messages.sort((left, right) =>
+      query.reverse === false
+        ? left.timestamp - right.timestamp
+        : right.timestamp - left.timestamp,
+    );
+    const offset = query.offset ?? 0;
+    const limit = query.limit ?? query.pageSize ?? messages.length;
+    return messages.slice(offset, offset + limit);
+  }
+
+  async upsertSummaries(summaries: MemorySummaryRecord[]): Promise<void> {
+    if (this.failSummaryWrites > 0) {
+      this.failSummaryWrites -= 1;
+      throw new Error("summary write failed");
+    }
+    for (const summary of summaries) {
+      const existing = this.summaries.get(summary.summaryId);
+      this.summaries.set(summary.summaryId, {
+        ...summary,
+        createdAt: existing?.createdAt ?? summary.createdAt,
+      });
+    }
+  }
+
+  async querySummaries(input: {
+    userId?: string;
+    pageSize?: number;
+  }): Promise<MemorySummaryRecord[]> {
+    return [...this.summaries.values()]
+      .filter((summary) => !input.userId || summary.userId === input.userId)
+      .slice(0, input.pageSize);
+  }
+
+  async hardDeleteArchived(): Promise<number> {
+    return this.hardDeleted;
+  }
+}
+
+function rawMessage(
+  messageId: string,
+  input: {
+    relationValue?: string;
+    sourceIdentity?: string;
+    applicability?: Record<string, unknown>;
+    timestamp?: number;
+  } = {},
+): RawMessage {
+  return {
+    messageId,
+    platform: "slack",
+    botId: "bot-1",
+    userId: OWNER.userId,
+    timestamp: input.timestamp ?? Math.floor(NOW / 1000),
+    content: `User language preference: ${input.relationValue ?? "zh"}`,
+    attachments: [],
+    metadata: {
+      relationGroup: "language",
+      relationValue: input.relationValue ?? "zh",
+      sourceIdentity: input.sourceIdentity ?? `source:${messageId}`,
+      memoryApplicability: input.applicability ?? { scope: "global" },
+    },
+    createdAt: input.timestamp ?? Math.floor(NOW / 1000),
+    memoryStage: "short",
+  };
+}
+
+async function storeEvidence(
+  manager: GraphLifecycleTestManager,
+  messages: RawMessage[],
+  input: { workspaceId?: string; now?: number } = {},
+) {
+  return storeRawMessagesWithGraphEvolution({
+    storage: manager,
+    messages,
+    graphEvolution: { enabled: true, workspaceId: input.workspaceId },
+    now: input.now ?? NOW,
+  });
+}
+
+async function snapshot(
+  manager: GraphLifecycleTestManager,
+  ownerScope: OwnerScope = OWNER,
+) {
+  return createRawMessageMemoryGraphStore({
+    storage: manager,
+    ownerScope,
+    now: () => NOW,
+  }).readSnapshot({ ownerScope, includeAuditOnly: true });
+}
+
+describe("memory graph lifecycle forgetting runtime", () => {
+  it("persists a representative before soft-deprecating stable cluster sources", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("zh-1")], { now: NOW });
+    await storeEvidence(
+      manager,
+      [rawMessage("zh-2", { timestamp: Math.floor(NOW / 1000) + 1 })],
+      { now: NOW + 1000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("zh-3", { timestamp: Math.floor(NOW / 1000) + 2 })],
+      { now: NOW + 2000 },
+    );
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      {
+        now: NOW + 3000,
+        graphLifecycle: { enabled: true },
+      },
+    );
+
+    expect(result.graphLifecycle).toEqual(
+      expect.objectContaining({
+        status: "applied",
+        stableClusters: 1,
+        createdSummaries: 1,
+        deprecatedRecords: 3,
+      }),
+    );
+    const storedSummary = [...manager.summaries.values()][0];
+    expect(storedSummary).toEqual(
+      expect.objectContaining({
+        sourceRecordIds: ["zh-1", "zh-2", "zh-3"],
+        messageCount: 3,
+      }),
+    );
+    expect(
+      await manager.querySummaries({ userId: OWNER.userId, pageSize: 10 }),
+    ).toEqual([storedSummary]);
+    const defaultRetrieval = await queryMemoryWithFallback(manager as never, {
+      userId: OWNER.userId,
+      limit: 10,
+      minRawResultsWithoutFallback: 1,
+    });
+    expect(defaultRetrieval.items).toEqual([
+      expect.objectContaining({
+        sourceType: "summary",
+        summary: expect.objectContaining({
+          summaryId: storedSummary?.summaryId,
+        }),
+      }),
+    ]);
+    const defaultRaw = await manager.queryMessages({
+      userId: OWNER.userId,
+      includeArchived: false,
+      includeDeprecated: false,
+    });
+    expect(defaultRaw.map((message) => message.messageId)).toEqual([]);
+    const auditRaw = await manager.queryMessages({
+      userId: OWNER.userId,
+      includeArchived: false,
+      includeDeprecated: true,
+    });
+    expect(
+      auditRaw.filter((message) => !message.messageId.startsWith("__")),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          messageId: "zh-1",
+          deprecatedAt: NOW + 3000,
+          supersededBySummaryId: storedSummary?.summaryId,
+        }),
+      ]),
+    );
+    const graph = await snapshot(manager);
+    expect(
+      graph.nodes.find((node) => node.id === storedSummary?.summaryId),
+    ).toEqual(
+      expect.objectContaining({ type: "summary", visibility: "default" }),
+    );
+    expect(
+      graph.nodes
+        .filter((node) => ["zh-1", "zh-2", "zh-3"].includes(node.id))
+        .every((node) => node.visibility === "audit-only"),
+    ).toBe(true);
+    expect(graph.clusters[0]).toEqual(
+      expect.objectContaining({
+        lifecycleStatus: "stable",
+        representativeNodeId: storedSummary?.summaryId,
+      }),
+    );
+    const audit = await createRawMessageMemoryGraphStore({
+      storage: manager,
+      ownerScope: OWNER,
+      now: () => NOW,
+    }).readAuditTrail({
+      ownerScope: OWNER,
+      nodeId: storedSummary?.summaryId ?? "",
+    });
+    expect(audit.sourceNodeIds).toEqual(
+      expect.arrayContaining(["zh-1", "zh-2", "zh-3"]),
+    );
+  });
+
+  it("keeps sources visible when summary persistence fails", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("fail-1")]);
+    await storeEvidence(manager, [rawMessage("fail-2")], { now: NOW + 1000 });
+    await storeEvidence(manager, [rawMessage("fail-3")], { now: NOW + 2000 });
+    manager.failSummaryWrites = 1;
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 3000, graphLifecycle: { enabled: true } },
+    );
+
+    expect(result.graphLifecycle?.status).toBe("partial-failure");
+    expect(manager.summaries.size).toBe(0);
+    expect(
+      (
+        await manager.queryMessages({
+          userId: OWNER.userId,
+          includeArchived: false,
+          includeDeprecated: false,
+        })
+      ).filter((message) => !message.messageId.startsWith("__")),
+    ).toHaveLength(3);
+    expect(
+      (await snapshot(manager)).clusters[0].representativeNodeId,
+    ).toBeUndefined();
+  });
+
+  it("does not deprecate sources when representative graph persistence fails", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("representative-fail-1")]);
+    await storeEvidence(manager, [rawMessage("representative-fail-2")], {
+      now: NOW + 1000,
+    });
+    await storeEvidence(manager, [rawMessage("representative-fail-3")], {
+      now: NOW + 2000,
+    });
+    manager.failLedgerWriteNumbers.add(manager.ledgerWriteCount + 2);
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 3000, graphLifecycle: { enabled: true } },
+    );
+
+    expect(result.graphLifecycle?.status).toBe("partial-failure");
+    expect(manager.summaries.size).toBe(1);
+    expect(
+      manager.messages.get("representative-fail-1")?.deprecatedAt,
+    ).toBeUndefined();
+    expect(
+      (await snapshot(manager)).clusters[0].representativeNodeId,
+    ).toBeUndefined();
+  });
+
+  it("retries a partial deprecation failure without duplicating the summary", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("retry-1")]);
+    await storeEvidence(manager, [rawMessage("retry-2")], { now: NOW + 1000 });
+    await storeEvidence(manager, [rawMessage("retry-3")], { now: NOW + 2000 });
+    manager.failDeprecationWrites = 1;
+
+    const failed = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 3000, graphLifecycle: { enabled: true } },
+    );
+    expect(failed.graphLifecycle?.status).toBe("partial-failure");
+    expect(manager.summaries.size).toBe(1);
+    expect(manager.messages.get("retry-1")?.deprecatedAt).toBeUndefined();
+
+    const retried = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 4000, graphLifecycle: { enabled: true } },
+    );
+    expect(retried.graphLifecycle?.status).toBe("applied");
+    expect(manager.summaries.size).toBe(1);
+    expect(manager.messages.get("retry-1")?.deprecatedAt).toBe(NOW + 4000);
+
+    const replay = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 5000, graphLifecycle: { enabled: true } },
+    );
+    expect(replay.graphLifecycle?.status).toBe("no-op");
+    expect(manager.messages.get("retry-1")?.deprecatedAt).toBe(NOW + 4000);
+  });
+
+  it("keeps summaries and raw visibility when the adapter cannot deprecate", async () => {
+    const manager = new GraphLifecycleTestManager({
+      supportsDeprecation: false,
+    });
+    await storeEvidence(manager, [rawMessage("no-adapter-1")]);
+    await storeEvidence(manager, [rawMessage("no-adapter-2")], {
+      now: NOW + 1000,
+    });
+    await storeEvidence(manager, [rawMessage("no-adapter-3")], {
+      now: NOW + 2000,
+    });
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 3000, graphLifecycle: { enabled: true } },
+    );
+
+    expect(result.graphLifecycle).toEqual(
+      expect.objectContaining({
+        status: "partial-failure",
+        createdSummaries: 1,
+        deprecatedRecords: 0,
+        reasonCodes: expect.arrayContaining([
+          "adapter_missing_deprecate_records",
+        ]),
+      }),
+    );
+    expect(manager.messages.get("no-adapter-1")?.deprecatedAt).toBeUndefined();
+    const graph = await snapshot(manager);
+    expect(
+      graph.nodes.find((node) => node.id === "no-adapter-1")?.visibility,
+    ).toBe("default");
+  });
+
+  it("supersedes sustained same-context competition but preserves contextual exceptions", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [
+      rawMessage("global-zh", { relationValue: "zh" }),
+    ]);
+    await storeEvidence(
+      manager,
+      [
+        rawMessage("task-en", {
+          relationValue: "en",
+          applicability: { scope: "task", key: "task-42" },
+        }),
+      ],
+      { now: NOW + 1000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("global-en-1", { relationValue: "en" })],
+      { now: NOW + 2000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("global-en-2", { relationValue: "en" })],
+      { now: NOW + 3000 },
+    );
+    await storeEvidence(
+      manager,
+      [rawMessage("global-en-3", { relationValue: "en" })],
+      { now: NOW + 4000 },
+    );
+
+    const result = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      { now: NOW + 5000, graphLifecycle: { enabled: true } },
+    );
+
+    expect(result.graphLifecycle?.createdSummaries).toBe(1);
+    const graph = await snapshot(manager);
+    const taskCluster = graph.clusters.find((cluster) =>
+      cluster.nodeIds.includes("task-en"),
+    );
+    const oldGlobalCluster = graph.clusters.find((cluster) =>
+      cluster.nodeIds.includes("global-zh"),
+    );
+    const newGlobalCluster = graph.clusters.find((cluster) =>
+      cluster.nodeIds.includes("global-en-1"),
+    );
+    expect(taskCluster?.lifecycleStatus).toBe("forming");
+    expect(oldGlobalCluster?.lifecycleStatus).toBe("superseded");
+    expect(newGlobalCluster).toEqual(
+      expect.objectContaining({
+        lifecycleStatus: "stable",
+        representativeNodeId: expect.any(String),
+      }),
+    );
+    expect(manager.messages.get("global-zh")?.deprecationReason).toMatch(
+      /^superseded_by_summary:/,
+    );
+    expect(manager.messages.get("global-en-1")?.deprecationReason).toMatch(
+      /^summarized_into:/,
+    );
+  });
+
+  it("supports dry-run, owner-scope isolation, and stale singleton decay", async () => {
+    const manager = new GraphLifecycleTestManager();
+    await storeEvidence(manager, [rawMessage("workspace-a")], {
+      workspaceId: "workspace-a",
+      now: NOW,
+    });
+
+    const wrongScope = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      {
+        now: NOW + 1000,
+        graphLifecycle: { enabled: true, workspaceId: "workspace-b" },
+      },
+    );
+    expect(wrongScope.graphLifecycle).toEqual(
+      expect.objectContaining({ status: "no-op", scannedClusters: 0 }),
+    );
+
+    const dryRun = await runMemoryForgettingCycle(
+      manager as never,
+      OWNER.userId,
+      {
+        dryRun: true,
+        now: NOW + 2000,
+        graphLifecycle: {
+          enabled: true,
+          workspaceId: "workspace-a",
+          decayAfterMs: 0,
+        },
+      },
+    );
+    expect(dryRun.graphLifecycle).toEqual(
+      expect.objectContaining({
+        status: "planned",
+        decayingClusters: 1,
+        createdSummaries: 0,
+      }),
+    );
+    expect(manager.summaries.size).toBe(0);
+    expect(
+      (
+        await snapshot(manager, {
+          userId: OWNER.userId,
+          workspaceId: "workspace-a",
+        })
+      ).clusters[0].lifecycleStatus,
+    ).toBe("forming");
+    expect(
+      manager.messages.has(
+        memoryGraphLedgerMessageId({
+          userId: OWNER.userId,
+          workspaceId: "workspace-a",
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/ai/memory-consolidation/docs/adr/0005-competition-before-supersession.md
+++ b/packages/ai/memory-consolidation/docs/adr/0005-competition-before-supersession.md
@@ -16,6 +16,11 @@ merged, retrieval cannot explain which alternative is active.
 Contradictory evidence creates or reinforces competition between distinct memory
 structures before any supersession decision.
 
+Competition membership is derived from connected active `compete` edges within
+the same exact applicability identity. Pairwise metadata must not split a
+multi-alternative competition or cause lifecycle policy to ignore one of the
+connected alternatives.
+
 Supersession requires sustained evidence, policy evaluation, and preserved
 provenance. Temporary or context-specific evidence remains scoped or contested
 unless it accumulates enough support to become the preferred alternative.

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -11,6 +11,7 @@
     "./evidence-cluster": "./src/evidence-cluster.ts",
     "./graph-contracts": "./src/graph-contracts.ts",
     "./graph-evolution": "./src/graph-evolution.ts",
+    "./graph-lifecycle": "./src/graph-lifecycle.ts",
     "./graph-retrieval": "./src/graph-retrieval.ts",
     "./governance": "./src/governance.ts",
     "./persistence": "./src/persistence.ts",

--- a/packages/ai/memory-consolidation/src/graph-evolution.ts
+++ b/packages/ai/memory-consolidation/src/graph-evolution.ts
@@ -127,7 +127,93 @@ export function applicabilityEquivalent(
   left: MemoryApplicabilityContext | undefined,
   right: MemoryApplicabilityContext | undefined,
 ): boolean {
-  return applicabilityKey(left) === applicabilityKey(right);
+  return (
+    applicabilityKey(left) === applicabilityKey(right) &&
+    left?.validFrom === right?.validFrom &&
+    left?.validUntil === right?.validUntil
+  );
+}
+
+export interface MemoryGraphCompetitionComponent {
+  componentKey: string;
+  clusters: MemoryGraphClusterSnapshot[];
+}
+
+export function buildMemoryGraphCompetitionComponents(input: {
+  ownerScope: OwnerScope;
+  clusters: MemoryGraphClusterSnapshot[];
+  edges: MemoryGraphEdge[];
+}): MemoryGraphCompetitionComponent[] {
+  const clustersById = new Map(
+    input.clusters.map((cluster) => [cluster.clusterId, cluster]),
+  );
+  const clusterIdByNodeId = new Map<string, string>();
+  for (const cluster of input.clusters) {
+    for (const nodeId of cluster.nodeIds) {
+      clusterIdByNodeId.set(nodeId, cluster.clusterId);
+    }
+  }
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of input.edges) {
+    if (
+      edge.kind !== "compete" ||
+      edge.weight <= 0 ||
+      edge.metadata?.inactive === true ||
+      edge.metadata?.rolledBack === true ||
+      !sameOwnerScope(edge.ownerScope, input.ownerScope)
+    ) {
+      continue;
+    }
+    const leftId = clusterIdByNodeId.get(edge.fromNodeId);
+    const rightId = clusterIdByNodeId.get(edge.toNodeId);
+    if (!leftId || !rightId || leftId === rightId) continue;
+    const left = clustersById.get(leftId);
+    const right = clustersById.get(rightId);
+    if (
+      !left ||
+      !right ||
+      !applicabilityEquivalent(left.applicability, right.applicability)
+    ) {
+      continue;
+    }
+    const leftPeers = adjacency.get(leftId) ?? new Set<string>();
+    leftPeers.add(rightId);
+    adjacency.set(leftId, leftPeers);
+    const rightPeers = adjacency.get(rightId) ?? new Set<string>();
+    rightPeers.add(leftId);
+    adjacency.set(rightId, rightPeers);
+  }
+
+  const components: MemoryGraphCompetitionComponent[] = [];
+  const visited = new Set<string>();
+  for (const clusterId of adjacency.keys()) {
+    if (visited.has(clusterId)) continue;
+    const queue = [clusterId];
+    const componentIds: string[] = [];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || visited.has(current)) continue;
+      visited.add(current);
+      componentIds.push(current);
+      for (const peer of adjacency.get(current) ?? []) {
+        if (!visited.has(peer)) queue.push(peer);
+      }
+    }
+    const clusters = componentIds
+      .map((id) => clustersById.get(id))
+      .filter((cluster): cluster is MemoryGraphClusterSnapshot =>
+        Boolean(cluster),
+      );
+    if (clusters.length < 2) continue;
+    components.push({
+      componentKey: `competition-component:${componentIds
+        .sort()
+        .map(stablePart)
+        .join(":")}`,
+      clusters,
+    });
+  }
+  return components;
 }
 
 function evidenceToRecord(

--- a/packages/ai/memory-consolidation/src/graph-lifecycle.ts
+++ b/packages/ai/memory-consolidation/src/graph-lifecycle.ts
@@ -11,7 +11,11 @@ import type {
   MemoryGraphUpdatePlan,
   OwnerScope,
 } from "./graph-contracts";
-import { ownerScopeKey, sameOwnerScope } from "./graph-evolution";
+import {
+  buildMemoryGraphCompetitionComponents,
+  ownerScopeKey,
+  sameOwnerScope,
+} from "./graph-evolution";
 
 export interface MemoryGraphLifecyclePolicyOptions {
   stableMinEvidence?: number;
@@ -121,9 +125,11 @@ function strength(
 function lifecycleOperationId(
   ownerScope: OwnerScope,
   clusterId: string,
+  fromStatus: MemoryClusterLifecycleStatus,
   toStatus: MemoryClusterLifecycleStatus,
+  expectedVersion: string,
 ): string {
-  return `memory-graph-lifecycle:${ownerScopeKey(ownerScope)}:${stablePart(clusterId)}:${toStatus}`;
+  return `memory-graph-lifecycle:${ownerScopeKey(ownerScope)}:${stablePart(clusterId)}:${fromStatus}:${toStatus}:${stablePart(expectedVersion)}`;
 }
 
 function planId(
@@ -217,19 +223,21 @@ export function buildMemoryGraphLifecyclePlan(
       rawSourceNodeIds(cluster, input.snapshot),
     ]),
   );
-  const competitionGroups = new Map<string, MemoryGraphClusterSnapshot[]>();
-  for (const cluster of clusters) {
-    if (!cluster.competitionKey) continue;
-    const group = competitionGroups.get(cluster.competitionKey) ?? [];
-    group.push(cluster);
-    competitionGroups.set(cluster.competitionKey, group);
-  }
-
-  const clearCompetitionWinner = new Map<
+  const competitionByClusterId = new Map<
     string,
-    { winner: MemoryGraphClusterSnapshot; losers: MemoryGraphClusterSnapshot[] }
+    {
+      key: string;
+      winner?: MemoryGraphClusterSnapshot;
+      losers: MemoryGraphClusterSnapshot[];
+      resolved: boolean;
+    }
   >();
-  for (const [competitionKey, group] of competitionGroups) {
+  for (const component of buildMemoryGraphCompetitionComponents({
+    clusters,
+    edges: input.snapshot.edges,
+    ownerScope: input.ownerScope,
+  })) {
+    const group = component.clusters;
     const ranked = [...group].sort((left, right) => {
       const rightSources = sourcesByCluster.get(right.clusterId) ?? [];
       const leftSources = sourcesByCluster.get(left.clusterId) ?? [];
@@ -246,6 +254,13 @@ export function buildMemoryGraphLifecyclePlan(
       strength(winner, winnerSources) - strength(runnerUp, runnerUpSources) <
         supersessionStrengthMargin
     ) {
+      for (const cluster of group) {
+        competitionByClusterId.set(cluster.clusterId, {
+          key: component.componentKey,
+          losers: [],
+          resolved: false,
+        });
+      }
       continue;
     }
     const losers = ranked.filter(
@@ -254,7 +269,14 @@ export function buildMemoryGraphLifecyclePlan(
         sameApplicability(cluster.applicability, winner.applicability),
     );
     if (losers.length > 0) {
-      clearCompetitionWinner.set(competitionKey, { winner, losers });
+      for (const cluster of group) {
+        competitionByClusterId.set(cluster.clusterId, {
+          key: component.componentKey,
+          winner,
+          losers,
+          resolved: true,
+        });
+      }
     }
   }
 
@@ -269,12 +291,9 @@ export function buildMemoryGraphLifecyclePlan(
     const sourceNodeIds = sourcesByCluster.get(cluster.clusterId) ?? [];
     let targetStatus: MemoryClusterLifecycleStatus = cluster.lifecycleStatus;
     let transitionReason = "cluster_lifecycle_unchanged";
-    const competition = cluster.competitionKey
-      ? clearCompetitionWinner.get(cluster.competitionKey)
-      : undefined;
-    const isWinner = competition?.winner.clusterId === cluster.clusterId;
-    const hasUnresolvedCompetition =
-      Boolean(cluster.competitionKey) && !competition;
+    const competition = competitionByClusterId.get(cluster.clusterId);
+    const isWinner = competition?.winner?.clusterId === cluster.clusterId;
+    const hasUnresolvedCompetition = competition?.resolved === false;
 
     if (
       cluster.lifecycleStatus === "superseded" &&
@@ -329,7 +348,9 @@ export function buildMemoryGraphLifecyclePlan(
         operationId: lifecycleOperationId(
           input.ownerScope,
           cluster.clusterId,
+          cluster.lifecycleStatus,
           targetStatus,
+          input.snapshot.version ?? "0",
         ),
         ownerScope: { ...input.ownerScope },
         kind: "set-cluster-lifecycle",
@@ -349,7 +370,7 @@ export function buildMemoryGraphLifecyclePlan(
         clusterId: cluster.clusterId,
         sourceNodeIds,
         supersededClusterIds,
-        competitionKey: cluster.competitionKey,
+        competitionKey: competition?.key ?? cluster.competitionKey,
         evidenceCount: sourceNodeIds.length,
         score: cluster.supportScore ?? 0,
         reasonCodes: unique([
@@ -423,9 +444,40 @@ export function buildMemoryGraphRepresentativePlan(
   const supersededSourceNodeIds = supersededClusters.flatMap((cluster) =>
     rawSourceNodeIds(cluster, input.snapshot),
   );
+  const nodesById = new Map(
+    input.snapshot.nodes.map((node) => [node.id, node]),
+  );
+  const supersededRepresentativeNodes = supersededClusters
+    .map((cluster) =>
+      cluster.representativeNodeId
+        ? nodesById.get(cluster.representativeNodeId)
+        : undefined,
+    )
+    .filter(
+      (node): node is MemoryGraphNode =>
+        Boolean(node) &&
+        (node?.type === "summary" || node?.type === "artifact") &&
+        node.visibility !== "audit-only",
+    )
+    .map(
+      (node): MemoryGraphNode => ({
+        ...node,
+        ownerScope: { ...node.ownerScope },
+        visibility: "audit-only",
+        updatedAt: input.now,
+        metadata: {
+          ...(node.metadata ?? {}),
+          supersededBySummaryId: input.summaryId,
+        },
+      }),
+    );
   const coveredSourceNodeIds = unique([
     ...input.candidate.sourceNodeIds,
     ...supersededSourceNodeIds,
+  ]);
+  const coveredNodeIds = unique([
+    ...coveredSourceNodeIds,
+    ...supersededRepresentativeNodes.map((node) => node.id),
   ]);
   const summaryNode: MemoryGraphNode = {
     id: input.summaryId,
@@ -444,9 +496,12 @@ export function buildMemoryGraphRepresentativePlan(
       supersededClusterIds: supersededClusters.map(
         (cluster) => cluster.clusterId,
       ),
+      supersededRepresentativeNodeIds: supersededRepresentativeNodes.map(
+        (node) => node.id,
+      ),
     },
   };
-  const candidateEdges: MemoryGraphEdge[] = coveredSourceNodeIds.map(
+  const candidateEdges: MemoryGraphEdge[] = coveredNodeIds.map(
     (sourceNodeId) => ({
       id: edgeId(sourceNodeId, input.summaryId),
       ownerScope: { ...input.ownerScope },
@@ -513,6 +568,19 @@ export function buildMemoryGraphRepresentativePlan(
         reasonCodes: [...edge.reasonCodes],
       }),
     ),
+    ...supersededRepresentativeNodes.map(
+      (node): MemoryGraphOperation => ({
+        operationId: operationId(
+          "supersede-representative",
+          `${node.id}:${input.summaryId}`,
+        ),
+        ownerScope: { ...input.ownerScope },
+        kind: "supersede-node",
+        nodeIds: [node.id],
+        supersededByNodeId: input.summaryId,
+        reasonCodes: ["sustained_competition_superseded"],
+      }),
+    ),
     {
       operationId: operationId("set-representative", input.summaryId),
       ownerScope: { ...input.ownerScope },
@@ -543,7 +611,7 @@ export function buildMemoryGraphRepresentativePlan(
   return {
     planId: planId("representative", input.ownerScope, input.summaryId),
     ownerScope: { ...input.ownerScope },
-    candidateNodes: [summaryNode],
+    candidateNodes: [summaryNode, ...supersededRepresentativeNodes],
     candidateEdges,
     candidateClusters: [updatedWinner, ...updatedLosers],
     operations,

--- a/packages/ai/memory-consolidation/src/graph-lifecycle.ts
+++ b/packages/ai/memory-consolidation/src/graph-lifecycle.ts
@@ -1,0 +1,619 @@
+import type {
+  ClusterLifecycleTransition,
+  MemoryApplicabilityContext,
+  MemoryClusterLifecycleStatus,
+  MemoryGraphClusterSnapshot,
+  MemoryGraphEdge,
+  MemoryGraphNode,
+  MemoryGraphOperation,
+  MemoryGraphPersistenceMode,
+  MemoryGraphSnapshot,
+  MemoryGraphUpdatePlan,
+  OwnerScope,
+} from "./graph-contracts";
+import { ownerScopeKey, sameOwnerScope } from "./graph-evolution";
+
+export interface MemoryGraphLifecyclePolicyOptions {
+  stableMinEvidence?: number;
+  stableMinSupportScore?: number;
+  decayAfterMs?: number;
+  supersessionMinEvidence?: number;
+  supersessionStrengthMargin?: number;
+}
+
+export interface MemoryGraphLifecycleConsolidationCandidate {
+  clusterId: string;
+  sourceNodeIds: string[];
+  supersededClusterIds: string[];
+  competitionKey?: string;
+  evidenceCount: number;
+  score: number;
+  reasonCodes: string[];
+}
+
+export interface BuildMemoryGraphLifecyclePlanInput {
+  ownerScope: OwnerScope;
+  snapshot: MemoryGraphSnapshot;
+  now: number;
+  persistence: MemoryGraphPersistenceMode;
+  policy?: MemoryGraphLifecyclePolicyOptions;
+}
+
+export interface BuildMemoryGraphLifecyclePlanResult {
+  plan: MemoryGraphUpdatePlan;
+  transitions: ClusterLifecycleTransition[];
+  consolidationCandidates: MemoryGraphLifecycleConsolidationCandidate[];
+  decayingClusterIds: string[];
+  reasonCodes: string[];
+}
+
+export interface BuildMemoryGraphRepresentativePlanInput {
+  ownerScope: OwnerScope;
+  snapshot: MemoryGraphSnapshot;
+  candidate: MemoryGraphLifecycleConsolidationCandidate;
+  summaryId: string;
+  now: number;
+  persistence: MemoryGraphPersistenceMode;
+}
+
+export interface BuildMemoryGraphVisibilityPlanInput {
+  ownerScope: OwnerScope;
+  snapshot: MemoryGraphSnapshot;
+  summaryId: string;
+  sourceNodeIds: string[];
+  now: number;
+  persistence: MemoryGraphPersistenceMode;
+}
+
+const DEFAULT_STABLE_MIN_EVIDENCE = 3;
+const DEFAULT_STABLE_MIN_SUPPORT_SCORE = 0.6;
+const DEFAULT_DECAY_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_SUPERSESSION_MIN_EVIDENCE = 3;
+const DEFAULT_SUPERSESSION_STRENGTH_MARGIN = 1;
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function stablePart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function applicabilityKey(
+  value: MemoryApplicabilityContext | undefined,
+): string {
+  if (!value) return "global";
+  return [
+    value.scope,
+    value.key ?? "",
+    value.validFrom ?? "",
+    value.validUntil ?? "",
+  ]
+    .map((part) => stablePart(String(part)))
+    .join(":");
+}
+
+function sameApplicability(
+  left: MemoryApplicabilityContext | undefined,
+  right: MemoryApplicabilityContext | undefined,
+): boolean {
+  return applicabilityKey(left) === applicabilityKey(right);
+}
+
+function rawSourceNodeIds(
+  cluster: MemoryGraphClusterSnapshot,
+  snapshot: MemoryGraphSnapshot,
+): string[] {
+  const nodesById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  return cluster.nodeIds.filter((nodeId) => {
+    const node = nodesById.get(nodeId);
+    return node?.type === "raw" && node.visibility !== "audit-only";
+  });
+}
+
+function strength(
+  cluster: MemoryGraphClusterSnapshot,
+  sourceNodeIds: string[],
+): number {
+  return sourceNodeIds.length + (cluster.supportScore ?? 0);
+}
+
+function lifecycleOperationId(
+  ownerScope: OwnerScope,
+  clusterId: string,
+  toStatus: MemoryClusterLifecycleStatus,
+): string {
+  return `memory-graph-lifecycle:${ownerScopeKey(ownerScope)}:${stablePart(clusterId)}:${toStatus}`;
+}
+
+function planId(
+  kind: string,
+  ownerScope: OwnerScope,
+  identity: string,
+): string {
+  return `memory-graph-${kind}:${ownerScopeKey(ownerScope)}:${stablePart(identity)}`;
+}
+
+function edgeId(fromNodeId: string, toNodeId: string): string {
+  return `memory-graph-edge:supersede:${stablePart(fromNodeId)}:${stablePart(toNodeId)}`;
+}
+
+function operationId(kind: string, identity: string): string {
+  return `memory-graph-operation:${kind}:${stablePart(identity)}`;
+}
+
+function copyCluster(
+  cluster: MemoryGraphClusterSnapshot,
+): MemoryGraphClusterSnapshot {
+  return {
+    ...cluster,
+    ownerScope: { ...cluster.ownerScope },
+    nodeIds: [...cluster.nodeIds],
+    reasonCodes: [...cluster.reasonCodes],
+    applicability: cluster.applicability
+      ? { ...cluster.applicability }
+      : undefined,
+    metadata: cluster.metadata ? { ...cluster.metadata } : undefined,
+  };
+}
+
+function emptyPlan(input: {
+  ownerScope: OwnerScope;
+  snapshot: MemoryGraphSnapshot;
+  persistence: MemoryGraphPersistenceMode;
+  kind: string;
+  identity: string;
+  reasonCodes: string[];
+}): MemoryGraphUpdatePlan {
+  return {
+    planId: planId(input.kind, input.ownerScope, input.identity),
+    ownerScope: { ...input.ownerScope },
+    candidateNodes: [],
+    candidateEdges: [],
+    candidateClusters: [],
+    operations: [],
+    expectedVersion: input.snapshot.version ?? "0",
+    persistence: input.persistence,
+    reasonCodes: input.reasonCodes,
+  };
+}
+
+export function buildMemoryGraphLifecyclePlan(
+  input: BuildMemoryGraphLifecyclePlanInput,
+): BuildMemoryGraphLifecyclePlanResult {
+  const stableMinEvidence = Math.max(
+    1,
+    Math.floor(input.policy?.stableMinEvidence ?? DEFAULT_STABLE_MIN_EVIDENCE),
+  );
+  const stableMinSupportScore = Math.max(
+    0,
+    Math.min(
+      1,
+      input.policy?.stableMinSupportScore ?? DEFAULT_STABLE_MIN_SUPPORT_SCORE,
+    ),
+  );
+  const decayAfterMs = Math.max(
+    0,
+    input.policy?.decayAfterMs ?? DEFAULT_DECAY_AFTER_MS,
+  );
+  const supersessionMinEvidence = Math.max(
+    1,
+    Math.floor(
+      input.policy?.supersessionMinEvidence ??
+        DEFAULT_SUPERSESSION_MIN_EVIDENCE,
+    ),
+  );
+  const supersessionStrengthMargin = Math.max(
+    0,
+    input.policy?.supersessionStrengthMargin ??
+      DEFAULT_SUPERSESSION_STRENGTH_MARGIN,
+  );
+  const clusters = input.snapshot.clusters.filter((cluster) =>
+    sameOwnerScope(cluster.ownerScope, input.ownerScope),
+  );
+  const sourcesByCluster = new Map(
+    clusters.map((cluster) => [
+      cluster.clusterId,
+      rawSourceNodeIds(cluster, input.snapshot),
+    ]),
+  );
+  const competitionGroups = new Map<string, MemoryGraphClusterSnapshot[]>();
+  for (const cluster of clusters) {
+    if (!cluster.competitionKey) continue;
+    const group = competitionGroups.get(cluster.competitionKey) ?? [];
+    group.push(cluster);
+    competitionGroups.set(cluster.competitionKey, group);
+  }
+
+  const clearCompetitionWinner = new Map<
+    string,
+    { winner: MemoryGraphClusterSnapshot; losers: MemoryGraphClusterSnapshot[] }
+  >();
+  for (const [competitionKey, group] of competitionGroups) {
+    const ranked = [...group].sort((left, right) => {
+      const rightSources = sourcesByCluster.get(right.clusterId) ?? [];
+      const leftSources = sourcesByCluster.get(left.clusterId) ?? [];
+      return strength(right, rightSources) - strength(left, leftSources);
+    });
+    const winner = ranked[0];
+    const runnerUp = ranked[1];
+    if (!winner || !runnerUp) continue;
+    const winnerSources = sourcesByCluster.get(winner.clusterId) ?? [];
+    const runnerUpSources = sourcesByCluster.get(runnerUp.clusterId) ?? [];
+    if (
+      winnerSources.length < supersessionMinEvidence ||
+      (winner.supportScore ?? 0) < stableMinSupportScore ||
+      strength(winner, winnerSources) - strength(runnerUp, runnerUpSources) <
+        supersessionStrengthMargin
+    ) {
+      continue;
+    }
+    const losers = ranked.filter(
+      (cluster) =>
+        cluster.clusterId !== winner.clusterId &&
+        sameApplicability(cluster.applicability, winner.applicability),
+    );
+    if (losers.length > 0) {
+      clearCompetitionWinner.set(competitionKey, { winner, losers });
+    }
+  }
+
+  const transitions: ClusterLifecycleTransition[] = [];
+  const candidateClusters: MemoryGraphClusterSnapshot[] = [];
+  const operations: MemoryGraphOperation[] = [];
+  const consolidationCandidates: MemoryGraphLifecycleConsolidationCandidate[] =
+    [];
+  const decayingClusterIds: string[] = [];
+
+  for (const cluster of clusters) {
+    const sourceNodeIds = sourcesByCluster.get(cluster.clusterId) ?? [];
+    let targetStatus: MemoryClusterLifecycleStatus = cluster.lifecycleStatus;
+    let transitionReason = "cluster_lifecycle_unchanged";
+    const competition = cluster.competitionKey
+      ? clearCompetitionWinner.get(cluster.competitionKey)
+      : undefined;
+    const isWinner = competition?.winner.clusterId === cluster.clusterId;
+    const hasUnresolvedCompetition =
+      Boolean(cluster.competitionKey) && !competition;
+
+    if (
+      cluster.lifecycleStatus === "superseded" &&
+      typeof cluster.metadata?.supersededBySummaryId === "string"
+    ) {
+      targetStatus = "superseded";
+      transitionReason = "supersession_preserved";
+    } else if (sourceNodeIds.length === 0) {
+      targetStatus = cluster.representativeNodeId
+        ? cluster.lifecycleStatus
+        : "audit-only";
+      transitionReason = "cluster_without_active_sources";
+    } else if (isWinner) {
+      targetStatus = "stable";
+      transitionReason = "sustained_competition_winner";
+    } else if (hasUnresolvedCompetition) {
+      targetStatus = sourceNodeIds.length >= 2 ? "active" : "forming";
+      transitionReason = "competition_preserved_before_supersession";
+    } else if (
+      sourceNodeIds.length >= stableMinEvidence &&
+      (cluster.supportScore ?? 0) >= stableMinSupportScore
+    ) {
+      targetStatus = "stable";
+      transitionReason = "repeated_support_reached_stable";
+    } else if (sourceNodeIds.length >= 2) {
+      targetStatus = "active";
+      transitionReason = "cluster_has_independent_support";
+    } else if (input.now - cluster.updatedAt >= decayAfterMs) {
+      targetStatus = "decaying";
+      transitionReason = "weak_isolated_cluster_stale";
+    } else {
+      targetStatus = "forming";
+      transitionReason = "cluster_still_forming";
+    }
+
+    if (targetStatus === "decaying") decayingClusterIds.push(cluster.clusterId);
+    if (targetStatus !== cluster.lifecycleStatus) {
+      const updated = copyCluster(cluster);
+      updated.lifecycleStatus = targetStatus;
+      updated.updatedAt = input.now;
+      updated.reasonCodes = unique([...updated.reasonCodes, transitionReason]);
+      candidateClusters.push(updated);
+      const transition: ClusterLifecycleTransition = {
+        ownerScope: { ...input.ownerScope },
+        clusterId: cluster.clusterId,
+        fromStatus: cluster.lifecycleStatus,
+        toStatus: targetStatus,
+        reasonCodes: [transitionReason],
+      };
+      transitions.push(transition);
+      operations.push({
+        operationId: lifecycleOperationId(
+          input.ownerScope,
+          cluster.clusterId,
+          targetStatus,
+        ),
+        ownerScope: { ...input.ownerScope },
+        kind: "set-cluster-lifecycle",
+        nodeIds: [...cluster.nodeIds],
+        clusterId: cluster.clusterId,
+        fromStatus: cluster.lifecycleStatus,
+        toStatus: targetStatus,
+        reasonCodes: [transitionReason],
+      });
+    }
+
+    if (targetStatus === "stable" && sourceNodeIds.length > 0) {
+      const supersededClusterIds = isWinner
+        ? (competition?.losers.map((loser) => loser.clusterId) ?? [])
+        : [];
+      consolidationCandidates.push({
+        clusterId: cluster.clusterId,
+        sourceNodeIds,
+        supersededClusterIds,
+        competitionKey: cluster.competitionKey,
+        evidenceCount: sourceNodeIds.length,
+        score: cluster.supportScore ?? 0,
+        reasonCodes: unique([
+          transitionReason,
+          ...(supersededClusterIds.length > 0
+            ? ["sustained_competition_can_supersede"]
+            : []),
+        ]),
+      });
+    }
+  }
+
+  const reasonCodes = unique([
+    "memory_graph_lifecycle_evaluated",
+    ...(transitions.length > 0 ? ["memory_graph_lifecycle_changed"] : []),
+    ...(consolidationCandidates.length > 0
+      ? ["stable_cluster_ready_for_consolidation"]
+      : []),
+    ...(decayingClusterIds.length > 0 ? ["weak_cluster_decaying"] : []),
+  ]);
+  const plan = emptyPlan({
+    ownerScope: input.ownerScope,
+    snapshot: input.snapshot,
+    persistence: input.persistence,
+    kind: "lifecycle",
+    identity: input.snapshot.version ?? "0",
+    reasonCodes,
+  });
+  plan.candidateClusters = candidateClusters;
+  plan.operations = operations;
+
+  return {
+    plan,
+    transitions,
+    consolidationCandidates,
+    decayingClusterIds,
+    reasonCodes,
+  };
+}
+
+export function buildMemoryGraphRepresentativePlan(
+  input: BuildMemoryGraphRepresentativePlanInput,
+): MemoryGraphUpdatePlan {
+  const winner = input.snapshot.clusters.find(
+    (cluster) =>
+      cluster.clusterId === input.candidate.clusterId &&
+      sameOwnerScope(cluster.ownerScope, input.ownerScope),
+  );
+  if (!winner) {
+    return emptyPlan({
+      ownerScope: input.ownerScope,
+      snapshot: input.snapshot,
+      persistence: input.persistence,
+      kind: "representative",
+      identity: input.summaryId,
+      reasonCodes: ["memory_graph_cluster_not_found"],
+    });
+  }
+  const supersededClusters = input.candidate.supersededClusterIds
+    .map((clusterId) =>
+      input.snapshot.clusters.find(
+        (cluster) =>
+          cluster.clusterId === clusterId &&
+          sameOwnerScope(cluster.ownerScope, input.ownerScope) &&
+          sameApplicability(cluster.applicability, winner.applicability),
+      ),
+    )
+    .filter((cluster): cluster is MemoryGraphClusterSnapshot =>
+      Boolean(cluster),
+    );
+  const supersededSourceNodeIds = supersededClusters.flatMap((cluster) =>
+    rawSourceNodeIds(cluster, input.snapshot),
+  );
+  const coveredSourceNodeIds = unique([
+    ...input.candidate.sourceNodeIds,
+    ...supersededSourceNodeIds,
+  ]);
+  const summaryNode: MemoryGraphNode = {
+    id: input.summaryId,
+    ownerScope: { ...input.ownerScope },
+    type: "summary",
+    sourceId: input.summaryId,
+    createdAt: input.now,
+    updatedAt: input.now,
+    visibility: "default",
+    applicability: winner.applicability
+      ? { ...winner.applicability }
+      : undefined,
+    metadata: {
+      clusterId: winner.clusterId,
+      sourceNodeIds: [...input.candidate.sourceNodeIds],
+      supersededClusterIds: supersededClusters.map(
+        (cluster) => cluster.clusterId,
+      ),
+    },
+  };
+  const candidateEdges: MemoryGraphEdge[] = coveredSourceNodeIds.map(
+    (sourceNodeId) => ({
+      id: edgeId(sourceNodeId, input.summaryId),
+      ownerScope: { ...input.ownerScope },
+      fromNodeId: sourceNodeId,
+      toNodeId: input.summaryId,
+      kind: "supersede",
+      weight: 1,
+      confidence: 1,
+      evidenceNodeIds: [sourceNodeId],
+      reasonCodes: [
+        input.candidate.sourceNodeIds.includes(sourceNodeId)
+          ? "stable_cluster_represented"
+          : "competing_cluster_superseded",
+      ],
+      applicability: winner.applicability
+        ? { ...winner.applicability }
+        : undefined,
+      createdAt: input.now,
+      updatedAt: input.now,
+    }),
+  );
+  const updatedWinner = copyCluster(winner);
+  updatedWinner.nodeIds = unique([...updatedWinner.nodeIds, input.summaryId]);
+  updatedWinner.representativeNodeId = input.summaryId;
+  updatedWinner.lifecycleStatus = "stable";
+  updatedWinner.updatedAt = input.now;
+  updatedWinner.reasonCodes = unique([
+    ...updatedWinner.reasonCodes,
+    "stable_cluster_representative_persisted",
+  ]);
+  const updatedLosers = supersededClusters.map((cluster) => {
+    const updated = copyCluster(cluster);
+    updated.lifecycleStatus = "superseded";
+    updated.updatedAt = input.now;
+    updated.reasonCodes = unique([
+      ...updated.reasonCodes,
+      "sustained_competition_superseded",
+    ]);
+    updated.metadata = {
+      ...(updated.metadata ?? {}),
+      supersededByClusterId: winner.clusterId,
+      supersededBySummaryId: input.summaryId,
+    };
+    return updated;
+  });
+  const operations: MemoryGraphOperation[] = [
+    {
+      operationId: operationId("create-summary-node", input.summaryId),
+      ownerScope: { ...input.ownerScope },
+      kind: "create-node",
+      nodeIds: [input.summaryId],
+      clusterId: winner.clusterId,
+      reasonCodes: ["stable_cluster_representative_persisted"],
+    },
+    ...candidateEdges.map(
+      (edge): MemoryGraphOperation => ({
+        operationId: operationId("supersede-edge", edge.id),
+        ownerScope: { ...input.ownerScope },
+        kind: "create-edge",
+        nodeIds: [edge.fromNodeId, edge.toNodeId],
+        edgeIds: [edge.id],
+        clusterId: winner.clusterId,
+        supersededByNodeId: input.summaryId,
+        reasonCodes: [...edge.reasonCodes],
+      }),
+    ),
+    {
+      operationId: operationId("set-representative", input.summaryId),
+      ownerScope: { ...input.ownerScope },
+      kind: "set-cluster-representative",
+      nodeIds: [...updatedWinner.nodeIds],
+      clusterId: winner.clusterId,
+      supersededByNodeId: input.summaryId,
+      reasonCodes: ["stable_cluster_representative_persisted"],
+    },
+    ...updatedLosers.map(
+      (cluster): MemoryGraphOperation => ({
+        operationId: operationId(
+          "supersede-cluster",
+          `${cluster.clusterId}:${input.summaryId}`,
+        ),
+        ownerScope: { ...input.ownerScope },
+        kind: "set-cluster-lifecycle",
+        nodeIds: [...cluster.nodeIds],
+        clusterId: cluster.clusterId,
+        fromStatus: cluster.lifecycleStatus,
+        toStatus: "superseded",
+        supersededByNodeId: input.summaryId,
+        reasonCodes: ["sustained_competition_superseded"],
+      }),
+    ),
+  ];
+
+  return {
+    planId: planId("representative", input.ownerScope, input.summaryId),
+    ownerScope: { ...input.ownerScope },
+    candidateNodes: [summaryNode],
+    candidateEdges,
+    candidateClusters: [updatedWinner, ...updatedLosers],
+    operations,
+    expectedVersion: input.snapshot.version ?? "0",
+    persistence: input.persistence,
+    reasonCodes: unique([
+      "stable_cluster_representative_persisted",
+      ...(updatedLosers.length > 0 ? ["sustained_competition_superseded"] : []),
+    ]),
+    metadata: {
+      summaryId: input.summaryId,
+      sourceNodeIds: [...input.candidate.sourceNodeIds],
+      coveredSourceNodeIds,
+    },
+  };
+}
+
+export function buildMemoryGraphVisibilityPlan(
+  input: BuildMemoryGraphVisibilityPlanInput,
+): MemoryGraphUpdatePlan {
+  const sourceIds = new Set(input.sourceNodeIds);
+  const candidateNodes = input.snapshot.nodes
+    .filter(
+      (node) =>
+        sourceIds.has(node.id) &&
+        node.type === "raw" &&
+        node.visibility !== "audit-only" &&
+        sameOwnerScope(node.ownerScope, input.ownerScope),
+    )
+    .map(
+      (node): MemoryGraphNode => ({
+        ...node,
+        ownerScope: { ...node.ownerScope },
+        visibility: "audit-only",
+        updatedAt: input.now,
+        metadata: {
+          ...(node.metadata ?? {}),
+          supersededBySummaryId: input.summaryId,
+        },
+      }),
+    );
+  const operations = candidateNodes.map(
+    (node): MemoryGraphOperation => ({
+      operationId: operationId(
+        "set-audit-only",
+        `${node.id}:${input.summaryId}`,
+      ),
+      ownerScope: { ...input.ownerScope },
+      kind: "supersede-node",
+      nodeIds: [node.id],
+      supersededByNodeId: input.summaryId,
+      reasonCodes: ["source_soft_deprecated_after_representative"],
+    }),
+  );
+  return {
+    planId: planId("visibility", input.ownerScope, input.summaryId),
+    ownerScope: { ...input.ownerScope },
+    candidateNodes,
+    candidateEdges: [],
+    candidateClusters: [],
+    operations,
+    expectedVersion: input.snapshot.version ?? "0",
+    persistence: input.persistence,
+    reasonCodes: unique([
+      "source_soft_deprecated_after_representative",
+      ...(operations.length === 0 ? ["visibility_already_converged"] : []),
+    ]),
+    metadata: {
+      summaryId: input.summaryId,
+      sourceNodeIds: [...input.sourceNodeIds],
+    },
+  };
+}

--- a/packages/ai/memory-consolidation/src/index.ts
+++ b/packages/ai/memory-consolidation/src/index.ts
@@ -4,6 +4,7 @@ export * from "./evaluation";
 export * from "./evidence-cluster";
 export * from "./graph-contracts";
 export * from "./graph-evolution";
+export * from "./graph-lifecycle";
 export * from "./graph-retrieval";
 export * from "./governance";
 export * from "./plan";

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -18,6 +18,7 @@ import {
   type RawMessageGraphEvolutionOptions,
   storeRawMessagesWithGraphEvolution,
 } from "./memory-graph-evolution";
+import type { RawMessageGraphLifecycleOptions } from "./memory-graph-lifecycle";
 import {
   ensureRawMessagesSQLiteMigration,
   migrateIndexedDBRawMessagesToSQLite,
@@ -52,6 +53,7 @@ export interface RunMemoryForgettingCycleForUserOptions {
   dryRun?: boolean;
   hardDeleteArchivedOlderThan?: number;
   shadowDiagnostics?: RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions;
+  graphLifecycle?: RawMessageGraphLifecycleOptions;
 }
 
 export interface RunMemoryForgettingCycleForUserResult {
@@ -62,6 +64,7 @@ export interface RunMemoryForgettingCycleForUserResult {
   archivedDetailRecords?: number;
   hardDeletedRecords?: number;
   shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
+  graphLifecycle?: RunMemoryForgettingCycleResult["graphLifecycle"];
   error?: string;
 }
 
@@ -480,6 +483,7 @@ export async function runMemoryForgettingCycleForUser(
       archivedDetailRecords: result.archivedDetailRecords,
       hardDeletedRecords: result.hardDeletedRecords,
       shadowDiagnostics: result.shadowDiagnostics,
+      graphLifecycle: result.graphLifecycle,
     };
   } catch (error) {
     console.error(

--- a/packages/indexeddb/src/client.ts
+++ b/packages/indexeddb/src/client.ts
@@ -9,6 +9,7 @@ import type {
 } from "./forgetting";
 import type {
   GroupByType,
+  IndexedDBManager,
   MemorySummaryRecord,
   RawMessage,
   RawMessageQuery,
@@ -68,7 +69,7 @@ export interface RunMemoryForgettingCycleForUserResult {
   error?: string;
 }
 
-let managerInstance: any = null;
+let managerInstance: IndexedDBManager | null = null;
 
 /**
  * Initialize IndexedDB manager (client-side only)
@@ -140,7 +141,7 @@ export async function storeRawMessagesFromInsight(
     embeddingContentHash?: string;
     embeddingDimensions?: number;
     embeddingUpdatedAt?: number;
-    metadata?: Record<string, any>;
+    metadata?: Record<string, unknown>;
   }>,
   graphEvolution?: RawMessageGraphEvolutionOptions,
 ): Promise<{
@@ -334,7 +335,7 @@ export async function queryRawMessagesWithFallback(
         embeddingDimensions: item.record.embeddingDimensions,
         embeddingUpdatedAt: item.record.embeddingUpdatedAt,
         metadata:
-          (item.record.metadata as Record<string, any> | undefined) ??
+          (item.record.metadata as Record<string, unknown> | undefined) ??
           undefined,
         createdAt: item.record.timestamp,
         memoryStage: item.record.tier,

--- a/packages/indexeddb/src/forgetting.ts
+++ b/packages/indexeddb/src/forgetting.ts
@@ -22,17 +22,13 @@ import {
   createMemoryQueryApi,
 } from "../../ai/src/memory";
 import { cosineSimilarity } from "./embedding";
-import type {
-  IndexedDBManager,
-  MemoryStage,
-  MemorySummaryRecord,
-  RawMessage,
-} from "./manager";
+import type { MemoryStage, MemorySummaryRecord, RawMessage } from "./manager";
 import {
   type MemoryGraphLifecycleRuntimeResult,
   type RawMessageGraphLifecycleOptions,
   runMemoryGraphLifecycleCycle,
 } from "./memory-graph-lifecycle";
+import type { RawMessageStorage } from "./storage";
 
 /**
  * Bridge layer between IndexedDB manager and the shared memory engine APIs.
@@ -208,7 +204,7 @@ type NativeRawSemanticSearchResult = {
   similarity: number;
 };
 
-type NativeSemanticSearchManager = IndexedDBManager & {
+type NativeSemanticSearchManager = RawMessageStorage & {
   searchMessagesSemantically?: (input: {
     userId: string;
     queryEmbedding: number[];
@@ -237,19 +233,9 @@ function hasMoreByLength<T>(items: T[], pageSize: number): MemoryPageResult<T> {
 }
 
 export function createIndexedDBMemoryStorageAdapter(
-  manager: IndexedDBManager,
+  manager: RawMessageStorage,
 ): MemoryStorageAdapter {
-  const deprecationManager = manager as IndexedDBManager & {
-    deprecateMessages?: (
-      messageIds: string[],
-      input?: {
-        userId?: string;
-        deprecatedAt?: number;
-        reason?: string;
-        supersededBySummaryId?: string;
-      },
-    ) => Promise<number>;
-  };
+  const deprecationManager = manager;
   return {
     async acquireLock(input) {
       // Process-local lock for re-entrancy control.
@@ -597,7 +583,7 @@ export interface RunMemoryForgettingCycleResult {
 }
 
 export async function runMemoryForgettingCycle(
-  manager: IndexedDBManager,
+  manager: RawMessageStorage,
   userId: string,
   options?: RunMemoryForgettingCycleOptions,
 ): Promise<RunMemoryForgettingCycleResult> {
@@ -715,7 +701,7 @@ export async function runMemoryForgettingCycle(
 }
 
 export async function queryMemoryWithFallback(
-  manager: IndexedDBManager,
+  manager: RawMessageStorage,
   query: MemorySearchQuery & {
     minRawResultsWithoutFallback?: number;
   },

--- a/packages/indexeddb/src/forgetting.ts
+++ b/packages/indexeddb/src/forgetting.ts
@@ -4,6 +4,7 @@ import type {
   RunMemoryConsolidationShadowDiagnosticsInput,
 } from "../../ai/memory-consolidation/src/shadow";
 import {
+  type MemoryDeprecateRecordsInput,
   type MemoryForgettingPolicyOverrides,
   type MemoryLockHandle,
   type MemoryPageResult,
@@ -27,6 +28,11 @@ import type {
   MemorySummaryRecord,
   RawMessage,
 } from "./manager";
+import {
+  type MemoryGraphLifecycleRuntimeResult,
+  type RawMessageGraphLifecycleOptions,
+  runMemoryGraphLifecycleCycle,
+} from "./memory-graph-lifecycle";
 
 /**
  * Bridge layer between IndexedDB manager and the shared memory engine APIs.
@@ -233,6 +239,17 @@ function hasMoreByLength<T>(items: T[], pageSize: number): MemoryPageResult<T> {
 export function createIndexedDBMemoryStorageAdapter(
   manager: IndexedDBManager,
 ): MemoryStorageAdapter {
+  const deprecationManager = manager as IndexedDBManager & {
+    deprecateMessages?: (
+      messageIds: string[],
+      input?: {
+        userId?: string;
+        deprecatedAt?: number;
+        reason?: string;
+        supersededBySummaryId?: string;
+      },
+    ) => Promise<number>;
+  };
   return {
     async acquireLock(input) {
       // Process-local lock for re-entrancy control.
@@ -313,6 +330,21 @@ export function createIndexedDBMemoryStorageAdapter(
       // Upsert keeps cycles idempotent when a run retries after partial progress.
       await manager.upsertSummaries(summaries.map(toSummaryRecord));
     },
+
+    ...(typeof deprecationManager.deprecateMessages === "function"
+      ? {
+          async deprecateRecords(input: MemoryDeprecateRecordsInput) {
+            return (
+              deprecationManager.deprecateMessages?.(input.ids, {
+                userId: input.userId,
+                deprecatedAt: input.deprecatedAt,
+                reason: input.reason,
+                supersededBySummaryId: input.supersededBySummaryId,
+              }) ?? 0
+            );
+          },
+        }
+      : {}),
 
     async transitionRecords(input) {
       // Persist stage transition and reference the generated summary for traceability.
@@ -545,6 +577,7 @@ export interface RunMemoryForgettingCycleOptions {
   policy?: MemoryForgettingPolicyOverrides;
   hardDeleteArchivedOlderThan?: number;
   shadowDiagnostics?: RunMemoryForgettingCycleShadowDiagnosticsOptions;
+  graphLifecycle?: RawMessageGraphLifecycleOptions;
 }
 
 export interface RunMemoryForgettingCycleResult {
@@ -560,6 +593,7 @@ export interface RunMemoryForgettingCycleResult {
   archivedDetailRecords: number;
   hardDeletedRecords: number;
   shadowDiagnostics?: MemoryConsolidationShadowDiagnosticsRunResult;
+  graphLifecycle?: MemoryGraphLifecycleRuntimeResult;
 }
 
 export async function runMemoryForgettingCycle(
@@ -569,14 +603,53 @@ export async function runMemoryForgettingCycle(
 ): Promise<RunMemoryForgettingCycleResult> {
   // Build engine with IndexedDB-backed adapter; policy can be overridden by caller.
   const storage = createIndexedDBMemoryStorageAdapter(manager);
-  const engine = createMemoryForgettingEngine({
-    storage,
-    policy: options?.policy,
-  });
   const now =
     options?.shadowDiagnostics === undefined
       ? options?.now
       : (options.now ?? Date.now());
+  if (options?.graphLifecycle?.enabled === true) {
+    const graphLifecycle = await runMemoryGraphLifecycleCycle({
+      manager,
+      storage,
+      userId,
+      options: {
+        ...options.graphLifecycle,
+        dryRun: options.graphLifecycle.dryRun ?? options.dryRun,
+      },
+      now,
+    });
+    let hardDeletedRecords = 0;
+    if (
+      !graphLifecycle.dryRun &&
+      options.hardDeleteArchivedOlderThan !== undefined
+    ) {
+      hardDeletedRecords = await manager.hardDeleteArchived(
+        options.hardDeleteArchivedOlderThan,
+        userId,
+      );
+    }
+    return {
+      status:
+        graphLifecycle.status === "skipped-locked"
+          ? "skipped_locked"
+          : "success",
+      dryRun: graphLifecycle.dryRun,
+      userId,
+      startedAt: now ?? Date.now(),
+      finishedAt: Date.now(),
+      scannedRecords: 0,
+      eligibleRecords: graphLifecycle.stableClusters,
+      createdSummaries: graphLifecycle.createdSummaries,
+      transitionedRecords: 0,
+      archivedDetailRecords: 0,
+      hardDeletedRecords,
+      graphLifecycle,
+    };
+  }
+  const engine = createMemoryForgettingEngine({
+    storage,
+    policy: options?.policy,
+  });
   let shadowDiagnostics:
     | MemoryConsolidationShadowDiagnosticsRunResult
     | undefined;

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -4,5 +4,6 @@ export * from "./extractor";
 export * from "./forgetting";
 export * from "./manager";
 export * from "./memory-graph-evolution";
+export * from "./memory-graph-lifecycle";
 export * from "./sqlite-client";
 export * from "./storage";

--- a/packages/indexeddb/src/memory-graph-evolution.ts
+++ b/packages/indexeddb/src/memory-graph-evolution.ts
@@ -473,7 +473,7 @@ export function createRawMessageMemoryGraphStore(input: {
   };
 }
 
-function ownerScopeFromMessage(message: RawMessage): OwnerScope {
+export function ownerScopeFromMessage(message: RawMessage): OwnerScope {
   const stored = message.metadata?.memoryOwnerScope;
   if (isRecord(stored) && typeof stored.userId === "string") {
     return {
@@ -485,7 +485,7 @@ function ownerScopeFromMessage(message: RawMessage): OwnerScope {
   return { userId: message.userId };
 }
 
-function applicabilityFromMessage(
+export function applicabilityFromMessage(
   message: RawMessage,
 ): MemoryApplicabilityContext {
   const stored = message.metadata?.memoryApplicability;

--- a/packages/indexeddb/src/memory-graph-lifecycle.ts
+++ b/packages/indexeddb/src/memory-graph-lifecycle.ts
@@ -20,11 +20,12 @@ import {
   type ScoredMemoryRecord,
   deprecateMemoryRecords,
 } from "../../ai/src/memory";
-import type { IndexedDBManager, RawMessage } from "./manager";
+import type { RawMessage } from "./manager";
 import {
   createRawMessageMemoryGraphStore,
   ownerScopeFromMessage,
 } from "./memory-graph-evolution";
+import type { RawMessageStorage } from "./storage";
 
 export interface RawMessageGraphLifecycleOptions extends MemoryGraphLifecyclePolicyOptions {
   enabled?: boolean;
@@ -70,7 +71,7 @@ export interface MemoryGraphLifecycleRuntimeResult {
 }
 
 export interface RunMemoryGraphLifecycleCycleInput {
-  manager: IndexedDBManager;
+  manager: RawMessageStorage;
   storage: MemoryStorageAdapter;
   userId: string;
   options: RawMessageGraphLifecycleOptions;
@@ -172,7 +173,7 @@ function graphPolicy(
 }
 
 async function loadScopedMessages(input: {
-  manager: IndexedDBManager;
+  manager: RawMessageStorage;
   ownerScope: OwnerScope;
   ids: string[];
 }): Promise<RawMessage[]> {
@@ -326,7 +327,9 @@ export async function runMemoryGraphLifecycleCycle(
       },
       policy: graphPolicy(input.options),
     });
-    lifecycle.reasonCodes.forEach((reasonCode) => reasonCodes.add(reasonCode));
+    for (const reasonCode of lifecycle.reasonCodes) {
+      reasonCodes.add(reasonCode);
+    }
     transitionedClusters = lifecycle.transitions.length;
     stableClusters = lifecycle.consolidationCandidates.length;
     decayingClusters = lifecycle.decayingClusterIds.length;
@@ -361,9 +364,9 @@ export async function runMemoryGraphLifecycleCycle(
     }
 
     const lifecyclePersistence = await graphStore.persistPlan(lifecycle.plan);
-    lifecyclePersistence.diagnostics.forEach((reasonCode) =>
-      reasonCodes.add(reasonCode),
-    );
+    for (const reasonCode of lifecyclePersistence.diagnostics) {
+      reasonCodes.add(reasonCode);
+    }
     if (lifecyclePersistence.conflict) {
       return {
         status: "conflict",
@@ -444,9 +447,9 @@ export async function runMemoryGraphLifecycleCycle(
         }
         const representativePersistence =
           await graphStore.persistPlan(representativePlan);
-        representativePersistence.diagnostics.forEach((reasonCode) =>
-          reasonCodes.add(reasonCode),
-        );
+        for (const reasonCode of representativePersistence.diagnostics) {
+          reasonCodes.add(reasonCode);
+        }
         if (representativePersistence.conflict) {
           partialFailure = true;
           candidateResults.push({
@@ -549,9 +552,9 @@ export async function runMemoryGraphLifecycleCycle(
           store: input.storage,
           now,
         });
-        deprecation.reasonCodes.forEach((reasonCode) =>
-          reasonCodes.add(reasonCode),
-        );
+        for (const reasonCode of deprecation.reasonCodes) {
+          reasonCodes.add(reasonCode);
+        }
         deprecatedRecords += deprecation.persistedCount;
         const coveredSourceIds = unique(
           deprecationCandidates.flatMap((item) => item.recordIds),
@@ -567,9 +570,9 @@ export async function runMemoryGraphLifecycleCycle(
           });
           const visibilityPersistence =
             await graphStore.persistPlan(visibilityPlan);
-          visibilityPersistence.diagnostics.forEach((reasonCode) =>
-            reasonCodes.add(reasonCode),
-          );
+          for (const reasonCode of visibilityPersistence.diagnostics) {
+            reasonCodes.add(reasonCode);
+          }
           if (visibilityPersistence.conflict) {
             partialFailure = true;
             reasonCodes.add("memory_graph_visibility_version_conflict");

--- a/packages/indexeddb/src/memory-graph-lifecycle.ts
+++ b/packages/indexeddb/src/memory-graph-lifecycle.ts
@@ -1,0 +1,658 @@
+import {
+  type MemoryGraphLifecyclePolicyOptions,
+  type MemoryGraphSnapshot,
+  type MemorySummaryCandidate,
+  type OwnerScope,
+  buildMemoryDeprecationEntries,
+  buildMemoryGraphLifecyclePlan,
+  buildMemoryGraphRepresentativePlan,
+  buildMemoryGraphVisibilityPlan,
+  ownerScopeKey,
+  sameOwnerScope,
+} from "../../ai/memory-consolidation/src";
+import {
+  type MemoryDimensions,
+  type MemoryGroup,
+  type MemoryRecord,
+  type MemoryStorageAdapter,
+  type MemorySummary,
+  RuleBasedMemorySummarizer,
+  type ScoredMemoryRecord,
+  deprecateMemoryRecords,
+} from "../../ai/src/memory";
+import type { IndexedDBManager, RawMessage } from "./manager";
+import {
+  createRawMessageMemoryGraphStore,
+  ownerScopeFromMessage,
+} from "./memory-graph-evolution";
+
+export interface RawMessageGraphLifecycleOptions extends MemoryGraphLifecyclePolicyOptions {
+  enabled?: boolean;
+  dryRun?: boolean;
+  workspaceId?: string;
+  tenantId?: string;
+}
+
+export type MemoryGraphLifecycleRuntimeStatus =
+  | "disabled"
+  | "planned"
+  | "applied"
+  | "no-op"
+  | "partial-failure"
+  | "conflict"
+  | "skipped-locked"
+  | "failed";
+
+export interface MemoryGraphLifecycleCandidateRunResult {
+  clusterId: string;
+  summaryId: string;
+  status: "planned" | "persisted" | "deprecation-no-op" | "failed" | "conflict";
+  sourceRecordIds: string[];
+  supersededClusterIds: string[];
+  deprecatedRecords: number;
+  reasonCodes: string[];
+  error?: { name: string; message: string };
+}
+
+export interface MemoryGraphLifecycleRuntimeResult {
+  status: MemoryGraphLifecycleRuntimeStatus;
+  dryRun: boolean;
+  ownerScope: OwnerScope;
+  scannedClusters: number;
+  transitionedClusters: number;
+  stableClusters: number;
+  decayingClusters: number;
+  createdSummaries: number;
+  deprecatedRecords: number;
+  candidateResults: MemoryGraphLifecycleCandidateRunResult[];
+  reasonCodes: string[];
+  error?: { name: string; message: string };
+}
+
+export interface RunMemoryGraphLifecycleCycleInput {
+  manager: IndexedDBManager;
+  storage: MemoryStorageAdapter;
+  userId: string;
+  options: RawMessageGraphLifecycleOptions;
+  now?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function parseRawMessageGraphLifecycleOptions(
+  value: unknown,
+): RawMessageGraphLifecycleOptions | undefined {
+  if (!isRecord(value)) return undefined;
+  const options: RawMessageGraphLifecycleOptions = {
+    workspaceId: optionalString(value.workspaceId),
+    tenantId: optionalString(value.tenantId),
+    stableMinEvidence: optionalFiniteNumber(value.stableMinEvidence),
+    stableMinSupportScore: optionalFiniteNumber(value.stableMinSupportScore),
+    decayAfterMs: optionalFiniteNumber(value.decayAfterMs),
+    supersessionMinEvidence: optionalFiniteNumber(
+      value.supersessionMinEvidence,
+    ),
+    supersessionStrengthMargin: optionalFiniteNumber(
+      value.supersessionStrengthMargin,
+    ),
+  };
+  if (typeof value.enabled === "boolean") options.enabled = value.enabled;
+  if (typeof value.dryRun === "boolean") options.dryRun = value.dryRun;
+  return options;
+}
+
+function normalizeTimestampToMs(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 0;
+  return (value as number) < 1e11
+    ? Math.floor((value as number) * 1000)
+    : Math.floor(value as number);
+}
+
+function toMemoryRecord(message: RawMessage): MemoryRecord {
+  const dimensions: MemoryDimensions = {
+    platform: message.platform,
+    botId: message.botId,
+    channel: message.channel,
+    person: message.person,
+  };
+  return {
+    id: message.messageId,
+    userId: message.userId,
+    timestamp: normalizeTimestampToMs(message.timestamp),
+    text: message.content,
+    mediaRefs: message.attachments?.map((attachment) => attachment.url),
+    tier: message.memoryStage ?? "short",
+    accessCount: message.accessCount,
+    lastAccessAt: normalizeTimestampToMs(message.lastAccessAt),
+    importanceScore: message.importanceScore,
+    isPinned: message.isPinned,
+    archivedAt: normalizeTimestampToMs(message.archivedAt),
+    dimensions,
+    metadata: message.metadata,
+    deprecatedAt: message.deprecatedAt,
+    deprecationReason: message.deprecationReason,
+    supersededBySummaryId: message.supersededBySummaryId,
+  };
+}
+
+function scored(record: MemoryRecord, now: number): ScoredMemoryRecord {
+  return {
+    ...record,
+    ageMs: Math.max(0, now - record.timestamp),
+    valueScore: record.importanceScore ?? 1,
+  };
+}
+
+function stableSummaryId(ownerScope: OwnerScope, clusterId: string): string {
+  return `memory-graph-summary:${ownerScopeKey(ownerScope)}:${encodeURIComponent(clusterId)}`;
+}
+
+function graphPolicy(
+  options: RawMessageGraphLifecycleOptions,
+): MemoryGraphLifecyclePolicyOptions {
+  return {
+    stableMinEvidence: options.stableMinEvidence,
+    stableMinSupportScore: options.stableMinSupportScore,
+    decayAfterMs: options.decayAfterMs,
+    supersessionMinEvidence: options.supersessionMinEvidence,
+    supersessionStrengthMargin: options.supersessionStrengthMargin,
+  };
+}
+
+async function loadScopedMessages(input: {
+  manager: IndexedDBManager;
+  ownerScope: OwnerScope;
+  ids: string[];
+}): Promise<RawMessage[]> {
+  const messages = await Promise.all(
+    input.ids.map((id) => input.manager.getMessageById(id)),
+  );
+  return messages.filter(
+    (message): message is RawMessage =>
+      message !== null &&
+      sameOwnerScope(ownerScopeFromMessage(message), input.ownerScope),
+  );
+}
+
+function sourceIdsForClusters(
+  snapshot: MemoryGraphSnapshot,
+  clusterIds: string[],
+): string[][] {
+  const nodesById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  return clusterIds.map((clusterId) => {
+    const cluster = snapshot.clusters.find(
+      (candidate) => candidate.clusterId === clusterId,
+    );
+    if (!cluster) return [];
+    return cluster.nodeIds.filter(
+      (nodeId) => nodesById.get(nodeId)?.type === "raw",
+    );
+  });
+}
+
+async function buildSummary(input: {
+  ownerScope: OwnerScope;
+  clusterId: string;
+  messages: RawMessage[];
+  now: number;
+}): Promise<MemorySummary> {
+  const records = input.messages
+    .map(toMemoryRecord)
+    .map((record) => scored(record, input.now))
+    .sort((left, right) => left.timestamp - right.timestamp);
+  const first = records[0];
+  const last = records.at(-1);
+  if (!first || !last)
+    throw new Error("Graph lifecycle summary has no source records");
+  const group: MemoryGroup = {
+    groupId: input.clusterId,
+    userId: input.ownerScope.userId,
+    sourceTier: first.tier,
+    targetTier: "long",
+    summaryTier: "L3",
+    records,
+    startTimestamp: first.timestamp,
+    endTimestamp: last.timestamp,
+    dimensions: first.dimensions,
+  };
+  const draft = await new RuleBasedMemorySummarizer().summarizeGroup(group);
+  return {
+    summaryId: stableSummaryId(input.ownerScope, input.clusterId),
+    userId: input.ownerScope.userId,
+    summaryTier: "L3",
+    sourceTier: first.tier,
+    startTimestamp: first.timestamp,
+    endTimestamp: last.timestamp,
+    messageCount: records.length,
+    sourceRecordIds: records.map((record) => record.id),
+    keyPoints: draft.keyPoints,
+    keywords: draft.keywords,
+    summaryText: draft.summaryText,
+    dimensions: first.dimensions,
+    qualityScore: draft.qualityScore,
+    createdAt: input.now,
+    updatedAt: input.now,
+  };
+}
+
+function errorInfo(error: unknown): { name: string; message: string } {
+  return error instanceof Error
+    ? { name: error.name, message: error.message }
+    : { name: "Error", message: String(error) };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export async function runMemoryGraphLifecycleCycle(
+  input: RunMemoryGraphLifecycleCycleInput,
+): Promise<MemoryGraphLifecycleRuntimeResult> {
+  const now = input.now ?? Date.now();
+  const ownerScope: OwnerScope = {
+    userId: input.userId,
+    workspaceId: input.options.workspaceId,
+    tenantId: input.options.tenantId,
+  };
+  const dryRun = input.options.dryRun === true;
+  const disabledResult: MemoryGraphLifecycleRuntimeResult = {
+    status: "disabled",
+    dryRun,
+    ownerScope,
+    scannedClusters: 0,
+    transitionedClusters: 0,
+    stableClusters: 0,
+    decayingClusters: 0,
+    createdSummaries: 0,
+    deprecatedRecords: 0,
+    candidateResults: [],
+    reasonCodes: ["memory_graph_lifecycle_disabled"],
+  };
+  if (input.options.enabled !== true) return disabledResult;
+
+  const lock = await input.storage.acquireLock({
+    key: `memory-graph-lifecycle:${ownerScopeKey(ownerScope)}`,
+    ttlMs: 5 * 60 * 1000,
+    now,
+  });
+  if (!lock) {
+    return {
+      ...disabledResult,
+      status: "skipped-locked",
+      reasonCodes: ["memory_graph_lifecycle_locked"],
+    };
+  }
+
+  const graphStore = createRawMessageMemoryGraphStore({
+    storage: input.manager,
+    ownerScope,
+    now: () => now,
+  });
+  const candidateResults: MemoryGraphLifecycleCandidateRunResult[] = [];
+  const reasonCodes = new Set<string>();
+  let createdSummaries = 0;
+  let deprecatedRecords = 0;
+  let transitionedClusters = 0;
+  let stableClusters = 0;
+  let decayingClusters = 0;
+  let scannedClusters = 0;
+  let partialFailure = false;
+
+  try {
+    let snapshot = await graphStore.readSnapshot({
+      ownerScope,
+      includeAuditOnly: true,
+    });
+    scannedClusters = snapshot.clusters.length;
+    const lifecycle = buildMemoryGraphLifecyclePlan({
+      ownerScope,
+      snapshot,
+      now,
+      persistence: {
+        mode: dryRun ? "dry-run" : "write",
+        enabled: !dryRun,
+      },
+      policy: graphPolicy(input.options),
+    });
+    lifecycle.reasonCodes.forEach((reasonCode) => reasonCodes.add(reasonCode));
+    transitionedClusters = lifecycle.transitions.length;
+    stableClusters = lifecycle.consolidationCandidates.length;
+    decayingClusters = lifecycle.decayingClusterIds.length;
+
+    if (dryRun) {
+      return {
+        status: "planned",
+        dryRun: true,
+        ownerScope,
+        scannedClusters,
+        transitionedClusters,
+        stableClusters,
+        decayingClusters,
+        createdSummaries: 0,
+        deprecatedRecords: 0,
+        candidateResults: lifecycle.consolidationCandidates.map(
+          (candidate) => ({
+            clusterId: candidate.clusterId,
+            summaryId: stableSummaryId(ownerScope, candidate.clusterId),
+            status: "planned",
+            sourceRecordIds: [...candidate.sourceNodeIds],
+            supersededClusterIds: [...candidate.supersededClusterIds],
+            deprecatedRecords: 0,
+            reasonCodes: [
+              ...candidate.reasonCodes,
+              "memory_graph_lifecycle_dry_run",
+            ],
+          }),
+        ),
+        reasonCodes: unique([...reasonCodes, "memory_graph_lifecycle_dry_run"]),
+      };
+    }
+
+    const lifecyclePersistence = await graphStore.persistPlan(lifecycle.plan);
+    lifecyclePersistence.diagnostics.forEach((reasonCode) =>
+      reasonCodes.add(reasonCode),
+    );
+    if (lifecyclePersistence.conflict) {
+      return {
+        status: "conflict",
+        dryRun: false,
+        ownerScope,
+        scannedClusters,
+        transitionedClusters: 0,
+        stableClusters,
+        decayingClusters,
+        createdSummaries: 0,
+        deprecatedRecords: 0,
+        candidateResults: [],
+        reasonCodes: unique([...reasonCodes, "memory_graph_version_conflict"]),
+      };
+    }
+    snapshot = await graphStore.readSnapshot({
+      ownerScope,
+      includeAuditOnly: true,
+    });
+
+    for (const candidate of lifecycle.consolidationCandidates) {
+      const summaryId = stableSummaryId(ownerScope, candidate.clusterId);
+      const sourceMessages = await loadScopedMessages({
+        manager: input.manager,
+        ownerScope,
+        ids: candidate.sourceNodeIds,
+      });
+      if (sourceMessages.length !== candidate.sourceNodeIds.length) {
+        partialFailure = true;
+        candidateResults.push({
+          clusterId: candidate.clusterId,
+          summaryId,
+          status: "failed",
+          sourceRecordIds: [...candidate.sourceNodeIds],
+          supersededClusterIds: [...candidate.supersededClusterIds],
+          deprecatedRecords: 0,
+          reasonCodes: [
+            "memory_graph_source_records_missing_or_scope_mismatch",
+          ],
+        });
+        reasonCodes.add(
+          "memory_graph_source_records_missing_or_scope_mismatch",
+        );
+        continue;
+      }
+
+      try {
+        const summary = await buildSummary({
+          ownerScope,
+          clusterId: candidate.clusterId,
+          messages: sourceMessages,
+          now,
+        });
+        await input.storage.saveSummaries([summary]);
+        createdSummaries += 1;
+
+        const representativePlan = buildMemoryGraphRepresentativePlan({
+          ownerScope,
+          snapshot,
+          candidate,
+          summaryId,
+          now,
+          persistence: { mode: "write", enabled: true },
+        });
+        if (representativePlan.operations.length === 0) {
+          partialFailure = true;
+          candidateResults.push({
+            clusterId: candidate.clusterId,
+            summaryId,
+            status: "failed",
+            sourceRecordIds: [...candidate.sourceNodeIds],
+            supersededClusterIds: [...candidate.supersededClusterIds],
+            deprecatedRecords: 0,
+            reasonCodes: ["memory_graph_representative_plan_empty"],
+          });
+          reasonCodes.add("memory_graph_representative_plan_empty");
+          continue;
+        }
+        const representativePersistence =
+          await graphStore.persistPlan(representativePlan);
+        representativePersistence.diagnostics.forEach((reasonCode) =>
+          reasonCodes.add(reasonCode),
+        );
+        if (representativePersistence.conflict) {
+          partialFailure = true;
+          candidateResults.push({
+            clusterId: candidate.clusterId,
+            summaryId,
+            status: "conflict",
+            sourceRecordIds: [...candidate.sourceNodeIds],
+            supersededClusterIds: [...candidate.supersededClusterIds],
+            deprecatedRecords: 0,
+            reasonCodes: ["memory_graph_representative_version_conflict"],
+          });
+          reasonCodes.add("memory_graph_representative_version_conflict");
+          snapshot = await graphStore.readSnapshot({
+            ownerScope,
+            includeAuditOnly: true,
+          });
+          continue;
+        }
+
+        snapshot = await graphStore.readSnapshot({
+          ownerScope,
+          includeAuditOnly: true,
+        });
+        const persistedRepresentative = snapshot.clusters.find(
+          (cluster) => cluster.clusterId === candidate.clusterId,
+        );
+        const representativeReady =
+          persistedRepresentative?.representativeNodeId === summaryId &&
+          snapshot.nodes.some(
+            (node) => node.id === summaryId && node.type === "summary",
+          );
+        if (!representativeReady) {
+          partialFailure = true;
+          candidateResults.push({
+            clusterId: candidate.clusterId,
+            summaryId,
+            status: "failed",
+            sourceRecordIds: [...candidate.sourceNodeIds],
+            supersededClusterIds: [...candidate.supersededClusterIds],
+            deprecatedRecords: 0,
+            reasonCodes: ["memory_graph_representative_not_persisted"],
+          });
+          reasonCodes.add("memory_graph_representative_not_persisted");
+          continue;
+        }
+        const supersededSourceGroups = sourceIdsForClusters(
+          snapshot,
+          candidate.supersededClusterIds,
+        );
+        const deprecationCandidates: MemorySummaryCandidate[] = [
+          {
+            clusterKey: candidate.clusterId,
+            competitionKey: candidate.competitionKey ?? candidate.clusterId,
+            recordIds: [...candidate.sourceNodeIds],
+            evidenceCount: candidate.evidenceCount,
+            score: candidate.score,
+            priority: candidate.score,
+            reasonCodes:
+              candidate.supersededClusterIds.length > 0
+                ? ["wins_competition"]
+                : ["strong_repeated_evidence"],
+            sourceAction: "preserve",
+          },
+          ...candidate.supersededClusterIds.map(
+            (clusterId, index): MemorySummaryCandidate => ({
+              clusterKey: clusterId,
+              competitionKey: candidate.competitionKey ?? candidate.clusterId,
+              recordIds: supersededSourceGroups[index] ?? [],
+              evidenceCount: (supersededSourceGroups[index] ?? []).length,
+              score: 0,
+              priority: 0,
+              reasonCodes: ["outscored_by_competitor"],
+              sourceAction: "preserve",
+            }),
+          ),
+        ];
+        const [winnerDeprecationCandidate, ...loserDeprecationCandidates] =
+          deprecationCandidates;
+        const winnerDeprecationPlan = buildMemoryDeprecationEntries({
+          persistedSummaryIds: winnerDeprecationCandidate ? [summaryId] : [],
+          summaryCandidates: winnerDeprecationCandidate
+            ? [winnerDeprecationCandidate]
+            : [],
+        });
+        const loserDeprecationEntries = loserDeprecationCandidates.flatMap(
+          (loserCandidate) =>
+            buildMemoryDeprecationEntries({
+              persistedSummaryIds: [summaryId],
+              summaryCandidates: [loserCandidate],
+              reasonFor: () => `superseded_by_summary:${summaryId}`,
+            }).entries,
+        );
+        const deprecationEntries = [
+          ...winnerDeprecationPlan.entries,
+          ...loserDeprecationEntries,
+        ];
+        const deprecation = await deprecateMemoryRecords({
+          userId: ownerScope.userId,
+          entries: deprecationEntries,
+          store: input.storage,
+          now,
+        });
+        deprecation.reasonCodes.forEach((reasonCode) =>
+          reasonCodes.add(reasonCode),
+        );
+        deprecatedRecords += deprecation.persistedCount;
+        const coveredSourceIds = unique(
+          deprecationCandidates.flatMap((item) => item.recordIds),
+        );
+        if (deprecation.status === "persisted") {
+          const visibilityPlan = buildMemoryGraphVisibilityPlan({
+            ownerScope,
+            snapshot,
+            summaryId,
+            sourceNodeIds: coveredSourceIds,
+            now,
+            persistence: { mode: "write", enabled: true },
+          });
+          const visibilityPersistence =
+            await graphStore.persistPlan(visibilityPlan);
+          visibilityPersistence.diagnostics.forEach((reasonCode) =>
+            reasonCodes.add(reasonCode),
+          );
+          if (visibilityPersistence.conflict) {
+            partialFailure = true;
+            reasonCodes.add("memory_graph_visibility_version_conflict");
+          }
+        }
+        const candidateStatus =
+          deprecation.status === "persisted"
+            ? "persisted"
+            : "deprecation-no-op";
+        if (candidateStatus === "deprecation-no-op") partialFailure = true;
+        candidateResults.push({
+          clusterId: candidate.clusterId,
+          summaryId,
+          status: candidateStatus,
+          sourceRecordIds: [...candidate.sourceNodeIds],
+          supersededClusterIds: [...candidate.supersededClusterIds],
+          deprecatedRecords: deprecation.persistedCount,
+          reasonCodes: unique([
+            ...candidate.reasonCodes,
+            ...deprecation.reasonCodes,
+          ]),
+        });
+        snapshot = await graphStore.readSnapshot({
+          ownerScope,
+          includeAuditOnly: true,
+        });
+      } catch (error) {
+        partialFailure = true;
+        const details = errorInfo(error);
+        candidateResults.push({
+          clusterId: candidate.clusterId,
+          summaryId,
+          status: "failed",
+          sourceRecordIds: [...candidate.sourceNodeIds],
+          supersededClusterIds: [...candidate.supersededClusterIds],
+          deprecatedRecords: 0,
+          reasonCodes: ["memory_graph_consolidation_candidate_failed"],
+          error: details,
+        });
+        reasonCodes.add("memory_graph_consolidation_candidate_failed");
+        snapshot = await graphStore.readSnapshot({
+          ownerScope,
+          includeAuditOnly: true,
+        });
+      }
+    }
+
+    const mutatesLifecycle = lifecyclePersistence.mutatesGraph;
+    const status: MemoryGraphLifecycleRuntimeStatus = partialFailure
+      ? "partial-failure"
+      : mutatesLifecycle ||
+          candidateResults.some((result) => result.status === "persisted")
+        ? "applied"
+        : "no-op";
+    return {
+      status,
+      dryRun: false,
+      ownerScope,
+      scannedClusters,
+      transitionedClusters,
+      stableClusters,
+      decayingClusters,
+      createdSummaries,
+      deprecatedRecords,
+      candidateResults,
+      reasonCodes: [...reasonCodes],
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      dryRun,
+      ownerScope,
+      scannedClusters,
+      transitionedClusters,
+      stableClusters,
+      decayingClusters,
+      createdSummaries,
+      deprecatedRecords,
+      candidateResults,
+      reasonCodes: unique([...reasonCodes, "memory_graph_lifecycle_failed"]),
+      error: errorInfo(error),
+    };
+  } finally {
+    await input.storage.releaseLock(lock);
+  }
+}

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -16,6 +16,7 @@ import type {
   MemoryGraphEvolutionRunResult,
   RawMessageGraphEvolutionOptions,
 } from "./memory-graph-evolution";
+import type { RawMessageGraphLifecycleOptions } from "./memory-graph-lifecycle";
 
 export type SQLiteRawMessageQueryResultItem =
   | (RawMessage & { sourceType: "raw" })
@@ -47,6 +48,7 @@ export interface SQLiteRunMemoryForgettingCycleForUserOptions {
   dryRun?: boolean;
   hardDeleteArchivedOlderThan?: number;
   shadowDiagnostics?: RunMemoryForgettingCycleSerializableShadowDiagnosticsOptions;
+  graphLifecycle?: RawMessageGraphLifecycleOptions;
 }
 
 export interface SQLiteRunMemoryForgettingCycleForUserResult {
@@ -57,6 +59,7 @@ export interface SQLiteRunMemoryForgettingCycleForUserResult {
   archivedDetailRecords?: number;
   hardDeletedRecords?: number;
   shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
+  graphLifecycle?: RunMemoryForgettingCycleResult["graphLifecycle"];
   error?: string;
 }
 
@@ -346,6 +349,7 @@ export async function sqliteRunMemoryForgettingCycleForUser(
       archivedDetailRecords: number;
       hardDeletedRecords: number;
       shadowDiagnostics?: RunMemoryForgettingCycleResult["shadowDiagnostics"];
+      graphLifecycle?: RunMemoryForgettingCycleResult["graphLifecycle"];
     };
   }>("forgettingCycle", { options });
   return {
@@ -356,6 +360,7 @@ export async function sqliteRunMemoryForgettingCycleForUser(
     archivedDetailRecords: response.result.archivedDetailRecords,
     hardDeletedRecords: response.result.hardDeletedRecords,
     shadowDiagnostics: response.result.shadowDiagnostics,
+    graphLifecycle: response.result.graphLifecycle,
   };
 }
 

--- a/packages/indexeddb/src/sqlite-client.ts
+++ b/packages/indexeddb/src/sqlite-client.ts
@@ -264,7 +264,7 @@ export async function sqliteStoreRawMessagesFromInsight(
     embeddingContentHash?: string;
     embeddingDimensions?: number;
     embeddingUpdatedAt?: number;
-    metadata?: Record<string, any>;
+    metadata?: Record<string, unknown>;
   }>,
   graphEvolution?: RawMessageGraphEvolutionOptions,
 ): Promise<{
@@ -498,8 +498,8 @@ export async function migrateIndexedDBRawMessagesToSQLite(options: {
 
   if (options.includeSummaries !== false) {
     offset = 0;
-    while (typeof (manager as any).querySummaries === "function") {
-      const summaries = await (manager as any).querySummaries({
+    while (true) {
+      const summaries = await manager.querySummaries({
         userId: options.userId,
         reverse: false,
         offset,


### PR DESCRIPTION
## Summary
- drive opt-in memory graph lifecycle through the existing forgetting cycle
- persist stable-cluster summaries and soft-deprecate superseded raw evidence
- preserve baseline behavior when graph lifecycle is disabled or unavailable
- align the raw-storage contract so the lifecycle path does not rely on unsafe casts

## Validation
- focused Vitest: 4 files, 56 tests
- Web TypeScript: `tsc --noEmit`
- Prettier, Biome lint, and `git diff --check`

## Stack
PR #336 is the merged evidence-evolution base. Correction, rollback, and publication atomicity remain in the follow-up stack and will be proposed after this PR lands.