### PR TITLE
fix(codex): classify transient retry events so they no longer render as fatal Agent Execution Timeout cards (#385)

### DIFF
--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -1667,6 +1667,28 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 }
                 return updated;
               }, chatIdForMessages);
+            } else if (data.type === "retry") {
+              // Codex CLI 0.144+ emits non-terminal retry/transport-fallback
+              // notices as `retry` AgentMessages (e.g. "Reconnecting... 2/5
+              // (request timed out)"). These are transient status events
+              // from a still-running turn, not terminal assistant errors.
+              // Surface a brief info toast for visibility, but do NOT push a
+              // chat part — the loading indicator stays up, the turn keeps
+              // running, and the final `turn.completed` / agent message will
+              // follow normally. Pushing a part here would leave a duplicate
+              // Agent Execution Timeout card above the eventual successful
+              // reply (issue #385).
+              const retryMessage =
+                data.content || data.message || "Codex is reconnecting…";
+              const attempt =
+                typeof data.attempt === "number" &&
+                typeof data.maxAttempts === "number"
+                  ? ` (${data.attempt}/${data.maxAttempts})`
+                  : "";
+              toast({
+                type: "info",
+                description: `${retryMessage}${attempt}`,
+              });
             } else if (data.type === "error") {
               console.error("[NativeAgent] Error:", data.message);
               const errorMessage = data.message || "Unknown error";

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -301,6 +301,12 @@ export class CodexAgent extends BaseAgent {
             continue;
           }
           if (message.type === "error") {
+            // Transient Codex retry/transport-fallback notices are projected
+            // to `type: "retry"` by the parser, not `type: "error"`, so they
+            // intentionally skip this branch and fall through to the default
+            // yield. They must not flip `sawRuntimeError`, which would
+            // suppress the final `result` even when the run ultimately
+            // succeeds (issue #385).
             sawRuntimeError = true;
           }
           if (message.type === "tool_use") {

--- a/apps/web/lib/ai/extensions/agent/codex/parser.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/parser.ts
@@ -14,6 +14,11 @@ import type { AgentMessage } from "@openloomi/ai/agent/types";
  *   { "type": "item.completed",  "item": { …same payload, plus status… } }
  *   { "type": "turn.completed",  "usage": { "input_tokens": N, "cached_input_tokens": N, "output_tokens": N } }
  *   { "type": "error",           "message": "…" }
+ *
+ * Note: Codex CLI 0.144+ emits non-terminal retry/transport-fallback
+ * notices using the same top-level `error` shape. We classify the message
+ * text and surface those as `retry` AgentMessages instead of fatal
+ * `error` AgentMessages (issue #385).
  */
 export function parseCodexJsonLine(line: string): AgentMessage[] {
   const trimmed = line.trim();
@@ -82,10 +87,80 @@ export function convertCodexEvent(event: unknown): AgentMessage[] {
       readString(record.message) ||
       readString(record.error) ||
       "Codex CLI reported an error";
-    return [{ type: "error", message }];
+    return [classifyCodexErrorMessage(message)];
   }
 
   return [];
+}
+
+/**
+ * Codex CLI 0.144+ emits non-terminal retry/transport-fallback notices as
+ * top-level `{"type":"error",…}` events (e.g. `Reconnecting... 2/5 (request
+ * timed out)`, `stream disconnected - retrying sampling request (1/5 ...)`,
+ * `falling back to HTTP`). Treating these as fatal would surface Codex's
+ * in-flight transport recovery as red Agent Execution Timeout cards above
+ * the successful reply (issue #385). We classify the message text and only
+ * fall through to a fatal `error` AgentMessage when the message does not
+ * look like a transient transport-retry notice.
+ */
+function classifyCodexErrorMessage(message: string): AgentMessage {
+  const transient = classifyTransientCodexError(message);
+  if (transient.kind === "retry") {
+    const retry: AgentMessage = { type: "retry", content: message };
+    if (typeof transient.attempt === "number") {
+      retry.attempt = transient.attempt;
+    }
+    if (typeof transient.maxAttempts === "number") {
+      retry.maxAttempts = transient.maxAttempts;
+    }
+    return retry;
+  }
+  return { type: "error", message };
+}
+
+type TransientCodexErrorClassification =
+  | { kind: "retry"; attempt?: number; maxAttempts?: number }
+  | { kind: "fatal" };
+
+function classifyTransientCodexError(
+  message: string,
+): TransientCodexErrorClassification {
+  const text = message.toLowerCase();
+
+  // Recognised transient shapes (case-insensitive, punctuation-tolerant):
+  //   - "Reconnecting... 2/5 (request timed out)"
+  //   - "stream disconnected - retrying sampling request (1/5 ...)"
+  //   - "falling back to http" / "falling back to https"
+  //   - "retrying sampling request"
+  const reconnectMatch = text.match(/reconnecting[^()]*?(\d+)\s*\/\s*(\d+)/);
+  if (reconnectMatch) {
+    return {
+      kind: "retry",
+      attempt: Number.parseInt(reconnectMatch[1], 10),
+      maxAttempts: Number.parseInt(reconnectMatch[2], 10),
+    };
+  }
+
+  const samplingMatch = text.match(
+    /retrying sampling request[^\d]*?(\d+)\s*\/\s*(\d+)/,
+  );
+  if (samplingMatch) {
+    return {
+      kind: "retry",
+      attempt: Number.parseInt(samplingMatch[1], 10),
+      maxAttempts: Number.parseInt(samplingMatch[2], 10),
+    };
+  }
+
+  if (
+    text.includes("falling back to http") ||
+    text.includes("stream disconnected") ||
+    text.includes("retrying sampling request")
+  ) {
+    return { kind: "retry" };
+  }
+
+  return { kind: "fatal" };
 }
 
 function convertCodexItem(

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -374,6 +374,79 @@ describe("Codex parser", () => {
     ).toEqual([{ type: "error", message: "boom" }]);
   });
 
+  // Issue #385 — Codex CLI 0.144+ emits non-terminal retry/transport
+  // fallback notices using the same top-level `{"type":"error",…}` shape
+  // as fatal errors (e.g. "Reconnecting... 2/5 (request timed out)"). These
+  // must NOT be projected to a fatal `error` AgentMessage; they are
+  // transient status from a still-running turn and the chat UI surfaces
+  // them via a brief info toast only.
+  it("classifies 'Reconnecting... n/m' as a retry, not a fatal error", () => {
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "error",
+        message: "Reconnecting... 2/5 (request timed out)",
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "retry",
+        content: "Reconnecting... 2/5 (request timed out)",
+        attempt: 2,
+        maxAttempts: 5,
+      },
+    ]);
+  });
+
+  it("classifies 'stream disconnected - retrying sampling request (n/m)' as a retry", () => {
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "error",
+        message: "stream disconnected - retrying sampling request (3/5 ...)",
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "retry",
+        content: "stream disconnected - retrying sampling request (3/5 ...)",
+        attempt: 3,
+        maxAttempts: 5,
+      },
+    ]);
+  });
+
+  it("classifies 'falling back to HTTP' as a retry without attempt numbers", () => {
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "error",
+        message: "falling back to HTTP",
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "retry",
+        content: "falling back to HTTP",
+      },
+    ]);
+  });
+
+  it("keeps a fatal Codex exit-code error fatal even when it mentions a transient keyword", () => {
+    // A genuine terminal error (here, a non-zero CLI exit) must still
+    // surface as `type: "error"` so the chat UI can render exactly one
+    // terminal error card per the acceptance criteria of #385.
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "error",
+        message: "Codex CLI exited with code 7: connection refused",
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "error",
+        message: "Codex CLI exited with code 7: connection refused",
+      },
+    ]);
+  });
+
   it("ignores unknown event types without crashing", () => {
     expect(
       parseCodexJsonLine(JSON.stringify({ type: "future.event", x: 1 })),
@@ -589,6 +662,96 @@ setTimeout(() => process.stdout.write(payload.subarray(split)), 10);
         expect.objectContaining({ type: "text", content: "你好" }),
       ]),
     );
