### PR TITLE
fix(cli): harden packaged native-agent one-shot runner

### DIFF
--- a/apps/web/lib/ai/native-agent/host.ts
+++ b/apps/web/lib/ai/native-agent/host.ts
@@ -1,13 +1,5 @@
 import { getAgentRegistry } from "@openloomi/ai/agent/registry";
 import type { NativeAgentHost } from "@openloomi/ai/agent/native-runner";
-
-import {
-  claudePlugin,
-  codexPlugin,
-  hermesPlugin,
-  openclawPlugin,
-  opencodePlugin,
-} from "@/lib/ai/extensions";
 import { getDocument, getDocumentChunks } from "@/lib/ai/rag/langchain-service";
 import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
 import {
@@ -17,22 +9,7 @@ import {
 import { readFile } from "@/lib/storage";
 import { detectSudoPasswordPrompt } from "./sudo";
 import { resolveNativeAgentProviderRequest } from "./provider-env";
-
-let providersRegistered = false;
-
-function registerNativeAgentProviders() {
-  if (providersRegistered) {
-    return;
-  }
-
-  const registry = getAgentRegistry();
-  registry.register(claudePlugin);
-  registry.register(codexPlugin);
-  registry.register(opencodePlugin);
-  registry.register(hermesPlugin);
-  registry.register(openclawPlugin);
-  providersRegistered = true;
-}
+import { registerNativeAgentProvider } from "./register-provider";
 
 /**
  * App-owned adapters for the package-level native agent runner.
@@ -43,7 +20,7 @@ function registerNativeAgentProviders() {
  */
 export const nativeAgentHost: NativeAgentHost = {
   registry: getAgentRegistry(),
-  registerProviders: registerNativeAgentProviders,
+  registerProvider: registerNativeAgentProvider,
   prepareRequest: (body) => resolveNativeAgentProviderRequest(body),
   getUserInsightSettings,
   getUserLlmProviderConfig,

--- a/apps/web/lib/ai/native-agent/register-provider.ts
+++ b/apps/web/lib/ai/native-agent/register-provider.ts
@@ -1,0 +1,75 @@
+import { getAgentRegistry } from "@openloomi/ai/agent/registry";
+import { NativeAgentRequestError } from "@openloomi/ai/agent/native-runner";
+import type { AgentPlugin } from "@openloomi/ai/agent/plugin";
+import type { AgentProvider } from "@openloomi/ai/agent/types";
+
+type ProviderLoader = () => Promise<AgentPlugin>;
+
+const PROVIDER_LOADERS: Record<string, ProviderLoader> = {
+  claude: async () => {
+    const { claudePlugin } = await import("@/lib/ai/extensions/agent/claude");
+    return claudePlugin;
+  },
+  codex: async () => {
+    const { codexPlugin } = await import("@/lib/ai/extensions/agent/codex");
+    return codexPlugin;
+  },
+  hermes: async () => {
+    const { hermesPlugin } = await import("@/lib/ai/extensions/agent/hermes");
+    return hermesPlugin;
+  },
+  openclaw: async () => {
+    const { openclawPlugin } =
+      await import("@/lib/ai/extensions/agent/openclaw");
+    return openclawPlugin;
+  },
+  opencode: async () => {
+    const { opencodePlugin } =
+      await import("@/lib/ai/extensions/agent/opencode");
+    return opencodePlugin;
+  },
+};
+
+const registrationPromises = new Map<string, Promise<void>>();
+
+/**
+ * Load and register exactly one native provider.
+ *
+ * Keeping each dynamic import pointed at the provider module (instead of the
+ * extensions barrel) is important: the packaged one-shot bundle must not
+ * initialize unrelated SDKs before provider selection.
+ */
+export async function registerNativeAgentProvider(provider: AgentProvider) {
+  const registry = getAgentRegistry();
+  if (registry.has(provider)) {
+    return;
+  }
+
+  const existing = registrationPromises.get(provider);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const loader = PROVIDER_LOADERS[provider];
+  if (!loader) {
+    throw new NativeAgentRequestError(
+      `Unsupported native agent provider: ${provider}.`,
+      500,
+    );
+  }
+
+  const registration = loader().then((plugin) => registry.register(plugin));
+
+  registrationPromises.set(provider, registration);
+  try {
+    await registration;
+  } finally {
+    // This map only deduplicates concurrent imports. The registry remains the
+    // source of truth, so an explicitly unregistered provider can be loaded
+    // again later and failed imports remain retryable.
+    if (registrationPromises.get(provider) === registration) {
+      registrationPromises.delete(provider);
+    }
+  }
+}

--- a/apps/web/lib/ai/provider-resolver.ts
+++ b/apps/web/lib/ai/provider-resolver.ts
@@ -281,9 +281,6 @@ class AgentRuntimeProvider implements LlmProvider {
   }
 
   async complete(request: LlmCompleteRequest): Promise<LlmCompleteResponse> {
-    // Ensure all runtimes are registered.
-    await nativeAgentHost.registerProviders?.();
-
     // Resolve the runtime's providerConfig + model from env (same source the
     // Loop tick uses, via `resolveNativeAgentProviderRequest`).
     const stub: NativeAgentRequest = {
@@ -291,9 +288,17 @@ class AgentRuntimeProvider implements LlmProvider {
       provider: this.options.runtime as AgentProvider,
     };
     const resolved = resolveNativeAgentProviderRequest(stub);
+    const provider = (resolved.provider ??
+      this.options.runtime) as AgentProvider;
+
+    if (nativeAgentHost.registerProvider) {
+      await nativeAgentHost.registerProvider(provider);
+    } else {
+      await nativeAgentHost.registerProviders?.();
+    }
 
     const config: AgentConfig = {
-      provider: (resolved.provider ?? this.options.runtime) as AgentProvider,
+      provider,
       model: request.model ?? resolved.modelConfig?.model,
       providerConfig: resolved.providerConfig,
       workDir: tmpdir(),

--- a/apps/web/scripts/build-native-agent-cli.js
+++ b/apps/web/scripts/build-native-agent-cli.js
@@ -3,44 +3,78 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(scriptPath);
 const webDir = path.resolve(__dirname, "..");
 const entry = path.join(webDir, "scripts", "native-agent-cli.ts");
 const outDir = path.join(webDir, "cli-bundle");
-const output = path.join(outDir, "native-agent-cli.cjs");
+const defaultOutput = path.join(outDir, "native-agent-cli.cjs");
+const importMetaUrlIdentifier = "__openloomiCjsImportMetaUrl";
 
-fs.mkdirSync(outDir, { recursive: true });
+const external = [
+  // Native modules stay external so they can be loaded from the packaged
+  // standalone node_modules directory with their platform-specific binaries.
+  "better-sqlite3",
+  "sqlite3",
+  "sqlite-vec",
+  "sqlite-vec-windows-x64",
+  "onnxruntime-node",
+  "zlib-sync",
+  "bun:sqlite",
+  "@photon-ai/imessage-kit",
+  "bufferutil",
+  "utf-8-validate",
+];
 
-console.log("[CLI] Bundling native-agent CLI runner...");
-await build({
-  entryPoints: [entry],
-  outfile: output,
-  bundle: true,
-  platform: "node",
-  format: "cjs",
-  target: "node22",
-  conditions: ["react-server", "node"],
-  tsconfig: path.join(webDir, "tsconfig.json"),
-  logLevel: "info",
-  sourcemap: false,
-  external: [
-    // Native modules stay external so they can be loaded from the packaged
-    // standalone node_modules directory with their platform-specific binaries.
-    "better-sqlite3",
-    "sqlite3",
-    "sqlite-vec",
-    "sqlite-vec-windows-x64",
-    "onnxruntime-node",
-    "zlib-sync",
-    "bun:sqlite",
-    "@photon-ai/imessage-kit",
-    "bufferutil",
-    "utf-8-validate",
-  ],
-});
+/**
+ * Build the standalone native-agent runner used by packaged openloomi-ctl.
+ *
+ * esbuild cannot preserve import.meta.url when lowering nested ESM packages to
+ * CommonJS: it otherwise emits an empty import_meta object. Several upstream
+ * dependencies, including the Claude Agent SDK, pass that URL to
+ * createRequire(). Replace every import.meta.url with the actual bundle URL so
+ * Node receives a valid absolute module location at runtime.
+ */
+export async function buildNativeAgentCli({
+  output = defaultOutput,
+  logLevel = "info",
+  quiet = false,
+} = {}) {
+  fs.mkdirSync(path.dirname(output), { recursive: true });
 
-if (!fs.existsSync(output)) {
-  throw new Error(`native-agent CLI bundle was not created at ${output}`);
+  if (!quiet) {
+    console.log("[CLI] Bundling native-agent CLI runner...");
+  }
+  await build({
+    entryPoints: [entry],
+    outfile: output,
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    target: "node22",
+    conditions: ["react-server", "node"],
+    tsconfig: path.join(webDir, "tsconfig.json"),
+    logLevel,
+    sourcemap: false,
+    banner: {
+      js: `const ${importMetaUrlIdentifier} = require("node:url").pathToFileURL(__filename).href;`,
+    },
+    define: {
+      "import.meta.url": importMetaUrlIdentifier,
+    },
+    external,
+  });
+
+  if (!fs.existsSync(output)) {
+    throw new Error(`native-agent CLI bundle was not created at ${output}`);
+  }
+
+  if (!quiet) {
+    console.log(`[CLI] Native-agent CLI runner bundled: ${output}`);
+  }
+  return output;
 }
 
-console.log(`[CLI] Native-agent CLI runner bundled: ${output}`);
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  await buildNativeAgentCli();
+}

--- a/apps/web/src-tauri/src/cli.rs
+++ b/apps/web/src-tauri/src/cli.rs
@@ -29,7 +29,6 @@ const DEFAULT_UPDATE_SPACE_BYTES: u64 = 512 * 1024 * 1024;
 const DEFAULT_ONE_SHOT_PLATFORM: &str = "cli";
 // One-shot agent runs can legitimately take a long time when tools/skills are involved.
 const ONE_SHOT_TIMEOUT_SECS: u64 = 1800;
-const ONE_SHOT_API_HEALTH_TIMEOUT_SECS: u64 = 2;
 // Test and CI callers can point the CLI at a non-default local API server.
 const OPENLOOMI_API_URL_ENV: &str = "OPENLOOMI_API_URL";
 // CI can provide auth without relying on the desktop token file.
@@ -846,9 +845,19 @@ async fn execute_one_shot_via_http(
     auth_token: &str,
 ) -> Result<OneShotStreamResult, CliError> {
     let base_url = one_shot_base_url();
-    // HTTP mode is now only a compatibility path for an already-running API.
-    // The CLI's primary path is the direct native-agent runner above.
-    ensure_one_shot_api_ready(&base_url).await?;
+    execute_one_shot_via_http_at(request_body, auth_token, &base_url).await
+}
+
+async fn execute_one_shot_via_http_at(
+    request_body: &OneShotAgentRequest<'_>,
+    auth_token: &str,
+    base_url: &str,
+) -> Result<OneShotStreamResult, CliError> {
+    // HTTP mode is only a compatibility path for an already-running API. Send
+    // the authenticated request directly instead of gating it on a separate
+    // unauthenticated GET probe: the probe can be redirected or rejected by
+    // middleware even when the real POST is healthy, and introduces a TOCTOU
+    // race between readiness and execution.
     let endpoint = format!("{}/api/native/agent", base_url.trim_end_matches('/'));
     let client = reqwest::Client::builder()
         .user_agent("openloomi-ctl")
@@ -1774,37 +1783,6 @@ fn one_shot_base_url() -> String {
         .unwrap_or_else(crate::constants::nextjs_url)
 }
 
-async fn ensure_one_shot_api_ready(base_url: &str) -> Result<(), CliError> {
-    if is_one_shot_api_ready(base_url).await {
-        return Ok(());
-    }
-
-    Err(CliError::new(
-        "service_unavailable",
-        format!(
-            "OpenLoomi agent API is not reachable at {}. Start OpenLoomi, set {} to a reachable API, or use the direct native-agent runner.",
-            base_url, OPENLOOMI_API_URL_ENV
-        ),
-    ))
-}
-
-async fn is_one_shot_api_ready(base_url: &str) -> bool {
-    let health_url = format!("{}/api/native/agent", base_url.trim_end_matches('/'));
-    let client = match reqwest::Client::builder()
-        .user_agent("openloomi-ctl")
-        .timeout(Duration::from_secs(ONE_SHOT_API_HEALTH_TIMEOUT_SECS))
-        .build()
-    {
-        Ok(client) => client,
-        Err(_) => return false,
-    };
-
-    match client.get(&health_url).send().await {
-        Ok(response) => matches!(response.status().as_u16(), 200 | 401 | 403 | 405),
-        Err(_) => false,
-    }
-}
-
 #[cfg(debug_assertions)]
 fn find_web_dir() -> Result<PathBuf, CliError> {
     // openloomi-ctl may be launched from the repo root, apps/web, or
@@ -2715,6 +2693,7 @@ Packaged desktop builds include openloomi-ctl in the app bundle resources.
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
 
     fn args(values: &[&str]) -> Vec<String> {
         std::iter::once("openloomi-ctl".to_string())
@@ -2871,6 +2850,68 @@ mod tests {
         assert!(!should_try_direct_one_shot_runner_for_env(None, Some("0")));
     }
 
+    #[tokio::test]
+    async fn http_fallback_posts_directly_with_saved_bearer_token() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_test_http_request(&mut stream);
+            request_tx.send(request).unwrap();
+
+            let body = concat!(
+                "data: {\"type\":\"session\",\"sessionId\":\"fallback-session\"}\n\n",
+                "data: {\"type\":\"text\",\"content\":\"HTTP_FALLBACK_OK\"}\n\n",
+                "data: {\"type\":\"done\"}\n\n",
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+            stream.flush().unwrap();
+        });
+
+        let options = OneShotArgs {
+            prompt: Some("fallback test".to_string()),
+            read_stdin: false,
+            json: true,
+            model: None,
+            provider: None,
+            platform: Some("cli-test".to_string()),
+            permission_mode: Some(OneShotPermissionMode::Deny),
+        };
+        let request_body = build_one_shot_agent_request(
+            "fallback test",
+            &options,
+            "cli-test",
+            "saved-token",
+            OneShotPermissionMode::Deny,
+        );
+
+        let result = execute_one_shot_via_http_at(
+            &request_body,
+            "saved-token",
+            &format!("http://{}", address),
+        )
+        .await
+        .unwrap();
+
+        server.join().unwrap();
+        let raw_request = request_rx.recv().unwrap();
+        let lowercase_request = raw_request.to_ascii_lowercase();
+        assert!(raw_request.starts_with("POST /api/native/agent HTTP/1.1"));
+        assert!(lowercase_request.contains("authorization: bearer saved-token"));
+        assert!(lowercase_request.contains("accept: text/event-stream"));
+        assert!(raw_request.contains("\"authToken\":\"saved-token\""));
+        assert_eq!(result.response, "HTTP_FALLBACK_OK");
+        assert_eq!(result.session_id.as_deref(), Some("fallback-session"));
+        assert_eq!(result.error, None);
+    }
+
     #[test]
     fn parses_dotenv_lines_without_losing_secret_padding() {
         assert_eq!(
@@ -2941,5 +2982,40 @@ mod tests {
         let result = parse_agent_sse(raw).unwrap();
         assert_eq!(result.event_count, 1);
         assert_eq!(result.error.as_deref(), Some("boom"));
+    }
+
+    fn read_test_http_request(stream: &mut std::net::TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 4096];
+
+        loop {
+            let read = stream.read(&mut chunk).unwrap();
+            if read == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..read]);
+
+            let Some(header_end) = bytes.windows(4).position(|part| part == b"\r\n\r\n") else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if bytes.len() >= header_end + 4 + content_length {
+                break;
+            }
+        }
+
+        String::from_utf8(bytes).unwrap()
     }
 }

--- a/apps/web/tests/unit/ai/provider-resolver.test.ts
+++ b/apps/web/tests/unit/ai/provider-resolver.test.ts
@@ -9,9 +9,13 @@ vi.mock("@/lib/ai/user-llm-api-settings", () => ({
 }));
 
 const registerProvidersMock = vi.fn();
+const registerProviderMock = vi.fn();
 
 vi.mock("@/lib/ai/native-agent/host", () => ({
-  nativeAgentHost: { registerProviders: registerProvidersMock },
+  nativeAgentHost: {
+    registerProvider: registerProviderMock,
+    registerProviders: registerProvidersMock,
+  },
 }));
 
 const resolveNativeAgentProviderRequestMock = vi.fn();
@@ -36,6 +40,8 @@ async function loadResolver() {
 describe("resolveLlmProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveNativeAgentProviderRequestMock.mockReset();
+    createAgentMock.mockReset();
     process.env = { ...ORIGINAL_ENV };
     process.env.OPENLOOMI_AGENT_PROVIDER = undefined;
   });
@@ -83,10 +89,15 @@ describe("resolveLlmProvider", () => {
   it("falls back to the agent runtime when no HTTP provider is configured", async () => {
     getUserLlmProviderConfigMock.mockResolvedValueOnce(undefined);
     process.env.OPENLOOMI_AGENT_PROVIDER = "codex";
-    resolveNativeAgentProviderRequestMock.mockReturnValueOnce({
+    resolveNativeAgentProviderRequestMock.mockReturnValue({
       provider: "codex",
       providerConfig: { codexPath: "codex" },
       modelConfig: { model: "gpt-5-codex" },
+    });
+    createAgentMock.mockReturnValue({
+      async *run() {
+        yield { type: "text", content: "CODEX_RUNTIME_OK" };
+      },
     });
     const resolve = await loadResolver();
     const provider = await resolve({
@@ -95,6 +106,23 @@ describe("resolveLlmProvider", () => {
     });
     expect(provider).toBeDefined();
     expect(provider?.flavor).toBe("agent_runtime");
+
+    const result = await provider?.complete({ userContent: "run codex" });
+
+    expect(registerProviderMock).toHaveBeenCalledOnce();
+    expect(registerProviderMock).toHaveBeenCalledWith("codex");
+    expect(registerProvidersMock).not.toHaveBeenCalled();
+    expect(createAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex",
+        model: "gpt-5-codex",
+        providerConfig: { codexPath: "codex" },
+      }),
+    );
+    expect(result).toMatchObject({
+      text: "CODEX_RUNTIME_OK",
+      model: "gpt-5-codex",
+    });
   });
 
   it("returns undefined when neither HTTP nor a non-claude agent runtime is configured", async () => {

--- a/apps/web/tests/unit/native-agent-cli-bundle.test.ts
+++ b/apps/web/tests/unit/native-agent-cli-bundle.test.ts
@@ -1,0 +1,166 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { buildNativeAgentCli } from "../../scripts/build-native-agent-cli.js";
+
+const webDir = fileURLToPath(new URL("../..", import.meta.url));
+const tempDirs: string[] = [];
+let bundlePath: string;
+
+beforeAll(async () => {
+  const bundleDir = await mkdtemp(join(webDir, ".native-agent-cli-test-"));
+  tempDirs.push(bundleDir);
+  bundlePath = join(bundleDir, "native-agent-cli.cjs");
+  await buildNativeAgentCli({
+    output: bundlePath,
+    logLevel: "silent",
+    quiet: true,
+  });
+}, 30_000);
+
+afterAll(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("packaged native-agent CLI bundle", () => {
+  it("does not contain createRequire calls backed by an empty import_meta URL", async () => {
+    const bundle = await readFile(bundlePath, "utf8");
+
+    expect(bundle).toContain("__openloomiCjsImportMetaUrl");
+    expect(bundle).toMatch(
+      /createRequire\)?\(__openloomiCjsImportMetaUrl\)|createRequire\)\(__openloomiCjsImportMetaUrl\)/,
+    );
+    expect(bundle).not.toMatch(
+      /createRequire\)?\(import_meta\d*\.url\)|createRequire\)\(import_meta\d*\.url\)/,
+    );
+  });
+
+  it("executes the built CJS bundle through Codex without an Anthropic key", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "openloomi-bundled-codex-"));
+    tempDirs.push(workDir);
+    await writeFile(
+      join(workDir, "exec"),
+      [
+        'console.log(JSON.stringify({ type: "thread.started", thread_id: "bundle-thread" }));',
+        'console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", id: "message-1", text: "PACKAGED_CODEX_OK" } }));',
+        'console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 2, output_tokens: 1 } }));',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const tokenPayload = Buffer.from(
+      JSON.stringify({
+        id: "bundle-test-user",
+        type: "regular",
+        exp: Math.floor(Date.now() / 1000) + 300,
+      }),
+      "utf8",
+    ).toString("base64url");
+    const input = {
+      prompt: "Reply PACKAGED_CODEX_OK only.",
+      authToken: `${tokenPayload}.test-signature`,
+      platform: "cli-test",
+      workDir,
+      useProvidedWorkDir: true,
+      cliPermissionMode: "deny",
+      skillsConfig: {
+        enabled: false,
+        userDirEnabled: false,
+        appDirEnabled: false,
+      },
+      mcpConfig: {
+        enabled: false,
+        userDirEnabled: false,
+        appDirEnabled: false,
+      },
+    };
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_OPTIONS: "--conditions=react-server",
+      OPENLOOMI_AGENT_PROVIDER: "codex",
+      OPENLOOMI_AGENT_CODEX_COMMAND: process.execPath,
+      OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK: "true",
+      DEPLOYMENT_MODE: "tauri",
+      IS_TAURI: "true",
+      TAURI_MODE: "1",
+      TAURI_DATA_DIR: join(workDir, "data"),
+      TAURI_DB_PATH: join(workDir, "data", "data.db"),
+    };
+    childEnv.ANTHROPIC_API_KEY = undefined;
+    childEnv.ANTHROPIC_AUTH_TOKEN = undefined;
+    childEnv.CLAUDE_CODE_OAUTH_TOKEN = undefined;
+
+    const result = await runProcess(
+      process.execPath,
+      [bundlePath],
+      `${JSON.stringify(input)}\n`,
+      { cwd: webDir, env: childEnv },
+    );
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain("createRequire");
+    const messages = result.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    expect(messages).toContainEqual({
+      kind: "result",
+      output: expect.objectContaining({
+        response: "PACKAGED_CODEX_OK",
+        session_id: "bundle-thread",
+        error: null,
+      }),
+    });
+  });
+});
+
+function runProcess(
+  command: string,
+  args: string[],
+  input: string,
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+) {
+  return new Promise<{
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+  }>((resolve, reject) => {
+    const child = spawn(command, args, {
+      ...options,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`native-agent bundle timed out: ${stderr}`));
+    }, 15_000);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(timeout);
+      resolve({ exitCode, stdout, stderr });
+    });
+    child.stdin.end(input);
+  });
+}

--- a/apps/web/tests/unit/native-agent-provider-registration.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-registration.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  claudeModuleLoads: 0,
+  register: vi.fn(),
+  has: vi.fn(() => false),
+}));
+
+vi.mock("@openloomi/ai/agent/registry", () => ({
+  getAgentRegistry: () => ({
+    has: state.has,
+    register: state.register,
+  }),
+}));
+
+const claudePlugin = {
+  metadata: {
+    type: "claude",
+    name: "Claude",
+    version: "test",
+    description: "test provider",
+    supportsPlan: true,
+    supportsStreaming: true,
+    supportsSandbox: true,
+  },
+  factory: vi.fn(),
+};
+
+vi.mock("@/lib/ai/extensions/agent/claude", () => {
+  state.claudeModuleLoads += 1;
+  return { claudePlugin };
+});
+
+const codexPlugin = {
+  metadata: {
+    type: "codex",
+    name: "Codex",
+    version: "test",
+    description: "test provider",
+    supportsPlan: true,
+    supportsStreaming: true,
+    supportsSandbox: true,
+  },
+  factory: vi.fn(),
+};
+
+vi.mock("@/lib/ai/extensions/agent/codex", () => ({ codexPlugin }));
+
+import { registerNativeAgentProvider } from "@/lib/ai/native-agent/register-provider";
+
+describe("native agent provider registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.claudeModuleLoads = 0;
+  });
+
+  it("loads and registers Codex without evaluating the Claude module", async () => {
+    await registerNativeAgentProvider("codex");
+
+    expect(state.claudeModuleLoads).toBe(0);
+    expect(state.register).toHaveBeenCalledOnce();
+    expect(state.register).toHaveBeenCalledWith(codexPlugin);
+
+    state.register.mockClear();
+    await registerNativeAgentProvider("claude");
+
+    expect(state.claudeModuleLoads).toBe(1);
+    expect(state.register).toHaveBeenCalledOnce();
+    expect(state.register).toHaveBeenCalledWith(claudePlugin);
+  });
+});

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -37,6 +37,37 @@ afterEach(async () => {
 });
 
 describe("native agent runner", () => {
+  it("normalizes the request before registering the selected provider", async () => {
+    const agent = new CapturingAgent();
+    const calls: string[] = [];
+    const host: NativeAgentHost = {
+      registry: createRegistry(agent),
+      prepareRequest: (body) => {
+        calls.push("prepare");
+        return { ...body, provider: "codex" };
+      },
+      registerProvider: (provider) => {
+        calls.push(`register:${provider}`);
+      },
+      getUserInsightSettings: async () => null,
+      logger: silentLogger,
+    };
+
+    const run = await runNativeAgentRequest(
+      { prompt: "use the configured runtime", provider: "claude" },
+      {
+        session: { user: { id: "user-1", type: "regular" } },
+        userId: "user-1",
+        abortController: new AbortController(),
+      },
+      host,
+    );
+    await collectMessages(run.generator);
+
+    expect(calls).toEqual(["prepare", "register:codex"]);
+    expect(agent.config).toMatchObject({ provider: "codex" });
+  });
+
   it("defaults to Claude when no env or request provider is configured", async () => {
     const agent = new CapturingAgent();
     const getUserLlmProviderConfig = vi.fn(async () => ({
@@ -214,7 +245,7 @@ describe("native agent runner", () => {
     tempDirs.push(workDir);
 
     const agent = new CapturingAgent();
-    const registerProviders = vi.fn();
+    const registerProvider = vi.fn();
     const getUserLlmProviderConfig = vi.fn(async () => ({
       apiKey: "saved-key",
       baseUrl: "https://llm.example.test",
@@ -222,7 +253,7 @@ describe("native agent runner", () => {
     }));
     const host: NativeAgentHost = {
       registry: createRegistry(agent),
-      registerProviders,
+      registerProvider,
       getUserInsightSettings: async () => ({
         aiSoulPrompt: "answer as the user's operator",
         language: "zh-CN",
@@ -262,7 +293,8 @@ describe("native agent runner", () => {
 
     const messages = await collectMessages(run.generator);
 
-    expect(registerProviders).toHaveBeenCalledTimes(1);
+    expect(registerProvider).toHaveBeenCalledOnce();
+    expect(registerProvider).toHaveBeenCalledWith("claude");
     expect(getUserLlmProviderConfig).toHaveBeenCalledWith({
       userId: "user-1",
       providerType: "anthropic_compatible",

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -135,6 +135,16 @@ export interface NativeAgentFocusedInsightData {
 
 export interface NativeAgentHost {
   registry?: AgentRegistry;
+  /**
+   * Register the provider selected after request normalization. Hosts should
+   * prefer this hook so optional provider SDKs can remain unloaded until they
+   * are actually requested.
+   */
+  registerProvider?: (provider: AgentProvider) => void | Promise<void>;
+  /**
+   * Legacy all-provider registration hook. Used only when registerProvider is
+   * not implemented by the host.
+   */
   registerProviders?: () => void | Promise<void>;
   prepareRequest?: (
     body: NativeAgentRequest,
@@ -173,8 +183,14 @@ export async function runNativeAgentRequest(
   context: NativeAgentRunnerContext,
   host: NativeAgentHost = {},
 ): Promise<NativeAgentRun> {
-  await host.registerProviders?.();
   const preparedBody = (await host.prepareRequest?.(body, context)) ?? body;
+  const provider = preparedBody.provider ?? "claude";
+
+  if (host.registerProvider) {
+    await host.registerProvider(provider);
+  } else {
+    await host.registerProviders?.();
+  }
 
   const finalPrompt = await buildNativeAgentPrompt(
     preparedBody,


### PR DESCRIPTION
## Why

The packaged `openloomi-ctl --one-shot` runner statically imported the native-agent extension barrel and registered every provider during startup.

As a result, selecting Codex still caused the bundled CommonJS runner to evaluate `@anthropic-ai/claude-agent-sdk` before provider selection. The Claude SDK calls `createRequire(import.meta.url)`, but esbuild lowered `import.meta` to an empty object in the CommonJS bundle. This caused `createRequire(undefined)` to throw before Codex execution started.

The HTTP compatibility fallback also performed a separate unauthenticated GET readiness probe before sending the real authenticated POST. That probe could fail even when the desktop agent endpoint was reachable.

## What changed

- Normalize the native-agent request before provider registration.
- Dynamically import and register only the selected provider.
- Keep the existing all-provider registration hook as a compatibility fallback.
- Inject a valid bundle URL for `import.meta.url` when building the CommonJS runner, allowing Claude and other ESM dependencies to initialize correctly when selected.
- Remove the separate HTTP readiness probe and send the authenticated agent POST directly.
- Add regression coverage that:
  - Builds and executes the real `native-agent-cli.cjs` bundle.
  - Runs Codex without Anthropic credentials.
  - Verifies the Codex path does not evaluate the Claude provider.
  - Verifies Claude can still be registered when selected.
  - Verifies the HTTP fallback sends the authenticated POST directly.

Fixes #374.
Fixes #377.