### PR TITLE
fix(web/proxy)+refactor(codex): drop configure-ai-provider, use native runtime

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -69,6 +69,15 @@ export async function proxy(request: NextRequest) {
   if (pathname.startsWith("/api/brave-search")) return NextResponse.next();
   if (pathname.startsWith("/api/password-reset")) return NextResponse.next();
   if (pathname.startsWith("/api/ai")) return NextResponse.next();
+  // /api/native/* exposes provider/agent metadata used by the Codex /
+  // Claude Code bridges and by the desktop app's runtime readiness
+  // probes. The route handler returns configuration data only — no
+  // user data — so it's safe to let through without a session cookie.
+  // Whitelisting here prevents the bridge from receiving a misleading
+  // 401 AUTH_REQUIRED before any provider has been configured (the
+  // status response itself is what tells the bridge whether the AI
+  // provider is set up).
+  if (pathname.startsWith("/api/native")) return NextResponse.next();
   if (pathname.startsWith("/api/preferences")) return NextResponse.next();
   if (pathname.startsWith("/api/integrations")) return NextResponse.next();
   // /api/loop/* and /api/llm/usage/* are guest-bootstrapping APIs: their


### PR DESCRIPTION
## Problem

Two coupled issues:

1. **`/api/native/providers` returned 401 from the Codex bridge** — the proxy whitelist in `apps/web/proxy.ts` had no entry for `/api/native/*`, so the bridge's `getNativeProviderStatus()` and `probeLocalApiUrl()` probes fell through to the session-cookie check and got rejected with `AUTH_REQUIRED` before they could read the actual configured provider. The bridge reported "needs to configure AI provider" — but the truth was the request never reached the route handler.

2. **The bridge carried a parallel `configure-ai-provider` command + `getAiProviderStatus()` path** that probed `/api/auth/set-token` + `/api/preferences/ai` with the session cookie, just to discover what the desktop already knows and reports via `/api/native/providers`. This was duplicative work, expanded the secrets-contract surface, and confused troubleshooting.

## Fix

### 1. Whitelist `/api/native` in the proxy (`apps/web/proxy.ts:72-80`)

```ts
if (pathname.startsWith("/api/native")) return NextResponse.next();
```

The route handler returns configuration metadata only (agents[] + defaultAgent), no user data, so it's safe to bypass the session cookie check. Placed next to `/api/ai` to match the existing pattern.

### 2. Drop the duplicate provider path in the Codex plugin

- **Remove `configure-ai-provider`** from `COMMANDS`, every `nextActionsWhenBlocked` list, and the `main()` switch.
- **Remove** `getAiProviderStatus`, `requestAiProviderStatus`, `summarizeAiPreferencePayload`, `summarizeRuntimeAiProviderAttempt`, `getExecutionProviderStatus` — no more `/api/auth/set-token` + `/api/preferences/ai` calls from the bridge.
- **`buildSetupStatus` reads `nativeProviderStatus` directly**:
  - `executionProviderReady` ← `nativeProviderStatus.active`
  - `executionProviderSource` ← `"native_codex_runtime"` when active
  - drops `aiProviderConfigured`, `aiProviderStatus`, `aiProviderRuntime` from the protocol contract
- **`getReadinessDecision`** loses the `aiProvider` argument; ready/blocked logic keys off discovery, token, native runtime, API probe, connectors only.
- **Troubleshooting copy** — README's `AI_PROVIDER_REQUIRED` section becomes "native runtime not detected"; install skill drops its `open_openloomi_ai_provider_setup` next-action row.
- **Secrets contract** — install-skill reminder now states the bridge never reports provider readiness from `/api/preferences/ai`.

## Tests

- `bridge.test.mjs`: `version` test no longer expects `configure-ai-provider`; `setup-status` contract test drops `aiProviderConfigured`; the "active native Codex runtime as execution-ready" test is renamed (the contrast is gone).
- `tests/e2e/setup.md`: removes the "AI provider is configured" prerequisite and the `aiProviderConfigured` field from expected output.

## Commits

- `ac02a15a` — `fix(web/proxy): whitelist /api/native so bridges can read provider status`
- `61225e25` — `refactor(codex): drop configure-ai-provider — native runtime is source of truth`

## Stats

- `apps/web/proxy.ts`: +9 lines (whitelist + comment)
- `plugins/codex/`: +92/-636 (net −544 lines — parallel provider path was larger than the native status it collapsed into)

## Test plan

- [x] `git diff main apps/web/proxy.ts` shows only the new whitelist entry
- [ ] Codex bridge smoke: `node plugins/codex/scripts/loomi-bridge.mjs setup-status` returns `executionProviderReady: true` when the desktop's `/api/native/providers` advertises codex
- [ ] With `OPENLOOMI_AGENT_PROVIDER=codex` set in the GUI launchd session, the bridge's `verify` block passes against the `expectDefaultAgent: "codex"` assertion
- [ ] No AI provider set → `/api/native/providers` still returns `defaultAgent: "claude"` (no behavior change in the route handler itself)
- [ ] `bridge.test.mjs` passes: 45 tests including the renamed "active native Codex runtime as execution-ready" case

🤖 Generated with [Claude Code](https://claude.com/claude-code)