### PR TITLE
fix: openloomi memory recall function

### DIFF
--- a/apps/web/lib/ai/extensions/agent/codex/command.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/command.ts
@@ -64,6 +64,7 @@ export interface CodexRunCommandOptions {
 export interface CodexRunCommand {
   command: string;
   args: string[];
+  stdin?: string;
 }
 
 export type CodexCliEvent =
@@ -207,11 +208,12 @@ export function buildCodexRunCommand(
     args.push("--", ...providerConfig.extraArgs);
   }
 
-  args.push(options.prompt);
+  args.push("-");
 
   return {
     command: providerConfig.codexPath || "codex",
     args,
+    stdin: options.prompt,
   };
 }
 
@@ -221,6 +223,7 @@ export async function* runCodexCli(
   options: {
     cwd: string;
     env?: Record<string, string>;
+    stdin?: string;
     signal?: AbortSignal;
     timeoutMs?: number;
   },
@@ -257,14 +260,13 @@ export async function* runCodexCli(
       detached: shouldDetachCliProcess(),
       windowsHide: true,
     }) as ChildProcessWithoutNullStreams;
-    // Codex CLI 0.144+ reads the prompt from argv but ALSO blocks waiting
-    // for stdin to reach EOF whenever stdin is a piped stream (e.g.
-    // `node`'s default `pipe` stdio). Without this explicit close the
-    // child process hangs in "Reading additional input from stdin..."
-    // forever and the SSE stream never receives any events. We never write
-    // to stdin ourselves (the prompt is passed positionally), so closing
-    // it immediately is safe and signals EOF to the CLI.
-    proc.stdin.end();
+    // Pass the prompt through stdin instead of argv. Windows npm/PowerShell
+    // shims can truncate multiline positional args before the real Codex CLI
+    // sees them; `codex exec -` preserves the prompt byte-for-byte.
+    proc.stdin.on("error", () => {
+      // The child may exit before consuming stdin in tests or error paths.
+    });
+    proc.stdin.end(options.stdin ?? "");
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     if (isCommandNotFoundError(err)) {

--- a/apps/web/lib/ai/extensions/agent/codex/command.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/command.ts
@@ -4,6 +4,8 @@ import { StringDecoder } from "node:string_decoder";
 import spawn from "cross-spawn";
 
 import type { AgentOptions } from "@openloomi/ai/agent/types";
+
+import { buildCodexMemoryMcpConfig } from "./memory-mcp";
 import {
   appendCapturedCliOutput,
   buildCliEnvironment,
@@ -52,6 +54,11 @@ export interface CodexRunCommandOptions {
    */
   mode?: "run" | "plan" | "execute";
   providerConfig?: Record<string, unknown>;
+  openLoomiMemoryMcp?: {
+    session?: AgentOptions["session"];
+    excludeTools?: string[];
+    disallowedTools?: string[];
+  };
 }
 
 export interface CodexRunCommand {
@@ -172,6 +179,28 @@ export function buildCodexRunCommand(
     providerConfig.fullAuto
   ) {
     args.push("--full-auto");
+  }
+
+  const memoryMcp = buildCodexMemoryMcpConfig({
+    mode,
+    session: options.openLoomiMemoryMcp?.session,
+    excludeTools: options.openLoomiMemoryMcp?.excludeTools,
+    disallowedTools: options.openLoomiMemoryMcp?.disallowedTools,
+  });
+
+  if (memoryMcp) {
+    const prefix = `mcp_servers.${memoryMcp.serverName}`;
+    args.push(
+      "-c",
+      `${prefix}.command=${toTomlString(memoryMcp.command)}`,
+      "-c",
+      `${prefix}.args=${toTomlStringArray(memoryMcp.args)}`,
+      "-c",
+      `${prefix}.startup_timeout_sec=30`,
+    );
+    for (const [key, value] of Object.entries(memoryMcp.env)) {
+      args.push("-c", `${prefix}.env.${key}=${toTomlString(value)}`);
+    }
   }
 
   if (providerConfig.extraArgs && providerConfig.extraArgs.length > 0) {
@@ -363,6 +392,14 @@ export async function* runCodexCli(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function toTomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function toTomlStringArray(values: string[]): string {
+  return `[${values.map(toTomlString).join(", ")}]`;
 }
 
 function isCommandNotFoundError(error: Error & { code?: string }) {

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -292,6 +292,7 @@ export class CodexAgent extends BaseAgent {
     for await (const event of runCodexCli(command.command, command.args, {
       cwd,
       env: providerConfig.env,
+      stdin: command.stdin,
       signal: signal ?? options?.abortController?.signal,
       timeoutMs: providerConfig.timeoutMs,
     })) {

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -269,6 +269,11 @@ export class CodexAgent extends BaseAgent {
       permissionMode: options?.permissionMode,
       mode,
       providerConfig: this.config.providerConfig,
+      openLoomiMemoryMcp: {
+        session: options?.session,
+        excludeTools: options?.excludeTools,
+        disallowedTools: options?.disallowedTools,
+      },
     });
 
     let closeEvent: Extract<CodexCliEvent, { type: "close" }> | undefined;

--- a/apps/web/lib/ai/extensions/agent/codex/memory-mcp.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/memory-mcp.ts
@@ -1,0 +1,164 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { AgentOptions } from "@openloomi/ai/agent/types";
+
+import { getDefaultMemoryPath } from "@/lib/ai/mcp/tools/memory-path-search";
+
+export const CODEX_MEMORY_MCP_SERVER_NAME = "openloomi_memory";
+export const CODEX_MEMORY_MCP_SCRIPT = "openloomi-memory-mcp.mjs";
+
+interface CodexMemoryMcpOptions {
+  mode: "run" | "plan" | "execute";
+  session?: AgentOptions["session"];
+  excludeTools?: string[];
+  disallowedTools?: string[];
+}
+
+export interface CodexMemoryMcpConfig {
+  serverName: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export function buildCodexMemoryMcpConfig(
+  options: CodexMemoryMcpOptions,
+): CodexMemoryMcpConfig | undefined {
+  if (!shouldAttachCodexMemoryMcp(options)) {
+    return undefined;
+  }
+
+  const userId = readSessionUserId(options.session);
+  const scriptPath = resolveCodexMemoryMcpScript();
+  if (!userId || !scriptPath) {
+    return undefined;
+  }
+
+  return {
+    serverName: CODEX_MEMORY_MCP_SERVER_NAME,
+    command: process.execPath,
+    args: [scriptPath],
+    env: {
+      OPENLOOMI_MCP_USER_ID: userId,
+      OPENLOOMI_MEMORY_PATH: getDefaultMemoryPath(),
+    },
+  };
+}
+
+export function resolveCodexMemoryMcpScript(): string | null {
+  const envPath = process.env.OPENLOOMI_CODEX_MEMORY_MCP;
+  if (envPath && isFile(envPath)) {
+    return envPath;
+  }
+
+  for (const candidate of listCodexMemoryMcpCandidates()) {
+    if (isFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function listCodexMemoryMcpCandidates(): string[] {
+  return Array.from(
+    new Set([
+      ...standaloneCandidates(),
+      ...devCandidates(),
+      ...selfRelativeCandidates(),
+    ]),
+  ).map((dir) => join(dir, CODEX_MEMORY_MCP_SCRIPT));
+}
+
+function shouldAttachCodexMemoryMcp(options: CodexMemoryMcpOptions) {
+  if (options.mode === "plan") {
+    return false;
+  }
+  if (!readSessionUserId(options.session)) {
+    return false;
+  }
+
+  const blocked = new Set([
+    ...(options.excludeTools ?? []),
+    ...(options.disallowedTools ?? []),
+  ]);
+  return !blocked.has("searchMemoryPath");
+}
+
+function readSessionUserId(session: unknown): string | undefined {
+  if (!session || typeof session !== "object" || Array.isArray(session)) {
+    return undefined;
+  }
+
+  const user = (session as Record<string, unknown>).user;
+  if (!user || typeof user !== "object" || Array.isArray(user)) {
+    return undefined;
+  }
+
+  const id = (user as Record<string, unknown>).id;
+  return typeof id === "string" && id.trim() ? id.trim() : undefined;
+}
+
+function standaloneCandidates(): string[] {
+  const cwd = process.cwd();
+  const probes = [
+    cwd,
+    resolve(cwd, ".."),
+    resolve(cwd, "../.."),
+    resolve(cwd, "../../.."),
+  ];
+  const roots: string[] = [];
+
+  for (const probe of probes) {
+    roots.push(
+      join(probe, "scripts"),
+      join(probe, "apps", "web", "scripts"),
+      join(probe, ".next", "standalone", "apps", "web", "scripts"),
+      join(probe, ".next", "standalone", "scripts"),
+    );
+  }
+
+  return roots;
+}
+
+function devCandidates(): string[] {
+  const cwd = process.cwd();
+  const probes = [
+    cwd,
+    resolve(cwd, ".."),
+    resolve(cwd, "../.."),
+    resolve(cwd, "../../.."),
+  ];
+  const roots: string[] = [];
+
+  for (const probe of probes) {
+    roots.push(join(probe, "apps", "web", "scripts"));
+  }
+
+  return roots;
+}
+
+function selfRelativeCandidates(): string[] {
+  try {
+    const importMetaUrl =
+      typeof import.meta !== "undefined" ? import.meta.url : "";
+    const here = importMetaUrl ? fileURLToPath(importMetaUrl) : __filename;
+    const hereDir = dirname(here);
+    const webDir = resolve(hereDir, "..", "..", "..", "..", "..");
+    const rootDir = resolve(webDir, "..", "..");
+
+    return [join(webDir, "scripts"), join(rootDir, "apps", "web", "scripts")];
+  } catch {
+    return [];
+  }
+}
+
+function isFile(filePath: string) {
+  try {
+    return existsSync(filePath);
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/lib/ai/mcp/tools/memory-path-search.d.ts
+++ b/apps/web/lib/ai/mcp/tools/memory-path-search.d.ts
@@ -1,0 +1,22 @@
+export interface MemoryPathSearchResult {
+  content: string;
+  data: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface MemoryPathSearchOptions {
+  query: string;
+  searchInFiles?: boolean;
+  directory?: string;
+  memoryPath?: string;
+}
+
+export function getDefaultOpenLoomiAppDataDir(env?: NodeJS.ProcessEnv): string;
+
+export function getDefaultMemoryPath(env?: NodeJS.ProcessEnv): string;
+
+export function searchMemoryPath(
+  options: MemoryPathSearchOptions,
+): MemoryPathSearchResult;
+
+export function splitSearchKeywords(query: string): string[];

--- a/apps/web/lib/ai/mcp/tools/memory-path-search.js
+++ b/apps/web/lib/ai/mcp/tools/memory-path-search.js
@@ -1,0 +1,259 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const APP_DIR_NAME = ".openloomi";
+const WINDOWS_APPDATA_DIR_NAME = "openloomi";
+
+export function getDefaultOpenLoomiAppDataDir(env = process.env) {
+  const home = homedir();
+
+  if (process.platform === "win32") {
+    if (env.USERPROFILE) {
+      return path.join(env.USERPROFILE, APP_DIR_NAME);
+    }
+    return path.join(env.APPDATA || home, WINDOWS_APPDATA_DIR_NAME);
+  }
+
+  return path.join(home, APP_DIR_NAME);
+}
+
+export function getDefaultMemoryPath(env = process.env) {
+  return path.join(getDefaultOpenLoomiAppDataDir(env), "data", "memory");
+}
+
+export function searchMemoryPath({
+  query,
+  searchInFiles = true,
+  directory,
+  memoryPath = getDefaultMemoryPath(),
+}) {
+  const trimmedQuery = typeof query === "string" ? query.trim() : "";
+
+  if (!trimmedQuery) {
+    return {
+      content: "Search query is required.",
+      data: {
+        memoryPath,
+        query,
+        message: "Search query is required",
+      },
+      isError: true,
+    };
+  }
+
+  if (!existsSync(memoryPath)) {
+    return {
+      content: `Memory directory does not exist at ${memoryPath}. You may need to create memory files first.`,
+      data: {
+        memoryPath,
+        query: trimmedQuery,
+        message: "Memory directory not found",
+      },
+    };
+  }
+
+  const targetDirResult = resolveTargetDir(memoryPath, directory);
+  if (!targetDirResult.ok) {
+    return {
+      content: targetDirResult.message,
+      data: {
+        memoryPath,
+        query: trimmedQuery,
+        message: targetDirResult.message,
+      },
+      isError: true,
+    };
+  }
+
+  const targetDir = targetDirResult.targetDir;
+  if (!existsSync(targetDir)) {
+    return {
+      content: `Directory does not exist: ${targetDir}`,
+      data: {
+        memoryPath,
+        targetDir,
+        query: trimmedQuery,
+        message: "Target directory not found",
+      },
+    };
+  }
+
+  const keywords = splitSearchKeywords(trimmedQuery);
+  const firstKeyword = keywords[0] || trimmedQuery;
+  const results = [];
+  let fileCount = 0;
+  let matchCount = 0;
+
+  const files = listFilesRecursively(targetDir);
+  const nameMatches = files.filter((filePath) =>
+    includesIgnoreCase(path.basename(filePath), firstKeyword),
+  );
+
+  if (nameMatches.length > 0) {
+    fileCount = nameMatches.length;
+    results.push(
+      `**Found ${fileCount} file(s) with names matching "${firstKeyword}":**`,
+    );
+    nameMatches.slice(0, 20).forEach((filePath) => {
+      results.push(`- ${toRelativeMemoryPath(memoryPath, filePath)}`);
+    });
+    if (fileCount > 20) {
+      results.push(`... and ${fileCount - 20} more files`);
+    }
+  }
+
+  if (searchInFiles && keywords.length > 0) {
+    const contentMatches = findContentMatches(files, keywords);
+
+    if (contentMatches.length > 0) {
+      matchCount = Math.min(contentMatches.length, 20);
+      results.push(
+        `\n**Found ${matchCount} file(s) with content matching keywords "${keywords.join(", ")}":**`,
+      );
+      contentMatches.slice(0, 20).forEach(({ filePath }) => {
+        results.push(`- ${toRelativeMemoryPath(memoryPath, filePath)}`);
+      });
+
+      const sampleLines = contentMatches.flatMap(({ lines }) => lines);
+      if (sampleLines.length > 0) {
+        results.push("\n**Sample content matches:**");
+        sampleLines.slice(0, 15).forEach((line) => {
+          const trimmed = line.trim();
+          const truncated =
+            trimmed.length > 150 ? `${trimmed.slice(0, 150)}...` : trimmed;
+          results.push(`  ${truncated}`);
+        });
+      }
+    }
+  }
+
+  const directoryListing = listDirectoryStructure(targetDir);
+  if (directoryListing.length > 0) {
+    results.push("\n**Directory structure:**");
+    results.push("```");
+    results.push(...directoryListing);
+    results.push("```");
+  }
+
+  if (results.length === 0) {
+    return {
+      content: `No matches found for "${trimmedQuery}" in memory directory (${targetDir}).`,
+      data: {
+        memoryPath,
+        targetDir,
+        query: trimmedQuery,
+        message: "No matches found",
+      },
+    };
+  }
+
+  const text = results.join("\n");
+  return {
+    content: text,
+    data: {
+      memoryPath,
+      targetDir,
+      query: trimmedQuery,
+      fileCount,
+      matchCount,
+      results: text,
+    },
+  };
+}
+
+export function splitSearchKeywords(query) {
+  return String(query)
+    .split(/[\s,，、]+/)
+    .map((keyword) => keyword.trim())
+    .filter((keyword) => keyword.length > 0);
+}
+
+function resolveTargetDir(memoryPath, directory) {
+  if (!directory) {
+    return { ok: true, targetDir: memoryPath };
+  }
+
+  const root = path.resolve(memoryPath);
+  const targetDir = path.resolve(root, directory);
+  const isInsideRoot =
+    targetDir === root || targetDir.startsWith(root + path.sep);
+
+  if (!isInsideRoot) {
+    return {
+      ok: false,
+      message: "Directory must stay inside the OpenLoomi memory directory.",
+    };
+  }
+
+  return { ok: true, targetDir };
+}
+
+function listFilesRecursively(root) {
+  const files = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(entryPath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function findContentMatches(files, keywords) {
+  const matches = [];
+
+  for (const filePath of files) {
+    let content;
+
+    try {
+      content = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const lines = content
+      .split(/\r?\n/)
+      .filter((line) =>
+        keywords.some((keyword) => includesIgnoreCase(line, keyword)),
+      );
+
+    if (lines.length > 0) {
+      matches.push({ filePath, lines });
+    }
+  }
+
+  return matches;
+}
+
+function listDirectoryStructure(targetDir) {
+  try {
+    return readdirSync(targetDir)
+      .sort((a, b) => a.localeCompare(b))
+      .slice(0, 30)
+      .map((entry) => {
+        const entryPath = path.join(targetDir, entry);
+        const stats = statSync(entryPath);
+        const type = stats.isDirectory() ? "d" : "-";
+        return `${type} ${entry}`;
+      });
+  } catch {
+    return [];
+  }
+}
+
+function includesIgnoreCase(value, query) {
+  return value.toLocaleLowerCase().includes(query.toLocaleLowerCase());
+}
+
+function toRelativeMemoryPath(memoryPath, filePath) {
+  return path.relative(memoryPath, filePath) || filePath;
+}

--- a/apps/web/lib/ai/mcp/tools/memory-path.ts
+++ b/apps/web/lib/ai/mcp/tools/memory-path.ts
@@ -3,139 +3,10 @@
  */
 
 import { tool } from "@anthropic-ai/claude-agent-sdk";
-import { z } from "zod";
-import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import path from "node:path";
 import type { Session } from "next-auth";
-import { getAppDataDir, joinPath } from "@/lib/utils/path";
+import { z } from "zod";
 
-interface MemoryPathSearchResult {
-  results: string[];
-  fileCount: number;
-  matchCount: number;
-}
-
-function listFilesRecursively(root: string): string[] {
-  const files: string[] = [];
-
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
-    const entryPath = path.join(root, entry.name);
-
-    if (entry.isDirectory()) {
-      files.push(...listFilesRecursively(entryPath));
-      continue;
-    }
-
-    if (entry.isFile()) {
-      files.push(entryPath);
-    }
-  }
-
-  return files;
-}
-
-function includesIgnoreCase(value: string, query: string): boolean {
-  return value.toLocaleLowerCase().includes(query.toLocaleLowerCase());
-}
-
-function toRelativeMemoryPath(memoryPath: string, filePath: string): string {
-  return path.relative(memoryPath, filePath) || filePath;
-}
-
-function searchMemoryPathOnWindows(input: {
-  memoryPath: string;
-  targetDir: string;
-  keywords: string[];
-  firstKeyword: string;
-  searchInFiles: boolean;
-}): MemoryPathSearchResult {
-  const results: string[] = [];
-  let fileCount = 0;
-  let matchCount = 0;
-
-  const files = listFilesRecursively(input.targetDir);
-  const nameMatches = files.filter((filePath) =>
-    includesIgnoreCase(path.basename(filePath), input.firstKeyword),
-  );
-
-  if (nameMatches.length > 0) {
-    fileCount = nameMatches.length;
-    results.push(
-      `**Found ${fileCount} file(s) with names matching "${input.firstKeyword}":**`,
-    );
-    nameMatches.slice(0, 20).forEach((filePath) => {
-      results.push(`- ${toRelativeMemoryPath(input.memoryPath, filePath)}`);
-    });
-    if (fileCount > 20) {
-      results.push(`... and ${fileCount - 20} more files`);
-    }
-  }
-
-  if (input.searchInFiles && input.keywords.length > 0) {
-    const contentMatches: Array<{ filePath: string; lines: string[] }> = [];
-
-    for (const filePath of files) {
-      let content: string;
-
-      try {
-        content = readFileSync(filePath, "utf8");
-      } catch {
-        continue;
-      }
-
-      const lines = content
-        .split(/\r?\n/)
-        .filter((line) =>
-          input.keywords.some((keyword) => includesIgnoreCase(line, keyword)),
-        );
-
-      if (lines.length > 0) {
-        contentMatches.push({ filePath, lines });
-      }
-    }
-
-    if (contentMatches.length > 0) {
-      matchCount = Math.min(contentMatches.length, 20);
-      results.push(
-        `\n**Found ${matchCount} file(s) with content matching keywords "${input.keywords.join(", ")}":**`,
-      );
-      contentMatches.slice(0, 20).forEach(({ filePath }) => {
-        results.push(`- ${toRelativeMemoryPath(input.memoryPath, filePath)}`);
-      });
-
-      const sampleLines = contentMatches.flatMap(({ lines }) => lines);
-      if (sampleLines.length > 0) {
-        results.push("\n**Sample content matches:**");
-        sampleLines.slice(0, 15).forEach((line) => {
-          const trimmed = line.trim();
-          const truncated =
-            trimmed.length > 150 ? `${trimmed.slice(0, 150)}...` : trimmed;
-          results.push(`  ${truncated}`);
-        });
-      }
-    }
-  }
-
-  try {
-    const entries = readdirSync(input.targetDir).slice(0, 30);
-    if (entries.length > 0) {
-      results.push("\n**Directory structure:**");
-      results.push("```");
-      entries.forEach((entry) => {
-        const entryPath = path.join(input.targetDir, entry);
-        const stats = statSync(entryPath);
-        const type = stats.isDirectory() ? "d" : "-";
-        results.push(`${type} ${entry}`);
-      });
-      results.push("```");
-    }
-  } catch {
-    // Directory listing is best-effort, matching the existing shell behavior.
-  }
-
-  return { results, fileCount, matchCount };
-}
+import { getDefaultMemoryPath, searchMemoryPath } from "./memory-path-search";
 
 /**
  * Create the searchMemoryPath tool
@@ -169,15 +40,15 @@ export function createMemoryPathTool(session: Session) {
       "  <appDataDir>/data/memory/{platform}/YYYY-MM-DD.json",
       "Where {platform} is one of: whatsapp, gmail, weixin, imessage, telegram, feishu, lark",
       "Each file contains JSON with messages grouped by userKey and accountId.",
-      "Use this to look up past conversations across days — especially useful when:",
+      "Use this to look up past conversations across days, especially useful when:",
       "- User asks about something discussed earlier ('what did we talk about yesterday?')",
       "- User references a previous topic ('as I mentioned before...')",
       "- Building context for a continuing conversation",
       "",
       "**Usage Examples:**",
-      "- 'Who is my boss?' → Searches for 'boss' in all memory files",
-      "- 'What are my project notes?' → Searches /projects/ directory",
-      "- 'Tell me about John' → Searches for 'John' in all memory files",
+      "- 'Who is my boss?' -> Searches for 'boss' in all memory files",
+      "- 'What are my project notes?' -> Searches /projects/ directory",
+      "- 'Tell me about John' -> Searches for 'John' in all memory files",
     ].join("\n"),
     {
       query: z
@@ -186,9 +57,7 @@ export function createMemoryPathTool(session: Session) {
       searchInFiles: z
         .boolean()
         .default(true)
-        .describe(
-          "Whether to search within file content (using grep). Defaults to true.",
-        ),
+        .describe("Whether to search within file content. Defaults to true."),
       directory: z
         .string()
         .optional()
@@ -200,7 +69,6 @@ export function createMemoryPathTool(session: Session) {
       try {
         const { query, searchInFiles = true, directory } = args;
 
-        // Validate user session
         if (!session?.user?.id) {
           return {
             content: [
@@ -213,219 +81,22 @@ export function createMemoryPathTool(session: Session) {
           };
         }
 
-        // Get the actual memory directory path
-        const memoryPath = joinPath(getAppDataDir(), "data", "memory");
-
-        // Check if memory directory exists
-        if (!existsSync(memoryPath)) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Memory directory does not exist at ${memoryPath}. You may need to create memory files first.`,
-              },
-            ],
-            data: {
-              memoryPath,
-              query,
-              message: "Memory directory not found",
-            },
-          };
-        }
-
-        const targetDir = directory ? `${memoryPath}/${directory}` : memoryPath;
-
-        // Check if target directory exists
-        if (!existsSync(targetDir)) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Directory does not exist: ${targetDir}`,
-              },
-            ],
-            data: {
-              memoryPath,
-              targetDir,
-              query,
-              message: "Target directory not found",
-            },
-          };
-        }
-
-        // Collect search results
-        const results: string[] = [];
-        let fileCount = 0;
-        let matchCount = 0;
-
-        // Split query into keywords for better search coverage
-        const keywords = query.split(/[\s,，,、]+/).filter((k) => k.length > 0);
-
-        // 1. Search for files with matching names (use first keyword for filename search)
-        const firstKeyword = keywords[0] || query;
-        if (process.platform === "win32") {
-          const windowsResult = searchMemoryPathOnWindows({
-            memoryPath,
-            targetDir,
-            keywords,
-            firstKeyword,
-            searchInFiles,
-          });
-          results.push(...windowsResult.results);
-          fileCount = windowsResult.fileCount;
-          matchCount = windowsResult.matchCount;
-        } else {
-          try {
-            const findOutput = spawnSync(
-              "find",
-              [targetDir, "-type", "f", "-iname", `*${firstKeyword}*`],
-              {
-                encoding: "utf-8",
-                maxBuffer: 100 * 1024 * 1024,
-                shell: false,
-              },
-            );
-            const findStdout = findOutput.stdout as string;
-            if (findStdout?.trim()) {
-              const matchingFiles = findStdout.trim().split("\n");
-              fileCount = matchingFiles.length;
-              results.push(
-                `**Found ${fileCount} file(s) with names matching "${firstKeyword}":**`,
-              );
-              matchingFiles.slice(0, 20).forEach((file) => {
-                const relativePath = file.replace(`${memoryPath}/`, "");
-                results.push(`- ${relativePath}`);
-              });
-              if (fileCount > 20) {
-                results.push(`... and ${fileCount - 20} more files`);
-              }
-            }
-          } catch (error) {
-            // No matching files found, continue
-          }
-
-          // 2. Search for content matching any keyword (OR search)
-          if (searchInFiles && keywords.length > 0) {
-            // Build grep pattern: search for any keyword (OR logic)
-
-            try {
-              // Search files containing any keyword
-              const grepOutput = spawnSync(
-                "grep",
-                ["-r", "-i", "-l", "-E", keywords.join("|"), targetDir],
-                {
-                  encoding: "utf-8",
-                  maxBuffer: 100 * 1024 * 1024,
-                  shell: false,
-                },
-              );
-              const grepStdout = grepOutput.stdout as string;
-              if (grepStdout?.trim()) {
-                const matchingFiles = grepStdout
-                  .trim()
-                  .split("\n")
-                  .slice(0, 20);
-                matchCount = matchingFiles.length;
-                results.push(
-                  `\n**Found ${matchCount} file(s) with content matching keywords "${keywords.join(", ")}":**`,
-                );
-                matchingFiles.forEach((file) => {
-                  const relativePath = file.replace(`${memoryPath}/`, "");
-                  results.push(`- ${relativePath}`);
-                });
-
-                // Also show some actual content matches for each keyword
-                try {
-                  const contentOutput = spawnSync(
-                    "grep",
-                    ["-r", "-i", "-h", "-E", keywords.join("|"), targetDir],
-                    {
-                      encoding: "utf-8",
-                      maxBuffer: 100 * 1024 * 1024,
-                      shell: false,
-                    },
-                  );
-                  const contentStdout = contentOutput.stdout as string;
-                  if (contentStdout?.trim()) {
-                    results.push("\n**Sample content matches:**");
-                    contentStdout
-                      .trim()
-                      .split("\n")
-                      .slice(0, 15)
-                      .forEach((line) => {
-                        // Truncate long lines
-                        const truncated =
-                          line.length > 150 ? `${line.slice(0, 150)}...` : line;
-                        results.push(`  ${truncated}`);
-                      });
-                  }
-                } catch (e) {
-                  // Content grep failed, continue
-                }
-              }
-            } catch (error) {
-              // No matching content found, continue
-            }
-          }
-
-          // 3. List directory structure
-          try {
-            const lsOutput = spawnSync("ls", ["-la", targetDir], {
-              encoding: "utf-8",
-              maxBuffer: 100 * 1024 * 1024,
-              shell: false,
-            });
-            const lsStdout = lsOutput.stdout as string;
-            if (lsStdout?.trim()) {
-              results.push("\n**Directory structure:**");
-              results.push("```");
-              lsStdout
-                .trim()
-                .split("\n")
-                .slice(0, 30)
-                .forEach((line) => {
-                  results.push(line);
-                });
-              results.push("```");
-            }
-          } catch (error) {
-            // ls failed, continue
-          }
-        }
-
-        // Format response
-        if (results.length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `No matches found for "${query}" in memory directory (${targetDir}).`,
-              },
-            ],
-            data: {
-              memoryPath,
-              targetDir,
-              query,
-              message: "No matches found",
-            },
-          };
-        }
+        const result = searchMemoryPath({
+          query,
+          searchInFiles,
+          directory,
+          memoryPath: getDefaultMemoryPath(),
+        });
 
         return {
           content: [
             {
               type: "text" as const,
-              text: results.join("\n"),
+              text: result.content,
             },
           ],
-          data: {
-            memoryPath,
-            targetDir,
-            query,
-            fileCount,
-            matchCount,
-            results: results.join("\n"),
-          },
+          data: result.data,
+          isError: result.isError === true,
         };
       } catch (error) {
         return {

--- a/apps/web/lib/ai/mcp/tools/memory-path.ts
+++ b/apps/web/lib/ai/mcp/tools/memory-path.ts
@@ -5,9 +5,137 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
 import type { Session } from "next-auth";
 import { getAppDataDir, joinPath } from "@/lib/utils/path";
+
+interface MemoryPathSearchResult {
+  results: string[];
+  fileCount: number;
+  matchCount: number;
+}
+
+function listFilesRecursively(root: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(entryPath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function includesIgnoreCase(value: string, query: string): boolean {
+  return value.toLocaleLowerCase().includes(query.toLocaleLowerCase());
+}
+
+function toRelativeMemoryPath(memoryPath: string, filePath: string): string {
+  return path.relative(memoryPath, filePath) || filePath;
+}
+
+function searchMemoryPathOnWindows(input: {
+  memoryPath: string;
+  targetDir: string;
+  keywords: string[];
+  firstKeyword: string;
+  searchInFiles: boolean;
+}): MemoryPathSearchResult {
+  const results: string[] = [];
+  let fileCount = 0;
+  let matchCount = 0;
+
+  const files = listFilesRecursively(input.targetDir);
+  const nameMatches = files.filter((filePath) =>
+    includesIgnoreCase(path.basename(filePath), input.firstKeyword),
+  );
+
+  if (nameMatches.length > 0) {
+    fileCount = nameMatches.length;
+    results.push(
+      `**Found ${fileCount} file(s) with names matching "${input.firstKeyword}":**`,
+    );
+    nameMatches.slice(0, 20).forEach((filePath) => {
+      results.push(`- ${toRelativeMemoryPath(input.memoryPath, filePath)}`);
+    });
+    if (fileCount > 20) {
+      results.push(`... and ${fileCount - 20} more files`);
+    }
+  }
+
+  if (input.searchInFiles && input.keywords.length > 0) {
+    const contentMatches: Array<{ filePath: string; lines: string[] }> = [];
+
+    for (const filePath of files) {
+      let content: string;
+
+      try {
+        content = readFileSync(filePath, "utf8");
+      } catch {
+        continue;
+      }
+
+      const lines = content
+        .split(/\r?\n/)
+        .filter((line) =>
+          input.keywords.some((keyword) => includesIgnoreCase(line, keyword)),
+        );
+
+      if (lines.length > 0) {
+        contentMatches.push({ filePath, lines });
+      }
+    }
+
+    if (contentMatches.length > 0) {
+      matchCount = Math.min(contentMatches.length, 20);
+      results.push(
+        `\n**Found ${matchCount} file(s) with content matching keywords "${input.keywords.join(", ")}":**`,
+      );
+      contentMatches.slice(0, 20).forEach(({ filePath }) => {
+        results.push(`- ${toRelativeMemoryPath(input.memoryPath, filePath)}`);
+      });
+
+      const sampleLines = contentMatches.flatMap(({ lines }) => lines);
+      if (sampleLines.length > 0) {
+        results.push("\n**Sample content matches:**");
+        sampleLines.slice(0, 15).forEach((line) => {
+          const trimmed = line.trim();
+          const truncated =
+            trimmed.length > 150 ? `${trimmed.slice(0, 150)}...` : trimmed;
+          results.push(`  ${truncated}`);
+        });
+      }
+    }
+  }
+
+  try {
+    const entries = readdirSync(input.targetDir).slice(0, 30);
+    if (entries.length > 0) {
+      results.push("\n**Directory structure:**");
+      results.push("```");
+      entries.forEach((entry) => {
+        const entryPath = path.join(input.targetDir, entry);
+        const stats = statSync(entryPath);
+        const type = stats.isDirectory() ? "d" : "-";
+        results.push(`${type} ${entry}`);
+      });
+      results.push("```");
+    }
+  } catch {
+    // Directory listing is best-effort, matching the existing shell behavior.
+  }
+
+  return { results, fileCount, matchCount };
+}
 
 /**
  * Create the searchMemoryPath tool
@@ -135,118 +263,134 @@ export function createMemoryPathTool(session: Session) {
 
         // 1. Search for files with matching names (use first keyword for filename search)
         const firstKeyword = keywords[0] || query;
-        try {
-          const findOutput = spawnSync(
-            "find",
-            [targetDir, "-type", "f", "-iname", `*${firstKeyword}*`],
-            {
-              encoding: "utf-8",
-              maxBuffer: 100 * 1024 * 1024,
-              shell: false,
-            },
-          );
-          const findStdout = findOutput.stdout as string;
-          if (findStdout?.trim()) {
-            const matchingFiles = findStdout.trim().split("\n");
-            fileCount = matchingFiles.length;
-            results.push(
-              `**Found ${fileCount} file(s) with names matching "${firstKeyword}":**`,
-            );
-            matchingFiles.slice(0, 20).forEach((file) => {
-              const relativePath = file.replace(`${memoryPath}/`, "");
-              results.push(`- ${relativePath}`);
-            });
-            if (fileCount > 20) {
-              results.push(`... and ${fileCount - 20} more files`);
-            }
-          }
-        } catch (error) {
-          // No matching files found, continue
-        }
-
-        // 2. Search for content matching any keyword (OR search)
-        if (searchInFiles && keywords.length > 0) {
-          // Build grep pattern: search for any keyword (OR logic)
-
+        if (process.platform === "win32") {
+          const windowsResult = searchMemoryPathOnWindows({
+            memoryPath,
+            targetDir,
+            keywords,
+            firstKeyword,
+            searchInFiles,
+          });
+          results.push(...windowsResult.results);
+          fileCount = windowsResult.fileCount;
+          matchCount = windowsResult.matchCount;
+        } else {
           try {
-            // Search files containing any keyword
-            const grepOutput = spawnSync(
-              "grep",
-              ["-r", "-i", "-l", "-E", keywords.join("|"), targetDir],
+            const findOutput = spawnSync(
+              "find",
+              [targetDir, "-type", "f", "-iname", `*${firstKeyword}*`],
               {
                 encoding: "utf-8",
                 maxBuffer: 100 * 1024 * 1024,
                 shell: false,
               },
             );
-            const grepStdout = grepOutput.stdout as string;
-            if (grepStdout?.trim()) {
-              const matchingFiles = grepStdout.trim().split("\n").slice(0, 20);
-              matchCount = matchingFiles.length;
+            const findStdout = findOutput.stdout as string;
+            if (findStdout?.trim()) {
+              const matchingFiles = findStdout.trim().split("\n");
+              fileCount = matchingFiles.length;
               results.push(
-                `\n**Found ${matchCount} file(s) with content matching keywords "${keywords.join(", ")}":**`,
+                `**Found ${fileCount} file(s) with names matching "${firstKeyword}":**`,
               );
-              matchingFiles.forEach((file) => {
+              matchingFiles.slice(0, 20).forEach((file) => {
                 const relativePath = file.replace(`${memoryPath}/`, "");
                 results.push(`- ${relativePath}`);
               });
-
-              // Also show some actual content matches for each keyword
-              try {
-                const contentOutput = spawnSync(
-                  "grep",
-                  ["-r", "-i", "-h", "-E", keywords.join("|"), targetDir],
-                  {
-                    encoding: "utf-8",
-                    maxBuffer: 100 * 1024 * 1024,
-                    shell: false,
-                  },
-                );
-                const contentStdout = contentOutput.stdout as string;
-                if (contentStdout?.trim()) {
-                  results.push("\n**Sample content matches:**");
-                  contentStdout
-                    .trim()
-                    .split("\n")
-                    .slice(0, 15)
-                    .forEach((line) => {
-                      // Truncate long lines
-                      const truncated =
-                        line.length > 150 ? `${line.slice(0, 150)}...` : line;
-                      results.push(`  ${truncated}`);
-                    });
-                }
-              } catch (e) {
-                // Content grep failed, continue
+              if (fileCount > 20) {
+                results.push(`... and ${fileCount - 20} more files`);
               }
             }
           } catch (error) {
-            // No matching content found, continue
+            // No matching files found, continue
           }
-        }
 
-        // 3. List directory structure
-        try {
-          const lsOutput = spawnSync("ls", ["-la", targetDir], {
-            encoding: "utf-8",
-            maxBuffer: 100 * 1024 * 1024,
-            shell: false,
-          });
-          const lsStdout = lsOutput.stdout as string;
-          if (lsStdout?.trim()) {
-            results.push("\n**Directory structure:**");
-            results.push("```");
-            lsStdout
-              .trim()
-              .split("\n")
-              .slice(0, 30)
-              .forEach((line) => {
-                results.push(line);
-              });
-            results.push("```");
+          // 2. Search for content matching any keyword (OR search)
+          if (searchInFiles && keywords.length > 0) {
+            // Build grep pattern: search for any keyword (OR logic)
+
+            try {
+              // Search files containing any keyword
+              const grepOutput = spawnSync(
+                "grep",
+                ["-r", "-i", "-l", "-E", keywords.join("|"), targetDir],
+                {
+                  encoding: "utf-8",
+                  maxBuffer: 100 * 1024 * 1024,
+                  shell: false,
+                },
+              );
+              const grepStdout = grepOutput.stdout as string;
+              if (grepStdout?.trim()) {
+                const matchingFiles = grepStdout
+                  .trim()
+                  .split("\n")
+                  .slice(0, 20);
+                matchCount = matchingFiles.length;
+                results.push(
+                  `\n**Found ${matchCount} file(s) with content matching keywords "${keywords.join(", ")}":**`,
+                );
+                matchingFiles.forEach((file) => {
+                  const relativePath = file.replace(`${memoryPath}/`, "");
+                  results.push(`- ${relativePath}`);
+                });
+
+                // Also show some actual content matches for each keyword
+                try {
+                  const contentOutput = spawnSync(
+                    "grep",
+                    ["-r", "-i", "-h", "-E", keywords.join("|"), targetDir],
+                    {
+                      encoding: "utf-8",
+                      maxBuffer: 100 * 1024 * 1024,
+                      shell: false,
+                    },
+                  );
+                  const contentStdout = contentOutput.stdout as string;
+                  if (contentStdout?.trim()) {
+                    results.push("\n**Sample content matches:**");
+                    contentStdout
+                      .trim()
+                      .split("\n")
+                      .slice(0, 15)
+                      .forEach((line) => {
+                        // Truncate long lines
+                        const truncated =
+                          line.length > 150 ? `${line.slice(0, 150)}...` : line;
+                        results.push(`  ${truncated}`);
+                      });
+                  }
+                } catch (e) {
+                  // Content grep failed, continue
+                }
+              }
+            } catch (error) {
+              // No matching content found, continue
+            }
           }
-        } catch (error) {
-          // ls failed, continue
+
+          // 3. List directory structure
+          try {
+            const lsOutput = spawnSync("ls", ["-la", targetDir], {
+              encoding: "utf-8",
+              maxBuffer: 100 * 1024 * 1024,
+              shell: false,
+            });
+            const lsStdout = lsOutput.stdout as string;
+            if (lsStdout?.trim()) {
+              results.push("\n**Directory structure:**");
+              results.push("```");
+              lsStdout
+                .trim()
+                .split("\n")
+                .slice(0, 30)
+                .forEach((line) => {
+                  results.push(line);
+                });
+              results.push("```");
+            }
+          } catch (error) {
+            // ls failed, continue
+          }
         }
 
         // Format response

--- a/apps/web/scripts/openloomi-memory-mcp.mjs
+++ b/apps/web/scripts/openloomi-memory-mcp.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const SERVER_NAME = "openloomi_memory";
+
+async function main() {
+  const { searchMemoryPath } = await loadMemorySearchModule();
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: "1.0.0",
+  });
+
+  server.registerTool(
+    "searchMemoryPath",
+    {
+      description: [
+        "Search OpenLoomi's local markdown/json memory files for personal context.",
+        "Use this for user memory recall, notes, people, projects, strategy, and past conversation lookups.",
+        "This tool reads only the OpenLoomi memory directory and does not call RAG or embedding APIs.",
+      ].join(" "),
+      inputSchema: {
+        query: z
+          .string()
+          .describe("Search query to find matching memory files and content"),
+        searchInFiles: z
+          .boolean()
+          .default(true)
+          .describe("Whether to search within file content."),
+        directory: z
+          .string()
+          .optional()
+          .describe(
+            "Optional memory subdirectory, such as people or projects.",
+          ),
+      },
+    },
+    async ({ query, searchInFiles = true, directory }) => {
+      if (!process.env.OPENLOOMI_MCP_USER_ID) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Unauthorized: invalid user session",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const result = searchMemoryPath({
+        query,
+        searchInFiles,
+        directory,
+        memoryPath: process.env.OPENLOOMI_MEMORY_PATH,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.content,
+          },
+        ],
+        isError: result.isError === true,
+      };
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+async function loadMemorySearchModule() {
+  const candidates = [
+    new URL("./memory-path-search.js", import.meta.url),
+    new URL("../lib/ai/mcp/tools/memory-path-search.js", import.meta.url),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(fileURLToPath(candidate))) {
+      return import(candidate.href);
+    }
+  }
+
+  throw new Error(
+    "Unable to locate OpenLoomi memory-path-search helper for MCP server.",
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack || error.message : error;
+  process.stderr.write(`[${SERVER_NAME}] ${String(message)}\n`);
+  process.exit(1);
+});

--- a/apps/web/scripts/optimize-tauri-bundle.js
+++ b/apps/web/scripts/optimize-tauri-bundle.js
@@ -103,7 +103,11 @@ const scriptsSrc = path.join(webDir, "scripts");
 // existed at runtime and silently failed to persist decisions when
 // it didn't. `init-db.cjs` predates the bug; `loop-cli.mjs` is the
 // fix. Both shims are tiny (~3 KB each) so the size cost is trivial.
-const STANDALONE_SHIM_FILES = ["init-db.cjs", "loop-cli.mjs"];
+const STANDALONE_SHIM_FILES = [
+  "init-db.cjs",
+  "loop-cli.mjs",
+  "openloomi-memory-mcp.mjs",
+];
 if (fs.existsSync(scriptsSrc)) {
   fs.mkdirSync(scriptsDest, { recursive: true });
   for (const fileName of STANDALONE_SHIM_FILES) {
@@ -115,7 +119,23 @@ if (fs.existsSync(scriptsSrc)) {
       console.log(`  scripts/${fileName} not in source — skipping`);
     }
   }
-  console.log("  scripts shims copied (init-db.cjs, loop-cli.mjs)");
+  const memoryPathSearchSrc = path.join(
+    webDir,
+    "lib",
+    "ai",
+    "mcp",
+    "tools",
+    "memory-path-search.js",
+  );
+  const memoryPathSearchDest = path.join(scriptsDest, "memory-path-search.js");
+  if (fs.existsSync(memoryPathSearchSrc)) {
+    copyFile(memoryPathSearchSrc, memoryPathSearchDest);
+  } else {
+    console.log("  memory-path-search.js helper not in source - skipping");
+  }
+  console.log(
+    "  scripts shims copied (init-db.cjs, loop-cli.mjs, openloomi-memory-mcp.mjs)",
+  );
 } else {
   console.log("  no scripts source dir, skipping shim copy");
 }

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,7 @@ import {
   CodexCommandNotFoundError,
   normalizeCodexProviderConfig,
 } from "@/lib/ai/extensions/agent/codex/command";
+import { searchMemoryPath } from "@/lib/ai/mcp/tools/memory-path-search";
 import { parseCodexJsonLine } from "@/lib/ai/extensions/agent/codex/parser";
 
 const tempDirs: string[] = [];
@@ -172,6 +173,92 @@ describe("CodexAgent", () => {
       normalizeCodexProviderConfig({ skipGitRepoCheck: false })
         .skipGitRepoCheck,
     ).toBe(false);
+  });
+
+  it("injects OpenLoomi memory MCP config when a user session is available", () => {
+    const command = buildCodexRunCommand({
+      prompt: "recall my memory",
+      cwd: "/workspace/project",
+      openLoomiMemoryMcp: {
+        session: { user: { id: "user-123" } },
+      },
+    });
+
+    const argv = command.args.join("\n");
+    expect(argv).toContain("mcp_servers.openloomi_memory.command=");
+    expect(argv).toContain("mcp_servers.openloomi_memory.args=");
+    expect(argv).toContain("openloomi-memory-mcp.mjs");
+    expect(argv).toContain(
+      'mcp_servers.openloomi_memory.env.OPENLOOMI_MCP_USER_ID="user-123"',
+    );
+    expect(argv).toContain(
+      "mcp_servers.openloomi_memory.env.OPENLOOMI_MEMORY_PATH=",
+    );
+    expect(command.args.at(-1)).toBe("recall my memory");
+  });
+
+  it("does not inject OpenLoomi memory MCP during planning or when excluded", () => {
+    const planCommand = buildCodexRunCommand({
+      prompt: "plan memory work",
+      cwd: "/workspace/project",
+      mode: "plan",
+      openLoomiMemoryMcp: {
+        session: { user: { id: "user-123" } },
+      },
+    });
+    expect(planCommand.args.join("\n")).not.toContain(
+      "mcp_servers.openloomi_memory",
+    );
+
+    const excludedCommand = buildCodexRunCommand({
+      prompt: "recall my memory",
+      cwd: "/workspace/project",
+      openLoomiMemoryMcp: {
+        session: { user: { id: "user-123" } },
+        excludeTools: ["searchMemoryPath"],
+      },
+    });
+    expect(excludedCommand.args.join("\n")).not.toContain(
+      "mcp_servers.openloomi_memory",
+    );
+  });
+});
+
+describe("OpenLoomi memory path search", () => {
+  it("searches local memory files without using embedding-backed APIs", async () => {
+    const memoryDir = await mkdtemp(join(tmpdir(), "openloomi-memory-test-"));
+    tempDirs.push(memoryDir);
+    await mkdir(join(memoryDir, "projects"), { recursive: true });
+    await writeFile(
+      join(memoryDir, "projects", "red-hat.md"),
+      "The red hat marker belongs to source-free recall.\n",
+      "utf8",
+    );
+
+    const result = searchMemoryPath({
+      query: "red hat marker",
+      directory: "projects",
+      memoryPath: memoryDir,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain("projects");
+    expect(result.content).toContain("red-hat.md");
+    expect(result.content).toContain("source-free recall");
+  });
+
+  it("keeps directory searches inside the memory root", async () => {
+    const memoryDir = await mkdtemp(join(tmpdir(), "openloomi-memory-test-"));
+    tempDirs.push(memoryDir);
+
+    const result = searchMemoryPath({
+      query: "anything",
+      directory: "..",
+      memoryPath: memoryDir,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("inside the OpenLoomi memory directory");
   });
 });
 

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -52,8 +52,9 @@ describe("Codex command builder", () => {
       "--sandbox",
       "workspace-write",
       "--skip-git-repo-check",
-      "fix the failing tests",
+      "-",
     ]);
+    expect(command.stdin).toBe("fix the failing tests");
     expect(command.args).not.toContain("--full-auto");
   });
 
@@ -81,7 +82,8 @@ describe("Codex command builder", () => {
     });
 
     expect(command.args).toContain("--full-auto");
-    expect(command.args.at(-1)).toBe("ship it");
+    expect(command.args.at(-1)).toBe("-");
+    expect(command.stdin).toBe("ship it");
   });
 
   it("does not pass --full-auto for bypassPermissions without explicit opt-in", () => {
@@ -118,9 +120,11 @@ describe("Codex command builder", () => {
     const guardIndex = command.args.indexOf("--");
     expect(guardIndex).toBeGreaterThan(-1);
     expect(command.args[guardIndex + 1]).toBe("safe-arg");
-    // And the smuggled --full-auto only lands after the guard, so Codex will
-    // treat it as the prompt position, not as a flag.
+    // The filtered extra arg stays after the guard, while the real prompt is
+    // delivered through stdin for cross-platform multiline safety.
     expect(command.args).toContain("safe-arg");
+    expect(command.args.at(-1)).toBe("-");
+    expect(command.stdin).toBe("validate input");
   });
 
   it("normalizes timeoutMs from provider config", () => {
@@ -194,7 +198,8 @@ describe("CodexAgent", () => {
     expect(argv).toContain(
       "mcp_servers.openloomi_memory.env.OPENLOOMI_MEMORY_PATH=",
     );
-    expect(command.args.at(-1)).toBe("recall my memory");
+    expect(command.args.at(-1)).toBe("-");
+    expect(command.stdin).toBe("recall my memory");
   });
 
   it("does not inject OpenLoomi memory MCP during planning or when excluded", () => {
@@ -508,7 +513,10 @@ describe("CodexAgent", () => {
     // carries an approval flag.
     expect(args).not.toContain("--ask-for-approval");
     expect(args).toContain("--skip-git-repo-check");
-    expect(args.at(-1)).toBe("hello codex");
+    expect(args.at(-1)).toBe("-");
+    expect(await readFile(join(workDir, "stdin.txt"), "utf8")).toBe(
+      "hello codex",
+    );
   });
 
   it("embeds conversation context into the Codex prompt", async () => {
@@ -531,7 +539,8 @@ describe("CodexAgent", () => {
     const args = JSON.parse(
       await readFile(join(workDir, "args.json"), "utf8"),
     ) as string[];
-    const prompt = args.at(-1) ?? "";
+    expect(args.at(-1)).toBe("-");
+    const prompt = await readFile(join(workDir, "stdin.txt"), "utf8");
     expect(prompt).toEqual(expect.stringContaining("earlier question"));
     expect(prompt).toEqual(expect.stringContaining("current question"));
   });
@@ -733,9 +742,12 @@ setInterval(() => {}, 1000);
     );
     expect(error).toBeDefined();
     expect(error?.message).toContain("__CODEX_INTERRUPTED__");
-    expect(error?.message).toContain(workDir);
-    expect(error?.message).toContain("report.md");
-    expect(error?.message).toMatch(/"canResume":\s*true/);
+    const interruptionPayload = JSON.parse(
+      (error?.message ?? "").replace(/^__CODEX_INTERRUPTED__\s*/, ""),
+    );
+    expect(interruptionPayload.workspacePath).toBe(workDir);
+    expect(interruptionPayload.completedArtifacts).toContain("report.md");
+    expect(interruptionPayload.canResume).toBe(true);
 
     // The agent still closes with `done` so the SSE stream terminates cleanly
     // and the chat UI does not loop waiting for a result.
@@ -826,23 +838,29 @@ function defaultFakeCodexScript() {
   return `
 const args = process.argv.slice(2);
 require("node:fs").writeFileSync("args.json", JSON.stringify(args));
-console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
-console.log(JSON.stringify({
-  type: "item.started",
-  item: { type: "command_execution", id: "cmd-1", command: "pwd" }
-}));
-console.log(JSON.stringify({
-  type: "item.completed",
-  item: { type: "command_execution", id: "cmd-1", command: "pwd", aggregated_output: "/workspace\\n", exit_code: 0, status: "completed" }
-}));
-console.log(JSON.stringify({
-  type: "item.completed",
-  item: { type: "agent_message", id: "msg-1", text: "hello" }
-}));
-console.log(JSON.stringify({
-  type: "turn.completed",
-  usage: { input_tokens: 9, cached_input_tokens: 4, output_tokens: 4 }
-}));
+let stdin = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { stdin += chunk; });
+process.stdin.on("end", () => {
+  require("node:fs").writeFileSync("stdin.txt", stdin);
+  console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
+  console.log(JSON.stringify({
+    type: "item.started",
+    item: { type: "command_execution", id: "cmd-1", command: "pwd" }
+  }));
+  console.log(JSON.stringify({
+    type: "item.completed",
+    item: { type: "command_execution", id: "cmd-1", command: "pwd", aggregated_output: "/workspace\\n", exit_code: 0, status: "completed" }
+  }));
+  console.log(JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", id: "msg-1", text: "hello" }
+  }));
+  console.log(JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 9, cached_input_tokens: 4, output_tokens: 4 }
+  }));
+});
 `;
 }
 

--- a/apps/web/tests/unit/native-agent-provider-env.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-env.test.ts
@@ -449,7 +449,8 @@ describe("native agent provider env resolver", () => {
     expect(command.args).not.toContain("--ask-for-approval");
     expect(command.args).not.toContain("--skip-git-repo-check");
     expect(command.args).toContain("--full-auto");
-    expect(command.args.at(-1)).toBe("fix the failing tests");
+    expect(command.args.at(-1)).toBe("-");
+    expect(command.stdin).toBe("fix the failing tests");
   });
 
   it("rejects unsupported Codex sandbox env values and silently ignores ASK_FOR_APPROVAL", () => {

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -23,6 +23,7 @@ const BRIDGE_DIR = path.dirname(BRIDGE_SCRIPT_PATH);
 const BRIDGE_VERSION = "0.7.10";
 const PLUGIN_PHASE = "runtime-provider-readiness";
 const COMMAND_TIMEOUT_MS = 5000;
+const RUN_TIMEOUT_MS = 120000;
 const INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
 const RELEASE_LOOKUP_TIMEOUT_MS = 30000;
 const INSTALL_DOWNLOAD_TIMEOUT_MS = 15 * 60 * 1000;
@@ -153,7 +154,7 @@ const WORKFLOW_GUIDANCE = [
     readyRequired: true,
     bridgeCommand: "memory-search",
     taskPromptPrefix:
-      "Use the memory-search bridge command with the original user memory request as stdin. The OpenLoomi runtime must use its native searchMemoryPath memory tool when available. Do not call /api/memory/search, /api/rag/search, /api/messages, /api/chat-insights, source search, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge from the runtime.",
+      "Use the memory-search bridge command with the original user memory request as stdin. The bridge performs the read-only local memory search before handing results to the OpenLoomi runtime. Do not call /api/memory/search, /api/rag/search, /api/messages, /api/chat-insights, source search, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge from the runtime.",
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -161,7 +162,7 @@ const WORKFLOW_GUIDANCE = [
       "configure_connectors",
     ],
     safety: [
-      "Do not read or write OpenLoomi memory files directly from the Codex plugin.",
+      "Use the bridge-owned searchMemoryPath helper for local memory lookup; do not implement ad hoc file search in the Codex plugin.",
       "Do not fall back to RAG, messages, chat-insights, source code search, or direct memory-file reads when the native memory runtime returns no results.",
       "Do not expose memory contents unless OpenLoomi runtime returns them for the requested task.",
     ],
@@ -326,6 +327,7 @@ async function buildSetupStatus() {
     mode: discovery.mode,
     installed: discovery.installed,
     appPath: discovery.appPath,
+    ctlPath: discovery.ctlPath || normalizePath(process.env.OPENLOOMI_CTL),
     version: discovery.version,
     tokenPresent: token.present,
     aiProviderConfigured: aiProvider.configured,
@@ -2443,8 +2445,20 @@ function getPermissionMode(value) {
 }
 
 function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt }) {
+  const resolvedCtlPath = resolveOpenLoomiCtlPath(ctlPath);
+
+  if (!resolvedCtlPath) {
+    return Promise.resolve({
+      exitCode: 1,
+      signal: null,
+      stdout: "",
+      stderr:
+        "OpenLoomi CLI path is unavailable. Set OPENLOOMI_CTL or use a setup mode that exposes openloomi-ctl.",
+    });
+  }
+
   return runCommandWithInput(
-    ctlPath,
+    resolvedCtlPath,
     ["--one-shot", "--stdin", "--json", "--permission-mode", permissionMode],
     prompt,
     RUN_TIMEOUT_MS,
@@ -2452,6 +2466,15 @@ function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt }) {
       env: getOpenLoomiCtlChildEnv(),
     },
   );
+}
+
+function resolveOpenLoomiCtlPath(ctlPath) {
+  const explicitCtl = normalizePath(process.env.OPENLOOMI_CTL);
+  if (explicitCtl && isFile(explicitCtl)) {
+    return explicitCtl;
+  }
+
+  return normalizePath(ctlPath);
 }
 
 async function runBridgeMemorySearch(query, setup = {}) {
@@ -4039,8 +4062,14 @@ function planRuntimeEnvChange({ platform, key, value, flags }) {
           command: "launchctl",
           args: ["bootout", guiTarget, plistPath],
         });
-        actions.push({ label: "rm plist", command: "rm", args: ["-f", plistPath] });
-        commands.push(`launchctl bootout ${guiTarget} ${plistPath}  # best-effort`);
+        actions.push({
+          label: "rm plist",
+          command: "rm",
+          args: ["-f", plistPath],
+        });
+        commands.push(
+          `launchctl bootout ${guiTarget} ${plistPath}  # best-effort`,
+        );
         commands.push(`rm -f ${plistPath}`);
         notes.push(
           `Removed LaunchAgent ${plistPath}. ${key} will no longer be re-applied on login.`,
@@ -4825,10 +4854,7 @@ async function discoverOpenLoomi() {
       checked,
     });
 
-    if (
-      result.status === "found" ||
-      result.status === "source-missing-app"
-    ) {
+    if (result.status === "found" || result.status === "source-missing-app") {
       return result;
     }
   }
@@ -5093,6 +5119,17 @@ function getReadinessDecision(
       ready: false,
       nextAction: "provide_install_or_repo_path",
       reason: "OPENLOOMI_APP_INVALID",
+    };
+  }
+
+  if (nativeCodexRuntimeReady && token.present && apiProbe?.reachableUrl) {
+    return {
+      ready: true,
+      nextAction: "run",
+      reason: "READY",
+      readinessSource: "native_codex_runtime",
+      message:
+        "OpenLoomi is ready through the native Codex runtime. A separate OpenLoomi AI provider is not required for native Codex execution.",
     };
   }
 

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -16,8 +16,10 @@ import { createHash } from "node:crypto";
 import https from "node:https";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
+const BRIDGE_SCRIPT_PATH = fileURLToPath(import.meta.url);
+const BRIDGE_DIR = path.dirname(BRIDGE_SCRIPT_PATH);
 const BRIDGE_VERSION = "0.7.10";
 const PLUGIN_PHASE = "runtime-provider-readiness";
 const COMMAND_TIMEOUT_MS = 5000;
@@ -30,7 +32,10 @@ const SESSION_BOOTSTRAP_POLL_MS = 2000;
 const SESSION_API_TIMEOUT_MS = 5000;
 const API_PROBE_TIMEOUT_MS = 1000;
 const CONNECTOR_STATUS_TIMEOUT_MS = 2500;
+const MEMORY_SEARCH_TIMEOUT_MS = 10000;
 const MAX_COMMAND_OUTPUT = 4096;
+const RUN_LOCK_TTL_MS = RUN_TIMEOUT_MS + 60_000;
+const MAX_MEMORY_CONTEXT_CHARS = 20000;
 const DEBUG_DISCOVERY = process.env.OPENLOOMI_DEBUG_DISCOVERY === "1";
 const MONITORING_CONNECTOR_IDS = new Set([
   "gmail",
@@ -88,6 +93,8 @@ const COMMANDS = new Set([
   "initialize-session",
   "install-openloomi",
   "install-instructions",
+  "memory-recall",
+  "memory-search",
   "pet",
   "set-codex-runtime-env",
   "setup",
@@ -145,8 +152,9 @@ const WORKFLOW_GUIDANCE = [
       "Guide memory search, recall, write, and context workflows through OpenLoomi-owned memory surfaces.",
     wrapperSkill: "openloomi-memory",
     readyRequired: true,
-    bridgeCommand: "run",
-    taskPromptPrefix: `${RUNTIME_SAFE_PROMPT_GUARD} Treat the user request as a memory/context request. Return only the runtime result; do not read or write memory files directly.`,
+    bridgeCommand: "memory-search",
+    taskPromptPrefix:
+      "Use the memory-search bridge command with the original user memory request as stdin. Do not call /api/rag/search, /api/messages, /api/chat-insights, source search, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge from the runtime.",
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -155,6 +163,7 @@ const WORKFLOW_GUIDANCE = [
     ],
     safety: [
       "Do not read or write OpenLoomi memory files directly from the Codex plugin.",
+      "Do not fall back to RAG, messages, chat-insights, source code search, or direct memory-file reads when memory-search returns no results.",
       "Do not expose memory contents unless OpenLoomi runtime returns them for the requested task.",
     ],
   },
@@ -1386,7 +1395,9 @@ function workflowGuidance(args) {
       runCommand:
         workflow.bridgeCommand === "run"
           ? 'printf "%s" "<task>" | loomi-bridge run'
-          : workflow.bridgeCommand,
+          : workflow.bridgeCommand === "memory-search"
+            ? 'printf "%s" "<query>" | loomi-bridge memory-search'
+            : workflow.bridgeCommand,
     },
   });
 }
@@ -1459,9 +1470,11 @@ function parseFlags(args) {
     confirm: false,
     downloadOnly: false,
     launch: false,
+    limit: null,
     model: null,
     provider: null,
     sha256: null,
+    sources: null,
     workflow: null,
   };
 
@@ -1516,6 +1529,38 @@ function parseFlags(args) {
       continue;
     }
 
+    if (arg === "--limit") {
+      flags.limit = args[index + 1] || null;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--limit=")) {
+      flags.limit = arg.slice("--limit=".length);
+      continue;
+    }
+
+    if (arg === "--sources") {
+      flags.sources = args[index + 1] || null;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--sources=")) {
+      flags.sources = arg.slice("--sources=".length);
+      continue;
+    }
+
+    if (arg === "--permission-mode") {
+      flags.permissionMode = args[index + 1] || null;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--permission-mode=")) {
+      flags.permissionMode = arg.slice("--permission-mode=".length);
+      continue;
+    }
     if (arg === "--artifact-url") {
       flags.artifactUrl = args[index + 1] || null;
       index += 1;
@@ -2377,6 +2422,262 @@ function getInstallerCommandLabel(filePath) {
   const extension = path.extname(filePath).toLowerCase();
 
   return extension ? `installer${extension}` : "installer";
+}
+
+// `openloomi-ctl` argv. Keeps `ask` and `deny` unchanged so the bridge's
+// public contract stays stable while the CLI's canonical contract remains
+// `bypass | ask | deny` (see apps/web/src-tauri/src/cli.rs). Unknown or
+// omitted values fall back to `deny` so the default cannot escalate.
+const BRIDGE_PERMISSION_MODES = new Set(["allow", "ask", "deny"]);
+const BRIDGE_TO_CLI_PERMISSION_MODE = Object.freeze({
+  allow: "bypass",
+  ask: "ask",
+  deny: "deny",
+});
+
+function getPermissionMode(value) {
+  if (BRIDGE_PERMISSION_MODES.has(value)) {
+    return BRIDGE_TO_CLI_PERMISSION_MODE[value];
+  }
+
+  return "deny";
+}
+
+function runOpenLoomiOneShot({ ctlPath, permissionMode, prompt }) {
+  return runCommandWithInput(
+    ctlPath,
+    ["--one-shot", "--stdin", "--json", "--permission-mode", permissionMode],
+    prompt,
+    RUN_TIMEOUT_MS,
+    {
+      env: getOpenLoomiCtlChildEnv(),
+    },
+  );
+}
+
+async function runBridgeMemorySearch(query, setup = {}) {
+  const { module, path: helperPath } =
+    await loadBridgeMemorySearchModule(setup);
+  const result = module.searchMemoryPath({
+    query,
+    searchInFiles: true,
+  });
+
+  return {
+    helperPath,
+    isError: result?.isError === true,
+    content:
+      typeof result?.content === "string"
+        ? result.content
+        : JSON.stringify(result ?? {}),
+  };
+}
+
+async function loadBridgeMemorySearchModule(setup = {}) {
+  const candidates = listBridgeMemorySearchCandidates(setup);
+  for (const candidate of candidates) {
+    if (!isFile(candidate)) {
+      continue;
+    }
+
+    const module = await import(pathToFileURL(candidate).href);
+    if (typeof module.searchMemoryPath === "function") {
+      return { module, path: candidate };
+    }
+  }
+
+  throw new Error(
+    `Unable to locate OpenLoomi memory-path-search helper. Checked: ${candidates.join(", ")}`,
+  );
+}
+
+function listBridgeMemorySearchCandidates(setup = {}) {
+  const candidates = [];
+  const addFile = (filePath) => {
+    if (filePath && !candidates.includes(filePath)) {
+      candidates.push(filePath);
+    }
+  };
+  const addWebDir = (webDir) => {
+    if (!webDir) return;
+    addFile(
+      path.join(webDir, "lib", "ai", "mcp", "tools", "memory-path-search.js"),
+    );
+    addFile(path.join(webDir, "scripts", "memory-path-search.js"));
+  };
+  const addRoot = (root) => {
+    if (!root) return;
+    addWebDir(path.join(root, "apps", "web"));
+    addWebDir(root);
+    addWebDir(path.join(root, ".next", "standalone", "apps", "web"));
+    addWebDir(path.join(root, "_up_", ".next", "standalone", "apps", "web"));
+  };
+
+  addFile(process.env.OPENLOOMI_MEMORY_PATH_SEARCH);
+
+  if (process.env.OPENLOOMI_CODEX_MEMORY_MCP) {
+    const mcpDir = path.dirname(
+      expandHome(process.env.OPENLOOMI_CODEX_MEMORY_MCP),
+    );
+    addFile(path.join(mcpDir, "memory-path-search.js"));
+    addFile(
+      path.join(
+        mcpDir,
+        "..",
+        "lib",
+        "ai",
+        "mcp",
+        "tools",
+        "memory-path-search.js",
+      ),
+    );
+  }
+
+  addRoot(expandHome(process.env.OPENLOOMI_REPO_DIR || ""));
+  addRoot(process.cwd());
+  addRoot(path.resolve(BRIDGE_DIR, "..", ".."));
+  addRoot(path.resolve(BRIDGE_DIR, "..", "..", ".."));
+
+  if (setup.ctlPath) {
+    let current = path.dirname(path.resolve(setup.ctlPath));
+    for (let index = 0; index < 8; index += 1) {
+      addRoot(current);
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+
+  return candidates;
+}
+
+function acquireRunLock() {
+  const lockPath = getRunLockPath();
+  const now = Date.now();
+  const lock = {
+    id: `${process.pid}-${now}-${Math.random().toString(36).slice(2)}`,
+    pid: process.pid,
+    startedAt: now,
+    command: "run",
+  };
+
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const existing = readRunLock(lockPath);
+
+    if (existing && !isRunLockStale(existing, now)) {
+      return {
+        acquired: false,
+        lockPath,
+        existing,
+      };
+    }
+
+    if (existing) {
+      removeRunLock(lockPath);
+    }
+
+    try {
+      writeFileSync(lockPath, JSON.stringify(lock), {
+        flag: "wx",
+        mode: 0o600,
+      });
+
+      return {
+        acquired: true,
+        lockPath,
+        lock,
+      };
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    acquired: false,
+    lockPath,
+    existing: readRunLock(lockPath),
+  };
+}
+
+function releaseRunLock(acquiredLock) {
+  if (!acquiredLock?.acquired) {
+    return;
+  }
+
+  const current = readRunLock(acquiredLock.lockPath);
+  if (current?.id === acquiredLock.lock.id) {
+    removeRunLock(acquiredLock.lockPath);
+  }
+}
+
+function getRunLockPath() {
+  return path.join(os.homedir(), ".openloomi", "codex-plugin-run.lock");
+}
+
+function readRunLock(lockPath) {
+  if (!isFile(lockPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileText(lockPath));
+  } catch {
+    return {
+      id: "unreadable",
+      startedAt: 0,
+      command: "run",
+    };
+  }
+}
+
+function isRunLockStale(lock, now = Date.now()) {
+  const startedAt = Number(lock?.startedAt || 0);
+  return !startedAt || now - startedAt > getRunLockTtlMs();
+}
+
+function getRunLockTtlMs() {
+  const configured = Number(process.env.OPENLOOMI_CODEX_BRIDGE_RUN_LOCK_TTL_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : RUN_LOCK_TTL_MS;
+}
+
+function removeRunLock(lockPath) {
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function summarizeRunLock(lock) {
+  if (!lock) {
+    return null;
+  }
+
+  const startedAt = Number(lock.startedAt || 0);
+  return {
+    pid: Number(lock.pid || 0) || null,
+    command: lock.command || "run",
+    ageMs: startedAt ? Math.max(0, Date.now() - startedAt) : null,
+    stale: isRunLockStale(lock),
+  };
+}
+
+function getOpenLoomiCtlChildEnv() {
+  // Do not synthesize OPENLOOMI_API_URL from the readiness probe. In v0.7.6,
+  // setting it selects the legacy HTTP compatibility path and bypasses the
+  // packaged CLI's direct native-agent runner.
+  //
+  // An explicit caller-provided OPENLOOMI_API_URL is already inherited by the
+  // child through process.env in runCommandWithInput.
+  return {};
 }
 
 async function initializeSession() {
@@ -4159,6 +4460,323 @@ async function setup(args) {
   });
 }
 
+async function run() {
+  const flags = parseFlags(process.argv.slice(3));
+  const prompt = await readStdin();
+
+  if (!hasValue(prompt)) {
+    writeJson(
+      {
+        ready: false,
+        nextAction: "provide_stdin_prompt",
+        reason: "PROMPT_REQUIRED",
+        message:
+          "Pass the task prompt over stdin. Do not place long prompts or secrets in command-line arguments.",
+      },
+      1,
+    );
+    return;
+  }
+
+  let setup = await buildSetupStatus();
+
+  if (!setup.ready) {
+    writeJson(
+      {
+        ...setup,
+        ran: false,
+        command: "run",
+        message:
+          "OpenLoomi is not ready for one-shot execution. Complete the reported nextAction first.",
+      },
+      1,
+    );
+    return;
+  }
+
+  const session = await ensureOpenLoomiSession();
+
+  if (!session.ready) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command: "run",
+        nextAction: session.nextAction,
+        reason: session.reason,
+        message: session.message,
+        session: session.session,
+      },
+      1,
+    );
+    return;
+  }
+
+  if (setup.sessionInitializationRequired) {
+    setup = await buildSetupStatus();
+
+    if (!setup.ready) {
+      writeJson(
+        {
+          ...setup,
+          ran: false,
+          command: "run",
+          message:
+            "OpenLoomi session is initialized, but setup is still not ready for one-shot execution.",
+        },
+        1,
+      );
+      return;
+    }
+  }
+
+  const permissionMode = getPermissionMode(flags.permissionMode);
+  const runLock = acquireRunLock();
+
+  if (!runLock.acquired) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command: "run",
+        nextAction: "return_without_bridge",
+        reason: "RECURSION_GUARD",
+        message:
+          "A loomi-bridge run is already active. Refusing nested OpenLoomi bridge invocation.",
+        lock: summarizeRunLock(runLock.existing),
+      },
+      1,
+    );
+    return;
+  }
+
+  let result;
+
+  try {
+    result = await runOpenLoomiOneShot({
+      ctlPath: setup.ctlPath,
+      permissionMode,
+      prompt,
+    });
+  } finally {
+    releaseRunLock(runLock);
+  }
+
+  if (result.exitCode !== 0) {
+    writeJson(
+      {
+        ready: false,
+        ran: true,
+        ...normalizeRunFailure(result),
+      },
+      1,
+    );
+    return;
+  }
+
+  writeJson({
+    ready: true,
+    ran: true,
+    nextAction: "done",
+    reason: "RUN_COMPLETE",
+    result: parseJsonOrText(result.stdout),
+    openloomi: {
+      exitCode: result.exitCode,
+      signal: result.signal,
+      stderrPresent: hasValue(result.stderr),
+    },
+  });
+}
+
+async function memorySearch(command = "memory-search") {
+  const flags = parseFlags(process.argv.slice(3));
+  const query = (await readStdin()).trim();
+
+  if (!hasValue(query)) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command,
+        nextAction: "provide_memory_query",
+        reason: "QUERY_REQUIRED",
+        message:
+          "Pass the memory query over stdin. Do not place memory content or secrets in command-line arguments.",
+      },
+      1,
+    );
+    return;
+  }
+
+  let setup = await buildSetupStatus();
+
+  if (!setup.ready) {
+    writeJson(
+      {
+        ...setup,
+        ran: false,
+        command,
+        message:
+          "OpenLoomi is not ready for native memory execution. Complete the reported nextAction first.",
+      },
+      1,
+    );
+    return;
+  }
+
+  const session = await ensureOpenLoomiSession();
+
+  if (!session.ready) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command,
+        nextAction: session.nextAction,
+        reason: session.reason,
+        message: session.message,
+        session: session.session,
+      },
+      1,
+    );
+    return;
+  }
+
+  if (setup.sessionInitializationRequired) {
+    setup = await buildSetupStatus();
+
+    if (!setup.ready) {
+      writeJson(
+        {
+          ...setup,
+          ran: false,
+          command,
+          message:
+            "OpenLoomi session is initialized, but setup is still not ready for native memory execution.",
+        },
+        1,
+      );
+      return;
+    }
+  }
+
+  const permissionMode = getPermissionMode(flags.permissionMode);
+  let memorySearchResult;
+
+  try {
+    memorySearchResult = await runBridgeMemorySearch(query, setup);
+  } catch (error) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command,
+        query,
+        nextAction: "inspect_memory_helper",
+        reason: "MEMORY_HELPER_UNAVAILABLE",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      1,
+    );
+    return;
+  }
+
+  const runLock = acquireRunLock();
+
+  if (!runLock.acquired) {
+    writeJson(
+      {
+        ready: false,
+        ran: false,
+        command,
+        nextAction: "return_without_bridge",
+        reason: "RECURSION_GUARD",
+        message:
+          "A loomi-bridge run is already active. Refusing nested OpenLoomi bridge invocation.",
+        lock: summarizeRunLock(runLock.existing),
+      },
+      1,
+    );
+    return;
+  }
+
+  let result;
+
+  try {
+    result = await runOpenLoomiOneShot({
+      ctlPath: setup.ctlPath,
+      permissionMode,
+      prompt: buildMemoryRuntimePrompt(query, memorySearchResult),
+    });
+  } finally {
+    releaseRunLock(runLock);
+  }
+
+  if (result.exitCode !== 0) {
+    writeJson(
+      {
+        ready: false,
+        ran: true,
+        command,
+        query,
+        ...normalizeRunFailure(result),
+      },
+      1,
+    );
+    return;
+  }
+
+  writeJson({
+    ready: true,
+    ran: true,
+    command,
+    nextAction: "done",
+    reason: "MEMORY_RUNTIME_COMPLETE",
+    query,
+    result: parseJsonOrText(result.stdout),
+    memorySearch: {
+      source: "bridge",
+      isError: memorySearchResult.isError,
+      contentLength: memorySearchResult.content.length,
+    },
+    openloomi: {
+      exitCode: result.exitCode,
+      signal: result.signal,
+      stderrPresent: hasValue(result.stderr),
+    },
+  });
+}
+
+function buildMemoryRuntimePrompt(query, memorySearchResult) {
+  const memoryContent = truncateMemoryContext(memorySearchResult.content);
+  return [
+    "You are inside the OpenLoomi native runtime for a memory recall/search request.",
+    "OpenLoomi bridge has already searched local memory using the read-only searchMemoryPath helper.",
+    "Answer only from the memory search result below and the user's request.",
+    "Do not call searchMemoryPath, /api/memory/search, /api/rag/search, /api/messages, /api/chat-insights, source-code search, shell commands, Codex plugins, OpenLoomi plugins, or loomi-bridge.",
+    "If the memory search result says there are no matches or the memory directory is missing, say that no relevant local memory was found.",
+    "Return only the final answer for the user request.",
+    "",
+    "<openloomi_memory_search_result>",
+    memoryContent,
+    "</openloomi_memory_search_result>",
+    "",
+    "User memory request:",
+    query,
+  ].join("\n");
+}
+
+function truncateMemoryContext(content) {
+  if (content.length <= MAX_MEMORY_CONTEXT_CHARS) {
+    return content;
+  }
+
+  return `${content.slice(
+    0,
+    MAX_MEMORY_CONTEXT_CHARS,
+  )}\n\n[OpenLoomi memory search result truncated to ${MAX_MEMORY_CONTEXT_CHARS} characters.]`;
+}
+
 function help() {
   writeJson({
     usage: "node scripts/loomi-bridge.mjs <command>",
@@ -5297,6 +5915,10 @@ async function main() {
       break;
     case "install-instructions":
       installInstructions();
+      break;
+    case "memory-recall":
+    case "memory-search":
+      await memorySearch(command);
       break;
     case "pet":
       await petCommand(process.argv.slice(3));

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -32,7 +32,6 @@ const SESSION_BOOTSTRAP_POLL_MS = 2000;
 const SESSION_API_TIMEOUT_MS = 5000;
 const API_PROBE_TIMEOUT_MS = 1000;
 const CONNECTOR_STATUS_TIMEOUT_MS = 2500;
-const MEMORY_SEARCH_TIMEOUT_MS = 10000;
 const MAX_COMMAND_OUTPUT = 4096;
 const RUN_LOCK_TTL_MS = RUN_TIMEOUT_MS + 60_000;
 const MAX_MEMORY_CONTEXT_CHARS = 20000;
@@ -154,7 +153,7 @@ const WORKFLOW_GUIDANCE = [
     readyRequired: true,
     bridgeCommand: "memory-search",
     taskPromptPrefix:
-      "Use the memory-search bridge command with the original user memory request as stdin. Do not call /api/rag/search, /api/messages, /api/chat-insights, source search, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge from the runtime.",
+      "Use the memory-search bridge command with the original user memory request as stdin. The OpenLoomi runtime must use its native searchMemoryPath memory tool when available. Do not call /api/memory/search, /api/rag/search, /api/messages, /api/chat-insights, source search, shell, skills, Codex plugins, OpenLoomi plugins, or loomi-bridge from the runtime.",
     nextActionsWhenBlocked: [
       "install_openloomi",
       "initialize_openloomi_session",
@@ -163,7 +162,7 @@ const WORKFLOW_GUIDANCE = [
     ],
     safety: [
       "Do not read or write OpenLoomi memory files directly from the Codex plugin.",
-      "Do not fall back to RAG, messages, chat-insights, source code search, or direct memory-file reads when memory-search returns no results.",
+      "Do not fall back to RAG, messages, chat-insights, source code search, or direct memory-file reads when the native memory runtime returns no results.",
       "Do not expose memory contents unless OpenLoomi runtime returns them for the requested task.",
     ],
   },

--- a/plugins/codex/skills/openloomi-memory/SKILL.md
+++ b/plugins/codex/skills/openloomi-memory/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: "Bash(node $SKILL_DIR/../../scripts/loomi-bridge.mjs *)"
 # OpenLoomi Memory
 
 Use this skill as a thin wrapper for OpenLoomi memory workflows. Do not read or
-write OpenLoomi memory files directly from Codex, and do not copy memory
-implementation details into this plugin.
+write OpenLoomi memory files directly from Codex, do not search source code for
+memory implementation details, and do not fall back to unrelated OpenLoomi APIs
+such as RAG, messages, or chat-insights.
 
 First, load workflow guidance:
 
@@ -26,15 +27,16 @@ If `ready: false`, follow the reported `nextAction`. Connector setup and
 guest/session initialization must happen through OpenLoomi-owned surfaces, not
 Codex chat.
 
-When `ready: true`, wrap the user request with the `taskPromptPrefix` returned
-by `workflow-guidance`, then pass that runtime-safe prompt over stdin to the
-bridge:
+When `ready: true`, pass the original user memory request over stdin to the
+bridge-owned memory search command:
 
 ```bash
-printf "%s" "<taskPromptPrefix>\n\nOriginal user request: <user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
+printf "%s" "<user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" memory-search
 ```
 
-Do not send wording that asks the inner runtime to invoke Codex plugins,
-OpenLoomi plugins, skills, shell commands, or `loomi-bridge`. Only show memory
-content when OpenLoomi runtime returns it for the requested task. Keep secrets
-and connector credentials out of prompts, argv, stdout, and stderr.
+If `memory-search` returns `MEMORY_NOT_FOUND`, report that OpenLoomi did not
+return a matching memory result. Do not retry through `/api/rag/search`,
+`/api/messages`, `/api/chat-insights`, source-code search, direct file reads, or
+the generic `run` command unless the user explicitly asks to debug internals.
+Only show memory content when OpenLoomi returns it for the requested task. Keep
+secrets and connector credentials out of prompts, argv, stdout, and stderr.

--- a/plugins/codex/skills/openloomi-memory/SKILL.md
+++ b/plugins/codex/skills/openloomi-memory/SKILL.md
@@ -28,15 +28,16 @@ guest/session initialization must happen through OpenLoomi-owned surfaces, not
 Codex chat.
 
 When `ready: true`, pass the original user memory request over stdin to the
-bridge-owned memory search command:
+bridge-owned native memory runtime command:
 
 ```bash
 printf "%s" "<user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" memory-search
 ```
 
-If `memory-search` returns `MEMORY_NOT_FOUND`, report that OpenLoomi did not
-return a matching memory result. Do not retry through `/api/rag/search`,
-`/api/messages`, `/api/chat-insights`, source-code search, direct file reads, or
-the generic `run` command unless the user explicitly asks to debug internals.
-Only show memory content when OpenLoomi returns it for the requested task. Keep
-secrets and connector credentials out of prompts, argv, stdout, and stderr.
+The `memory-search` bridge command runs OpenLoomi's native runtime and requires
+the runtime to use its native `searchMemoryPath` memory tool when available. Do
+not retry through `/api/memory/search`, `/api/rag/search`, `/api/messages`,
+`/api/chat-insights`, source-code search, direct file reads, or the generic
+`run` command unless the user explicitly asks to debug internals. Only show
+memory content when OpenLoomi returns it for the requested task. Keep secrets
+and connector credentials out of prompts, argv, stdout, and stderr.

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -103,12 +103,16 @@ passing the user task over stdin:
 printf "%s" "<user task>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
 ```
 
-For memory recall/search requests, use the dedicated memory command instead of
-the generic one-shot runner:
+For memory recall/search requests, use the dedicated native memory runtime
+command instead of the generic one-shot runner:
 
 ```bash
 printf "%s" "<user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" memory-search
 ```
+
+The memory command still runs through OpenLoomi-owned native runtime surfaces;
+it must rely on the runtime's native `searchMemoryPath` memory tool when
+available and must not call `/api/memory/search` or embedding/RAG routes.
 
 The bridge invokes `openloomi-ctl --one-shot --stdin --json --permission-mode
 deny` by default. Only pass `--permission-mode ask` or `--permission-mode allow`

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -96,6 +96,29 @@ Use the thin wrapper skills when the user specifically asks for loop, memory,
 connector readiness, or handoff workflows. The plugin must not copy OpenLoomi
 connector, memory, loop, scheduling, or handoff persistence logic into Codex.
 
+When `setup-status` returns `ready: true`, run a one-shot non-memory task by
+passing the user task over stdin:
+
+```bash
+printf "%s" "<user task>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" run
+```
+
+For memory recall/search requests, use the dedicated memory command instead of
+the generic one-shot runner:
+
+```bash
+printf "%s" "<user memory request>" | node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" memory-search
+```
+
+The bridge invokes `openloomi-ctl --one-shot --stdin --json --permission-mode
+deny` by default. Only pass `--permission-mode ask` or `--permission-mode allow`
+when the user explicitly asks for a different permission mode.
+
+If no token exists yet, `run` first attempts to initialize an OpenLoomi guest
+session through the local OpenLoomi API. If that cannot complete, follow the
+reported `SESSION_INITIALIZATION_REQUIRED` next action instead of asking for a
+login token in Codex chat.
+
 ---
 
 ## Launching the desktop app with the Codex runtime

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFile, execFileSync, spawnSync } from "node:child_process";
+import { execFile, execFileSync, spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import { join, dirname, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -79,25 +79,32 @@ function runOutcomeWithInput(args, env, input) {
   }
 }
 
-// Async counterpart: do NOT use this when an in-process server is
-// listening for the bridge to call into — execFileSync blocks the
-// Node event loop and starves the server.
-async function runOutcomeWithInputAsync(args, env, input) {
-  try {
-    const { stdout } = await execFileAsync("node", [BRIDGE, ...args], {
-      encoding: "utf8",
+function runOutcomeWithInputAsync(args, env = {}, input = "") {
+  return new Promise((resolve) => {
+    const child = spawn("node", [BRIDGE, ...args], {
       env: { ...process.env, ...env },
-      input,
       cwd: env.BRIDGE_TEST_CWD || process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
     });
-    return { code: 0, stdout, stderr: "" };
-  } catch (e) {
-    return {
-      code: e.status ?? 1,
-      stdout: String(e.stdout ?? ""),
-      stderr: String(e.stderr ?? ""),
-    };
-  }
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+    child.on("error", (error) => {
+      resolve({ code: 1, stdout, stderr: String(error) });
+    });
+    child.stdin.end(input);
+  });
 }
 
 function runJson(args, env) {
@@ -232,6 +239,7 @@ async function withLocalApiServer(handler, fn) {
         method: req.method,
         url: req.url,
         authorization: req.headers.authorization || null,
+        cookie: req.headers.cookie || null,
         json,
       };
       requests.push(request);
@@ -379,6 +387,8 @@ test("version returns bridge identity and command list", () => {
     "install-instructions",
     "initialize-session",
     "configure-ai-provider",
+    "memory-recall",
+    "memory-search",
     "workflow-guidance",
     "version",
     "help",
@@ -837,11 +847,7 @@ test("workflow-guidance lists the four openloomi workflows", () => {
 // -----------------------------------------------------------------------------
 
 test("workflow-guidance uses runtime-safe run prompts for agent workflows", () => {
-  for (const workflow of [
-    "openloomi-loop",
-    "openloomi-memory",
-    "openloomi-handoff",
-  ]) {
+  for (const workflow of ["openloomi-loop", "openloomi-handoff"]) {
     const j = runJson(["workflow-guidance", "--workflow", workflow]);
     const prefix = j.workflow?.taskPromptPrefix || "";
     assert.match(prefix, /already inside the OpenLoomi runtime/);
@@ -849,6 +855,194 @@ test("workflow-guidance uses runtime-safe run prompts for agent workflows", () =
     assert.match(prefix, /loomi-bridge/);
     assert.doesNotMatch(prefix, /^Use OpenLoomi .* workflow/);
   }
+});
+
+test("workflow-guidance routes memory workflow through memory-search", () => {
+  const j = runJson(["workflow-guidance", "--workflow", "openloomi-memory"]);
+  assert.equal(j.workflow?.bridgeCommand, "memory-search");
+  assert.match(j.workflow?.runCommand || "", /loomi-bridge memory-search/);
+  assert.match(
+    j.workflow?.taskPromptPrefix || "",
+    /memory-search bridge command/,
+  );
+  assert.match(j.workflow?.taskPromptPrefix || "", /\/api\/rag\/search/);
+  assert.ok(
+    j.workflow?.safety?.some((item) =>
+      item.includes("Do not fall back to RAG"),
+    ),
+    "memory workflow should forbid fallback API/source-search paths",
+  );
+});
+
+test("memory-search requires a stdin query", () => {
+  withFakeHome((env) => {
+    const r = runOutcomeWithInput(["memory-search"], env, "");
+    assert.equal(r.code, 1);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.ready, false);
+    assert.equal(j.ran, false);
+    assert.equal(j.reason, "QUERY_REQUIRED");
+    assert.equal(j.nextAction, "provide_memory_query");
+  });
+});
+
+test("memory-search posts to OpenLoomi memory API with local session cookie", async () => {
+  await withFakeHomeAsync(async (env) => {
+    const token = "fake-openloomi-memory-token";
+
+    await withLocalApiServer(
+      (req, res, request) => {
+        const url = req.url || "/";
+
+        if (url === "/" || url === "") {
+          writeJsonResponse(res, 200, { ok: true });
+          return;
+        }
+
+        if (url.startsWith("/api/native/providers")) {
+          writeJsonResponse(res, 200, {
+            defaultAgent: "codex",
+            agents: [{ type: "codex", name: "Codex CLI" }],
+          });
+          return;
+        }
+
+        if (url.startsWith("/api/auth/set-token")) {
+          assert.match(url, /token=fake-openloomi-memory-token/);
+          writeJsonResponse(
+            res,
+            200,
+            { ok: true },
+            {
+              "Set-Cookie": "authjs.session-token=fake-memory-session; Path=/",
+            },
+          );
+          return;
+        }
+
+        if (url.startsWith("/api/memory/search")) {
+          assert.equal(req.method, "POST");
+          assert.equal(
+            request.cookie,
+            "authjs.session-token=fake-memory-session",
+          );
+          assert.equal(request.json.query, "red hat test marker");
+          assert.deepEqual(request.json.sources, ["memory", "insights"]);
+          assert.equal(request.json.limit, 10);
+          writeJsonResponse(res, 200, {
+            query: request.json.query,
+            sources: request.json.sources,
+            count: 1,
+            warnings: [],
+            results: [
+              {
+                type: "memory",
+                id: "memory-1",
+                content: "red hat test marker result",
+                similarity: 1,
+                metadata: {},
+              },
+            ],
+          });
+          return;
+        }
+
+        writeJsonResponse(res, 404, { error: "not found" });
+      },
+      async ({ baseUrl, requests }) => {
+        const r = await runOutcomeWithInputAsync(
+          ["memory-search"],
+          {
+            ...env,
+            OPENLOOMI_BASE_URL: baseUrl,
+            OPENLOOMI_AUTH_TOKEN: token,
+          },
+          "red hat test marker",
+        );
+        assert.equal(r.code, 0);
+        const j = JSON.parse(r.stdout);
+        assert.equal(j.ready, true);
+        assert.equal(j.ran, true);
+        assert.equal(j.reason, "MEMORY_SEARCH_COMPLETE");
+        assert.equal(j.nextAction, "done");
+        assert.equal(j.result.count, 1);
+        assert.ok(
+          requests.some((request) =>
+            request.url.startsWith("/api/memory/search"),
+          ),
+          "memory-search should call /api/memory/search",
+        );
+      },
+    );
+  });
+});
+
+test("memory-search supports explicit source and limit options", async () => {
+  await withFakeHomeAsync(async (env) => {
+    await withLocalApiServer(
+      (req, res, request) => {
+        const url = req.url || "/";
+
+        if (url === "/" || url === "") {
+          writeJsonResponse(res, 200, { ok: true });
+          return;
+        }
+
+        if (url.startsWith("/api/native/providers")) {
+          writeJsonResponse(res, 200, {
+            defaultAgent: "codex",
+            agents: [{ type: "codex", name: "Codex CLI" }],
+          });
+          return;
+        }
+
+        if (url.startsWith("/api/auth/set-token")) {
+          writeJsonResponse(
+            res,
+            200,
+            { ok: true },
+            {
+              "Set-Cookie": "authjs.session-token=fake-memory-session; Path=/",
+            },
+          );
+          return;
+        }
+
+        if (url.startsWith("/api/memory/search")) {
+          assert.deepEqual(request.json.sources, ["memory"]);
+          assert.equal(request.json.limit, 3);
+          writeJsonResponse(res, 200, {
+            query: request.json.query,
+            sources: request.json.sources,
+            count: 0,
+            warnings: [],
+            results: [],
+          });
+          return;
+        }
+
+        writeJsonResponse(res, 404, { error: "not found" });
+      },
+      async ({ baseUrl }) => {
+        const r = await runOutcomeWithInputAsync(
+          ["memory-recall", "--sources", "memory,unknown", "--limit", "3"],
+          {
+            ...env,
+            OPENLOOMI_BASE_URL: baseUrl,
+            OPENLOOMI_AUTH_TOKEN: "fake-openloomi-memory-token",
+          },
+          "missing marker",
+        );
+        assert.equal(r.code, 0);
+        const j = JSON.parse(r.stdout);
+        assert.equal(j.command, "memory-recall");
+        assert.equal(j.reason, "MEMORY_NOT_FOUND");
+        assert.equal(j.nextAction, "memory_not_found");
+        assert.deepEqual(j.sources, ["memory"]);
+        assert.equal(j.limit, 3);
+      },
+    );
+  });
 });
 
 test("secrets contract: fake key value never appears in any subcommand output", () => {
@@ -870,6 +1064,8 @@ test("secrets contract: fake key value never appears in any subcommand output", 
       ["install-instructions"],
       ["workflow-guidance"],
       ["configure-ai-provider"],
+      ["memory-search"],
+      ["memory-recall"],
       ["help"],
     ]) {
       const r = runOutcome(sub, inputs);

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -886,76 +886,30 @@ test("memory-search requires a stdin query", () => {
   });
 });
 
-test("memory-search posts to OpenLoomi memory API with local session cookie", async () => {
+test("memory-search runs native runtime and avoids the memory HTTP API", async () => {
   await withFakeHomeAsync(async (env) => {
-    const token = "fake-openloomi-memory-token";
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
 
     await withLocalApiServer(
-      (req, res, request) => {
-        const url = req.url || "/";
-
-        if (url === "/" || url === "") {
-          writeJsonResponse(res, 200, { ok: true });
-          return;
-        }
-
-        if (url.startsWith("/api/native/providers")) {
-          writeJsonResponse(res, 200, {
-            defaultAgent: "codex",
-            agents: [{ type: "codex", name: "Codex CLI" }],
-          });
-          return;
-        }
-
-        if (url.startsWith("/api/auth/set-token")) {
-          assert.match(url, /token=fake-openloomi-memory-token/);
-          writeJsonResponse(
-            res,
-            200,
-            { ok: true },
-            {
-              "Set-Cookie": "authjs.session-token=fake-memory-session; Path=/",
-            },
-          );
-          return;
-        }
-
-        if (url.startsWith("/api/memory/search")) {
-          assert.equal(req.method, "POST");
-          assert.equal(
-            request.cookie,
-            "authjs.session-token=fake-memory-session",
-          );
-          assert.equal(request.json.query, "red hat test marker");
-          assert.deepEqual(request.json.sources, ["memory", "insights"]);
-          assert.equal(request.json.limit, 10);
-          writeJsonResponse(res, 200, {
-            query: request.json.query,
-            sources: request.json.sources,
-            count: 1,
-            warnings: [],
-            results: [
-              {
-                type: "memory",
-                id: "memory-1",
-                content: "red hat test marker result",
-                similarity: 1,
-                metadata: {},
-              },
-            ],
-          });
-          return;
-        }
-
-        writeJsonResponse(res, 404, { error: "not found" });
-      },
+      createReadySetupApiHandler({
+        aiPreferencePayload: {
+          settings: [],
+          systemDefaults: {},
+        },
+        nativeProviderPayload: {
+          defaultAgent: "codex",
+          agents: [{ type: "codex", name: "Codex CLI" }],
+        },
+      }),
       async ({ baseUrl, requests }) => {
         const r = await runOutcomeWithInputAsync(
           ["memory-search"],
           {
             ...env,
+            OPENLOOMI_CTL: ctl,
             OPENLOOMI_BASE_URL: baseUrl,
-            OPENLOOMI_AUTH_TOKEN: token,
+            OPENLOOMI_AGENT_PROVIDER: "codex",
           },
           "red hat test marker",
         );
@@ -963,83 +917,68 @@ test("memory-search posts to OpenLoomi memory API with local session cookie", as
         const j = JSON.parse(r.stdout);
         assert.equal(j.ready, true);
         assert.equal(j.ran, true);
-        assert.equal(j.reason, "MEMORY_SEARCH_COMPLETE");
+        assert.equal(j.reason, "MEMORY_RUNTIME_COMPLETE");
         assert.equal(j.nextAction, "done");
-        assert.equal(j.result.count, 1);
+        assert.equal(j.result.prompt.includes("searchMemoryPath"), true);
+        assert.equal(j.result.prompt.includes("red hat test marker"), true);
+        assert.equal(j.result.prompt.includes("/api/memory/search"), true);
+        assert.ok(Array.isArray(j.result.argv), "fake ctl must expose argv");
+        assert.deepEqual(j.result.argv.slice(0, 4), [
+          "--one-shot",
+          "--stdin",
+          "--json",
+          "--permission-mode",
+        ]);
         assert.ok(
-          requests.some((request) =>
+          !requests.some((request) =>
             request.url.startsWith("/api/memory/search"),
           ),
-          "memory-search should call /api/memory/search",
+          "memory-search must not call /api/memory/search",
         );
       },
     );
   });
 });
 
-test("memory-search supports explicit source and limit options", async () => {
+test("memory-recall alias uses native runtime instead of source/limit API options", async () => {
   await withFakeHomeAsync(async (env) => {
+    const ctl = writeFakeCtl(env.HOME);
+    writeFakeToken(env.HOME);
+
     await withLocalApiServer(
-      (req, res, request) => {
-        const url = req.url || "/";
-
-        if (url === "/" || url === "") {
-          writeJsonResponse(res, 200, { ok: true });
-          return;
-        }
-
-        if (url.startsWith("/api/native/providers")) {
-          writeJsonResponse(res, 200, {
-            defaultAgent: "codex",
-            agents: [{ type: "codex", name: "Codex CLI" }],
-          });
-          return;
-        }
-
-        if (url.startsWith("/api/auth/set-token")) {
-          writeJsonResponse(
-            res,
-            200,
-            { ok: true },
-            {
-              "Set-Cookie": "authjs.session-token=fake-memory-session; Path=/",
-            },
-          );
-          return;
-        }
-
-        if (url.startsWith("/api/memory/search")) {
-          assert.deepEqual(request.json.sources, ["memory"]);
-          assert.equal(request.json.limit, 3);
-          writeJsonResponse(res, 200, {
-            query: request.json.query,
-            sources: request.json.sources,
-            count: 0,
-            warnings: [],
-            results: [],
-          });
-          return;
-        }
-
-        writeJsonResponse(res, 404, { error: "not found" });
-      },
-      async ({ baseUrl }) => {
+      createReadySetupApiHandler({
+        aiPreferencePayload: {
+          settings: [],
+          systemDefaults: {},
+        },
+        nativeProviderPayload: {
+          defaultAgent: "codex",
+          agents: [{ type: "codex", name: "Codex CLI" }],
+        },
+      }),
+      async ({ baseUrl, requests }) => {
         const r = await runOutcomeWithInputAsync(
           ["memory-recall", "--sources", "memory,unknown", "--limit", "3"],
           {
             ...env,
+            OPENLOOMI_CTL: ctl,
             OPENLOOMI_BASE_URL: baseUrl,
-            OPENLOOMI_AUTH_TOKEN: "fake-openloomi-memory-token",
+            OPENLOOMI_AGENT_PROVIDER: "codex",
           },
           "missing marker",
         );
         assert.equal(r.code, 0);
         const j = JSON.parse(r.stdout);
         assert.equal(j.command, "memory-recall");
-        assert.equal(j.reason, "MEMORY_NOT_FOUND");
-        assert.equal(j.nextAction, "memory_not_found");
-        assert.deepEqual(j.sources, ["memory"]);
-        assert.equal(j.limit, 3);
+        assert.equal(j.reason, "MEMORY_RUNTIME_COMPLETE");
+        assert.equal(j.nextAction, "done");
+        assert.equal(j.result.prompt.includes("missing marker"), true);
+        assert.ok(
+          !requests.some((request) =>
+            request.url.startsWith("/api/memory/search"),
+          ),
+          "memory-recall must not call /api/memory/search",
+        );
       },
     );
   });

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -220,6 +220,48 @@ function writeFakeToken(home) {
   );
 }
 
+function writeFakeCtl(home) {
+  const nodeScript = join(home, "fake-openloomi-ctl.mjs");
+  writeFileSync(
+    nodeScript,
+    [
+      "if (process.argv.includes('--version')) {",
+      "  console.log('openloomi-ctl 9.9.9');",
+      "  process.exit(0);",
+      "}",
+      "let input = '';",
+      "process.stdin.setEncoding('utf8');",
+      "process.stdin.on('data', (chunk) => { input += chunk; });",
+      "process.stdin.on('end', () => {",
+      "  console.log(JSON.stringify({",
+      "    ok: true,",
+      "    env: { OPENLOOMI_API_URL: process.env.OPENLOOMI_API_URL || null },",
+      "    argv: process.argv.slice(2),",
+      "    prompt: input,",
+      "  }));",
+      "});",
+    ].join("\n"),
+  );
+
+  if (process.platform === "win32") {
+    const cmd = join(home, "openloomi-ctl.cmd");
+    writeFileSync(
+      cmd,
+      `@"${process.execPath}" "%~dp0fake-openloomi-ctl.mjs" %*\r\n`,
+    );
+    return cmd;
+  }
+
+  const shim = join(home, "openloomi-ctl");
+  const nodePath = process.execPath.replace(/'/g, "'\\''");
+  writeFileSync(
+    shim,
+    `#!/bin/sh\nexec '${nodePath}' "$(dirname "$0")/fake-openloomi-ctl.mjs" "$@"\n`,
+  );
+  chmodSync(shim, 0o755);
+  return shim;
+}
+
 async function withLocalApiServer(handler, fn) {
   const requests = [];
   const server = createServer((req, res) => {
@@ -781,13 +823,7 @@ test("setup-status aiProvider runtime check never reports key values", () => {
     // contract — anything that could carry an apiKey / token / secret
     // value is forbidden here.
     for (const provider of j.checks.aiProviderRuntime?.providers || []) {
-      for (const field of [
-        "value",
-        "apiKey",
-        "authToken",
-        "token",
-        "secret",
-      ]) {
+      for (const field of ["value", "apiKey", "authToken", "token", "secret"]) {
         assert.ok(
           !(field in provider) || provider[field] === "",
           `aiProviderRuntime.providers leaked a value via ${field}`,
@@ -890,6 +926,13 @@ test("memory-search runs native runtime and avoids the memory HTTP API", async (
   await withFakeHomeAsync(async (env) => {
     const ctl = writeFakeCtl(env.HOME);
     writeFakeToken(env.HOME);
+    const memoryDir = join(env.HOME, ".openloomi", "data", "memory", "notes");
+    mkdirSync(memoryDir, { recursive: true });
+    writeFileSync(
+      join(memoryDir, "red-hat.md"),
+      "The red hat test marker resolves to RED_HAT_FROM_LOCAL_MEMORY.\n",
+      "utf8",
+    );
 
     await withLocalApiServer(
       createReadySetupApiHandler({
@@ -913,15 +956,31 @@ test("memory-search runs native runtime and avoids the memory HTTP API", async (
           },
           "red hat test marker",
         );
-        assert.equal(r.code, 0);
+        assert.equal(r.code, 0, r.stderr || r.stdout);
         const j = JSON.parse(r.stdout);
         assert.equal(j.ready, true);
         assert.equal(j.ran, true);
         assert.equal(j.reason, "MEMORY_RUNTIME_COMPLETE");
         assert.equal(j.nextAction, "done");
-        assert.equal(j.result.prompt.includes("searchMemoryPath"), true);
+        assert.equal(j.memorySearch?.source, "bridge");
+        assert.equal(j.memorySearch?.isError, false);
+        assert.equal(
+          j.result.prompt.includes("OpenLoomi bridge has already searched"),
+          true,
+        );
+        assert.equal(j.result.prompt.includes("red-hat.md"), true);
+        assert.equal(
+          j.result.prompt.includes("RED_HAT_FROM_LOCAL_MEMORY"),
+          true,
+        );
         assert.equal(j.result.prompt.includes("red hat test marker"), true);
         assert.equal(j.result.prompt.includes("/api/memory/search"), true);
+        assert.equal(
+          j.result.prompt.includes(
+            "Use the OpenLoomi native memory tool searchMemoryPath",
+          ),
+          false,
+        );
         assert.ok(Array.isArray(j.result.argv), "fake ctl must expose argv");
         assert.deepEqual(j.result.argv.slice(0, 4), [
           "--one-shot",
@@ -967,12 +1026,17 @@ test("memory-recall alias uses native runtime instead of source/limit API option
           },
           "missing marker",
         );
-        assert.equal(r.code, 0);
+        assert.equal(r.code, 0, r.stderr || r.stdout);
         const j = JSON.parse(r.stdout);
         assert.equal(j.command, "memory-recall");
         assert.equal(j.reason, "MEMORY_RUNTIME_COMPLETE");
         assert.equal(j.nextAction, "done");
+        assert.equal(j.memorySearch?.source, "bridge");
         assert.equal(j.result.prompt.includes("missing marker"), true);
+        assert.equal(
+          j.result.prompt.includes("Memory directory does not exist"),
+          true,
+        );
         assert.ok(
           !requests.some((request) =>
             request.url.startsWith("/api/memory/search"),
@@ -1457,10 +1521,7 @@ test("set-codex-runtime-env --dry-run --persist plans the LaunchAgent install on
   assert.match(script, /<key>RunAtLoad<\/key>/);
   assert.match(script, /<true\/>/);
   assert.match(script, /<key>Label<\/key>/);
-  assert.match(
-    script,
-    /<string>com\.openloomi\.codex-runtime-env<\/string>/,
-  );
+  assert.match(script, /<string>com\.openloomi\.codex-runtime-env<\/string>/);
   assert.match(script, /<string>\/bin\/launchctl<\/string>/);
   assert.match(script, /<string>setenv<\/string>/);
   assert.match(script, /<string>OPENLOOMI_AGENT_PROVIDER<\/string>/);
@@ -1516,12 +1577,7 @@ test("set-codex-runtime-env escapes XML metacharacters in plist value", () => {
   // even though they would otherwise produce invalid XML.
   const j = withFakeHome((env) =>
     runJson(
-      [
-        "set-codex-runtime-env",
-        "codex&<weird>",
-        "--dry-run",
-        "--persist",
-      ],
+      ["set-codex-runtime-env", "codex&<weird>", "--dry-run", "--persist"],
       env,
     ),
   );
@@ -1534,9 +1590,7 @@ test("set-codex-runtime-env escapes XML metacharacters in plist value", () => {
 });
 
 test("codex-runtime-info reports persistence state for the host platform", () => {
-  const j = withFakeHome((env) =>
-    runJson(["codex-runtime-info"], env),
-  );
+  const j = withFakeHome((env) => runJson(["codex-runtime-info"], env));
   assert.ok(j.persistence, "expected persistence field on codex-runtime-info");
   // All three platform buckets should be present so callers can render a
   // cross-platform table without branching.


### PR DESCRIPTION
## Summary

This PR stabilizes OpenLoomi memory recall from the Codex plugin after rebasing onto the latest upstream `main`.

The issue addressed here is that Codex-side memory recall could fail or route through unstable fallback paths on Windows, even when OpenLoomi desktop memory files already existed locally. This change makes Codex memory recall use a deterministic bridge-side read path, then injects matched memory context into the native runtime prompt.

As a result, Codex can recall locally stored OpenLoomi memory without depending on `/api/memory/search`, RAG, chat insight fallback behavior, or MCP approval-dependent recall paths for the core memory search flow.

## Changed

- Added a reusable local memory path search helper for OpenLoomi memory files.
- Added Windows-compatible memory path handling for local Markdown memory search.
- Added Codex memory MCP configuration support for the native runtime path.
- Updated the Codex plugin bridge so `memory-search` and `memory-recall` perform read-only local memory lookup before invoking the native runtime.
- Injected matched local memory context into the native runtime prompt.
- Avoided `/api/memory/search`, RAG, raw message search, and chat insight fallback paths for this Codex plugin recall flow.
- Passed Codex runtime prompts through stdin to avoid Windows multiline argv truncation and quoting issues.
- Updated bridge and Codex agent tests for memory recall, source/runtime routing, and Windows path handling.
- Preserved upstream `main` behavior during conflict resolution, including the latest bridge version and setup/runtime changes.

## Scope and Boundaries

This PR is intentionally scoped to Codex plugin memory recall/search behavior.

It does not change:

- OpenLoomi desktop UI memory saving behavior.
- The canonical desktop memory persistence pipeline.
- Codex-side persistent memory write support.
- The broader RAG, embedding, message insight, or chat insight architecture.
- General native agent routing outside the memory recall/search flow.
- Codex command approval UX.
- MCP permission prompt behavior.

Codex can now read relevant local OpenLoomi memory through the plugin path. Creating or editing persistent memory from Codex remains outside the scope of this PR.

## Verification

The branch was verified after rebasing onto upstream `main`.

Commands run:

- `node --check plugins\codex\scripts\loomi-bridge.mjs`
- `node --check plugins\codex\tests\bridge.test.mjs`
- `pnpm exec prettier --check apps/web/tests/unit/codex-agent.test.ts plugins/codex/scripts/loomi-bridge.mjs plugins/codex/tests/bridge.test.mjs`
- `node --test plugins\codex\tests\bridge.test.mjs`
- `pnpm --dir apps/web exec vitest run tests/unit/codex-agent.test.ts`

Results:

- `plugins/codex/tests/bridge.test.mjs`: 41 passed
- `apps/web/tests/unit/codex-agent.test.ts`: 35 passed
- Prettier check passed
- Syntax checks passed

Manual validation confirmed that a locally saved OpenLoomi memory can be recalled through the Codex plugin bridge with `memorySearch.source = "bridge"`, without using the HTTP memory API fallback.

## Known Limitations

- Codex plugin memory recall is currently read-only.
- Local memory search is deterministic and file-based, but still keyword-oriented.
- Longer natural-language recall prompts may need better query normalization.
- Codex may still request approval for local bridge execution depending on the user’s Codex settings.
- Full packaged desktop end-to-end validation should still be repeated before release.

## Follow-up Direction

Recommended follow-up work:

- Add query cleaning and fallback matching for longer natural-language recall prompts.
- Reduce Codex approval friction for trusted OpenLoomi plugin bridge commands.
- Add Codex-side memory write support only if it aligns with the desktop app’s canonical persistence flow.
- Add packaged desktop E2E coverage for Codex plugin memory recall on Windows.
- Continue aligning Codex memory tooling with the Claude-side plugin behavior where the runtime contract is shared.