+  });
+
+  // Issue #385 — non-terminal Codex retry/transport-fallback events must
+  // not be projected to a fatal `error` AgentMessage and must not suppress
+  // the final success `result`. The chat UI relies on this invariant to
+  // avoid rendering duplicate Agent Execution Timeout cards above a
+  // successful reply.
+  it("treats Codex retry events as transient and still yields a success result", async () => {
+    const workDir = await createFakeCodexWorkDir(`
+require("node:fs").writeFileSync("args.json", JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
+// Non-terminal transport-fallback notices that used to be projected as
+// fatal error AgentMessages and rendered as duplicate Agent Execution
+// Timeout cards. The parser must classify them as retry and the agent
+// must keep the turn alive through to the successful reply.
+console.log(JSON.stringify({ type: "error", message: "Reconnecting... 2/5 (request timed out)" }));
+console.log(JSON.stringify({ type: "error", message: "Reconnecting... 3/5 (request timed out)" }));
+console.log(JSON.stringify({ type: "error", message: "stream disconnected - retrying sampling request (4/5 ...)" }));
+console.log(JSON.stringify({ type: "error", message: "falling back to HTTP" }));
+console.log(JSON.stringify({
+  type: "item.completed",
+  item: { type: "agent_message", id: "msg-1", text: "测试成功" }
+}));
+console.log(JSON.stringify({
+  type: "turn.completed",
+  usage: { input_tokens: 7, output_tokens: 3 }
+}));
+`);
+
+    const agent = new CodexAgent({
+      provider: "codex",
+      workDir,
+      providerConfig: { codexPath: process.execPath },
+    });
+
+    const messages = await collectMessages(agent.run("只回复：测试成功"));
+
+    // No fatal error was emitted — every transport-fallback line is a retry.
+    expect(
+      messages.find((message) => message.type === "error"),
+    ).toBeUndefined();
+
+    // The four retry notices survive as `retry` AgentMessages carrying
+    // attempt/maxAttempts where the original text encodes them.
+    const retries = messages.filter((message) => message.type === "retry");
+    expect(retries).toHaveLength(4);
+    expect(retries[0]).toMatchObject({
+      type: "retry",
+      content: "Reconnecting... 2/5 (request timed out)",
+      attempt: 2,
+      maxAttempts: 5,
+    });
+    expect(retries[1]).toMatchObject({
+      type: "retry",
+      content: "Reconnecting... 3/5 (request timed out)",
+      attempt: 3,
+      maxAttempts: 5,
+    });
+    expect(retries[2]).toMatchObject({
+      type: "retry",
+      content: "stream disconnected - retrying sampling request (4/5 ...)",
+      attempt: 4,
+      maxAttempts: 5,
+    });
+    // "falling back to HTTP" carries no attempt numbers.
+    expect(retries[3]).toMatchObject({
+      type: "retry",
+      content: "falling back to HTTP",
+    });
+    expect((retries[3] as { attempt?: number }).attempt).toBeUndefined();
+    expect(
+      (retries[3] as { maxAttempts?: number }).maxAttempts,
+    ).toBeUndefined();
+
+    // The successful reply still arrives exactly once.
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "测试成功" }),
+        expect.objectContaining({
+          type: "result",
+          content: "success",
+          usage: { inputTokens: 7, outputTokens: 3 },
+        }),
+      ]),
+    );
+    expect(
+      messages.filter((message) => message.type === "result"),
+    ).toHaveLength(1);
+
+    expect(messages.at(-1)?.type).toBe("done");
   });
 
   // Issue #356 — provider-timeout interruption must not leave in-flight tool


### PR DESCRIPTION
## Summary

Codex CLI 0.144+ emits non-terminal transport-recovery notices using the same top-level `{"type":"error",…}` shape as fatal errors — `Reconnecting... 2/5 (request timed out)`, `stream disconnected - retrying sampling request (n/m ...)`, `falling back to HTTP/HTTPS`. Each was being projected to a fatal `error` AgentMessage and rendered as a red **Agent Execution Timeout** card in the chat. When Codex later fell back to HTTPS and the turn completed, all the cards stayed above the successful reply.

This PR classifies those messages as transient `retry` AgentMessages at the parser, lets them flow through `CodexAgent` without tripping `sawRuntimeError`, and handles them in the chat reducer with a brief info toast instead of a persistent error part.

## Changes

- **`apps/web/lib/ai/extensions/agent/codex/parser.ts`** — new `classifyTransientCodexError` helper. When the message matches a recognised transient pattern, returns a `{ type: "retry", content, attempt?, maxAttempts? }` AgentMessage. Otherwise returns the existing fatal `error` AgentMessage. Recognised patterns: `Reconnecting... n/m (request timed out)`, `stream disconnected - retrying sampling request (n/m ...)`, `falling back to http/https`, bare `retrying sampling request`.
- **`apps/web/lib/ai/extensions/agent/codex/index.ts`** — comment-only change: clarifies that `sawRuntimeError` only matches `type === "error"`, so retries fall through to the default yield and do not suppress the final success `result`.
- **`apps/web/components/chat-context.tsx`** — new `data.type === "retry"` branch in the SSE `onUpdate` reducer. Emits an info toast (`Reconnecting... 2/5`) and returns without pushing a part. The chat loading indicator stays visible while Codex retries; the eventual `turn.completed` and `agent_message` arrive normally and are not preceded by duplicate error cards.

## Acceptance criteria

- [x] A Codex run that retries five times and then succeeds produces one assistant response and zero persistent timeout cards.
- [x] A Codex run that ultimately fails produces exactly one terminal error card (existing nonzero-exit path is unchanged).
- [x] Retry/fallback status is visible (info toast) while the turn is still running and disappears on terminal completion (toast auto-dismiss).
- [x] Regression test added: parser cases for the three transient patterns and one fatal-exit negative case, plus an end-to-end `CodexAgent` test that walks `retry` errors → `falling back to HTTP` → `agent_message` → `turn.completed` and asserts no `error` type, exactly one `result` with `content: "success"`, and the agent message text intact.

## Test plan

- [x] `pnpm --filter web test` — 36/36 codex-agent tests pass (5 new + 31 existing). The only suite-wide failure (`tests/unit/loop/cli-path.test.ts`) is a pre-existing environment issue on `main` (unrelated — verified via `git stash` baseline run).
- [x] `pnpm lint` — clean for `apps/web` (the warnings shown are in `apps/marketing` and pre-existing).
- [x] `pnpm tsc` — exit 0.
- [x] `pnpm format` — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)