### PR TITLE
Fix/codex connectors sandbox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,23 @@ on:
     branches: [main]
 
 jobs:
+  connector-plugin-contract:
+    name: Connector plugin contract (Node.js ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 24]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Test connector client and MCP transport
+        run: node --test plugins/codex/tests/connectors.test.mjs
+
   pre-test:
     name: Lint, Format & Type Check
     runs-on: ubuntu-latest
@@ -22,7 +39,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -55,7 +72,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/apps/marketing/content/plugins/codex.mdx
+++ b/apps/marketing/content/plugins/codex.mdx
@@ -17,6 +17,7 @@ The Codex plugin turns **Codex CLI** into a coding shell for a local **OpenLoomi
 The Codex plugin is a **companion integration**, not a replacement for OpenLoomi Desktop. Codex provides the coding surface; OpenLoomi provides the runtime that the bridge calls into. The plugin ships:
 
 - a Node bridge (`scripts/loomi-bridge.mjs`) that exposes 13 commands
+- a narrow host-side stdio MCP server for native connector operations, so connector calls do not depend on sandboxed shell loopback
 - 8 workflow skills (`openloomi`, `openloomi-install`, `openloomi-loop`, `openloomi-memory`, `openloomi-connectors`, `openloomi-handoff`, `openloomi-api`, `openloomi-feature-guide`) plus `composio`
 - an opt-in Pet mirror that maps Codex lifecycle events onto the OpenLoomi Pet
 
@@ -509,7 +510,7 @@ The plugin ships these sub-skills under `plugins/codex/skills/`:
 | `openloomi`               | Main entry point — triggers on `OpenLoomi` / `Loomi` mention and dispatches to the right sub-skill.                                                   |
 | `openloomi-install`       | Walks install, first-use setup, AI provider setup, and `SESSION_INITIALIZATION_REQUIRED` recovery flows.                                              |
 | `openloomi-loop`          | Run attention-loop and follow-up workflows.                                                                                                           |
-| `openloomi-connectors`    | Check whether Slack, GitHub, Gmail, Calendar, and other sources are configured before acting. Reports status only.                                    |
+| `openloomi-connectors`    | Manage OpenLoomi's native 7 through host-side MCP tools; credentials and interactive authorization stay in Desktop.                                   |
 | `openloomi-memory`        | Search or write memory through OpenLoomi-owned runtime surfaces. Thin wrapper — does not implement memory storage.                                    |
 | `openloomi-handoff`       | Send the current Codex task to Loomi for follow-up. The Claude Code plugin exposes the same capability through `/openloomi:*` slash commands instead. |
 | `openloomi-api`           | OpenLoomi HTTP API reference (auth, chat, RAG, workspace, integrations, feedback). Triggered by API/backend questions.                                |

--- a/apps/marketing/content/plugins/codex.mdx
+++ b/apps/marketing/content/plugins/codex.mdx
@@ -17,7 +17,6 @@ The Codex plugin turns **Codex CLI** into a coding shell for a local **OpenLoomi
 The Codex plugin is a **companion integration**, not a replacement for OpenLoomi Desktop. Codex provides the coding surface; OpenLoomi provides the runtime that the bridge calls into. The plugin ships:
 
 - a Node bridge (`scripts/loomi-bridge.mjs`) that exposes 13 commands
-- a narrow host-side stdio MCP server for native connector operations, so connector calls do not depend on sandboxed shell loopback
 - 8 workflow skills (`openloomi`, `openloomi-install`, `openloomi-loop`, `openloomi-memory`, `openloomi-connectors`, `openloomi-handoff`, `openloomi-api`, `openloomi-feature-guide`) plus `composio`
 - an opt-in Pet mirror that maps Codex lifecycle events onto the OpenLoomi Pet
 
@@ -510,7 +509,7 @@ The plugin ships these sub-skills under `plugins/codex/skills/`:
 | `openloomi`               | Main entry point — triggers on `OpenLoomi` / `Loomi` mention and dispatches to the right sub-skill.                                                   |
 | `openloomi-install`       | Walks install, first-use setup, AI provider setup, and `SESSION_INITIALIZATION_REQUIRED` recovery flows.                                              |
 | `openloomi-loop`          | Run attention-loop and follow-up workflows.                                                                                                           |
-| `openloomi-connectors`    | Manage OpenLoomi's native 7 through host-side MCP tools; credentials and interactive authorization stay in Desktop.                                   |
+| `openloomi-connectors`    | Check whether Slack, GitHub, Gmail, Calendar, and other sources are configured before acting. Reports status only.                                    |
 | `openloomi-memory`        | Search or write memory through OpenLoomi-owned runtime surfaces. Thin wrapper — does not implement memory storage.                                    |
 | `openloomi-handoff`       | Send the current Codex task to Loomi for follow-up. The Claude Code plugin exposes the same capability through `/openloomi:*` slash commands instead. |
 | `openloomi-api`           | OpenLoomi HTTP API reference (auth, chat, RAG, workspace, integrations, feedback). Triggered by API/backend questions.                                |

--- a/apps/marketing/content/reference/agent-runtimes/codex.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/codex.mdx
@@ -66,9 +66,12 @@ Leave either value unset to use the corresponding Codex CLI configuration. `CODE
 
 Executable paths, profiles, models, sandbox modes, Git checks, and timeouts are server-owned configuration. Values supplied in native-agent request bodies are ignored, so a caller cannot switch the runtime or weaken its policy.
 
+Native connector operations use the plugin's narrow stdio MCP server. That server runs as a host-side plugin process and reaches the authenticated OpenLoomi Desktop API directly, so connector access does not require enabling network access for model-generated shell commands.
+
 ## Troubleshooting
 
 - **Executable not found:** run `codex --version` as the OpenLoomi service user, or set `OPENLOOMI_AGENT_CODEX_COMMAND` to the absolute executable path.
 - **Login or model error:** run the verification command above with the same `HOME`/`USERPROFILE` and `CODEX_HOME` used by OpenLoomi.
 - **Not inside a trusted directory:** keep `OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK=true` for non-repository work directories, or run tasks in a Git repository and set it to `false`.
+- **A connector shell command cannot reach the local API:** use the plugin's connector MCP tools. They run host-side and do not require opening the Codex shell sandbox. The CLI command remains a normal-terminal fallback.
 - **Run times out:** increase `OPENLOOMI_AGENT_CODEX_TIMEOUT_MS` and verify the selected model is reachable from the Codex CLI itself.

--- a/apps/web/app/api/contacts/route.ts
+++ b/apps/web/app/api/contacts/route.ts
@@ -1,12 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { auth } from "@/app/(auth)/auth";
+import { authenticateCloudRequest } from "@/lib/auth/cloud-auth";
 import { getUserContacts } from "@/lib/db/queries";
 
 export async function GET(request: NextRequest) {
   try {
-    const session = await auth();
+    const user = await authenticateCloudRequest(request);
 
-    if (!session?.user) {
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const page = Number.parseInt(searchParams.get("page") || "1", 10);
     const pageSize = Number.parseInt(searchParams.get("pageSize") || "10", 10);
 
-    const contacts = await getUserContacts(session.user.id);
+    const contacts = await getUserContacts(user.id);
 
     let resultContacts = contacts.map((c) => {
       const meta = c.contactMeta as Record<string, unknown> | null;

--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { auth } from "@/app/(auth)/auth";
+import { authenticateCloudRequest } from "@/lib/auth/cloud-auth";
 import { sendMessage } from "@/lib/bots/message-service";
 import type { SendMessageParams } from "@/lib/bots/message-service";
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
+    const user = await authenticateCloudRequest(request);
 
-    if (!session?.user) {
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -18,6 +18,7 @@ export async function POST(request: NextRequest) {
       recipients,
       message,
       messageHtml,
+      subject,
       cc,
       bcc,
       attachments,
@@ -55,6 +56,7 @@ export async function POST(request: NextRequest) {
       recipients,
       message,
       messageHtml,
+      subject,
       cc,
       bcc,
       attachments,
@@ -65,7 +67,7 @@ export async function POST(request: NextRequest) {
       params.withAppSuffix = withAppSuffix;
     }
 
-    const result = await sendMessage(params, session.user.id);
+    const result = await sendMessage(params, user.id);
 
     return NextResponse.json(result);
   } catch (error) {

--- a/apps/web/lib/bots/message-service.ts
+++ b/apps/web/lib/bots/message-service.ts
@@ -32,12 +32,12 @@ export interface SendMessageResult {
 /**
  * Unified message sending service
  * @param params Send parameters
- * @param userId User ID (optional, will be fetched from bot if not provided)
+ * @param userId Authenticated user ID used to enforce bot ownership
  * @returns Send result
  */
 export async function sendMessage(
   params: SendMessageParams,
-  userId?: string,
+  userId: string,
 ): Promise<SendMessageResult> {
   const {
     botId,

--- a/apps/web/lib/bots/send-reply.ts
+++ b/apps/web/lib/bots/send-reply.ts
@@ -117,7 +117,7 @@ export async function sendReplyByBotId({
   weixinContextToken,
 }: {
   id: string;
-  userId?: string;
+  userId: string;
   recipients: string[];
   cc?: string[];
   bcc?: string[];
@@ -129,7 +129,10 @@ export async function sendReplyByBotId({
   weixinContextToken?: string;
 }) {
   try {
-    const bot = await getBotWithAccountById({ id });
+    // Authenticated callers must never load or dispatch through another
+    // user's bot. Keeping this constraint in the query also makes a foreign
+    // bot indistinguishable from a missing bot to the caller.
+    const bot = await getBotWithAccountById({ id, userId });
     if (!bot) {
       throw new AppError(
         "bad_request:bot",
@@ -146,7 +149,7 @@ export async function sendReplyByBotId({
       };
     }
 
-    const ownerId = userId ?? bot.userId;
+    const ownerId = userId;
     const suffix = withAppSuffix ? " (By openloomi AI)" : "";
     const sentMessage = (message ?? "").trim() + suffix;
     const normalizedHtml =

--- a/apps/web/lib/db/queries.ts
+++ b/apps/web/lib/db/queries.ts
@@ -1671,14 +1671,19 @@ export async function getBotById({ id }: { id: string }) {
 }
 
 /**
- * Retrieve a single bot with its associated account by bot UUID
+ * Retrieve a single bot with its associated account by bot UUID.
+ * When userId is provided, ownership is enforced in the query so callers do
+ * not load another user's bot before performing an authenticated operation.
  * @param id Unique identifier of the bot
+ * @param userId Optional owner identifier used to scope the lookup
  * @returns BotWithAccount object if found, undefined otherwise
  */
 export async function getBotWithAccountById({
   id,
+  userId,
 }: {
   id: string;
+  userId?: string;
 }): Promise<BotWithAccount | undefined> {
   try {
     const [found] = await db
@@ -1691,7 +1696,11 @@ export async function getBotWithAccountById({
         integrationAccounts,
         eq(bot.platformAccountId, integrationAccounts.id),
       )
-      .where(eq(bot.id, id));
+      .where(
+        userId === undefined
+          ? eq(bot.id, id)
+          : and(eq(bot.id, id), eq(bot.userId, userId)),
+      );
 
     if (!found) {
       return undefined;

--- a/apps/web/src-tauri/src/node.rs
+++ b/apps/web/src-tauri/src/node.rs
@@ -1099,6 +1099,10 @@ pub fn try_start_nextjs(
         // across all API requests (module-level singletons are not shared across cluster workers).
         .env("WORKERS", "1")
         .env("PORT", "3414")
+        // The connector API carries a local bearer token. Keep the packaged
+        // Next.js server on loopback even if the host has LAN interfaces;
+        // the plugin's host-side MCP transport reaches it locally.
+        .env("HOSTNAME", "127.0.0.1")
         .env("IS_TAURI", "true")
         .env("TAURI_MODE", "1")
         .env("DEPLOYMENT_MODE", "tauri")

--- a/apps/web/tests/api/connectors-auth.route.test.ts
+++ b/apps/web/tests/api/connectors-auth.route.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const sessionMocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/app/(auth)/auth", () => sessionMocks);
+
+const dbMocks = vi.hoisted(() => ({
+  getUserById: vi.fn(),
+  getUserTypeForService: vi.fn(),
+  getUserContacts: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => dbMocks);
+
+const messageMocks = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/bots/message-service", () => messageMocks);
+
+import { GET as queryContacts } from "@/app/api/contacts/route";
+import { POST as sendMessage } from "@/app/api/messages/route";
+import { generateToken } from "@/lib/auth/remote-auth-utils";
+
+const AUTH_SECRET = "connector-route-test-secret";
+const originalAuthSecret = process.env.AUTH_SECRET;
+
+function bearerRequest(
+  url: string,
+  token: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) {
+  return new NextRequest(url, {
+    ...init,
+    headers: {
+      ...Object.fromEntries(new Headers(init?.headers).entries()),
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+describe("connector-facing API bearer authentication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUTH_SECRET = AUTH_SECRET;
+    sessionMocks.auth.mockResolvedValue(null);
+    dbMocks.getUserById.mockResolvedValue({
+      id: "user-from-bearer",
+      email: "ada@example.com",
+      name: "Ada",
+      avatarUrl: null,
+    });
+    dbMocks.getUserTypeForService.mockResolvedValue("regular");
+    dbMocks.getUserContacts.mockResolvedValue([]);
+    messageMocks.sendMessage.mockResolvedValue({ success: true });
+  });
+
+  afterAll(() => {
+    if (originalAuthSecret === undefined) {
+      Reflect.deleteProperty(process.env, "AUTH_SECRET");
+    } else {
+      process.env.AUTH_SECRET = originalAuthSecret;
+    }
+  });
+
+  test("queries contacts with a valid signed bearer token", async () => {
+    const token = generateToken("user-from-bearer", "ada@example.com");
+    const request = bearerRequest(
+      "http://localhost/api/contacts?name=Ada&page=1&pageSize=10",
+      token,
+    );
+
+    const response = await queryContacts(request);
+
+    expect(response.status).toBe(200);
+    expect(dbMocks.getUserById).toHaveBeenCalledWith("user-from-bearer");
+    expect(dbMocks.getUserTypeForService).toHaveBeenCalledWith(
+      "user-from-bearer",
+    );
+    expect(dbMocks.getUserContacts).toHaveBeenCalledWith("user-from-bearer");
+    expect(sessionMocks.auth).not.toHaveBeenCalled();
+  });
+
+  test("rejects a bearer token with a forged signature", async () => {
+    const token = generateToken("user-from-bearer", "ada@example.com");
+    const [payload] = token.split(".");
+    const request = bearerRequest(
+      "http://localhost/api/contacts",
+      `${payload}.forged-signature`,
+    );
+
+    const response = await queryContacts(request);
+
+    expect(response.status).toBe(401);
+    expect(dbMocks.getUserById).not.toHaveBeenCalled();
+    expect(dbMocks.getUserContacts).not.toHaveBeenCalled();
+    expect(sessionMocks.auth).not.toHaveBeenCalled();
+  });
+
+  test("rejects a valid bearer token when its database user is missing", async () => {
+    dbMocks.getUserById.mockResolvedValue(null);
+    const token = generateToken("missing-user", "missing@example.com");
+    const request = bearerRequest("http://localhost/api/contacts", token);
+
+    const response = await queryContacts(request);
+
+    expect(response.status).toBe(401);
+    expect(dbMocks.getUserById).toHaveBeenNthCalledWith(1, "missing-user");
+    expect(dbMocks.getUserById).toHaveBeenNthCalledWith(
+      2,
+      "cloud_missing-user",
+    );
+    expect(dbMocks.getUserContacts).not.toHaveBeenCalled();
+  });
+
+  test("rejects a contacts request without authentication", async () => {
+    const response = await queryContacts(
+      new NextRequest("http://localhost/api/contacts"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(sessionMocks.auth).toHaveBeenCalledOnce();
+    expect(dbMocks.getUserContacts).not.toHaveBeenCalled();
+  });
+
+  test("sends with a valid signed bearer token and preserves subject", async () => {
+    const token = generateToken("user-from-bearer", "ada@example.com");
+    const request = bearerRequest("http://localhost/api/messages", token, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-1",
+        recipients: ["ada@example.com"],
+        message: "Hello",
+        subject: "Greeting",
+      }),
+    });
+
+    const response = await sendMessage(request);
+
+    expect(response.status).toBe(200);
+    expect(messageMocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botId: "bot-1",
+        recipients: ["ada@example.com"],
+        message: "Hello",
+        subject: "Greeting",
+      }),
+      "user-from-bearer",
+    );
+  });
+
+  test("rejects an unauthenticated send before parsing or dispatching", async () => {
+    const response = await sendMessage(
+      new NextRequest("http://localhost/api/messages", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(sessionMocks.auth).toHaveBeenCalledOnce();
+    expect(messageMocks.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/api/messages-ownership.route.test.ts
+++ b/apps/web/tests/api/messages-ownership.route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const authMocks = vi.hoisted(() => ({
+  authenticateCloudRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/cloud-auth", () => authMocks);
+
+const dbMocks = vi.hoisted(() => ({
+  getBotWithAccountById: vi.fn(),
+  getContact: vi.fn(),
+  getContactsByName: vi.fn(),
+  getContactsBySearchTerm: vi.fn(),
+  getContactByIMessageIdentifier: vi.fn(),
+  updateIntegrationAccount: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => dbMocks);
+
+const credentialMocks = vi.hoisted(() => ({
+  getBotCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/bots/token", () => credentialMocks);
+
+const connectorMocks = vi.hoisted(() => ({
+  constructSlackAdapter: vi.fn(),
+  sendMessages: vi.fn(),
+  kill: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/integrations/slack", () => ({
+  SlackAdapter: class {
+    constructor(options: unknown) {
+      connectorMocks.constructSlackAdapter(options);
+    }
+
+    sendMessages = connectorMocks.sendMessages;
+    kill = connectorMocks.kill;
+  },
+}));
+
+vi.mock("@/lib/integrations/providers/file-ingester", () => ({
+  fileIngester: {},
+}));
+
+vi.mock("@/lib/integrations/telegram/client-registry", () => ({
+  telegramClientRegistry: {},
+}));
+
+import { POST } from "@/app/api/messages/route";
+
+describe("POST /api/messages bot ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.authenticateCloudRequest.mockResolvedValue({
+      id: "requesting-user",
+      email: "requester@example.com",
+    });
+
+    // Emulate an existing bot owned by somebody else. A correctly scoped
+    // lookup must not return it; an id-only lookup would continue to Slack.
+    dbMocks.getBotWithAccountById.mockImplementation(
+      async ({ userId }: { userId?: string }) =>
+        userId === "requesting-user"
+          ? undefined
+          : {
+              id: "foreign-bot",
+              userId: "other-user",
+              adapter: "slack",
+            },
+    );
+    dbMocks.getContact.mockResolvedValue({
+      botId: "foreign-bot",
+      contactId: "foreign-channel",
+    });
+    dbMocks.getContactsByName.mockResolvedValue([]);
+    dbMocks.getContactsBySearchTerm.mockResolvedValue([]);
+    credentialMocks.getBotCredentials.mockResolvedValue("foreign-secret");
+  });
+
+  test("rejects a cross-user bot without invoking its connector", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          botId: "foreign-bot",
+          recipients: ["Foreign channel"],
+          message: "This must not be sent",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "No valid account provided for the reply",
+    });
+    expect(dbMocks.getBotWithAccountById).toHaveBeenCalledWith({
+      id: "foreign-bot",
+      userId: "requesting-user",
+    });
+    expect(credentialMocks.getBotCredentials).not.toHaveBeenCalled();
+    expect(connectorMocks.constructSlackAdapter).not.toHaveBeenCalled();
+    expect(connectorMocks.sendMessages).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/plugins/claude/skills/openloomi-connectors/SKILL.md
+++ b/plugins/claude/skills/openloomi-connectors/SKILL.md
@@ -1,362 +1,88 @@
 ---
 name: openloomi-connectors
-description: "openloomi Connectors tools - manage platform integrations (OAuth connections, list accounts, check status). Triggers: connect platform, integration status, list accounts, disconnect. Pair with the composio skill to also list composio-linked accounts."
+description: "Manage OpenLoomi's native connector accounts: list platforms or accounts, check status, open a safe connection handoff, disconnect, query contacts, and send a reply. Trigger for native connector/account requests; pair with Composio only for Composio-managed apps."
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+# OpenLoomi Connectors
 
-# OpenLoomi Connectors Skill
+Use the bundled client for OpenLoomi's seven native connectors. It reads the
+local bearer token internally, performs a best-effort expected-response check
+before sending that token, and returns structured JSON.
 
-OpenLoomi Connectors provides access to 7 messaging and productivity platform integrations. It allows AI agents to manage OAuth connections, list connected accounts, check connection status, and disconnect platforms on behalf of the user.
+## Native platforms
 
-> **Pairing with the `composio` skill:** This skill covers openloomi's **native 7 integrations** listed below. For accounts connected through **Composio** (a broader 1000+ apps surface — e.g. X, LinkedIn, Notion, HubSpot, Linear, Jira, etc.), invoke the `composio` skill in parallel: use the `composio-cli` to list connections, or call `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with `action: "list"`. When the user asks "what am I connected to?" or "list my accounts", run both — `list-accounts` here **and** the composio connection listing — and present the union. Keep auth, OAuth, and disconnect flows native to each skill.
+| ID | Name | Aliases |
+| --- | --- | --- |
+| `telegram` | Telegram | `tg` |
+| `whatsapp` | WhatsApp | — |
+| `imessage` | iMessage | — |
+| `feishu` | Lark/Feishu | `lark`, `飞书` |
+| `dingtalk` | DingTalk | `钉钉` |
+| `qqbot` | QQ | `qq`, `qq_bot` |
+| `weixin` | WeChat | `wechat`, `微信`, `wechat_work`, `wecom`, `企业微信` |
 
----
+Slack, Gmail, Outlook, GitHub, Notion, Linear, and other non-native apps are
+handled by OpenLoomi Desktop or Composio. For an all-sources account audit,
+run `list-accounts` here and the Composio connection listing in parallel,
+then label and combine the results.
 
-## What is openloomi?
+## Security
 
-Most AI assistants function as workflow tools—users give commands, they execute tasks, with no persistent knowledge of who you are or what matters to you.
+- Never request, print, or put connector credentials or the OpenLoomi bearer
+  token in prompts or command arguments.
+- If the user pastes a real credential, do not repeat it and recommend
+  rotating it after redirecting setup to Desktop.
+- `connect` accepts only a native platform and returns a local OpenLoomi
+  Desktop handoff URL. The user completes credentials, QR, or OAuth there.
+- Get explicit approval for the exact account before disconnecting.
+- Get approval for the exact bot, recipients, and message before sending.
+- Use account `id` for disconnect and its separate `botId` for sending.
 
-**openloomi takes a fundamentally different approach: it operates as a proactive digital partner** that watches, learns, remembers, and acts on your behalf. The difference is architectural.
-
-### How It Works
-
-When users connect messaging platforms and integrations to openloomi, they sync with permission:
-- Raw messages and communications
-- Meetings and calendar events
-- Emails and tweets
-- Voice calls
-- Notes and captured ideas
-
-This aggregated data becomes "the single source of truth for openloomi's brain."
-
-### The Continuous Sync Loop
-
-openloomi runs a background agent on a continuous sync loop, actively gathering information from all connected sources. An agent without this loop can only respond based on stale context. With it, every conversation—and every moment—makes openloomi smarter and more aligned with you.
-
----
-
-## Supported Platforms (7)
-
-The CLI `list-platforms` returns these 7 platforms. Other connectable
-platforms (Slack, Discord, X, Gmail, Outlook, LinkedIn, Google Calendar,
-Google Drive, Google Docs, HubSpot, Notion, etc.) are managed via the
-desktop UI or the `composio` skill — see "Platform Connection Methods"
-below for details.
-
-| ID | Display Name | Aliases |
-|----|-------------|---------|
-| `telegram` | Telegram | tg |
-| `whatsapp` | WhatsApp | |
-| `imessage` | iMessage | |
-| `feishu` | Lark/Feishu | lark, 飞书 |
-| `dingtalk` | DingTalk | 钉钉 |
-| `qqbot` | QQ | qq, qq_bot |
-| `weixin` | WeChat | wechat, 微信, wechat_work, wecom, 企业微信 |
-
----
-
-## Authentication
-
-The CLI auto-reads your token from `~/.openloomi/token` (base64 encoded JWT).
-
-### Local API Access
-
-The local API server runs on port **3414** (fallback: **3515**). If 3414 is unavailable, try 3515.
-
----
-
-## API Endpoints
-
-### Integration Accounts
-
-#### GET `/api/integrations/accounts` - List Connected Accounts
-
-Returns all connected platform accounts for the authenticated user.
+## Commands
 
 ```bash
-curl http://localhost:3414/api/integrations/accounts \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "accounts": [
-    {
-      "id": "int_xxx",
-      "platform": "gmail",
-      "externalId": "user@gmail.com",
-      "displayName": "My Gmail",
-      "status": "active",
-      "metadata": {},
-      "createdAt": "2024-01-01T00:00:00Z",
-      "botId": "bot_xxx"
-    }
-  ]
-}
-```
-
-**Note:** Each account includes a `botId` field which is used for `send-reply` and other bot operations.
-
----
-
-### OAuth Start Endpoints
-
-#### GET `/api/integrations/slack/oauth/start?userId=<userId>` - Start Slack OAuth
-
-Returns the Slack OAuth authorization URL. The CLI opens this URL in the browser for the user to complete authorization.
-
-```bash
-curl "http://localhost:3414/api/integrations/slack/oauth/start?userId=<userId>"
-```
-
-**Response:**
-```json
-{
-  "authorizationUrl": "https://slack.com/oauth/v2/authorize?...",
-  "state": "userId:uuid"
-}
-```
-
-#### GET `/api/integrations/discord/oauth/start?userId=<userId>` - Start Discord OAuth
-
-Returns the Discord OAuth authorization URL.
-
-#### GET `/api/integrations/x/oauth/start?userId=<userId>` - Start X OAuth
-
-Returns the X/Twitter OAuth authorization URL.
-
----
-
-### OAuth Exchange Endpoints
-
-#### GET `/api/integrations/slack/oauth/exchange?code=<code>&state=<state>` - Exchange Slack Code
-
-Exchange OAuth code for Slack access.
-
-#### GET `/api/integrations/discord/oauth/exchange?code=<code>&state=<state>` - Exchange Discord Code
-
-Exchange OAuth code for Discord access.
-
----
-
-### OAuth Callbacks
-
-| Platform | Endpoint |
-|----------|----------|
-| Feishu | `POST /api/feishu/listener/init` |
-| DingTalk | `POST /api/dingtalk/listener/init` |
-| QQ Bot | `POST /api/qqbot/listener/init` |
-| WeChat | `POST /api/weixin/listener/init` |
-| Telegram | `POST /api/telegram/user-listener/init` |
-| WhatsApp | `POST /api/whatsapp/register-socket` |
-| iMessage | `POST /api/imessage/init-self-listener` |
-
----
-
-### DELETE `/api/integrations/:id` - Disconnect Account
-
-Delete a connected integration account.
-
-```bash
-curl -X DELETE http://localhost:3414/api/integrations/int_xxx \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "deletedAccountId": "int_xxx",
-  "deletedBotIds": ["bot_xxx"]
-}
-```
-
----
-
-### GET `/api/contacts` - Query Contacts
-
-Query user contacts with optional filtering and pagination.
-
-```bash
-curl "http://localhost:3414/api/contacts?name=John&page=1&pageSize=10" \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Parameters:**
-- `name` (string, optional) - Filter contacts by name (partial match)
-- `page` (number, default 1) - Page number
-- `pageSize` (number, default 10) - Items per page (max 100)
-
-**Response:**
-```json
-{
-  "success": true,
-  "contacts": [
-    {
-      "id": "contact_xxx",
-      "name": "John Doe",
-      "type": "email",
-      "botId": "bot_xxx",
-      "platform": "gmail"
-    }
-  ],
-  "pagination": {
-    "page": 1,
-    "pageSize": 10,
-    "totalCount": 50,
-    "totalPages": 5,
-    "hasMore": true,
-    "hasPrevious": false
-  }
-}
-```
-
----
-
-### POST `/api/messages` - Send Message
-
-Send a message via a connected platform bot.
-
-```bash
-curl -X POST http://localhost:3414/api/messages \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "botId": "bot_xxx",
-    "recipients": ["John"],
-    "message": "Hello!",
-    "subject": "Optional subject"
-  }'
-```
-
-**Parameters:**
-- `botId` (string, required) - The bot ID to send from
-- `recipients` (array, required) - List of recipient names
-- `message` (string, required) - Message content
-- `subject` (string, optional) - Email subject line
-- `cc` (array, optional) - CC recipients
-- `bcc` (array, optional) - BCC recipients
-
-**Note:** `botId` is returned by `list-accounts` in the `botId` field (different from account `id`).
-
----
-
-## Platform Aliases Reference
-
-Aliases are case-insensitive and support both English and Chinese:
-
-| Alias | Platform |
-|-------|----------|
-| `tg` | telegram |
-| `wechat`, `微信` | weixin |
-| `lark`, `飞书` | feishu |
-| `钉钉` | dingtalk |
-| `qq`, `qq_bot` | qqbot |
-
----
-
-## Desktop UI
-
-Users can also authorize accounts directly through the openloomi desktop application without using CLI commands.
-
-### Adding Account Authorization via Desktop UI
-
-1. **Open openloomi desktop app** on your computer
-2. **Navigate to Settings** (gear icon in the sidebar or top-right menu)
-3. **Go to Integrations** tab/section
-4. **Click on the platform** you want to connect (e.g., Telegram, Slack, Discord, Gmail, etc.)
-5. **Follow the platform-specific authorization flow:**
-   - **OAuth platforms** (Slack, Discord, X/Twitter): Click "Connect" → you'll be redirected to the platform's authorization page in your browser → Approve the permissions → you'll be redirected back
-   - **App Password platforms** (Gmail, Outlook): Enter your email and app password
-   - **App Credentials platforms** (DingTalk, Feishu, QQ): Enter your appId and appSecret
-   - **QR/Interactive platforms** (WhatsApp, Telegram, iMessage): Scan the QR code or follow the in-app instructions
-
-6. **Verify connection** — once authorized, the platform will show as "Connected" with a green checkmark
-
-### Managing Connected Accounts
-
-- **List connected accounts**: Settings → Integrations → shows all connected platforms with status
-- **Disconnect account**: Settings → Integrations → click on connected platform → "Disconnect" or remove
-- **Check status**: Connected platforms show green "Active" badge; expired/disconnected shows red "Inactive" badge
-
----
-
-## CLI Script
-
-### Quick Start
-
-```bash
-# List all supported platforms
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-platforms
-
-# List all connected accounts (includes botId for send-reply)
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-
-# Cross-source audit: openloomi-native + composio-linked accounts (run together, present union)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-# In parallel, invoke the `composio` skill (e.g. `composio list-connections` via composio-cli,
-# or `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with action: "list")
-
-# Check connection status for a platform
 node $SKILL_DIR/scripts/openloomi-connectors.cjs status telegram
-
-# Connect a platform (opens browser for OAuth)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs connect slack
-
-# Disconnect an account by ID
-node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx
-
-# Query contacts
+node $SKILL_DIR/scripts/openloomi-connectors.cjs connect telegram
+node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx --confirmed=true
 node $SKILL_DIR/scripts/openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-
-# Send a message (requires botId from list-accounts)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
+node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello" --confirmed=true
 ```
 
-### Commands
+Never add `--password`, `--clientSecret`, `--appSecret`, or `--token`
+to `connect`; secret-bearing options are rejected by design.
 
-| Command | Description |
-|---------|-------------|
-| `list-platforms` | List all 7 supported platforms with IDs and aliases |
-| `list-accounts` | List all connected integration accounts (includes `botId`) |
-| `status <platform>` | Check if a platform is connected (e.g., telegram, slack) |
-| `connect <platform> [options]` | Connect a platform (OAuth, App Password, or App Credentials) |
-| `disconnect <accountId>` | Disconnect a specific account by ID |
-| `query-contacts [options]` | Query contacts (--name=, --page=, --pageSize=) |
-| `send-reply --botId= --recipients= --message=` | Send a message via REST API |
+The client honors `OPENLOOMI_API_URL` or `OPENLOOMI_BASE_URL` when set to
+an explicit loopback origin. Otherwise it probes ports 3414 and 3515.
 
-### Platform Connection Methods
+## Workflow
 
-| Method | Platforms |
-|--------|-----------|
-| OAuth (auto-opens browser) | `slack`, `discord`, `x` |
-| App Password | `gmail --email=x --password=xxxx`, `outlook --email=x --password=xxxx` |
-| App Credentials | `dingtalk --clientId=x --clientSecret=x`, `feishu --appId=x --appSecret=x`, `qq --appId=x --appSecret=x` |
-| iLink Token | `wechat --token=x` |
-| Browser Required (QR/interactive) | `whatsapp`, `telegram`, `imessage` |
+- Use `list-accounts` for “what am I connected to?”
+- Use `status <platform>` only for a native ID or alias.
+- Use `connect <platform>`, return its `handoffUrl`, and verify with
+  `status` after the user completes the Desktop flow.
+- If only a platform is given for disconnect, list matching accounts and ask
+  which exact account ID to remove.
+- Query contacts before sending when the recipient is ambiguous; pass exact
+  returned contact `name` values as recipients.
+- Call a platform connected only when it has at least one `active` account.
+  Expired accounts may still be listed but are not connected.
+- Treat an empty, successful account list as empty. Never translate a
+  transport or authentication failure into “disconnected.”
 
----
+## Structured failures
 
-## AI Agent Workflow
+| Code | Response |
+| --- | --- |
+| `AUTH_TOKEN_MISSING`, `AUTH_TOKEN_INVALID`, `AUTH_FAILED` | Ask the user to sign in again in OpenLoomi Desktop. |
+| `LOCAL_API_UNREACHABLE` | Ask the user to start/restart OpenLoomi Desktop; do not claim connector state. |
+| `SANDBOX_BLOCKED` | Report that loopback was blocked in this execution environment; use a host-side connector tool if one is available. |
+| `REQUEST_OUTCOME_UNKNOWN` | A mutation may have arrived and was not retried. Verify state before retrying. |
+| `API_OPERATION_FAILED` | OpenLoomi rejected the requested mutation. Report failure; do not claim it completed. |
+| `INVALID_API_RESPONSE`, `API_HTTP_ERROR` | Report the safe code/message without printing token or raw secrets. |
 
-**Triggered when the user asks about:**
-
-1. Connecting a platform - "connect telegram", "link my slack"
-2. Listing integrations - "show my connected accounts", "what platforms am I connected to"
-3. Checking status - "is my github connected?", "telegram status"
-4. Disconnecting - "disconnect my discord", "remove whatsapp"
-5. Querying contacts - "show my contacts", "find John in contacts"
-6. Sending messages - "send email to John", "reply to that message"
-7. Cross-source account audit - "show everything I'm connected to (openloomi + composio)", "list all linked accounts across both" → run `list-accounts` here **and** the `composio` skill in parallel, then present the union
-
-**Execution Flow:**
-
-1. **Identify intent** - connect / list / status / disconnect / query-contacts / send-reply
-2. **Resolve platform** - use alias normalization (e.g., `gh` -> `github`)
-3. **Execute command** - use Bash tool
-4. **Format output** - report results naturally in user's language
-
-**Note on send-reply:** The `botId` is returned by `list-accounts` in the `botId` field.
+This client can verify an unknown disconnect through a fresh account listing.
+It cannot query message delivery history, so verify an unknown send in
+OpenLoomi Desktop or the target conversation before retrying.

--- a/plugins/claude/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
+++ b/plugins/claude/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
@@ -1,555 +1,707 @@
 #!/usr/bin/env node
-const http = require('node:http');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
-const { execSync } = require('node:child_process');
+"use strict";
 
-const PORTS = [3414, 3515, 3415]; // dev, local fallback, prod
-const TOKEN_PATH = path.join(os.homedir(), '.openloomi', 'token');
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
 
-// Platform definitions matching connector-target.ts
-// Platforms listed here must be enabled in `platform-connectability.ts`
-// (`isIntegrationPlatformConnectable`). COMING_SOON / HIDDEN platforms
-// (e.g. github, instagram, facebook_messenger, teams, asana, jira, linear,
-// google_meet) are intentionally omitted — they cannot start a new
-// connection from the connector UI.
-// `outlook_calendar` is gated behind NEXT_PUBLIC_OUTLOOK_CALENDAR_ENABLED.
+const DEFAULT_BASE_URLS = ["http://127.0.0.1:3414", "http://127.0.0.1:3515"];
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const SAFE_PRECONNECT_ERRORS = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "ETIMEDOUT",
+]);
+
+// Keep this list aligned with the platforms that the Desktop connector UI can
+// start today. Connection setup itself intentionally remains in Desktop so an
+// agent never receives connector credentials or QR/login challenges.
 const PLATFORMS = [
-  { id: 'telegram', name: 'Telegram', aliases: ['tg'] },
-  { id: 'whatsapp', name: 'WhatsApp', aliases: [] },
-  { id: 'imessage', name: 'iMessage', aliases: [] },
-  { id: 'feishu', name: 'Lark/Feishu', aliases: ['lark', '飞书'] },
-  { id: 'dingtalk', name: 'DingTalk', aliases: ['钉钉'] },
-  { id: 'qqbot', name: 'QQ', aliases: ['qq', 'qq_bot'] },
-  { id: 'weixin', name: 'WeChat', aliases: ['wechat', '微信', 'wechat_work', 'wecom', '企业微信'] },
+  { id: "telegram", name: "Telegram", aliases: ["tg"] },
+  { id: "whatsapp", name: "WhatsApp", aliases: [] },
+  { id: "imessage", name: "iMessage", aliases: [] },
+  { id: "feishu", name: "Lark/Feishu", aliases: ["lark", "飞书"] },
+  { id: "dingtalk", name: "DingTalk", aliases: ["钉钉"] },
+  { id: "qqbot", name: "QQ", aliases: ["qq", "qq_bot"] },
+  {
+    id: "weixin",
+    name: "WeChat",
+    aliases: ["wechat", "微信", "wechat_work", "wecom", "企业微信"],
+  },
 ];
 
-// Build alias lookup map (case-insensitive)
-const ALIAS_TO_PLATFORM = {};
-for (const p of PLATFORMS) {
-  ALIAS_TO_PLATFORM[p.id] = p.id;
-  for (const alias of p.aliases) {
-    ALIAS_TO_PLATFORM[alias.toLowerCase()] = p.id;
+const ALIAS_TO_PLATFORM = new Map();
+for (const platform of PLATFORMS) {
+  ALIAS_TO_PLATFORM.set(platform.id, platform.id);
+  for (const alias of platform.aliases) {
+    ALIAS_TO_PLATFORM.set(alias.toLowerCase(), platform.id);
   }
 }
 
-// OAuth start endpoints by platform
-const OAUTH_ENDPOINTS = {
-  slack: '/api/integrations/slack/oauth/start',
-  discord: '/api/integrations/discord/oauth/start',
-  x: '/api/integrations/x/oauth/start',
-};
+class ConnectorError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ConnectorError";
+    this.code = code;
+    this.details = details;
+  }
+
+  toJSON() {
+    return { code: this.code, message: this.message, ...this.details };
+  }
+}
+
+function resolvePlatform(input) {
+  if (typeof input !== "string") return null;
+  return ALIAS_TO_PLATFORM.get(input.trim().toLowerCase()) || null;
+}
+
+function getTokenPath() {
+  return (
+    process.env.OPENLOOMI_TOKEN_PATH?.trim() ||
+    path.join(os.homedir(), ".openloomi", "token")
+  );
+}
+
+function readTokenState() {
+  let encoded;
+  try {
+    encoded = fs.readFileSync(getTokenPath(), "utf8").trim();
+  } catch (error) {
+    if (error?.code === "ENOENT") return { present: false, token: null };
+    throw new ConnectorError(
+      "AUTH_TOKEN_UNREADABLE",
+      "OpenLoomi's local authentication token could not be read.",
+      { tokenPresent: false },
+    );
+  }
+
+  if (!encoded) return { present: false, token: null };
+  try {
+    const bytes = Buffer.from(encoded, "base64");
+    const canonical = bytes.toString("base64").replace(/=+$/, "");
+    if (canonical !== encoded.replace(/=+$/, "")) {
+      return { present: true, token: null, invalid: true };
+    }
+    const decoded = Buffer.from(encoded, "base64").toString("utf8").trim();
+    if (!decoded || decoded.includes("\0")) {
+      return { present: true, token: null, invalid: true };
+    }
+    return { present: true, token: decoded, invalid: false };
+  } catch {
+    return { present: true, token: null, invalid: true };
+  }
+}
 
 function getAuthToken() {
   try {
-    const encoded = fs.readFileSync(TOKEN_PATH, 'utf8').trim();
-    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-    return decoded;
+    return readTokenState().token || null;
   } catch {
     return null;
   }
 }
 
-function apiRequest(endpoint, method = 'GET', body = null, portIndex = 0) {
-  return new Promise((resolve, reject) => {
-    if (portIndex >= PORTS.length) {
-      reject(new Error('openloomi server not running. Tried ports: ' + PORTS.join(', ')));
-      return;
+function requireAuthToken() {
+  const state = readTokenState();
+  if (state.invalid) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_INVALID",
+      "OpenLoomi's local authentication token is invalid. Sign in again in OpenLoomi Desktop.",
+      { tokenPresent: true },
+    );
+  }
+  if (!state.token) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_MISSING",
+      "OpenLoomi's local authentication token is missing. Sign in in OpenLoomi Desktop first.",
+      { tokenPresent: false },
+    );
+  }
+  return state.token;
+}
+
+function normalizeLoopbackUrl(value, envName) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" || !LOOPBACK_HOSTS.has(url.hostname.toLowerCase())) {
+      throw new Error("must be an http loopback URL");
     }
+    if (url.username || url.password) throw new Error("must not include credentials");
+    if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+      throw new Error("must contain only an origin");
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch (error) {
+    throw new ConnectorError(
+      "INVALID_API_URL",
+      `${envName} must be an HTTP URL on localhost, 127.0.0.1, or ::1.`,
+      { env: envName, reason: error.message },
+    );
+  }
+}
 
-    const port = PORTS[portIndex];
-    const url = new URL(endpoint, `http://localhost:${port}`);
+function getBaseUrls() {
+  if (process.env.OPENLOOMI_API_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_API_URL.trim(), "OPENLOOMI_API_URL")];
+  }
+  if (process.env.OPENLOOMI_BASE_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_BASE_URL.trim(), "OPENLOOMI_BASE_URL")];
+  }
+  return [...DEFAULT_BASE_URLS];
+}
+
+function redact(value, depth = 0) {
+  if (depth > 4) return "[truncated]";
+  if (Array.isArray(value)) return value.slice(0, 50).map((item) => redact(item, depth + 1));
+  if (!value || typeof value !== "object") {
+    if (typeof value !== "string") return value;
     const token = getAuthToken();
+    const withoutToken = token ? value.split(token).join("[redacted]") : value;
+    const withoutBearer = withoutToken.replace(/Bearer\s+[^\s,;]+/gi, "Bearer [redacted]");
+    return withoutBearer.length > 1_000 ? `${withoutBearer.slice(0, 1_000)}…` : withoutBearer;
+  }
+  const result = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (/token|secret|password|credential|authorization|cookie/i.test(key)) {
+      result[key] = "[redacted]";
+    } else {
+      result[key] = redact(item, depth + 1);
+    }
+  }
+  return result;
+}
 
-    const options = {
-      hostname: url.hostname,
-      port: url.port,
-      path: url.pathname + url.search,
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token && { 'Authorization': `Bearer ${token}` })
-      }
-    };
+function configuredTimeout(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || !Number.isInteger(parsed) || parsed < 50 || parsed > 60_000) {
+    throw new ConnectorError(
+      "INVALID_TIMEOUT",
+      `${name} must be an integer between 50 and 60000 milliseconds.`,
+    );
+  }
+  return parsed;
+}
 
-    const req = http.request(options, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json);
-        } catch {
-          resolve(data);
-        }
+function parseResponseBody(text, context) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi returned malformed JSON.",
+      context,
+    );
+  }
+}
+
+function requestOnce(
+  baseUrl,
+  endpoint,
+  {
+    method = "GET",
+    body = null,
+    token = null,
+    timeoutMs = configuredTimeout("OPENLOOMI_API_TIMEOUT_MS", DEFAULT_REQUEST_TIMEOUT_MS),
+  } = {},
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(endpoint, `${baseUrl}/`);
+    let connected = false;
+    let settled = false;
+    const payload = body === null ? null : JSON.stringify(body);
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: {
+          Accept: "application/json",
+          ...(payload && {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(payload),
+          }),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        connected = true;
+        let responseText = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          if (responseText.length < 1_000_000) responseText += chunk;
+        });
+        res.on("end", () => {
+          if (settled) return;
+          settled = true;
+          const status = res.statusCode || 0;
+          if (status < 200 || status >= 300) {
+            let responseBody = responseText;
+            try {
+              responseBody = responseText ? JSON.parse(responseText) : null;
+            } catch {
+              // Preserve a bounded, redacted response excerpt for diagnostics.
+            }
+            const authenticationFailure = status === 401 || status === 403;
+            reject(
+              new ConnectorError(
+                authenticationFailure ? "AUTH_FAILED" : "API_HTTP_ERROR",
+                authenticationFailure
+                  ? "OpenLoomi rejected the local authentication token. Sign in again in OpenLoomi Desktop."
+                  : `OpenLoomi returned HTTP ${status}.`,
+                {
+                  status,
+                  method,
+                  endpoint: url.pathname,
+                  ...(authenticationFailure ? {} : { response: redact(responseBody) }),
+                },
+              ),
+            );
+            return;
+          }
+          let responseBody;
+          try {
+            responseBody = parseResponseBody(responseText, {
+              status,
+              method,
+              endpoint: url.pathname,
+            });
+          } catch (error) {
+            reject(error);
+            return;
+          }
+          resolve({ data: responseBody, status, baseUrl });
+        });
+        const rejectResponseFailure = (sourceError) => {
+          if (settled) return;
+          settled = true;
+          const error = sourceError instanceof Error ? sourceError : new Error("Response was aborted");
+          error.code ||= "ECONNRESET";
+          error.connected = true;
+          reject(error);
+        };
+        res.on("aborted", () => rejectResponseFailure());
+        res.on("error", rejectResponseFailure);
+      },
+    );
+
+    req.on("socket", (socket) => {
+      if (!socket.connecting) connected = true;
+      socket.once("connect", () => {
+        connected = true;
       });
     });
-
-    req.on('error', () => {
-      // Try next port on connection error
-      apiRequest(endpoint, method, body, portIndex + 1).then(resolve).catch(reject);
+    req.setTimeout(timeoutMs, () => {
+      const error = new Error(`Request timed out after ${timeoutMs}ms`);
+      error.code = "ETIMEDOUT";
+      req.destroy(error);
     });
-    if (body) req.write(JSON.stringify(body));
+    req.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      error.connected = connected;
+      reject(error);
+    });
+    if (payload) req.write(payload);
     req.end();
   });
 }
 
-function openUrl(url) {
-  const cmd = os.platform() === 'darwin' ? 'open' : os.platform() === 'win32' ? 'start' : 'xdg-open';
-  execSync(`${cmd} "${url}"`, { stdio: 'ignore' });
+function matchesOpenLoomiProviderShape(data) {
+  return Boolean(
+    data &&
+      typeof data === "object" &&
+      Array.isArray(data.agents) &&
+      typeof data.defaultAgent === "string",
+  );
 }
 
-function resolvePlatform(input) {
-  if (!input) return null;
-  const normalized = input.toLowerCase().trim();
-  return ALIAS_TO_PLATFORM[normalized] || null;
-}
-
-async function listPlatforms() {
+function attemptSummary(baseUrl, stage, error) {
   return {
-    platforms: PLATFORMS.map(p => ({
-      id: p.id,
-      name: p.name,
-      aliases: p.aliases
-    })),
-    total: PLATFORMS.length
+    baseUrl,
+    stage,
+    code: error.code || "UNKNOWN_ERROR",
+    ...(error.details?.status ? { status: error.details.status } : {}),
+    connected: Boolean(error.connected),
   };
 }
 
+function isTransportError(error) {
+  return !(error instanceof ConnectorError) && typeof error?.code === "string";
+}
+
+function unreachableError(attempts, tokenPresent) {
+  const transportAttempts = attempts.filter((attempt) =>
+    [
+      "ECONNREFUSED",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "ENETDOWN",
+      "ETIMEDOUT",
+      "ECONNRESET",
+    ].includes(attempt.code),
+  );
+  const loopbackAccessAmbiguous =
+    transportAttempts.length > 0 &&
+    transportAttempts.every((attempt) =>
+      ["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "ENETDOWN", "ETIMEDOUT", "ECONNRESET"].includes(
+        attempt.code,
+      ),
+    );
+  const sandboxDisabled = process.env.CODEX_SANDBOX_NETWORK_DISABLED === "1";
+  return new ConnectorError(
+    sandboxDisabled ? "SANDBOX_BLOCKED" : "LOCAL_API_UNREACHABLE",
+    sandboxDisabled
+      ? "Codex sandbox network access is disabled; the local OpenLoomi API cannot be reached."
+      : "The local OpenLoomi API could not be reached or identified.",
+    { attempts, tokenPresent, loopbackAccessAmbiguous },
+  );
+}
+
+async function probeCandidate(baseUrl) {
+  const response = await requestOnce(baseUrl, "/api/native/providers", {
+    timeoutMs: configuredTimeout("OPENLOOMI_API_PROBE_TIMEOUT_MS", DEFAULT_PROBE_TIMEOUT_MS),
+  });
+  if (!matchesOpenLoomiProviderShape(response.data)) {
+    throw new ConnectorError(
+      "NOT_OPENLOOMI_API",
+      "The loopback service did not match the expected OpenLoomi API response shape.",
+      { baseUrl, endpoint: "/api/native/providers" },
+    );
+  }
+  return response;
+}
+
+async function discoverOpenLoomi() {
+  const attempts = [];
+  let tokenPresent = false;
+  try {
+    tokenPresent = readTokenState().present;
+  } catch {
+    // Connection handoff does not require a token; token state is diagnostic only.
+  }
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+      return { baseUrl, attempts };
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+    }
+  }
+  throw unreachableError(attempts, tokenPresent);
+}
+
+async function apiRequest(endpoint, method = "GET", body = null) {
+  const upperMethod = method.toUpperCase();
+  const readOnly = upperMethod === "GET" || upperMethod === "HEAD";
+  const token = requireAuthToken();
+  const attempts = [];
+
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+      continue;
+    }
+
+    try {
+      const response = await requestOnce(baseUrl, endpoint, {
+        method: upperMethod,
+        body,
+        token,
+      });
+      return response.data;
+    } catch (error) {
+      if (error instanceof ConnectorError) throw error;
+      attempts.push(attemptSummary(baseUrl, "request", error));
+      if (readOnly) continue;
+      if (!error.connected && SAFE_PRECONNECT_ERRORS.has(error.code)) continue;
+      throw new ConnectorError(
+        "REQUEST_OUTCOME_UNKNOWN",
+        `The ${upperMethod} request failed after connecting; it will not be retried automatically.`,
+        { method: upperMethod, endpoint, baseUrl, cause: error.code || "NETWORK_ERROR" },
+      );
+    }
+  }
+
+  throw unreachableError(attempts, Boolean(token));
+}
+
+function sanitizeAccount(account) {
+  if (!account || typeof account !== "object") return null;
+  const allowed = [
+    "id",
+    "platform",
+    "displayName",
+    "status",
+    "createdAt",
+    "updatedAt",
+    "botId",
+    "hasValidContextToken",
+  ];
+  return Object.fromEntries(allowed.filter((key) => account[key] !== undefined).map((key) => [key, account[key]]));
+}
+
+async function listPlatforms() {
+  return { platforms: PLATFORMS.map(({ id, name, aliases }) => ({ id, name, aliases })), total: PLATFORMS.length };
+}
+
 async function listAccounts() {
-  return apiRequest('/api/integrations/accounts');
+  const data = await apiRequest("/api/integrations/accounts");
+  const accounts = Array.isArray(data) ? data : data?.accounts;
+  if (!Array.isArray(accounts)) {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi's accounts response did not contain an accounts array.",
+    );
+  }
+  const sanitized = accounts.map(sanitizeAccount).filter(Boolean);
+  return { accounts: sanitized, total: sanitized.length };
 }
 
 async function getStatus(platform) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const data = await apiRequest('/api/integrations/accounts');
-  const accounts = data.accounts || [];
-  const matching = accounts.filter(a => a.platform === platformId);
-
-  if (matching.length === 0) {
-    return {
-      platform: platformId,
-      connected: false,
-      accounts: []
-    };
-  }
-
+  const { accounts } = await listAccounts();
+  const matching = accounts.filter((account) => account.platform === platformId);
   return {
     platform: platformId,
-    connected: true,
-    accounts: matching.map(a => ({
-      id: a.id,
-      displayName: a.displayName,
-      status: a.status,
-      connectedAt: a.createdAt
-    }))
+    connected: matching.some((account) => account.status === "active"),
+    accounts: matching.map(({ platform: _platform, ...account }) => account),
   };
 }
 
-async function getOAuthUrl(platform) {
+async function connectPlatform(platform, options = {}) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const endpoint = OAUTH_ENDPOINTS[platformId];
-  if (!endpoint) {
-    throw new Error(`OAuth not supported for ${platformId} via CLI. Use the web UI to connect.`);
+  if (options && Object.keys(options).length > 0) {
+    throw new ConnectorError(
+      "SECRETS_NOT_ACCEPTED",
+      "Connect accepts no credentials or secrets. Complete setup in OpenLoomi Desktop.",
+    );
   }
-
-  // Get userId from token for OAuth start
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated. Please log in to openloomi first.');
-  }
-
-  // Decode JWT to get userId (payload is base64 of JSON)
-  let userId = 'local';
-  try {
-    const parts = token.split('.');
-    if (parts.length >= 2) {
-      const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
-      userId = payload.sub || payload.userId || 'local';
-    }
-  } catch {
-    // Use default
-  }
-
-  const data = await apiRequest(`${endpoint}?userId=${encodeURIComponent(userId)}`);
+  const { baseUrl } = await discoverOpenLoomi();
+  const handoff = new URL("/connectors", `${baseUrl}/`);
+  handoff.searchParams.set("addPlatform", "true");
+  handoff.searchParams.set("platform", platformId);
   return {
     platform: platformId,
-    authorizationUrl: data.authorizationUrl,
-    state: data.state,
-    instructions: 'Open the URL in your browser to authorize. The CLI will attempt to open it automatically.'
+    handoffUrl: handoff.toString(),
+    instructions: "Open this URL in the running OpenLoomi Desktop app to complete the connection.",
   };
 }
 
 async function disconnectAccount(accountId) {
-  if (!accountId) {
-    throw new Error('Account ID required: disconnect <accountId>');
+  if (typeof accountId !== "string" || !accountId.trim()) {
+    throw new ConnectorError("INVALID_ARGUMENT", "Account ID is required.");
   }
-  return apiRequest(`/api/integrations/${accountId}`, 'DELETE');
+  const result = await apiRequest(
+    `/api/integrations/${encodeURIComponent(accountId.trim())}`,
+    "DELETE",
+  );
+  return requireOperationSuccess(result, "disconnect");
 }
 
 async function queryContacts(options = {}) {
-  const { name, page = 1, pageSize = 10 } = options;
-  const params = new URLSearchParams();
-  if (name) params.set('name', name);
-  params.set('page', String(page));
-  params.set('pageSize', String(pageSize));
-  return apiRequest(`/api/contacts?${params.toString()}`);
+  const page = Number.isInteger(options.page) && options.page > 0 ? options.page : 1;
+  const pageSize = Number.isInteger(options.pageSize) && options.pageSize > 0 ? Math.min(options.pageSize, 100) : 10;
+  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+  if (typeof options.name === "string" && options.name.trim()) params.set("name", options.name.trim());
+  return apiRequest(`/api/contacts?${params}`);
 }
 
 async function sendReply(options = {}) {
   const { botId, recipients, message, subject, cc, bcc } = options;
-  if (!botId || !recipients || !message) {
-    throw new Error('botId, recipients, and message are required');
+  const validStringList = (value, { required = false } = {}) =>
+    value === undefined
+      ? !required
+      : Array.isArray(value) &&
+        (!required || value.length > 0) &&
+        value.every(
+          (item) => typeof item === "string" && item.trim().length > 0,
+        );
+  if (
+    typeof botId !== "string" ||
+    !botId.trim() ||
+    !validStringList(recipients, { required: true }) ||
+    typeof message !== "string" ||
+    !message.trim() ||
+    (subject !== undefined && typeof subject !== "string") ||
+    !validStringList(cc) ||
+    !validStringList(bcc)
+  ) {
+    throw new ConnectorError("INVALID_ARGUMENT", "botId, a non-empty recipients array, and message are required.");
   }
-  return apiRequest('/api/messages', 'POST', { botId, recipients, message, subject, cc, bcc });
+  const result = await apiRequest("/api/messages", "POST", {
+    botId: botId.trim(),
+    recipients: recipients.map((item) => item.trim()),
+    message,
+    subject,
+    cc: cc?.map((item) => item.trim()),
+    bcc: bcc?.map((item) => item.trim()),
+  });
+  return requireOperationSuccess(result, "send_reply");
 }
 
-async function connectEmailPlatform(platformId, email, appPassword) {
-  const validateEndpoint = platformId === 'gmail' ? '/api/google/validate' : '/api/outlook/validate';
-
-  // Validate credentials first
-  const validateResult = await apiRequest(validateEndpoint, 'POST', {
-    email,
-    appPassword
-  });
-
-  if (validateResult.error) {
-    throw new Error(validateResult.error);
+function requireOperationSuccess(result, operation) {
+  if (result && typeof result === "object" && result.success === true) {
+    return result;
   }
-
-  // Create the integration account
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: email,
-    displayName: validateResult.name || email.split('@')[0],
-    credentials: {
-      email,
-      appPassword
-    },
-    metadata: {
-      email,
-      name: validateResult.name || email.split('@')[0]
-    },
-    bot: {
-      name: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} · ${validateResult.name || email}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter: platformId,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    email,
-    account,
-    message: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} account connected successfully!`
-  };
-}
-
-// Platforms that use appId/appSecret credentials (no validation API needed)
-async function connectAppCredentialsPlatform(platformId, credentials, displayName) {
-  const adapterMap = {
-    dingtalk: 'dingtalk',
-    qqbot: 'qqbot',
-    feishu: 'feishu'
-  };
-
-  const adapter = adapterMap[platformId];
-  if (!adapter) {
-    throw new Error(`${platformId} does not support CLI connection with credentials`);
+  if (result && typeof result === "object" && result.success === false) {
+    throw new ConnectorError(
+      "API_OPERATION_FAILED",
+      `OpenLoomi could not complete ${operation}.`,
+      { operation },
+    );
   }
-
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: credentials.clientId || credentials.appId || displayName,
-    displayName: displayName || platformId,
-    credentials,
-    metadata: {
-      name: displayName || platformId
-    },
-    bot: {
-      name: `${platformId} · ${displayName || 'Bot'}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    account,
-    message: `${platformId} connected successfully!`
-  };
+  throw new ConnectorError(
+    "INVALID_API_RESPONSE",
+    `OpenLoomi returned an invalid ${operation} response.`,
+    { operation },
+  );
 }
 
-// WeChat iLink Token connection
-async function connectWeChat(token) {
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: 'weixin',
-    externalId: 'wechat',
-    displayName: 'WeChat',
-    credentials: {
-      ilinkToken: token
-    },
-    metadata: {
-      type: 'wechat'
-    },
-    bot: {
-      name: 'WeChat · Bot',
-      description: 'Automatically created through iLink Token authorization',
-      adapter: 'weixin',
-      enable: true
-    }
-  });
-
-  return {
-    platform: 'weixin',
-    account,
-    message: 'WeChat connected successfully!'
-  };
+function parseNamedArgs(args) {
+  const result = {};
+  for (const arg of args) {
+    if (!arg.startsWith("--") || !arg.includes("=")) continue;
+    const separator = arg.indexOf("=");
+    result[arg.slice(2, separator)] = arg.slice(separator + 1);
+  }
+  return result;
 }
 
-const command = process.argv[2];
-const args = process.argv.slice(3);
+function printJson(value, stream = process.stdout) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
 
-async function main() {
+async function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
   try {
+    let result;
     switch (command) {
-      case 'list-platforms': {
-        const result = await listPlatforms();
-        console.log(JSON.stringify(result, null, 2));
+      case "list-platforms":
+        result = await listPlatforms();
+        break;
+      case "list-accounts":
+        result = await listAccounts();
+        break;
+      case "status":
+        result = await getStatus(args[0]);
+        break;
+      case "connect": {
+        if (!args[0]) throw new ConnectorError("INVALID_ARGUMENT", "Platform is required: connect <platform>.");
+        if (args.length > 1) {
+          throw new ConnectorError(
+            "SECRETS_NOT_ACCEPTED",
+            "Connect accepts only a platform name. Complete setup in OpenLoomi Desktop.",
+          );
+        }
+        const named = parseNamedArgs(args.slice(1));
+        result = await connectPlatform(args[0], named);
         break;
       }
-
-      case 'list-accounts': {
-        const result = await listAccounts();
-        console.log(JSON.stringify(result, null, 2));
+      case "disconnect":
+        if (parseNamedArgs(args.slice(1)).confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Disconnect requires --confirmed=true after the user approves the exact account.",
+          );
+        }
+        result = await disconnectAccount(args[0]);
         break;
-      }
-
-      case 'status': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: status <platform>');
-        const result = await getStatus(platform);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'connect': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: connect <platform>');
-
-        const platformId = resolvePlatform(platform);
-        if (!platformId) {
-          throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
-        }
-
-        // Email platforms (gmail, outlook) - require validation
-        if (platformId === 'gmail' || platformId === 'outlook') {
-          const emailArg = args.find(a => a.startsWith('--email='));
-          const passwordArg = args.find(a => a.startsWith('--password='));
-
-          if (!emailArg || !passwordArg) {
-            throw new Error(`Missing credentials. For ${platformId}, provide:\n  connect ${platformId} --email=you@example.com --password=your_app_password`);
-          }
-
-          const email = emailArg.split('=')[1];
-          const appPassword = passwordArg.split('=')[1];
-
-          if (platformId === 'gmail' && appPassword.length !== 16) {
-            throw new Error('Gmail app password must be exactly 16 characters');
-          }
-
-          const result = await connectEmailPlatform(platformId, email, appPassword);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // DingTalk (clientId + clientSecret)
-        if (platformId === 'dingtalk') {
-          const clientIdArg = args.find(a => a.startsWith('--clientId='));
-          const clientSecretArg = args.find(a => a.startsWith('--clientSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!clientIdArg || !clientSecretArg) {
-            throw new Error("Missing credentials. For DingTalk, provide:\n  connect dingtalk --clientId=your_client_id --clientSecret=your_client_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            clientId: clientIdArg.split('=')[1],
-            clientSecret: clientSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'DingTalk');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // QQ Bot (appId + appSecret)
-        if (platformId === 'qqbot') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For QQ Bot, provide:\n  connect qq --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'QQ Bot');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // Feishu (appId + appSecret)
-        if (platformId === 'feishu') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For Feishu, provide:\n  connect feishu --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'Feishu');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // WeChat (iLink Token)
-        if (platformId === 'weixin') {
-          const tokenArg = args.find(a => a.startsWith('--token='));
-
-          if (!tokenArg) {
-            throw new Error("Missing iLink token. For WeChat, provide:\n  connect wechat --token=your_ilink_token");
-          }
-
-          const result = await connectWeChat(tokenArg.split('=')[1]);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // OAuth platforms (auto-opens browser)
-        if (OAUTH_ENDPOINTS[platformId]) {
-          const result = await getOAuthUrl(platform);
-          console.log(JSON.stringify(result, null, 2));
-          try {
-            openUrl(result.authorizationUrl);
-          } catch {
-            // Silently ignore if open fails
-          }
-          break;
-        }
-
-        // Platforms requiring browser (WhatsApp, etc)
-        throw new Error(`${platformId} requires browser interaction. Open in browser:\n  open "http://localhost:3414/connectors?addPlatform=true&platform=${platformId}"`);
-      }
-
-      case 'disconnect': {
-        const accountId = args[0];
-        const result = await disconnectAccount(accountId);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'query-contacts': {
-        const nameArg = args.find(a => a.startsWith('--name='));
-        const pageArg = args.find(a => a.startsWith('--page='));
-        const pageSizeArg = args.find(a => a.startsWith('--pageSize='));
-        const result = await queryContacts({
-          name: nameArg ? nameArg.split('=')[1] : undefined,
-          page: pageArg ? Number.parseInt(pageArg.split('=')[1], 10) : 1,
-          pageSize: pageSizeArg ? Number.parseInt(pageSizeArg.split('=')[1], 10) : 10
+      case "query-contacts": {
+        const named = parseNamedArgs(args);
+        result = await queryContacts({
+          name: named.name,
+          page: named.page ? Number.parseInt(named.page, 10) : 1,
+          pageSize: named.pageSize ? Number.parseInt(named.pageSize, 10) : 10,
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
-      case 'send-reply': {
-        const botIdArg = args.find(a => a.startsWith('--botId='));
-        const recipientsArg = args.find(a => a.startsWith('--recipients='));
-        const messageArg = args.find(a => a.startsWith('--message='));
-        const subjectArg = args.find(a => a.startsWith('--subject='));
-        const ccArg = args.find(a => a.startsWith('--cc='));
-        const bccArg = args.find(a => a.startsWith('--bcc='));
-        if (!botIdArg || !recipientsArg || !messageArg) {
-          throw new Error('botId, recipients, and message required');
+      case "send-reply": {
+        const named = parseNamedArgs(args);
+        if (named.confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Sending requires --confirmed=true after the user approves the exact bot, recipients, and message.",
+          );
         }
-        const result = await sendReply({
-          botId: botIdArg.split('=')[1],
-          recipients: recipientsArg.split('=')[1].split(','),
-          message: messageArg.split('=')[1],
-          subject: subjectArg ? subjectArg.split('=')[1] : undefined,
-          cc: ccArg ? ccArg.split('=')[1].split(',') : undefined,
-          bcc: bccArg ? bccArg.split('=')[1].split(',') : undefined
+        result = await sendReply({
+          botId: named.botId,
+          recipients: named.recipients?.split(",").map((item) => item.trim()).filter(Boolean),
+          message: named.message,
+          subject: named.subject,
+          cc: named.cc?.split(",").map((item) => item.trim()).filter(Boolean),
+          bcc: named.bcc?.split(",").map((item) => item.trim()).filter(Boolean),
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
+      case undefined:
+      case "help":
+      case "--help":
+      case "-h":
+        result = {
+          usage: [
+            "list-platforms",
+            "list-accounts",
+            "status <platform>",
+            "connect <platform>",
+            "disconnect <accountId> --confirmed=true",
+            "query-contacts [--name=] [--page=] [--pageSize=]",
+            "send-reply --botId= --recipients= --message= --confirmed=true [--subject=] [--cc=] [--bcc=]",
+          ],
+        };
+        break;
       default:
-        console.log(JSON.stringify({
-          error: 'Unknown command',
-          usage: `
-Commands:
-  list-platforms                                List all supported platforms
-  list-accounts                                List all connected accounts (includes botId)
-  status <platform>                            Check connection status for a platform
-  connect <platform> [options]                  Connect a platform
-  disconnect <accountId>                        Disconnect an account by ID
-  query-contacts [options]                      Query contacts (--name=, --page=, --pageSize=)
-  send-reply --botId= --recipients= --message= Send a message
-
-Platform Connection Methods:
-  OAuth (auto-opens browser):
-    connect slack
-    connect discord
-    connect x
-
-  Email (App Password):
-    connect gmail --email=x@gmail.com --password=xxxx_xxxx_xxxx_xxxx
-    connect outlook --email=x@outlook.com --password=xxxx
-
-  App Credentials:
-    connect dingtalk --clientId=x --clientSecret=x
-    connect feishu --appId=x --appSecret=x
-    connect qq --appId=x --appSecret=x
-
-  iLink Token:
-    connect wechat --token=x
-
-  Browser Required (QR scan / interactive):
-    connect whatsapp
-    connect telegram (phone/qr/bot login)
-    connect imessage
-
-Examples:
-  node openloomi-connectors.cjs list-platforms
-  node openloomi-connectors.cjs list-accounts
-  node openloomi-connectors.cjs status telegram
-  node openloomi-connectors.cjs connect gmail --email=my@gmail.com --password=abcdefghijklnop
-  node openloomi-connectors.cjs disconnect int_xxx
-  node openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-  node openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
-          `.trim()
-        }, null, 2));
+        throw new ConnectorError(
+          "UNKNOWN_COMMAND",
+          "Unknown command. Run with --help for usage.",
+        );
     }
+    printJson(result);
   } catch (error) {
-    console.error(JSON.stringify({ error: error.message }, null, 2));
-    process.exit(1);
+    const structured = error instanceof ConnectorError
+      ? error.toJSON()
+      : { code: "INTERNAL_ERROR", message: error?.message || "Unexpected connector error." };
+    printJson({ error: structured }, process.stderr);
+    process.exitCode = 1;
   }
 }
 
-main();
+module.exports = {
+  ConnectorError,
+  PLATFORMS,
+  apiRequest,
+  connectPlatform,
+  disconnectAccount,
+  discoverOpenLoomi,
+  getBaseUrls,
+  getStatus,
+  listAccounts,
+  listPlatforms,
+  queryContacts,
+  readTokenState,
+  resolvePlatform,
+  sanitizeAccount,
+  sendReply,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "keywords": ["openloomi", "loomi", "assistant", "memory", "codex"],
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "OpenLoomi",
@@ -16,7 +17,7 @@
     "longDescription": "Connect Codex to a local OpenLoomi runtime for setup readiness, personal memory workflows, and future one-shot task execution.",
     "developerName": "OpenLoomi",
     "category": "Productivity",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": ["Read", "Write", "Interactive"],
     "defaultPrompt": [
       "Check whether OpenLoomi is ready",
       "Show OpenLoomi setup next steps",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,13 +1,19 @@
 {
   "name": "openloomi",
   "version": "0.8.4",
-  "description": "Use local OpenLoomi from Codex as a personal assistant and memory layer.",
+  "description": "Use local OpenLoomi from Codex as a personal assistant, memory layer, and self-healing setup bridge (auto-recovers from Codex sandbox loopback false negatives via a host-side probe cache).",
   "author": {
     "name": "OpenLoomi"
   },
   "homepage": "https://openloomi.ai/docs/getting-started",
   "license": "Apache-2.0",
-  "keywords": ["openloomi", "loomi", "assistant", "memory", "codex"],
+  "keywords": [
+    "openloomi",
+    "loomi",
+    "assistant",
+    "memory",
+    "codex"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",
@@ -17,13 +23,17 @@
     "longDescription": "Connect Codex to a local OpenLoomi runtime for setup readiness, personal memory workflows, and future one-shot task execution.",
     "developerName": "OpenLoomi",
     "category": "Productivity",
-    "capabilities": ["Read", "Write", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "defaultPrompt": [
       "Check whether OpenLoomi is ready",
       "Show OpenLoomi setup next steps",
-      "Send this task to Loomi for follow-up",
       "Switch the OpenLoomi desktop app to the Codex runtime",
-      "Show how to verify the desktop app is using Codex as its agent runtime"
+      "Show how to verify the desktop app is using Codex as its agent runtime",
+      "Recover from Codex sandbox loopback false negatives",
+      "Run the host probe and merge it into the next setup-status"
     ],
     "brandColor": "#2563EB",
     "logo": "./assets/logo.png"

--- a/plugins/codex/.mcp.json
+++ b/plugins/codex/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "openloomi": {
+      "command": "node",
+      "args": ["scripts/openloomi-mcp-server.cjs"],
+      "cwd": "."
+    }
+  }
+}

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -122,10 +122,11 @@ always entered inside OpenLoomi-owned UI.
 
 Codex sandboxing can block GitHub release lookup/download, writes to system
 application directories such as `/Applications`, installer execution, and GUI
-launching. On a likely sandbox-related network or permission failure, request
-approval and retry the same bridge command outside the sandbox before treating
-the release URL as unavailable or the installer as broken. Keep the retry on
-`loomi-bridge`; do not bypass its official-artifact allowlist and verification.
+launching. The embedded adapter uses non-interactive `codex exec`, so it cannot
+pause for an out-of-sandbox approval. Run the printed `loomi-bridge` command
+in a normal terminal when installation needs host network or GUI access. Do not
+bypass its official-artifact allowlist and verification, and do not treat a
+sandbox failure as proof that an artifact is unavailable.
 
 You can run the same wizard from a terminal:
 
@@ -385,6 +386,24 @@ should report `codex` inside `agents` and `defaultAgent: "codex"`. If you
 still see `defaultAgent: "claude"`, the env change didn't stick — re-run
 `launchctl getenv OPENLOOMI_AGENT_PROVIDER` to confirm the GUI session
 actually has it.
+
+### Host-side connector transport
+
+The plugin registers a narrow local stdio MCP server through `.mcp.json`.
+Native connector tools (`list_accounts`, `connector_status`, `connect`,
+`disconnect`, `query_contacts`, and `send_reply`) run in that host-side
+process and call the authenticated OpenLoomi Desktop API directly. This avoids
+depending on a model-generated shell command crossing macOS's host-loopback
+sandbox boundary; it does **not** expose an arbitrary host shell or connector
+credentials, and it does not enable network access for shell commands.
+
+Before sending the bearer token, the connector client probes
+`/api/native/providers` without credentials and checks the expected response
+shape as a best-effort guard against accidentally targeting an unrelated
+loopback service. This is not cryptographic service identity; the token file
+and local host remain within the user's trust boundary. The CLI remains
+available as a compatibility path, with structured transport/authentication
+failures and mutation-safe retry rules.
 
 To pull the same switch plan as structured JSON (handy for surfacing inside
 Codex without retyping the shell snippets):
@@ -668,10 +687,11 @@ credentials inside OpenLoomi-owned surfaces.
 When every loopback probe fails with `NETWORK_ERROR`, `setup-status` sets
 `loopbackAccessAmbiguous: true`. This does not prove that OpenLoomi is stopped:
 Codex network sandboxing may prevent the bridge process from reaching services
-on the host's `localhost`. Consumers should request approval to run the
-provided `loopbackAccess.verification.commands` outside the sandbox before
-recommending an application restart. A successful outside-sandbox API request
-means the in-sandbox readiness result was a false negative.
+on the host's `localhost`. The embedded non-interactive adapter cannot request
+an out-of-sandbox retry. Prefer a host-side MCP tool where available; otherwise
+present `loopbackAccess.verification.commands` for the user to run in a normal
+terminal before recommending an application restart. A successful host-side
+request means the sandboxed readiness result was a false negative.
 
 **Common `nextAction` values:**
 
@@ -743,8 +763,8 @@ After OpenLoomi starts, the plugin guides users toward OpenLoomi-related
 skills and workflows that are useful from Codex. The Codex plugin ships
 one main entry skill (`openloomi`) plus eight sub-skills under
 `skills/`. Each sub-skill is auto-loaded by Codex on demand based on its
-frontmatter `description` — they share the same `loomi-bridge.mjs`
-runtime, no business logic is duplicated.
+frontmatter `description`. Runtime business logic stays in OpenLoomi; the
+skills use the bridge or a narrow connector API client.
 
 | Skill                     | Path                                      | Trigger words                                                           | What it does                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------- | ----------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -752,7 +772,7 @@ runtime, no business logic is duplicated.
 | `openloomi-install`       | `skills/openloomi-install/SKILL.md`       | install, first-use setup, `SESSION_INITIALIZATION_REQUIRED`             | Walks install / first-use / session recovery. Translates `setup-status` `reason` codes into concrete next actions.                                                                                                                                                                                                                                           |
 | `openloomi-loop`          | `skills/openloomi-loop/SKILL.md`          | loop tick, loop schedule, loop inbox, register loop type, add loop rule | The proactive execution brain — pull signals, classify into decisions, schedule actions, register custom decision types / signal channels / classifier rules. Thin wrapper around `/api/loop/*`.                                                                                                                                                             |
 | `openloomi-memory`        | `skills/openloomi-memory/SKILL.md`        | memory search, knowledge base, documents, insights                      | Search or write memory through OpenLoomi-owned runtime surfaces. Thin wrapper — does **not** implement memory storage.                                                                                                                                                                                                                                       |
-| `openloomi-connectors`    | `skills/openloomi-connectors/SKILL.md`    | connect platform, integration status, list accounts, disconnect         | Check whether Slack, GitHub, Gmail, Calendar, and other sources are configured before acting. Reports status only; pair with `composio` for non-native accounts.                                                                                                                                                                                             |
+| `openloomi-connectors`    | `skills/openloomi-connectors/SKILL.md`    | connect platform, integration status, list accounts, disconnect         | Manage OpenLoomi's native 7 through host-side MCP tools; credentials stay in the Desktop UI. Pair with `composio` for non-native accounts.                                                                                                                                                                                                                   |
 | `openloomi-handoff`       | `skills/openloomi-handoff/SKILL.md`       | hand off, delegate, queue, remind, follow up                            | **Codex-only.** Send the current Codex task to Loomi for follow-up. The Claude Code plugin exposes the same capability through its own `/openloomi:*` slash-command surface instead — see [Handoff parity note](#handoff-parity-note) below.                                                                                                                 |
 | `openloomi-pet`           | `skills/openloomi-pet/SKILL.md`           | pet state, set pet, fox sprite, capybara sprite, custom pet theme       | The 9-state Loomi Pet vocabulary (`happy`/`idle`/`juggling`/`needsinput`/`presenting`/`sleeping`/`sweeping`/`thinking`/`working`). Mirrors the Claude plugin's `openloomi-pet` skill with Codex-specific deltas (no slash command, `codex-plugin` source tag). For custom themes & sprite overrides see the [Customize your Loomi Pet](/docs/pet) user docs. |
 | `openloomi-api`           | `skills/openloomi-api/SKILL.md`           | API endpoints, backend routes, auth, local API, integrations            | Reference for the 131 OpenLoomi HTTP routes (auth, AI, RAG, Loop, Pet, workspace, integrations). Triggered on API / backend questions.                                                                                                                                                                                                                       |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -390,12 +390,11 @@ actually has it.
 ### Host-side connector transport
 
 The plugin registers a narrow local stdio MCP server through `.mcp.json`.
-Native connector tools (`list_accounts`, `connector_status`, `connect`,
-`disconnect`, `query_contacts`, and `send_reply`) run in that host-side
-process and call the authenticated OpenLoomi Desktop API directly. This avoids
-depending on a model-generated shell command crossing macOS's host-loopback
-sandbox boundary; it does **not** expose an arbitrary host shell or connector
-credentials, and it does not enable network access for shell commands.
+Native connector tools (`list_platforms`, `list_accounts`,
+`connector_status`, `connect`, `disconnect`, `query_contacts`, and
+`send_reply`) run in that host-side process and call the authenticated
+OpenLoomi Desktop API directly. This avoids depending on a model-generated
+shell command crossing macOS's host-loopback sandbox boundary.
 
 Before sending the bearer token, the connector client probes
 `/api/native/providers` without credentials and checks the expected response
@@ -403,7 +402,9 @@ shape as a best-effort guard against accidentally targeting an unrelated
 loopback service. This is not cryptographic service identity; the token file
 and local host remain within the user's trust boundary. The CLI remains
 available as a compatibility path, with structured transport/authentication
-failures and mutation-safe retry rules.
+failures and mutation-safe retry rules. This connector-scoped transport does
+not expose an arbitrary host shell, grant network access to model-generated
+shell commands, or replace `setup-status`'s separate host-probe recovery.
 
 To pull the same switch plan as structured JSON (handy for surfacing inside
 Codex without retyping the shell snippets):
@@ -763,8 +764,8 @@ After OpenLoomi starts, the plugin guides users toward OpenLoomi-related
 skills and workflows that are useful from Codex. The Codex plugin ships
 one main entry skill (`openloomi`) plus eight sub-skills under
 `skills/`. Each sub-skill is auto-loaded by Codex on demand based on its
-frontmatter `description`. Runtime business logic stays in OpenLoomi; the
-skills use the bridge or a narrow connector API client.
+frontmatter `description` — they share the same `loomi-bridge.mjs`
+runtime, no business logic is duplicated.
 
 | Skill                     | Path                                      | Trigger words                                                           | What it does                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------- | ----------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -772,19 +773,18 @@ skills use the bridge or a narrow connector API client.
 | `openloomi-install`       | `skills/openloomi-install/SKILL.md`       | install, first-use setup, `SESSION_INITIALIZATION_REQUIRED`             | Walks install / first-use / session recovery. Translates `setup-status` `reason` codes into concrete next actions.                                                                                                                                                                                                                                           |
 | `openloomi-loop`          | `skills/openloomi-loop/SKILL.md`          | loop tick, loop schedule, loop inbox, register loop type, add loop rule | The proactive execution brain — pull signals, classify into decisions, schedule actions, register custom decision types / signal channels / classifier rules. Thin wrapper around `/api/loop/*`.                                                                                                                                                             |
 | `openloomi-memory`        | `skills/openloomi-memory/SKILL.md`        | memory search, knowledge base, documents, insights                      | Search or write memory through OpenLoomi-owned runtime surfaces. Thin wrapper — does **not** implement memory storage.                                                                                                                                                                                                                                       |
-| `openloomi-connectors`    | `skills/openloomi-connectors/SKILL.md`    | connect platform, integration status, list accounts, disconnect         | Manage OpenLoomi's native 7 through host-side MCP tools; credentials stay in the Desktop UI. Pair with `composio` for non-native accounts.                                                                                                                                                                                                                   |
-| `openloomi-handoff`       | `skills/openloomi-handoff/SKILL.md`       | hand off, delegate, queue, remind, follow up                            | **Codex-only.** Send the current Codex task to Loomi for follow-up. The Claude Code plugin exposes the same capability through its own `/openloomi:*` slash-command surface instead — see [Handoff parity note](#handoff-parity-note) below.                                                                                                                 |
+| `openloomi-connectors`    | `skills/openloomi-connectors/SKILL.md`    | connect platform, integration status, list accounts, disconnect         | Check whether Slack, GitHub, Gmail, Calendar, and other sources are configured before acting. Reports status only; pair with `composio` for non-native accounts.                                                                                                                                                                                             |
 | `openloomi-pet`           | `skills/openloomi-pet/SKILL.md`           | pet state, set pet, fox sprite, capybara sprite, custom pet theme       | The 9-state Loomi Pet vocabulary (`happy`/`idle`/`juggling`/`needsinput`/`presenting`/`sleeping`/`sweeping`/`thinking`/`working`). Mirrors the Claude plugin's `openloomi-pet` skill with Codex-specific deltas (no slash command, `codex-plugin` source tag). For custom themes & sprite overrides see the [Customize your Loomi Pet](/docs/pet) user docs. |
 | `openloomi-api`           | `skills/openloomi-api/SKILL.md`           | API endpoints, backend routes, auth, local API, integrations            | Reference for the 131 OpenLoomi HTTP routes (auth, AI, RAG, Loop, Pet, workspace, integrations). Triggered on API / backend questions.                                                                                                                                                                                                                       |
 | `openloomi-feature-guide` | `skills/openloomi-feature-guide/SKILL.md` | "what can openloomi do", "怎么用", "how does openloomi work"            | Product overview, capability tour, and how-tos for non-developer questions.                                                                                                                                                                                                                                                                                  |
 | `composio`                | `skills/composio/SKILL.md`                | composio, 1000+ apps, external integrations                             | Third-party 1000+ app integration router (Gmail, Slack, GitHub, Linear, Jira, Notion, etc.) via the Composio CLI. Platform-agnostic; not OpenLoomi business logic.                                                                                                                                                                                           |
 
 The `workflow-guidance` bridge command exposes structured guidance for the
-four workflow skills (`openloomi-loop`, `openloomi-memory`,
-`openloomi-connectors`, `openloomi-handoff`). All other skills are
-documentation or routing helpers. The plugin must not copy OpenLoomi
-connector, memory, loop, scheduling, or handoff persistence logic into
-Codex — runtime implementations stay inside the OpenLoomi desktop runtime.
+three workflow skills (`openloomi-loop`, `openloomi-memory`,
+`openloomi-connectors`). All other skills are documentation or routing
+helpers. The plugin must not copy OpenLoomi connector, memory, or loop
+logic into Codex — runtime implementations stay inside the OpenLoomi
+desktop runtime.
 
 **Pairing notes:**
 
@@ -798,23 +798,6 @@ Codex — runtime implementations stay inside the OpenLoomi desktop runtime.
   via `/api/loop/action/schedule`. It is read/derive, never destructive.
 - `openloomi-memory` is the canonical store. `openloomi-loop` deliberately
   delegates persistence to memory instead of duplicating it.
-
-#### Handoff parity note
-
-Codex and Claude Code expose the same "send current task to Loomi for
-follow-up" capability through **different surfaces**:
-
-- **Codex** (`@OpenLoomi …`): the `openloomi-handoff` skill above — wraps
-  the request with the `taskPromptPrefix` returned by `workflow-guidance`
-  and sends it through the workflow's dedicated bridge command or API route.
-- **Claude Code** (`/openloomi:*`): the slash-command surface. There is no
-  dedicated `openloomi-handoff` skill because `/openloomi:setup` /
-  `/openloomi:status` already cover the same user need through the
-  plugin's own commands.
-
-Both surfaces route to the same OpenLoomi runtime — the plugin stays a
-thin wrapper; persistence and notification routing live inside the
-OpenLoomi desktop runtime.
 
 ### Pet state control
 

--- a/plugins/codex/scripts/openloomi-mcp-server.cjs
+++ b/plugins/codex/scripts/openloomi-mcp-server.cjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+"use strict";
+
+const readline = require("node:readline");
+const connectors = require("../skills/openloomi-connectors/scripts/openloomi-connectors.cjs");
+const pluginManifest = require("../.codex-plugin/plugin.json");
+
+const SERVER_INFO = {
+  name: "openloomi-connectors",
+  version: pluginManifest.version,
+};
+const PROTOCOL_VERSION = "2025-03-26";
+const MAX_REQUEST_BYTES = 1024 * 1024;
+
+const readOnlyAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+const TOOLS = [
+  {
+    name: "list_platforms",
+    description:
+      "List the seven connector platforms supported by the local OpenLoomi Desktop app.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    annotations: readOnlyAnnotations,
+  },
+  {
+    name: "list_accounts",
+    description:
+      "List connected OpenLoomi accounts with credential and metadata fields removed.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    annotations: readOnlyAnnotations,
+  },
+  {
+    name: "connector_status",
+    description:
+      "Check whether a supported connector platform has connected accounts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        platform: {
+          type: "string",
+          minLength: 1,
+          description: "Platform ID or supported alias.",
+        },
+      },
+      required: ["platform"],
+      additionalProperties: false,
+    },
+    annotations: readOnlyAnnotations,
+  },
+  {
+    name: "connect",
+    description:
+      "Return a handoff URL for completing a connector login in the running OpenLoomi Desktop app. This tool never accepts secrets.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        platform: {
+          type: "string",
+          minLength: 1,
+          description: "Platform ID or supported alias.",
+        },
+      },
+      required: ["platform"],
+      additionalProperties: false,
+    },
+    annotations: readOnlyAnnotations,
+  },
+  {
+    name: "disconnect",
+    description:
+      "Disconnect an OpenLoomi connector account. Requires confirmed=true because this deletes the connection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        accountId: {
+          type: "string",
+          minLength: 1,
+          description: "Account ID returned by list_accounts.",
+        },
+        confirmed: {
+          type: "boolean",
+          const: true,
+          description: "Explicit confirmation of disconnection.",
+        },
+      },
+      required: ["accountId", "confirmed"],
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "query_contacts",
+    description: "Search contacts available to connected OpenLoomi accounts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", minLength: 1 },
+        page: { type: "integer", minimum: 1, default: 1 },
+        pageSize: { type: "integer", minimum: 1, maximum: 100, default: 10 },
+      },
+      additionalProperties: false,
+    },
+    annotations: readOnlyAnnotations,
+  },
+  {
+    name: "send_reply",
+    description:
+      "Send a message through a connected bot. Requires confirmed=true because delivery is an external side effect.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        botId: { type: "string", minLength: 1 },
+        recipients: {
+          type: "array",
+          minItems: 1,
+          items: { type: "string", minLength: 1 },
+        },
+        message: { type: "string", minLength: 1 },
+        subject: { type: "string", minLength: 1 },
+        cc: {
+          type: "array",
+          items: { type: "string", minLength: 1 },
+        },
+        bcc: {
+          type: "array",
+          items: { type: "string", minLength: 1 },
+        },
+        confirmed: {
+          type: "boolean",
+          const: true,
+          description: "Explicit confirmation to send.",
+        },
+      },
+      required: ["botId", "recipients", "message", "confirmed"],
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+];
+
+function connectorError(error) {
+  if (error instanceof connectors.ConnectorError) return error.toJSON();
+  return {
+    code: "INTERNAL_ERROR",
+    message: error?.message || "Unexpected connector error.",
+  };
+}
+
+function toolResult(value) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+function requireConfirmation(args, action) {
+  if (args.confirmed !== true) {
+    throw new connectors.ConnectorError(
+      "CONFIRMATION_REQUIRED",
+      `${action} requires confirmed=true after the user explicitly approves it.`,
+    );
+  }
+}
+
+function checkedArguments(args, allowedKeys) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw new connectors.ConnectorError(
+      "INVALID_ARGUMENT",
+      "Tool arguments must be an object.",
+    );
+  }
+  const unexpected = Object.keys(args).filter(
+    (key) => !allowedKeys.includes(key),
+  );
+  if (unexpected.length > 0) {
+    throw new connectors.ConnectorError(
+      "INVALID_ARGUMENT",
+      "Unexpected tool arguments were provided.",
+    );
+  }
+  return args;
+}
+
+function requiredString(value, field) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new connectors.ConnectorError(
+      "INVALID_ARGUMENT",
+      `${field} must be a non-empty string.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalString(value, field) {
+  return value === undefined ? undefined : requiredString(value, field);
+}
+
+function stringArray(value, field, { required = false } = {}) {
+  if (value === undefined && !required) return undefined;
+  if (
+    !Array.isArray(value) ||
+    (required && value.length === 0) ||
+    value.some((item) => typeof item !== "string" || !item.trim())
+  ) {
+    throw new connectors.ConnectorError(
+      "INVALID_ARGUMENT",
+      `${field} must be ${required ? "a non-empty" : "an"} array of non-empty strings.`,
+    );
+  }
+  return value.map((item) => item.trim());
+}
+
+function optionalInteger(value, field, maximum) {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || value < 1 || value > maximum) {
+    throw new connectors.ConnectorError(
+      "INVALID_ARGUMENT",
+      `${field} must be an integer between 1 and ${maximum}.`,
+    );
+  }
+  return value;
+}
+
+async function callTool(name, args = {}) {
+  switch (name) {
+    case "list_platforms":
+      checkedArguments(args, []);
+      return connectors.listPlatforms();
+    case "list_accounts":
+      checkedArguments(args, []);
+      return connectors.listAccounts();
+    case "connector_status": {
+      const input = checkedArguments(args, ["platform"]);
+      return connectors.getStatus(requiredString(input.platform, "platform"));
+    }
+    case "connect": {
+      const input = checkedArguments(args, ["platform"]);
+      return connectors.connectPlatform(
+        requiredString(input.platform, "platform"),
+      );
+    }
+    case "disconnect": {
+      const input = checkedArguments(args, ["accountId", "confirmed"]);
+      requireConfirmation(input, "Disconnect");
+      return connectors.disconnectAccount(
+        requiredString(input.accountId, "accountId"),
+      );
+    }
+    case "query_contacts": {
+      const input = checkedArguments(args, ["name", "page", "pageSize"]);
+      return connectors.queryContacts({
+        name: optionalString(input.name, "name"),
+        page: optionalInteger(input.page, "page", Number.MAX_SAFE_INTEGER),
+        pageSize: optionalInteger(input.pageSize, "pageSize", 100),
+      });
+    }
+    case "send_reply": {
+      const input = checkedArguments(args, [
+        "botId",
+        "recipients",
+        "message",
+        "subject",
+        "cc",
+        "bcc",
+        "confirmed",
+      ]);
+      requireConfirmation(input, "Sending a reply");
+      return connectors.sendReply({
+        botId: requiredString(input.botId, "botId"),
+        recipients: stringArray(input.recipients, "recipients", {
+          required: true,
+        }),
+        message: requiredString(input.message, "message"),
+        subject: optionalString(input.subject, "subject"),
+        cc: stringArray(input.cc, "cc"),
+        bcc: stringArray(input.bcc, "bcc"),
+      });
+    }
+    default:
+      throw new connectors.ConnectorError(
+        "UNKNOWN_TOOL",
+        "Unknown connector tool.",
+      );
+  }
+}
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+async function handleRequest(request) {
+  const { id, method, params = {} } = request;
+  if (
+    method === "notifications/initialized" ||
+    method === "notifications/cancelled"
+  )
+    return;
+  if (id === undefined || id === null) return;
+
+  try {
+    let result;
+    switch (method) {
+      case "initialize":
+        result = {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: SERVER_INFO,
+          instructions:
+            "Use these host-side tools for native OpenLoomi connector operations. Never place connector credentials in tool arguments; connect returns a Desktop UI handoff.",
+        };
+        break;
+      case "ping":
+        result = {};
+        break;
+      case "tools/list":
+        result = { tools: TOOLS };
+        break;
+      case "tools/call":
+        try {
+          result = toolResult(
+            await callTool(params.name, params.arguments || {}),
+          );
+        } catch (error) {
+          const structured = { error: connectorError(error) };
+          result = { ...toolResult(structured), isError: true };
+        }
+        break;
+      default:
+        send({
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32601, message: `Method not found: ${method}` },
+        });
+        return;
+    }
+    send({ jsonrpc: "2.0", id, result });
+  } catch (error) {
+    send({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32603, message: error?.message || "Internal error" },
+    });
+  }
+}
+
+function startServer() {
+  const input = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+  input.on("line", (line) => {
+    if (!line.trim()) return;
+    if (Buffer.byteLength(line) > MAX_REQUEST_BYTES) {
+      send({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32600, message: "MCP request exceeded 1 MiB." },
+      });
+      return;
+    }
+    let request;
+    try {
+      request = JSON.parse(line);
+    } catch {
+      send({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      });
+      return;
+    }
+    void handleRequest(request);
+  });
+}
+
+module.exports = { TOOLS, callTool, handleRequest, startServer };
+
+if (require.main === module) {
+  startServer();
+}

--- a/plugins/codex/skills/openloomi-connectors/SKILL.md
+++ b/plugins/codex/skills/openloomi-connectors/SKILL.md
@@ -1,382 +1,137 @@
 ---
 name: openloomi-connectors
-description: "openloomi Connectors tools - manage platform integrations (OAuth connections, list accounts, check status). Triggers: connect platform, integration status, list accounts, disconnect. Pair with the composio skill to also list composio-linked accounts."
-allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
+description: "Manage OpenLoomi's native connector accounts: list platforms or accounts, check status, open a safe connection handoff, disconnect, query contacts, and send a reply. Trigger for native OpenLoomi connector/account questions; pair with Composio only when the user also asks about Composio-managed apps."
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+# OpenLoomi Connectors
 
-# OpenLoomi Connectors Skill
+Use OpenLoomi's host-side MCP tools for native connector work. They reach the
+local Desktop API without asking a shell command inside Codex's sandbox to
+cross the host loopback boundary.
 
-OpenLoomi Connectors provides access to 7 messaging and productivity platform integrations. It allows AI agents to manage OAuth connections, list connected accounts, check connection status, and disconnect platforms on behalf of the user.
+## Execution order
 
-> **Pairing with the `composio` skill:** This skill covers openloomi's **native 7 integrations** listed below. For accounts connected through **Composio** (a broader 1000+ apps surface — e.g. X, LinkedIn, Notion, HubSpot, Linear, Jira, etc.), invoke the `composio` skill in parallel: use the `composio-cli` to list connections, or call `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with `action: "list"`. When the user asks "what am I connected to?" or "list my accounts", run both — `list-accounts` here **and** the composio connection listing — and present the union. Keep auth, OAuth, and disconnect flows native to each skill.
+1. Use the `openloomi` MCP server first:
 
----
+   | Intent | Tool |
+   | --- | --- |
+   | List native platforms | `mcp__openloomi__list_platforms` |
+   | List connected native accounts | `mcp__openloomi__list_accounts` |
+   | Check one native platform | `mcp__openloomi__connector_status` |
+   | Start a connection | `mcp__openloomi__connect` |
+   | Disconnect an account | `mcp__openloomi__disconnect` |
+   | Find contacts | `mcp__openloomi__query_contacts` |
+   | Send a message | `mcp__openloomi__send_reply` |
 
-## What is openloomi?
+2. Use the bundled CLI only when those MCP tools are unavailable. The CLI is a
+   compatibility path, not the preferred Codex transport.
+3. Report the structured result. Never infer "disconnected" from a transport
+   error.
 
-Most AI assistants function as workflow tools—users give commands, they execute tasks, with no persistent knowledge of who you are or what matters to you.
+Do not ask for an out-of-sandbox retry. OpenLoomi launches Codex through
+non-interactive `codex exec`, so an interactive escalation cannot be serviced.
+The host-side MCP transport is the automatic path; it does not enable network
+access for model-generated shell commands.
 
-**openloomi takes a fundamentally different approach: it operates as a proactive digital partner** that watches, learns, remembers, and acts on your behalf. The difference is architectural.
+## Native platforms
 
-### How It Works
+This skill covers exactly seven native platforms:
 
-When users connect messaging platforms and integrations to openloomi, they sync with permission:
-- Raw messages and communications
-- Meetings and calendar events
-- Emails and tweets
-- Voice calls
-- Notes and captured ideas
+| ID | Name | Aliases |
+| --- | --- | --- |
+| `telegram` | Telegram | `tg` |
+| `whatsapp` | WhatsApp | — |
+| `imessage` | iMessage | — |
+| `feishu` | Lark/Feishu | `lark`, `飞书` |
+| `dingtalk` | DingTalk | `钉钉` |
+| `qqbot` | QQ | `qq`, `qq_bot` |
+| `weixin` | WeChat | `wechat`, `微信`, `wechat_work`, `wecom`, `企业微信` |
 
-This aggregated data becomes "the single source of truth for openloomi's brain."
+Slack, Gmail, Outlook, GitHub, Notion, Linear, and other non-native apps are
+handled by OpenLoomi Desktop or Composio. Do not pass those names to
+`connector_status` and present an "unknown native platform" response as a
+connection result.
 
-### The Continuous Sync Loop
+When the user asks for every linked account across OpenLoomi and Composio, run
+`list_accounts` here and the Composio connection listing in parallel, then
+label and combine the two sources. A Composio success is not a substitute for
+a failed native OpenLoomi lookup.
 
-openloomi runs a background agent on a continuous sync loop, actively gathering information from all connected sources. An agent without this loop can only respond based on stale context. With it, every conversation—and every moment—makes openloomi smarter and more aligned with you.
+## Security and confirmation
 
----
+- Never request, print, or place OAuth tokens, app passwords, client secrets,
+  app secrets, iLink tokens, or the OpenLoomi bearer token in prompts or argv.
+  If the user pastes a real credential, do not repeat it and recommend rotating
+  it after redirecting setup to Desktop.
+- `connect` accepts only a native platform name. It returns a local OpenLoomi
+  Desktop URL; the user enters credentials or completes QR/OAuth interaction
+  there.
+- Call `disconnect` with `confirmed: true` only after the user has identified
+  and approved the exact account.
+- Call `send_reply` with `confirmed: true` only when the user has approved the
+  exact sender bot, recipients, and message. A direct request containing all
+  of those details counts as approval; otherwise show the draft first.
+- Use the account `id` for disconnect. Use its separate `botId` for sending.
 
-## Supported Platforms (7)
+## Core workflows
 
-The CLI `list-platforms` returns these 7 platforms. Other connectable
-platforms (Slack, Discord, X, Gmail, Outlook, LinkedIn, Google Calendar,
-Google Drive, Google Docs, HubSpot, Notion, etc.) are managed via the
-desktop UI or the `composio` skill — see "Platform Connection Methods"
-below for details.
+### List or check status
 
-| ID | Display Name | Aliases |
-|----|-------------|---------|
-| `telegram` | Telegram | tg |
-| `whatsapp` | WhatsApp | |
-| `imessage` | iMessage | |
-| `feishu` | Lark/Feishu | lark, 飞书 |
-| `dingtalk` | DingTalk | 钉钉 |
-| `qqbot` | QQ | qq, qq_bot |
-| `weixin` | WeChat | wechat, 微信, wechat_work, wecom, 企业微信 |
+- Use `list_accounts` for "what am I connected to?".
+- Use `connector_status` for one of the native platform IDs or aliases.
+- Treat an empty, successfully returned `accounts` array as "no native
+  accounts". `connected: true` means at least one matching account is
+  `active`; expired accounts remain visible but are not called connected. Do
+  not treat an API error as an empty list.
 
----
+### Connect
 
-## Authentication
+Call `connect` with only `platform`. Return its `handoffUrl` as a
+clickable local link and explain that completion happens inside OpenLoomi.
+After the user completes the UI flow, re-run `connector_status` to verify it.
 
-The CLI auto-reads your token from `~/.openloomi/token` (base64 encoded JWT).
+### Disconnect
 
-### Local API Access
+If the user gave only a platform name, call `list_accounts`, show matching
+account IDs/display names, and ask which account to remove. Then call
+`disconnect` once with the approved `accountId` and `confirmed: true`.
 
-The local API server runs on port **3414** (fallback: **3515**). If 3414 is unavailable, try 3515.
+### Query contacts and send
 
----
+Use `query_contacts` to resolve ambiguous recipients. Before sending, make
+sure the selected account exposes a `botId`; pass the exact returned contact
+`name` values as `recipients`. Do not automatically retry a send whose result
+is reported as unknown. This tool set cannot query message delivery history,
+so verify an unknown send in OpenLoomi Desktop or the target conversation.
 
-## Sandbox and network
+## Structured failures
 
-If any connector command (`list-accounts`, `status`, `connect`, `disconnect`,
-`send-reply`, `query-contacts`) fails with a network error
-(`ECONNREFUSED`, `ETIMEDOUT`, "unreachable", or missing accounts), check
-whether Codex is running inside a sandbox before concluding the local API
-or a remote platform is down. Codex network sandboxing can block:
+Handle client error codes as follows:
 
-- Loopback access to the host's `localhost` (e.g. `http://localhost:3414`).
-- Outbound traffic to OAuth providers and integration APIs (Slack, Discord,
-  X, Gmail, Outlook, Telegram, WhatsApp, etc.).
+| Code | Response |
+| --- | --- |
+| `AUTH_TOKEN_MISSING`, `AUTH_TOKEN_INVALID`, `AUTH_FAILED` | Ask the user to sign in again in OpenLoomi Desktop. Do not expose token contents. |
+| `LOCAL_API_UNREACHABLE` | Say the local API could not be verified; ask the user to start/restart OpenLoomi Desktop. Do not claim accounts are disconnected. |
+| `SANDBOX_BLOCKED` | The CLI fallback was sandboxed. Retry with the MCP tool if present; do not promise an unavailable interactive escalation. |
+| `REQUEST_OUTCOME_UNKNOWN` | Explain that a mutating request may have arrived and was deliberately not retried. Verify account/message state before any retry. |
+| `API_OPERATION_FAILED` | OpenLoomi safely rejected the requested send/disconnect. Report failure; never claim the action completed. |
+| `AUTH_TOKEN_UNREADABLE`, `INVALID_API_RESPONSE`, `API_HTTP_ERROR` | Report the safe message/code and the suggested local-app action. Never print raw token data. |
 
-Request approval and retry the same command outside the sandbox. If the
-outside-sandbox retry succeeds, treat the in-sandbox failure as a sandbox
-artifact and continue with the response. Do not conclude that a platform
-is disconnected or that OpenLoomi is stopped until the outside-sandbox
-retry also fails.
+## CLI compatibility path
 
----
-
-## API Endpoints
-
-### Integration Accounts
-
-#### GET `/api/integrations/accounts` - List Connected Accounts
-
-Returns all connected platform accounts for the authenticated user.
+The script reads the base64-encoded local token internally. It supports
+`OPENLOOMI_API_URL` or `OPENLOOMI_BASE_URL` for an explicit loopback origin and
+otherwise probes ports 3414 and 3515.
 
 ```bash
-curl http://localhost:3414/api/integrations/accounts \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "accounts": [
-    {
-      "id": "int_xxx",
-      "platform": "gmail",
-      "externalId": "user@gmail.com",
-      "displayName": "My Gmail",
-      "status": "active",
-      "metadata": {},
-      "createdAt": "2024-01-01T00:00:00Z",
-      "botId": "bot_xxx"
-    }
-  ]
-}
-```
-
-**Note:** Each account includes a `botId` field which is used for `send-reply` and other bot operations.
-
----
-
-### OAuth Start Endpoints
-
-#### GET `/api/integrations/slack/oauth/start?userId=<userId>` - Start Slack OAuth
-
-Returns the Slack OAuth authorization URL. The CLI opens this URL in the browser for the user to complete authorization.
-
-```bash
-curl "http://localhost:3414/api/integrations/slack/oauth/start?userId=<userId>"
-```
-
-**Response:**
-```json
-{
-  "authorizationUrl": "https://slack.com/oauth/v2/authorize?...",
-  "state": "userId:uuid"
-}
-```
-
-#### GET `/api/integrations/discord/oauth/start?userId=<userId>` - Start Discord OAuth
-
-Returns the Discord OAuth authorization URL.
-
-#### GET `/api/integrations/x/oauth/start?userId=<userId>` - Start X OAuth
-
-Returns the X/Twitter OAuth authorization URL.
-
----
-
-### OAuth Exchange Endpoints
-
-#### GET `/api/integrations/slack/oauth/exchange?code=<code>&state=<state>` - Exchange Slack Code
-
-Exchange OAuth code for Slack access.
-
-#### GET `/api/integrations/discord/oauth/exchange?code=<code>&state=<state>` - Exchange Discord Code
-
-Exchange OAuth code for Discord access.
-
----
-
-### OAuth Callbacks
-
-| Platform | Endpoint |
-|----------|----------|
-| Feishu | `POST /api/feishu/listener/init` |
-| DingTalk | `POST /api/dingtalk/listener/init` |
-| QQ Bot | `POST /api/qqbot/listener/init` |
-| WeChat | `POST /api/weixin/listener/init` |
-| Telegram | `POST /api/telegram/user-listener/init` |
-| WhatsApp | `POST /api/whatsapp/register-socket` |
-| iMessage | `POST /api/imessage/init-self-listener` |
-
----
-
-### DELETE `/api/integrations/:id` - Disconnect Account
-
-Delete a connected integration account.
-
-```bash
-curl -X DELETE http://localhost:3414/api/integrations/int_xxx \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "deletedAccountId": "int_xxx",
-  "deletedBotIds": ["bot_xxx"]
-}
-```
-
----
-
-### GET `/api/contacts` - Query Contacts
-
-Query user contacts with optional filtering and pagination.
-
-```bash
-curl "http://localhost:3414/api/contacts?name=John&page=1&pageSize=10" \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Parameters:**
-- `name` (string, optional) - Filter contacts by name (partial match)
-- `page` (number, default 1) - Page number
-- `pageSize` (number, default 10) - Items per page (max 100)
-
-**Response:**
-```json
-{
-  "success": true,
-  "contacts": [
-    {
-      "id": "contact_xxx",
-      "name": "John Doe",
-      "type": "email",
-      "botId": "bot_xxx",
-      "platform": "gmail"
-    }
-  ],
-  "pagination": {
-    "page": 1,
-    "pageSize": 10,
-    "totalCount": 50,
-    "totalPages": 5,
-    "hasMore": true,
-    "hasPrevious": false
-  }
-}
-```
-
----
-
-### POST `/api/messages` - Send Message
-
-Send a message via a connected platform bot.
-
-```bash
-curl -X POST http://localhost:3414/api/messages \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "botId": "bot_xxx",
-    "recipients": ["John"],
-    "message": "Hello!",
-    "subject": "Optional subject"
-  }'
-```
-
-**Parameters:**
-- `botId` (string, required) - The bot ID to send from
-- `recipients` (array, required) - List of recipient names
-- `message` (string, required) - Message content
-- `subject` (string, optional) - Email subject line
-- `cc` (array, optional) - CC recipients
-- `bcc` (array, optional) - BCC recipients
-
-**Note:** `botId` is returned by `list-accounts` in the `botId` field (different from account `id`).
-
----
-
-## Platform Aliases Reference
-
-Aliases are case-insensitive and support both English and Chinese:
-
-| Alias | Platform |
-|-------|----------|
-| `tg` | telegram |
-| `wechat`, `微信` | weixin |
-| `lark`, `飞书` | feishu |
-| `钉钉` | dingtalk |
-| `qq`, `qq_bot` | qqbot |
-
----
-
-## Desktop UI
-
-Users can also authorize accounts directly through the openloomi desktop application without using CLI commands.
-
-### Adding Account Authorization via Desktop UI
-
-1. **Open openloomi desktop app** on your computer
-2. **Navigate to Settings** (gear icon in the sidebar or top-right menu)
-3. **Go to Integrations** tab/section
-4. **Click on the platform** you want to connect (e.g., Telegram, Slack, Discord, Gmail, etc.)
-5. **Follow the platform-specific authorization flow:**
-   - **OAuth platforms** (Slack, Discord, X/Twitter): Click "Connect" → you'll be redirected to the platform's authorization page in your browser → Approve the permissions → you'll be redirected back
-   - **App Password platforms** (Gmail, Outlook): Enter your email and app password
-   - **App Credentials platforms** (DingTalk, Feishu, QQ): Enter your appId and appSecret
-   - **QR/Interactive platforms** (WhatsApp, Telegram, iMessage): Scan the QR code or follow the in-app instructions
-
-6. **Verify connection** — once authorized, the platform will show as "Connected" with a green checkmark
-
-### Managing Connected Accounts
-
-- **List connected accounts**: Settings → Integrations → shows all connected platforms with status
-- **Disconnect account**: Settings → Integrations → click on connected platform → "Disconnect" or remove
-- **Check status**: Connected platforms show green "Active" badge; expired/disconnected shows red "Inactive" badge
-
----
-
-## CLI Script
-
-### Quick Start
-
-```bash
-# List all supported platforms
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-platforms
-
-# List all connected accounts (includes botId for send-reply)
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-
-# Cross-source audit: openloomi-native + composio-linked accounts (run together, present union)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-# In parallel, invoke the `composio` skill (e.g. `composio list-connections` via composio-cli,
-# or `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with action: "list")
-
-# Check connection status for a platform
 node $SKILL_DIR/scripts/openloomi-connectors.cjs status telegram
-
-# Connect a platform (opens browser for OAuth)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs connect slack
-
-# Disconnect an account by ID
-node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx
-
-# Query contacts
+node $SKILL_DIR/scripts/openloomi-connectors.cjs connect telegram
+node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx --confirmed=true
 node $SKILL_DIR/scripts/openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-
-# Send a message (requires botId from list-accounts)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
+node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello" --confirmed=true
 ```
 
-### Commands
-
-| Command | Description |
-|---------|-------------|
-| `list-platforms` | List all 7 supported platforms with IDs and aliases |
-| `list-accounts` | List all connected integration accounts (includes `botId`) |
-| `status <platform>` | Check if a platform is connected (e.g., telegram, slack) |
-| `connect <platform> [options]` | Connect a platform (OAuth, App Password, or App Credentials) |
-| `disconnect <accountId>` | Disconnect a specific account by ID |
-| `query-contacts [options]` | Query contacts (--name=, --page=, --pageSize=) |
-| `send-reply --botId= --recipients= --message=` | Send a message via REST API |
-
-### Platform Connection Methods
-
-| Method | Platforms |
-|--------|-----------|
-| OAuth (auto-opens browser) | `slack`, `discord`, `x` |
-| App Password | `gmail --email=x --password=xxxx`, `outlook --email=x --password=xxxx` |
-| App Credentials | `dingtalk --clientId=x --clientSecret=x`, `feishu --appId=x --appSecret=x`, `qq --appId=x --appSecret=x` |
-| iLink Token | `wechat --token=x` |
-| Browser Required (QR/interactive) | `whatsapp`, `telegram`, `imessage` |
-
----
-
-## AI Agent Workflow
-
-**Triggered when the user asks about:**
-
-1. Connecting a platform - "connect telegram", "link my slack"
-2. Listing integrations - "show my connected accounts", "what platforms am I connected to"
-3. Checking status - "is my github connected?", "telegram status"
-4. Disconnecting - "disconnect my discord", "remove whatsapp"
-5. Querying contacts - "show my contacts", "find John in contacts"
-6. Sending messages - "send email to John", "reply to that message"
-7. Cross-source account audit - "show everything I'm connected to (openloomi + composio)", "list all linked accounts across both" → run `list-accounts` here **and** the `composio` skill in parallel, then present the union
-
-**Execution Flow:**
-
-1. **Identify intent** - connect / list / status / disconnect / query-contacts / send-reply
-2. **Resolve platform** - use alias normalization (e.g., `gh` -> `github`)
-3. **Execute command** - use Bash tool
-4. **Format output** - report results naturally in user's language
-
-**Note on send-reply:** The `botId` is returned by `list-accounts` in the `botId` field.
+Never append credential options to `connect`; the client rejects them by
+design.

--- a/plugins/codex/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
+++ b/plugins/codex/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
@@ -1,555 +1,707 @@
 #!/usr/bin/env node
-const http = require('node:http');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
-const { execSync } = require('node:child_process');
+"use strict";
 
-const PORTS = [3414, 3515, 3415]; // dev, local fallback, prod
-const TOKEN_PATH = path.join(os.homedir(), '.openloomi', 'token');
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
 
-// Platform definitions matching connector-target.ts
-// Platforms listed here must be enabled in `platform-connectability.ts`
-// (`isIntegrationPlatformConnectable`). COMING_SOON / HIDDEN platforms
-// (e.g. github, instagram, facebook_messenger, teams, asana, jira, linear,
-// google_meet) are intentionally omitted — they cannot start a new
-// connection from the connector UI.
-// `outlook_calendar` is gated behind NEXT_PUBLIC_OUTLOOK_CALENDAR_ENABLED.
+const DEFAULT_BASE_URLS = ["http://127.0.0.1:3414", "http://127.0.0.1:3515"];
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const SAFE_PRECONNECT_ERRORS = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "ETIMEDOUT",
+]);
+
+// Keep this list aligned with the platforms that the Desktop connector UI can
+// start today. Connection setup itself intentionally remains in Desktop so an
+// agent never receives connector credentials or QR/login challenges.
 const PLATFORMS = [
-  { id: 'telegram', name: 'Telegram', aliases: ['tg'] },
-  { id: 'whatsapp', name: 'WhatsApp', aliases: [] },
-  { id: 'imessage', name: 'iMessage', aliases: [] },
-  { id: 'feishu', name: 'Lark/Feishu', aliases: ['lark', '飞书'] },
-  { id: 'dingtalk', name: 'DingTalk', aliases: ['钉钉'] },
-  { id: 'qqbot', name: 'QQ', aliases: ['qq', 'qq_bot'] },
-  { id: 'weixin', name: 'WeChat', aliases: ['wechat', '微信', 'wechat_work', 'wecom', '企业微信'] },
+  { id: "telegram", name: "Telegram", aliases: ["tg"] },
+  { id: "whatsapp", name: "WhatsApp", aliases: [] },
+  { id: "imessage", name: "iMessage", aliases: [] },
+  { id: "feishu", name: "Lark/Feishu", aliases: ["lark", "飞书"] },
+  { id: "dingtalk", name: "DingTalk", aliases: ["钉钉"] },
+  { id: "qqbot", name: "QQ", aliases: ["qq", "qq_bot"] },
+  {
+    id: "weixin",
+    name: "WeChat",
+    aliases: ["wechat", "微信", "wechat_work", "wecom", "企业微信"],
+  },
 ];
 
-// Build alias lookup map (case-insensitive)
-const ALIAS_TO_PLATFORM = {};
-for (const p of PLATFORMS) {
-  ALIAS_TO_PLATFORM[p.id] = p.id;
-  for (const alias of p.aliases) {
-    ALIAS_TO_PLATFORM[alias.toLowerCase()] = p.id;
+const ALIAS_TO_PLATFORM = new Map();
+for (const platform of PLATFORMS) {
+  ALIAS_TO_PLATFORM.set(platform.id, platform.id);
+  for (const alias of platform.aliases) {
+    ALIAS_TO_PLATFORM.set(alias.toLowerCase(), platform.id);
   }
 }
 
-// OAuth start endpoints by platform
-const OAUTH_ENDPOINTS = {
-  slack: '/api/integrations/slack/oauth/start',
-  discord: '/api/integrations/discord/oauth/start',
-  x: '/api/integrations/x/oauth/start',
-};
+class ConnectorError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ConnectorError";
+    this.code = code;
+    this.details = details;
+  }
+
+  toJSON() {
+    return { code: this.code, message: this.message, ...this.details };
+  }
+}
+
+function resolvePlatform(input) {
+  if (typeof input !== "string") return null;
+  return ALIAS_TO_PLATFORM.get(input.trim().toLowerCase()) || null;
+}
+
+function getTokenPath() {
+  return (
+    process.env.OPENLOOMI_TOKEN_PATH?.trim() ||
+    path.join(os.homedir(), ".openloomi", "token")
+  );
+}
+
+function readTokenState() {
+  let encoded;
+  try {
+    encoded = fs.readFileSync(getTokenPath(), "utf8").trim();
+  } catch (error) {
+    if (error?.code === "ENOENT") return { present: false, token: null };
+    throw new ConnectorError(
+      "AUTH_TOKEN_UNREADABLE",
+      "OpenLoomi's local authentication token could not be read.",
+      { tokenPresent: false },
+    );
+  }
+
+  if (!encoded) return { present: false, token: null };
+  try {
+    const bytes = Buffer.from(encoded, "base64");
+    const canonical = bytes.toString("base64").replace(/=+$/, "");
+    if (canonical !== encoded.replace(/=+$/, "")) {
+      return { present: true, token: null, invalid: true };
+    }
+    const decoded = Buffer.from(encoded, "base64").toString("utf8").trim();
+    if (!decoded || decoded.includes("\0")) {
+      return { present: true, token: null, invalid: true };
+    }
+    return { present: true, token: decoded, invalid: false };
+  } catch {
+    return { present: true, token: null, invalid: true };
+  }
+}
 
 function getAuthToken() {
   try {
-    const encoded = fs.readFileSync(TOKEN_PATH, 'utf8').trim();
-    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-    return decoded;
+    return readTokenState().token || null;
   } catch {
     return null;
   }
 }
 
-function apiRequest(endpoint, method = 'GET', body = null, portIndex = 0) {
-  return new Promise((resolve, reject) => {
-    if (portIndex >= PORTS.length) {
-      reject(new Error('openloomi server not running. Tried ports: ' + PORTS.join(', ')));
-      return;
+function requireAuthToken() {
+  const state = readTokenState();
+  if (state.invalid) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_INVALID",
+      "OpenLoomi's local authentication token is invalid. Sign in again in OpenLoomi Desktop.",
+      { tokenPresent: true },
+    );
+  }
+  if (!state.token) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_MISSING",
+      "OpenLoomi's local authentication token is missing. Sign in in OpenLoomi Desktop first.",
+      { tokenPresent: false },
+    );
+  }
+  return state.token;
+}
+
+function normalizeLoopbackUrl(value, envName) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" || !LOOPBACK_HOSTS.has(url.hostname.toLowerCase())) {
+      throw new Error("must be an http loopback URL");
     }
+    if (url.username || url.password) throw new Error("must not include credentials");
+    if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+      throw new Error("must contain only an origin");
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch (error) {
+    throw new ConnectorError(
+      "INVALID_API_URL",
+      `${envName} must be an HTTP URL on localhost, 127.0.0.1, or ::1.`,
+      { env: envName, reason: error.message },
+    );
+  }
+}
 
-    const port = PORTS[portIndex];
-    const url = new URL(endpoint, `http://localhost:${port}`);
+function getBaseUrls() {
+  if (process.env.OPENLOOMI_API_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_API_URL.trim(), "OPENLOOMI_API_URL")];
+  }
+  if (process.env.OPENLOOMI_BASE_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_BASE_URL.trim(), "OPENLOOMI_BASE_URL")];
+  }
+  return [...DEFAULT_BASE_URLS];
+}
+
+function redact(value, depth = 0) {
+  if (depth > 4) return "[truncated]";
+  if (Array.isArray(value)) return value.slice(0, 50).map((item) => redact(item, depth + 1));
+  if (!value || typeof value !== "object") {
+    if (typeof value !== "string") return value;
     const token = getAuthToken();
+    const withoutToken = token ? value.split(token).join("[redacted]") : value;
+    const withoutBearer = withoutToken.replace(/Bearer\s+[^\s,;]+/gi, "Bearer [redacted]");
+    return withoutBearer.length > 1_000 ? `${withoutBearer.slice(0, 1_000)}…` : withoutBearer;
+  }
+  const result = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (/token|secret|password|credential|authorization|cookie/i.test(key)) {
+      result[key] = "[redacted]";
+    } else {
+      result[key] = redact(item, depth + 1);
+    }
+  }
+  return result;
+}
 
-    const options = {
-      hostname: url.hostname,
-      port: url.port,
-      path: url.pathname + url.search,
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token && { 'Authorization': `Bearer ${token}` })
-      }
-    };
+function configuredTimeout(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || !Number.isInteger(parsed) || parsed < 50 || parsed > 60_000) {
+    throw new ConnectorError(
+      "INVALID_TIMEOUT",
+      `${name} must be an integer between 50 and 60000 milliseconds.`,
+    );
+  }
+  return parsed;
+}
 
-    const req = http.request(options, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json);
-        } catch {
-          resolve(data);
-        }
+function parseResponseBody(text, context) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi returned malformed JSON.",
+      context,
+    );
+  }
+}
+
+function requestOnce(
+  baseUrl,
+  endpoint,
+  {
+    method = "GET",
+    body = null,
+    token = null,
+    timeoutMs = configuredTimeout("OPENLOOMI_API_TIMEOUT_MS", DEFAULT_REQUEST_TIMEOUT_MS),
+  } = {},
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(endpoint, `${baseUrl}/`);
+    let connected = false;
+    let settled = false;
+    const payload = body === null ? null : JSON.stringify(body);
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: {
+          Accept: "application/json",
+          ...(payload && {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(payload),
+          }),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        connected = true;
+        let responseText = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          if (responseText.length < 1_000_000) responseText += chunk;
+        });
+        res.on("end", () => {
+          if (settled) return;
+          settled = true;
+          const status = res.statusCode || 0;
+          if (status < 200 || status >= 300) {
+            let responseBody = responseText;
+            try {
+              responseBody = responseText ? JSON.parse(responseText) : null;
+            } catch {
+              // Preserve a bounded, redacted response excerpt for diagnostics.
+            }
+            const authenticationFailure = status === 401 || status === 403;
+            reject(
+              new ConnectorError(
+                authenticationFailure ? "AUTH_FAILED" : "API_HTTP_ERROR",
+                authenticationFailure
+                  ? "OpenLoomi rejected the local authentication token. Sign in again in OpenLoomi Desktop."
+                  : `OpenLoomi returned HTTP ${status}.`,
+                {
+                  status,
+                  method,
+                  endpoint: url.pathname,
+                  ...(authenticationFailure ? {} : { response: redact(responseBody) }),
+                },
+              ),
+            );
+            return;
+          }
+          let responseBody;
+          try {
+            responseBody = parseResponseBody(responseText, {
+              status,
+              method,
+              endpoint: url.pathname,
+            });
+          } catch (error) {
+            reject(error);
+            return;
+          }
+          resolve({ data: responseBody, status, baseUrl });
+        });
+        const rejectResponseFailure = (sourceError) => {
+          if (settled) return;
+          settled = true;
+          const error = sourceError instanceof Error ? sourceError : new Error("Response was aborted");
+          error.code ||= "ECONNRESET";
+          error.connected = true;
+          reject(error);
+        };
+        res.on("aborted", () => rejectResponseFailure());
+        res.on("error", rejectResponseFailure);
+      },
+    );
+
+    req.on("socket", (socket) => {
+      if (!socket.connecting) connected = true;
+      socket.once("connect", () => {
+        connected = true;
       });
     });
-
-    req.on('error', () => {
-      // Try next port on connection error
-      apiRequest(endpoint, method, body, portIndex + 1).then(resolve).catch(reject);
+    req.setTimeout(timeoutMs, () => {
+      const error = new Error(`Request timed out after ${timeoutMs}ms`);
+      error.code = "ETIMEDOUT";
+      req.destroy(error);
     });
-    if (body) req.write(JSON.stringify(body));
+    req.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      error.connected = connected;
+      reject(error);
+    });
+    if (payload) req.write(payload);
     req.end();
   });
 }
 
-function openUrl(url) {
-  const cmd = os.platform() === 'darwin' ? 'open' : os.platform() === 'win32' ? 'start' : 'xdg-open';
-  execSync(`${cmd} "${url}"`, { stdio: 'ignore' });
+function matchesOpenLoomiProviderShape(data) {
+  return Boolean(
+    data &&
+      typeof data === "object" &&
+      Array.isArray(data.agents) &&
+      typeof data.defaultAgent === "string",
+  );
 }
 
-function resolvePlatform(input) {
-  if (!input) return null;
-  const normalized = input.toLowerCase().trim();
-  return ALIAS_TO_PLATFORM[normalized] || null;
-}
-
-async function listPlatforms() {
+function attemptSummary(baseUrl, stage, error) {
   return {
-    platforms: PLATFORMS.map(p => ({
-      id: p.id,
-      name: p.name,
-      aliases: p.aliases
-    })),
-    total: PLATFORMS.length
+    baseUrl,
+    stage,
+    code: error.code || "UNKNOWN_ERROR",
+    ...(error.details?.status ? { status: error.details.status } : {}),
+    connected: Boolean(error.connected),
   };
 }
 
+function isTransportError(error) {
+  return !(error instanceof ConnectorError) && typeof error?.code === "string";
+}
+
+function unreachableError(attempts, tokenPresent) {
+  const transportAttempts = attempts.filter((attempt) =>
+    [
+      "ECONNREFUSED",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "ENETDOWN",
+      "ETIMEDOUT",
+      "ECONNRESET",
+    ].includes(attempt.code),
+  );
+  const loopbackAccessAmbiguous =
+    transportAttempts.length > 0 &&
+    transportAttempts.every((attempt) =>
+      ["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "ENETDOWN", "ETIMEDOUT", "ECONNRESET"].includes(
+        attempt.code,
+      ),
+    );
+  const sandboxDisabled = process.env.CODEX_SANDBOX_NETWORK_DISABLED === "1";
+  return new ConnectorError(
+    sandboxDisabled ? "SANDBOX_BLOCKED" : "LOCAL_API_UNREACHABLE",
+    sandboxDisabled
+      ? "Codex sandbox network access is disabled; the local OpenLoomi API cannot be reached."
+      : "The local OpenLoomi API could not be reached or identified.",
+    { attempts, tokenPresent, loopbackAccessAmbiguous },
+  );
+}
+
+async function probeCandidate(baseUrl) {
+  const response = await requestOnce(baseUrl, "/api/native/providers", {
+    timeoutMs: configuredTimeout("OPENLOOMI_API_PROBE_TIMEOUT_MS", DEFAULT_PROBE_TIMEOUT_MS),
+  });
+  if (!matchesOpenLoomiProviderShape(response.data)) {
+    throw new ConnectorError(
+      "NOT_OPENLOOMI_API",
+      "The loopback service did not match the expected OpenLoomi API response shape.",
+      { baseUrl, endpoint: "/api/native/providers" },
+    );
+  }
+  return response;
+}
+
+async function discoverOpenLoomi() {
+  const attempts = [];
+  let tokenPresent = false;
+  try {
+    tokenPresent = readTokenState().present;
+  } catch {
+    // Connection handoff does not require a token; token state is diagnostic only.
+  }
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+      return { baseUrl, attempts };
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+    }
+  }
+  throw unreachableError(attempts, tokenPresent);
+}
+
+async function apiRequest(endpoint, method = "GET", body = null) {
+  const upperMethod = method.toUpperCase();
+  const readOnly = upperMethod === "GET" || upperMethod === "HEAD";
+  const token = requireAuthToken();
+  const attempts = [];
+
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+      continue;
+    }
+
+    try {
+      const response = await requestOnce(baseUrl, endpoint, {
+        method: upperMethod,
+        body,
+        token,
+      });
+      return response.data;
+    } catch (error) {
+      if (error instanceof ConnectorError) throw error;
+      attempts.push(attemptSummary(baseUrl, "request", error));
+      if (readOnly) continue;
+      if (!error.connected && SAFE_PRECONNECT_ERRORS.has(error.code)) continue;
+      throw new ConnectorError(
+        "REQUEST_OUTCOME_UNKNOWN",
+        `The ${upperMethod} request failed after connecting; it will not be retried automatically.`,
+        { method: upperMethod, endpoint, baseUrl, cause: error.code || "NETWORK_ERROR" },
+      );
+    }
+  }
+
+  throw unreachableError(attempts, Boolean(token));
+}
+
+function sanitizeAccount(account) {
+  if (!account || typeof account !== "object") return null;
+  const allowed = [
+    "id",
+    "platform",
+    "displayName",
+    "status",
+    "createdAt",
+    "updatedAt",
+    "botId",
+    "hasValidContextToken",
+  ];
+  return Object.fromEntries(allowed.filter((key) => account[key] !== undefined).map((key) => [key, account[key]]));
+}
+
+async function listPlatforms() {
+  return { platforms: PLATFORMS.map(({ id, name, aliases }) => ({ id, name, aliases })), total: PLATFORMS.length };
+}
+
 async function listAccounts() {
-  return apiRequest('/api/integrations/accounts');
+  const data = await apiRequest("/api/integrations/accounts");
+  const accounts = Array.isArray(data) ? data : data?.accounts;
+  if (!Array.isArray(accounts)) {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi's accounts response did not contain an accounts array.",
+    );
+  }
+  const sanitized = accounts.map(sanitizeAccount).filter(Boolean);
+  return { accounts: sanitized, total: sanitized.length };
 }
 
 async function getStatus(platform) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const data = await apiRequest('/api/integrations/accounts');
-  const accounts = data.accounts || [];
-  const matching = accounts.filter(a => a.platform === platformId);
-
-  if (matching.length === 0) {
-    return {
-      platform: platformId,
-      connected: false,
-      accounts: []
-    };
-  }
-
+  const { accounts } = await listAccounts();
+  const matching = accounts.filter((account) => account.platform === platformId);
   return {
     platform: platformId,
-    connected: true,
-    accounts: matching.map(a => ({
-      id: a.id,
-      displayName: a.displayName,
-      status: a.status,
-      connectedAt: a.createdAt
-    }))
+    connected: matching.some((account) => account.status === "active"),
+    accounts: matching.map(({ platform: _platform, ...account }) => account),
   };
 }
 
-async function getOAuthUrl(platform) {
+async function connectPlatform(platform, options = {}) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const endpoint = OAUTH_ENDPOINTS[platformId];
-  if (!endpoint) {
-    throw new Error(`OAuth not supported for ${platformId} via CLI. Use the web UI to connect.`);
+  if (options && Object.keys(options).length > 0) {
+    throw new ConnectorError(
+      "SECRETS_NOT_ACCEPTED",
+      "Connect accepts no credentials or secrets. Complete setup in OpenLoomi Desktop.",
+    );
   }
-
-  // Get userId from token for OAuth start
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated. Please log in to openloomi first.');
-  }
-
-  // Decode JWT to get userId (payload is base64 of JSON)
-  let userId = 'local';
-  try {
-    const parts = token.split('.');
-    if (parts.length >= 2) {
-      const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
-      userId = payload.sub || payload.userId || 'local';
-    }
-  } catch {
-    // Use default
-  }
-
-  const data = await apiRequest(`${endpoint}?userId=${encodeURIComponent(userId)}`);
+  const { baseUrl } = await discoverOpenLoomi();
+  const handoff = new URL("/connectors", `${baseUrl}/`);
+  handoff.searchParams.set("addPlatform", "true");
+  handoff.searchParams.set("platform", platformId);
   return {
     platform: platformId,
-    authorizationUrl: data.authorizationUrl,
-    state: data.state,
-    instructions: 'Open the URL in your browser to authorize. The CLI will attempt to open it automatically.'
+    handoffUrl: handoff.toString(),
+    instructions: "Open this URL in the running OpenLoomi Desktop app to complete the connection.",
   };
 }
 
 async function disconnectAccount(accountId) {
-  if (!accountId) {
-    throw new Error('Account ID required: disconnect <accountId>');
+  if (typeof accountId !== "string" || !accountId.trim()) {
+    throw new ConnectorError("INVALID_ARGUMENT", "Account ID is required.");
   }
-  return apiRequest(`/api/integrations/${accountId}`, 'DELETE');
+  const result = await apiRequest(
+    `/api/integrations/${encodeURIComponent(accountId.trim())}`,
+    "DELETE",
+  );
+  return requireOperationSuccess(result, "disconnect");
 }
 
 async function queryContacts(options = {}) {
-  const { name, page = 1, pageSize = 10 } = options;
-  const params = new URLSearchParams();
-  if (name) params.set('name', name);
-  params.set('page', String(page));
-  params.set('pageSize', String(pageSize));
-  return apiRequest(`/api/contacts?${params.toString()}`);
+  const page = Number.isInteger(options.page) && options.page > 0 ? options.page : 1;
+  const pageSize = Number.isInteger(options.pageSize) && options.pageSize > 0 ? Math.min(options.pageSize, 100) : 10;
+  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+  if (typeof options.name === "string" && options.name.trim()) params.set("name", options.name.trim());
+  return apiRequest(`/api/contacts?${params}`);
 }
 
 async function sendReply(options = {}) {
   const { botId, recipients, message, subject, cc, bcc } = options;
-  if (!botId || !recipients || !message) {
-    throw new Error('botId, recipients, and message are required');
+  const validStringList = (value, { required = false } = {}) =>
+    value === undefined
+      ? !required
+      : Array.isArray(value) &&
+        (!required || value.length > 0) &&
+        value.every(
+          (item) => typeof item === "string" && item.trim().length > 0,
+        );
+  if (
+    typeof botId !== "string" ||
+    !botId.trim() ||
+    !validStringList(recipients, { required: true }) ||
+    typeof message !== "string" ||
+    !message.trim() ||
+    (subject !== undefined && typeof subject !== "string") ||
+    !validStringList(cc) ||
+    !validStringList(bcc)
+  ) {
+    throw new ConnectorError("INVALID_ARGUMENT", "botId, a non-empty recipients array, and message are required.");
   }
-  return apiRequest('/api/messages', 'POST', { botId, recipients, message, subject, cc, bcc });
+  const result = await apiRequest("/api/messages", "POST", {
+    botId: botId.trim(),
+    recipients: recipients.map((item) => item.trim()),
+    message,
+    subject,
+    cc: cc?.map((item) => item.trim()),
+    bcc: bcc?.map((item) => item.trim()),
+  });
+  return requireOperationSuccess(result, "send_reply");
 }
 
-async function connectEmailPlatform(platformId, email, appPassword) {
-  const validateEndpoint = platformId === 'gmail' ? '/api/google/validate' : '/api/outlook/validate';
-
-  // Validate credentials first
-  const validateResult = await apiRequest(validateEndpoint, 'POST', {
-    email,
-    appPassword
-  });
-
-  if (validateResult.error) {
-    throw new Error(validateResult.error);
+function requireOperationSuccess(result, operation) {
+  if (result && typeof result === "object" && result.success === true) {
+    return result;
   }
-
-  // Create the integration account
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: email,
-    displayName: validateResult.name || email.split('@')[0],
-    credentials: {
-      email,
-      appPassword
-    },
-    metadata: {
-      email,
-      name: validateResult.name || email.split('@')[0]
-    },
-    bot: {
-      name: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} · ${validateResult.name || email}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter: platformId,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    email,
-    account,
-    message: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} account connected successfully!`
-  };
-}
-
-// Platforms that use appId/appSecret credentials (no validation API needed)
-async function connectAppCredentialsPlatform(platformId, credentials, displayName) {
-  const adapterMap = {
-    dingtalk: 'dingtalk',
-    qqbot: 'qqbot',
-    feishu: 'feishu'
-  };
-
-  const adapter = adapterMap[platformId];
-  if (!adapter) {
-    throw new Error(`${platformId} does not support CLI connection with credentials`);
+  if (result && typeof result === "object" && result.success === false) {
+    throw new ConnectorError(
+      "API_OPERATION_FAILED",
+      `OpenLoomi could not complete ${operation}.`,
+      { operation },
+    );
   }
-
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: credentials.clientId || credentials.appId || displayName,
-    displayName: displayName || platformId,
-    credentials,
-    metadata: {
-      name: displayName || platformId
-    },
-    bot: {
-      name: `${platformId} · ${displayName || 'Bot'}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    account,
-    message: `${platformId} connected successfully!`
-  };
+  throw new ConnectorError(
+    "INVALID_API_RESPONSE",
+    `OpenLoomi returned an invalid ${operation} response.`,
+    { operation },
+  );
 }
 
-// WeChat iLink Token connection
-async function connectWeChat(token) {
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: 'weixin',
-    externalId: 'wechat',
-    displayName: 'WeChat',
-    credentials: {
-      ilinkToken: token
-    },
-    metadata: {
-      type: 'wechat'
-    },
-    bot: {
-      name: 'WeChat · Bot',
-      description: 'Automatically created through iLink Token authorization',
-      adapter: 'weixin',
-      enable: true
-    }
-  });
-
-  return {
-    platform: 'weixin',
-    account,
-    message: 'WeChat connected successfully!'
-  };
+function parseNamedArgs(args) {
+  const result = {};
+  for (const arg of args) {
+    if (!arg.startsWith("--") || !arg.includes("=")) continue;
+    const separator = arg.indexOf("=");
+    result[arg.slice(2, separator)] = arg.slice(separator + 1);
+  }
+  return result;
 }
 
-const command = process.argv[2];
-const args = process.argv.slice(3);
+function printJson(value, stream = process.stdout) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
 
-async function main() {
+async function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
   try {
+    let result;
     switch (command) {
-      case 'list-platforms': {
-        const result = await listPlatforms();
-        console.log(JSON.stringify(result, null, 2));
+      case "list-platforms":
+        result = await listPlatforms();
+        break;
+      case "list-accounts":
+        result = await listAccounts();
+        break;
+      case "status":
+        result = await getStatus(args[0]);
+        break;
+      case "connect": {
+        if (!args[0]) throw new ConnectorError("INVALID_ARGUMENT", "Platform is required: connect <platform>.");
+        if (args.length > 1) {
+          throw new ConnectorError(
+            "SECRETS_NOT_ACCEPTED",
+            "Connect accepts only a platform name. Complete setup in OpenLoomi Desktop.",
+          );
+        }
+        const named = parseNamedArgs(args.slice(1));
+        result = await connectPlatform(args[0], named);
         break;
       }
-
-      case 'list-accounts': {
-        const result = await listAccounts();
-        console.log(JSON.stringify(result, null, 2));
+      case "disconnect":
+        if (parseNamedArgs(args.slice(1)).confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Disconnect requires --confirmed=true after the user approves the exact account.",
+          );
+        }
+        result = await disconnectAccount(args[0]);
         break;
-      }
-
-      case 'status': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: status <platform>');
-        const result = await getStatus(platform);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'connect': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: connect <platform>');
-
-        const platformId = resolvePlatform(platform);
-        if (!platformId) {
-          throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
-        }
-
-        // Email platforms (gmail, outlook) - require validation
-        if (platformId === 'gmail' || platformId === 'outlook') {
-          const emailArg = args.find(a => a.startsWith('--email='));
-          const passwordArg = args.find(a => a.startsWith('--password='));
-
-          if (!emailArg || !passwordArg) {
-            throw new Error(`Missing credentials. For ${platformId}, provide:\n  connect ${platformId} --email=you@example.com --password=your_app_password`);
-          }
-
-          const email = emailArg.split('=')[1];
-          const appPassword = passwordArg.split('=')[1];
-
-          if (platformId === 'gmail' && appPassword.length !== 16) {
-            throw new Error('Gmail app password must be exactly 16 characters');
-          }
-
-          const result = await connectEmailPlatform(platformId, email, appPassword);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // DingTalk (clientId + clientSecret)
-        if (platformId === 'dingtalk') {
-          const clientIdArg = args.find(a => a.startsWith('--clientId='));
-          const clientSecretArg = args.find(a => a.startsWith('--clientSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!clientIdArg || !clientSecretArg) {
-            throw new Error("Missing credentials. For DingTalk, provide:\n  connect dingtalk --clientId=your_client_id --clientSecret=your_client_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            clientId: clientIdArg.split('=')[1],
-            clientSecret: clientSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'DingTalk');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // QQ Bot (appId + appSecret)
-        if (platformId === 'qqbot') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For QQ Bot, provide:\n  connect qq --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'QQ Bot');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // Feishu (appId + appSecret)
-        if (platformId === 'feishu') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For Feishu, provide:\n  connect feishu --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'Feishu');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // WeChat (iLink Token)
-        if (platformId === 'weixin') {
-          const tokenArg = args.find(a => a.startsWith('--token='));
-
-          if (!tokenArg) {
-            throw new Error("Missing iLink token. For WeChat, provide:\n  connect wechat --token=your_ilink_token");
-          }
-
-          const result = await connectWeChat(tokenArg.split('=')[1]);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // OAuth platforms (auto-opens browser)
-        if (OAUTH_ENDPOINTS[platformId]) {
-          const result = await getOAuthUrl(platform);
-          console.log(JSON.stringify(result, null, 2));
-          try {
-            openUrl(result.authorizationUrl);
-          } catch {
-            // Silently ignore if open fails
-          }
-          break;
-        }
-
-        // Platforms requiring browser (WhatsApp, etc)
-        throw new Error(`${platformId} requires browser interaction. Open in browser:\n  open "http://localhost:3414/connectors?addPlatform=true&platform=${platformId}"`);
-      }
-
-      case 'disconnect': {
-        const accountId = args[0];
-        const result = await disconnectAccount(accountId);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'query-contacts': {
-        const nameArg = args.find(a => a.startsWith('--name='));
-        const pageArg = args.find(a => a.startsWith('--page='));
-        const pageSizeArg = args.find(a => a.startsWith('--pageSize='));
-        const result = await queryContacts({
-          name: nameArg ? nameArg.split('=')[1] : undefined,
-          page: pageArg ? Number.parseInt(pageArg.split('=')[1], 10) : 1,
-          pageSize: pageSizeArg ? Number.parseInt(pageSizeArg.split('=')[1], 10) : 10
+      case "query-contacts": {
+        const named = parseNamedArgs(args);
+        result = await queryContacts({
+          name: named.name,
+          page: named.page ? Number.parseInt(named.page, 10) : 1,
+          pageSize: named.pageSize ? Number.parseInt(named.pageSize, 10) : 10,
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
-      case 'send-reply': {
-        const botIdArg = args.find(a => a.startsWith('--botId='));
-        const recipientsArg = args.find(a => a.startsWith('--recipients='));
-        const messageArg = args.find(a => a.startsWith('--message='));
-        const subjectArg = args.find(a => a.startsWith('--subject='));
-        const ccArg = args.find(a => a.startsWith('--cc='));
-        const bccArg = args.find(a => a.startsWith('--bcc='));
-        if (!botIdArg || !recipientsArg || !messageArg) {
-          throw new Error('botId, recipients, and message required');
+      case "send-reply": {
+        const named = parseNamedArgs(args);
+        if (named.confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Sending requires --confirmed=true after the user approves the exact bot, recipients, and message.",
+          );
         }
-        const result = await sendReply({
-          botId: botIdArg.split('=')[1],
-          recipients: recipientsArg.split('=')[1].split(','),
-          message: messageArg.split('=')[1],
-          subject: subjectArg ? subjectArg.split('=')[1] : undefined,
-          cc: ccArg ? ccArg.split('=')[1].split(',') : undefined,
-          bcc: bccArg ? bccArg.split('=')[1].split(',') : undefined
+        result = await sendReply({
+          botId: named.botId,
+          recipients: named.recipients?.split(",").map((item) => item.trim()).filter(Boolean),
+          message: named.message,
+          subject: named.subject,
+          cc: named.cc?.split(",").map((item) => item.trim()).filter(Boolean),
+          bcc: named.bcc?.split(",").map((item) => item.trim()).filter(Boolean),
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
+      case undefined:
+      case "help":
+      case "--help":
+      case "-h":
+        result = {
+          usage: [
+            "list-platforms",
+            "list-accounts",
+            "status <platform>",
+            "connect <platform>",
+            "disconnect <accountId> --confirmed=true",
+            "query-contacts [--name=] [--page=] [--pageSize=]",
+            "send-reply --botId= --recipients= --message= --confirmed=true [--subject=] [--cc=] [--bcc=]",
+          ],
+        };
+        break;
       default:
-        console.log(JSON.stringify({
-          error: 'Unknown command',
-          usage: `
-Commands:
-  list-platforms                                List all supported platforms
-  list-accounts                                List all connected accounts (includes botId)
-  status <platform>                            Check connection status for a platform
-  connect <platform> [options]                  Connect a platform
-  disconnect <accountId>                        Disconnect an account by ID
-  query-contacts [options]                      Query contacts (--name=, --page=, --pageSize=)
-  send-reply --botId= --recipients= --message= Send a message
-
-Platform Connection Methods:
-  OAuth (auto-opens browser):
-    connect slack
-    connect discord
-    connect x
-
-  Email (App Password):
-    connect gmail --email=x@gmail.com --password=xxxx_xxxx_xxxx_xxxx
-    connect outlook --email=x@outlook.com --password=xxxx
-
-  App Credentials:
-    connect dingtalk --clientId=x --clientSecret=x
-    connect feishu --appId=x --appSecret=x
-    connect qq --appId=x --appSecret=x
-
-  iLink Token:
-    connect wechat --token=x
-
-  Browser Required (QR scan / interactive):
-    connect whatsapp
-    connect telegram (phone/qr/bot login)
-    connect imessage
-
-Examples:
-  node openloomi-connectors.cjs list-platforms
-  node openloomi-connectors.cjs list-accounts
-  node openloomi-connectors.cjs status telegram
-  node openloomi-connectors.cjs connect gmail --email=my@gmail.com --password=abcdefghijklnop
-  node openloomi-connectors.cjs disconnect int_xxx
-  node openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-  node openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
-          `.trim()
-        }, null, 2));
+        throw new ConnectorError(
+          "UNKNOWN_COMMAND",
+          "Unknown command. Run with --help for usage.",
+        );
     }
+    printJson(result);
   } catch (error) {
-    console.error(JSON.stringify({ error: error.message }, null, 2));
-    process.exit(1);
+    const structured = error instanceof ConnectorError
+      ? error.toJSON()
+      : { code: "INTERNAL_ERROR", message: error?.message || "Unexpected connector error." };
+    printJson({ error: structured }, process.stderr);
+    process.exitCode = 1;
   }
 }
 
-main();
+module.exports = {
+  ConnectorError,
+  PLATFORMS,
+  apiRequest,
+  connectPlatform,
+  disconnectAccount,
+  discoverOpenLoomi,
+  getBaseUrls,
+  getStatus,
+  listAccounts,
+  listPlatforms,
+  queryContacts,
+  readTokenState,
+  resolvePlatform,
+  sanitizeAccount,
+  sendReply,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -24,12 +24,21 @@ auth tokens into Codex chat.
 
 When `setup-status` returns `loopbackAccessAmbiguous: true`, do not conclude
 that OpenLoomi is stopped. Codex network sandboxing can block access to the
-host's `localhost` even while the desktop API is listening. The embedded
-non-interactive `codex exec` adapter cannot service an approval-and-retry
-prompt. Use a host-side OpenLoomi MCP tool where available; otherwise present
-the commands in `loopbackAccess.verification.commands` for the user to run in
-a normal terminal. If that request reaches `/api/native/providers`, report the
-sandbox probe as a false negative.
+host's `localhost` even while the desktop API is listening. Prefer the
+bridge's own auto-recovery path over manual `lsof` / `curl` paste: invoke
+
+```bash
+node $SKILL_DIR/../../scripts/loomi-bridge.mjs run-host-probe
+```
+
+from a Codex shell where loopback is allowed. The command probes
+`/api/native/providers` outside the sandbox, writes the result to
+`~/.openloomi/codex-host-probe-cache.json` (5 minute TTL), and the very next
+`setup-status` call rebuilds its readiness decision from that cache
+(`ready: true`, `reason: "READY_VIA_HOST_PROBE_CACHE"`). When `setup-status`
+returns `nextAction: "run_host_probe"`, run this command yourself instead of
+asking the user to paste anything. Fall back to the manual
+`loopbackAccess.verification.commands` only if the host probe itself fails.
 
 OpenLoomi guest sessions are supported. A missing token is not a request for
 account registration or manual token entry. When the bridge reports

--- a/plugins/codex/skills/openloomi/SKILL.md
+++ b/plugins/codex/skills/openloomi/SKILL.md
@@ -24,10 +24,12 @@ auth tokens into Codex chat.
 
 When `setup-status` returns `loopbackAccessAmbiguous: true`, do not conclude
 that OpenLoomi is stopped. Codex network sandboxing can block access to the
-host's `localhost` even while the desktop API is listening. Request approval
-to run the commands in `loopbackAccess.verification.commands` outside the
-sandbox. If an outside-sandbox request reaches `/api/native/providers`, report
-OpenLoomi as running and identify the sandbox probe as a false negative.
+host's `localhost` even while the desktop API is listening. The embedded
+non-interactive `codex exec` adapter cannot service an approval-and-retry
+prompt. Use a host-side OpenLoomi MCP tool where available; otherwise present
+the commands in `loopbackAccess.verification.commands` for the user to run in
+a normal terminal. If that request reaches `/api/native/providers`, report the
+sandbox probe as a false negative.
 
 OpenLoomi guest sessions are supported. A missing token is not a request for
 account registration or manual token entry. When the bridge reports
@@ -50,7 +52,7 @@ If the user asks to install OpenLoomi or explicitly approves installation, run t
 node "$SKILL_DIR/../../scripts/loomi-bridge.mjs" setup --yes
 ```
 
-That walks the whole state machine: resolve the official release → download → install → set `OPENLOOMI_AGENT_PROVIDER=codex` in the GUI launchd / environment.d → launch the OpenLoomi desktop app → wait for the local API on `http://localhost:3414` → mint a guest session token into `~/.openloomi/token`. Invoking this skill (or the user saying "install" / "install and run" / "一键装好并跑起来") counts as explicit approval to pass `--yes`. Sandbox prompts for network / install to `/Applications` / launching the GUI will appear — that's expected; approve them and the wizard continues.
+That walks the whole state machine: resolve the official release → download → install → set `OPENLOOMI_AGENT_PROVIDER=codex` in the GUI launchd / environment.d → launch the OpenLoomi desktop app → wait for the local API on `http://localhost:3414` → mint a guest session token into `~/.openloomi/token`. Invoking this skill (or the user saying "install" / "install and run" / "一键装好并跑起来") counts as explicit approval to pass `--yes`. If the embedded sandbox lacks the required GitHub, application-directory, or GUI access, give the same verified `loomi-bridge` command to the user for a normal terminal; do not promise an interactive escalation that `codex exec` cannot service.
 
 The bridge resolves the official GitHub release artifact for the current
 platform and architecture automatically, downloads it, and installs it with the

--- a/plugins/codex/tests/connectors.test.mjs
+++ b/plugins/codex/tests/connectors.test.mjs
@@ -1,0 +1,1250 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, "../../..");
+const CLIENT = join(
+  REPO_ROOT,
+  "plugins/codex/skills/openloomi-connectors/scripts/openloomi-connectors.cjs",
+);
+const MCP_SERVER = join(
+  REPO_ROOT,
+  "plugins/codex/scripts/openloomi-mcp-server.cjs",
+);
+const MCP_CONFIG = join(REPO_ROOT, "plugins/codex/.mcp.json");
+const PLUGIN_MANIFEST = join(
+  REPO_ROOT,
+  "plugins/codex/.codex-plugin/plugin.json",
+);
+const CODEX_CONNECTOR_SKILL = join(
+  REPO_ROOT,
+  "plugins/codex/skills/openloomi-connectors/SKILL.md",
+);
+const CONNECTOR_COPIES = [
+  join(
+    REPO_ROOT,
+    "skills/openloomi-connectors/scripts/openloomi-connectors.cjs",
+  ),
+  join(
+    REPO_ROOT,
+    "plugins/claude/skills/openloomi-connectors/scripts/openloomi-connectors.cjs",
+  ),
+  CLIENT,
+];
+const SECRET = "connector-test-secret-that-must-never-leak";
+
+function testEnv(home, extra = {}) {
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    OPENLOOMI_API_URL: "",
+    OPENLOOMI_BASE_URL: "",
+    OPENLOOMI_API_TIMEOUT_MS: "250",
+    OPENLOOMI_API_PROBE_TIMEOUT_MS: "100",
+    CODEX_SANDBOX_NETWORK_DISABLED: "",
+    ...extra,
+  };
+}
+
+function makeHome(token = SECRET) {
+  const home = mkdtempSync(join(tmpdir(), "openloomi-connectors-test-"));
+  const tokenDir = join(home, ".openloomi");
+  mkdirSync(tokenDir, { recursive: true });
+  writeFileSync(join(tokenDir, "token"), Buffer.from(token).toString("base64"));
+  return home;
+}
+
+async function runClient(args, env) {
+  try {
+    const result = await execFileAsync(process.execPath, [CLIENT, ...args], {
+      env,
+      encoding: "utf8",
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    };
+  }
+}
+
+function jsonOutput(result) {
+  const output =
+    result.code === 0 ? result.stdout : result.stderr || result.stdout;
+  assert.notEqual(output.trim(), "", "connector CLI returned no JSON");
+  return JSON.parse(output);
+}
+
+function readBody(request) {
+  return new Promise((resolveBody) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolveBody(body));
+  });
+}
+
+function sendJson(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+function sendProviderIdentity(response) {
+  sendJson(response, 200, {
+    agents: [{ id: "codex", type: "codex" }],
+    defaultAgent: "codex",
+  });
+}
+
+async function startServer(handler, port = 0) {
+  const server = createServer(handler);
+  await new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+  const address = server.address();
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolveClose) => server.close(resolveClose)),
+  };
+}
+
+async function withApi(handler, callback) {
+  const home = makeHome();
+  const api = await startServer(handler);
+  try {
+    return await callback({
+      home,
+      url: api.url,
+      env: testEnv(home, { OPENLOOMI_API_URL: api.url }),
+    });
+  } finally {
+    await api.close();
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test("all three packaged connector clients stay byte-for-byte identical", () => {
+  const [canonical, ...copies] = CONNECTOR_COPIES.map((file) =>
+    readFileSync(file, "utf8"),
+  );
+  for (let index = 0; index < copies.length; index += 1) {
+    assert.equal(
+      copies[index],
+      canonical,
+      `${CONNECTOR_COPIES[index + 1]} drifted from ${CONNECTOR_COPIES[0]}`,
+    );
+  }
+});
+
+test("an explicit loopback URL is probed without credentials before Bearer auth", async () => {
+  const requests = [];
+  await withApi(
+    async (request, response) => {
+      requests.push({
+        method: request.method,
+        url: request.url,
+        authorization: request.headers.authorization,
+      });
+      if (requests.length === 1) {
+        sendProviderIdentity(response);
+      } else {
+        sendJson(response, 200, { accounts: [] });
+      }
+    },
+    async ({ env }) => {
+      const result = await runClient(["list-accounts"], env);
+      assert.equal(result.code, 0, result.stderr);
+      assert.deepEqual(jsonOutput(result), { accounts: [], total: 0 });
+    },
+  );
+
+  assert.ok(requests.length >= 2, JSON.stringify(requests));
+  assert.equal(requests[0].authorization, undefined);
+  assert.equal(requests.at(-1).url, "/api/integrations/accounts");
+  assert.equal(requests.at(-1).authorization, `Bearer ${SECRET}`);
+});
+
+test("a missing token fails before any authenticated API request", async () => {
+  let requestCount = 0;
+  const api = await startServer((_request, response) => {
+    requestCount += 1;
+    sendProviderIdentity(response);
+  });
+  const home = mkdtempSync(join(tmpdir(), "openloomi-connectors-no-token-"));
+  try {
+    const result = await runClient(
+      ["list-accounts"],
+      testEnv(home, { OPENLOOMI_API_URL: api.url }),
+    );
+    assert.notEqual(result.code, 0);
+    assert.equal(jsonOutput(result).error.code, "AUTH_TOKEN_MISSING");
+    assert.equal(requestCount, 0);
+  } finally {
+    await api.close();
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an invalid encoded token fails safely without network or token disclosure", async () => {
+  const home = makeHome();
+  const invalidToken = "not-valid-base64!";
+  writeFileSync(join(home, ".openloomi", "token"), invalidToken);
+  try {
+    const result = await runClient(["list-accounts"], testEnv(home));
+    assert.notEqual(result.code, 0);
+    assert.equal(jsonOutput(result).error.code, "AUTH_TOKEN_INVALID");
+    assert.ok(!`${result.stdout}${result.stderr}`.includes(invalidToken));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("list-accounts redacts credentials and sensitive account fields without leaking the token", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) {
+        sendProviderIdentity(response);
+        return;
+      }
+      sendJson(response, 200, {
+        accounts: [
+          {
+            id: "account-1",
+            platform: "telegram",
+            displayName: "Safe display name",
+            status: "active",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            botId: "bot-1",
+            externalId: "private@example.test",
+            credentials: { password: "account-password" },
+            accessToken: "account-access-token",
+            refreshToken: "account-refresh-token",
+            metadata: { apiSecret: "metadata-secret" },
+          },
+        ],
+      });
+    },
+    async ({ env }) => {
+      const result = await runClient(["list-accounts"], env);
+      assert.equal(result.code, 0, result.stderr);
+      const output = `${result.stdout}\n${result.stderr}`;
+      for (const forbidden of [
+        SECRET,
+        "private@example.test",
+        "account-password",
+        "account-access-token",
+        "account-refresh-token",
+        "metadata-secret",
+      ]) {
+        assert.ok(!output.includes(forbidden), `leaked ${forbidden}`);
+      }
+      const parsed = jsonOutput(result);
+      assert.deepEqual(parsed.accounts, [
+        {
+          id: "account-1",
+          platform: "telegram",
+          displayName: "Safe display name",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          botId: "bot-1",
+        },
+      ]);
+    },
+  );
+});
+
+test("status filters accounts and exposes only its public account projection", async () => {
+  const seen = [];
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      seen.push({ method: request.method, url: request.url });
+      sendJson(response, 200, {
+        accounts: [
+          {
+            id: "tg-1",
+            platform: "telegram",
+            displayName: "Telegram",
+            status: "active",
+            createdAt: "2026-01-01T00:00:00Z",
+            botId: "bot-tg",
+            credentials: { token: "hidden" },
+          },
+          {
+            id: "wa-1",
+            platform: "whatsapp",
+            credentials: { token: "hidden-2" },
+          },
+        ],
+      });
+    },
+    async ({ env }) => {
+      const result = await runClient(["status", "tg"], env);
+      assert.equal(result.code, 0, result.stderr);
+      assert.deepEqual(jsonOutput(result), {
+        platform: "telegram",
+        connected: true,
+        accounts: [
+          {
+            id: "tg-1",
+            displayName: "Telegram",
+            status: "active",
+            createdAt: "2026-01-01T00:00:00Z",
+            botId: "bot-tg",
+          },
+        ],
+      });
+      assert.ok(!result.stdout.includes("hidden"));
+    },
+  );
+  assert.deepEqual(seen, [
+    { method: "GET", url: "/api/integrations/accounts" },
+  ]);
+});
+
+test("status does not call an expired account connected", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      sendJson(response, 200, {
+        accounts: [
+          { id: "tg-expired", platform: "telegram", status: "expired" },
+        ],
+      });
+    },
+    async ({ env }) => {
+      const result = await runClient(["status", "telegram"], env);
+      assert.equal(result.code, 0, result.stderr);
+      assert.equal(jsonOutput(result).connected, false);
+    },
+  );
+});
+
+test("query-contacts sends the encoded GET path", async () => {
+  const seen = [];
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      seen.push({ method: request.method, url: request.url });
+      sendJson(response, 200, { contacts: [], success: true });
+    },
+    async ({ env }) => {
+      const result = await runClient(
+        ["query-contacts", "--name=Jane Doe/+", "--page=2", "--pageSize=25"],
+        env,
+      );
+      assert.equal(result.code, 0, result.stderr);
+    },
+  );
+  assert.deepEqual(seen, [
+    {
+      method: "GET",
+      url: "/api/contacts?page=2&pageSize=25&name=Jane+Doe%2F%2B",
+    },
+  ]);
+});
+
+test("send-reply sends the documented POST body", async () => {
+  const seen = [];
+  await withApi(
+    async (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      seen.push({
+        method: request.method,
+        url: request.url,
+        body: JSON.parse(await readBody(request)),
+      });
+      sendJson(response, 200, { success: true, messageId: "message-1" });
+    },
+    async ({ env }) => {
+      const result = await runClient(
+        [
+          "send-reply",
+          "--botId=bot-1",
+          "--recipients=alice,bob",
+          "--message=Hello there",
+          "--confirmed=true",
+          "--subject=Subject",
+          "--cc=carol",
+          "--bcc=dave,erin",
+        ],
+        env,
+      );
+      assert.equal(result.code, 0, result.stderr);
+    },
+  );
+  assert.deepEqual(seen, [
+    {
+      method: "POST",
+      url: "/api/messages",
+      body: {
+        botId: "bot-1",
+        recipients: ["alice", "bob"],
+        message: "Hello there",
+        subject: "Subject",
+        cc: ["carol"],
+        bcc: ["dave", "erin"],
+      },
+    },
+  ]);
+});
+
+test("disconnect sends DELETE to the encoded account path", async () => {
+  const seen = [];
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      seen.push({ method: request.method, url: request.url });
+      sendJson(response, 200, { success: true });
+    },
+    async ({ env }) => {
+      const result = await runClient(
+        ["disconnect", "account:one", "--confirmed=true"],
+        env,
+      );
+      assert.equal(result.code, 0, result.stderr);
+    },
+  );
+  assert.deepEqual(seen, [
+    { method: "DELETE", url: "/api/integrations/account%3Aone" },
+  ]);
+});
+
+test("HTTP 200 operation failures are structured CLI failures without secret leakage", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      sendJson(response, 200, {
+        success: false,
+        error: `foreign connector detail: ${SECRET}`,
+      });
+    },
+    async ({ env }) => {
+      const result = await runClient(
+        [
+          "send-reply",
+          "--botId=bot-1",
+          "--recipients=alice",
+          "--message=hello",
+          "--confirmed=true",
+        ],
+        env,
+      );
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "API_OPERATION_FAILED");
+      assert.ok(!`${result.stdout}${result.stderr}`.includes(SECRET));
+    },
+  );
+});
+
+for (const [name, body] of [
+  ["missing success", {}],
+  ["non-boolean success", { success: "true" }],
+]) {
+  test(`HTTP 200 ${name} mutation responses are rejected by the CLI`, async () => {
+    await withApi(
+      (request, response) => {
+        if (!request.headers.authorization)
+          return sendProviderIdentity(response);
+        sendJson(response, 200, body);
+      },
+      async ({ env }) => {
+        const result = await runClient(
+          ["disconnect", "account-1", "--confirmed=true"],
+          env,
+        );
+        assert.notEqual(result.code, 0);
+        assert.equal(jsonOutput(result).error.code, "INVALID_API_RESPONSE");
+      },
+    );
+  });
+}
+
+test("CLI mutations require an explicit confirmation flag", async () => {
+  const home = makeHome();
+  try {
+    for (const args of [
+      ["disconnect", "account-1"],
+      ["send-reply", "--botId=bot", "--recipients=alice", "--message=hello"],
+    ]) {
+      const result = await runClient(args, testEnv(home));
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "CONFIRMATION_REQUIRED");
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+for (const failure of [
+  {
+    name: "401",
+    status: 401,
+    body: { error: "bad credentials" },
+    code: "AUTH_FAILED",
+  },
+  {
+    name: "500",
+    status: 500,
+    body: { error: "database failed" },
+    code: "API_HTTP_ERROR",
+  },
+]) {
+  test(`${failure.name} responses are structured failures, not successful account lists`, async () => {
+    await withApi(
+      (request, response) => {
+        if (!request.headers.authorization)
+          return sendProviderIdentity(response);
+        sendJson(response, failure.status, failure.body);
+      },
+      async ({ env }) => {
+        const result = await runClient(["list-accounts"], env);
+        assert.notEqual(result.code, 0);
+        const error = jsonOutput(result);
+        assert.equal(error.error.code, failure.code);
+        assert.equal(error.error.status, failure.status);
+        assert.ok(!`${result.stdout}${result.stderr}`.includes(SECRET));
+      },
+    );
+  });
+}
+
+test("malformed JSON is a structured INVALID_API_RESPONSE failure", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("{ definitely not json");
+    },
+    async ({ env }) => {
+      const result = await runClient(["list-accounts"], env);
+      assert.notEqual(result.code, 0);
+      const error = jsonOutput(result);
+      assert.equal(error.error.code, "INVALID_API_RESPONSE");
+    },
+  );
+});
+
+test("a successful response without an accounts array is not reported as disconnected", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      sendJson(response, 200, { success: true });
+    },
+    async ({ env }) => {
+      const result = await runClient(["status", "telegram"], env);
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "INVALID_API_RESPONSE");
+    },
+  );
+});
+
+test("connection refusal reports attempts without claiming the sandbox is responsible", async () => {
+  const closed = await startServer((_request, response) => response.end());
+  const url = closed.url;
+  await closed.close();
+  const home = makeHome();
+  try {
+    const result = await runClient(
+      ["list-accounts"],
+      testEnv(home, { OPENLOOMI_API_URL: url }),
+    );
+    assert.notEqual(result.code, 0);
+    const error = jsonOutput(result);
+    assert.equal(error.error.code, "LOCAL_API_UNREACHABLE");
+    assert.equal(error.error.tokenPresent, true);
+    assert.equal(error.error.loopbackAccessAmbiguous, true);
+    assert.ok(
+      Array.isArray(error.error.attempts) && error.error.attempts.length >= 1,
+    );
+    assert.ok(!`${result.stdout}${result.stderr}`.includes(SECRET));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("the Codex sandbox marker upgrades an unreachable loopback error to SANDBOX_BLOCKED", async () => {
+  const closed = await startServer((_request, response) => response.end());
+  const url = closed.url;
+  await closed.close();
+  const home = makeHome();
+  try {
+    const result = await runClient(
+      ["list-accounts"],
+      testEnv(home, {
+        OPENLOOMI_API_URL: url,
+        CODEX_SANDBOX_NETWORK_DISABLED: "1",
+      }),
+    );
+    assert.notEqual(result.code, 0);
+    const error = jsonOutput(result);
+    assert.equal(error.error.code, "SANDBOX_BLOCKED");
+    assert.equal(error.error.tokenPresent, true);
+    assert.equal(error.error.loopbackAccessAmbiguous, true);
+    assert.ok(Array.isArray(error.error.attempts));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+async function startFixedMutationServers(mutationBehavior) {
+  let fallbackRequests = 0;
+  const first = await startServer((request, response) => {
+    if (request.url === "/api/native/providers") {
+      sendProviderIdentity(response);
+      return;
+    }
+    mutationBehavior(request, response);
+  }, 3414);
+  try {
+    const fallback = await startServer((_request, response) => {
+      fallbackRequests += 1;
+      sendJson(response, 200, { success: true });
+    }, 3515);
+    return {
+      fallbackRequests: () => fallbackRequests,
+      close: async () => {
+        await Promise.all([first.close(), fallback.close()]);
+      },
+    };
+  } catch (error) {
+    await first.close();
+    throw error;
+  }
+}
+
+test(
+  "a timed-out mutation is not replayed on the fallback port",
+  { concurrency: false },
+  async (t) => {
+    let servers;
+    try {
+      servers = await startFixedMutationServers((_request, _response) => {
+        // Deliberately accept the request but never produce a response. Once a
+        // mutation reaches this point its outcome is unknown and replay is unsafe.
+      });
+    } catch (error) {
+      if (error.code === "EADDRINUSE")
+        return t.skip("OpenLoomi development ports are in use");
+      throw error;
+    }
+    const home = makeHome();
+    try {
+      const result = await runClient(
+        [
+          "send-reply",
+          "--botId=bot",
+          "--recipients=alice",
+          "--message=hello",
+          "--confirmed=true",
+        ],
+        testEnv(home, {
+          OPENLOOMI_API_TIMEOUT_MS: "80",
+          OPENLOOMI_API_PROBE_TIMEOUT_MS: "80",
+        }),
+      );
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "REQUEST_OUTCOME_UNKNOWN");
+      assert.equal(servers.fallbackRequests(), 0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      await servers.close();
+    }
+  },
+);
+
+test(
+  "an ECONNRESET mutation is not replayed on the fallback port",
+  { concurrency: false },
+  async (t) => {
+    let servers;
+    try {
+      servers = await startFixedMutationServers((request) => {
+        request.socket.destroy();
+      });
+    } catch (error) {
+      if (error.code === "EADDRINUSE")
+        return t.skip("OpenLoomi development ports are in use");
+      throw error;
+    }
+    const home = makeHome();
+    try {
+      const result = await runClient(
+        ["disconnect", "account-1", "--confirmed=true"],
+        testEnv(home),
+      );
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "REQUEST_OUTCOME_UNKNOWN");
+      assert.equal(servers.fallbackRequests(), 0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      await servers.close();
+    }
+  },
+);
+
+test(
+  "a read request retries the verified fallback port",
+  { concurrency: false },
+  async (t) => {
+    let first;
+    let fallback;
+    try {
+      first = await startServer((request, response) => {
+        if (request.url === "/api/native/providers") {
+          sendProviderIdentity(response);
+          return;
+        }
+        request.socket.destroy();
+      }, 3414);
+      fallback = await startServer((request, response) => {
+        if (request.url === "/api/native/providers") {
+          sendProviderIdentity(response);
+          return;
+        }
+        sendJson(response, 200, {
+          accounts: [
+            { id: "fallback-account", platform: "telegram", status: "active" },
+          ],
+        });
+      }, 3515);
+    } catch (error) {
+      if (first?.server.listening) await first.close();
+      await fallback?.close();
+      if (error.code === "EADDRINUSE")
+        return t.skip("OpenLoomi development ports are in use");
+      throw error;
+    }
+
+    const home = makeHome();
+    try {
+      const result = await runClient(["list-accounts"], testEnv(home));
+      assert.equal(result.code, 0, result.stderr);
+      assert.deepEqual(jsonOutput(result), {
+        accounts: [
+          {
+            id: "fallback-account",
+            platform: "telegram",
+            status: "active",
+          },
+        ],
+        total: 1,
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      await Promise.all([
+        first.server.listening ? first.close() : Promise.resolve(),
+        fallback.close(),
+      ]);
+    }
+  },
+);
+
+test(
+  "a mutation retries the fallback only when the first request never connects",
+  { concurrency: false },
+  async (t) => {
+    let first;
+    let fallback;
+    let fallbackMutations = 0;
+    try {
+      first = await startServer((request, response) => {
+        if (request.url === "/api/native/providers") {
+          // Stop accepting connections before completing the successful
+          // identity response. The subsequent mutation is therefore known
+          // not to have reached this candidate and is safe to try elsewhere.
+          first.server.close();
+          response.setHeader("connection", "close");
+          setTimeout(() => sendProviderIdentity(response), 40);
+        }
+      }, 3414);
+      fallback = await startServer((request, response) => {
+        if (request.url === "/api/native/providers") {
+          sendProviderIdentity(response);
+          return;
+        }
+        fallbackMutations += 1;
+        sendJson(response, 200, { success: true });
+      }, 3515);
+    } catch (error) {
+      if (first?.server.listening) await first.close();
+      await fallback?.close();
+      if (error.code === "EADDRINUSE")
+        return t.skip("OpenLoomi development ports are in use");
+      throw error;
+    }
+
+    const home = makeHome();
+    try {
+      const result = await runClient(
+        ["disconnect", "account-1", "--confirmed=true"],
+        testEnv(home, { OPENLOOMI_API_PROBE_TIMEOUT_MS: "500" }),
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.equal(fallbackMutations, 1);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      await Promise.all([
+        first.server.listening ? first.close() : Promise.resolve(),
+        fallback.close(),
+      ]);
+    }
+  },
+);
+
+test("connect returns a desktop UI handoff and never submits connector credentials", async () => {
+  await withApi(
+    (request, response) => {
+      assert.equal(request.headers.authorization, undefined);
+      sendProviderIdentity(response);
+    },
+    async ({ env }) => {
+      const result = await runClient(["connect", "telegram"], env);
+      assert.equal(result.code, 0, result.stderr);
+      const handoff = jsonOutput(result);
+      assert.equal(handoff.platform, "telegram");
+      assert.deepEqual(Object.keys(handoff).sort(), [
+        "handoffUrl",
+        "instructions",
+        "platform",
+      ]);
+      assert.match(
+        handoff.handoffUrl,
+        /^http:\/\/127\.0\.0\.1:\d+\/connectors\?/,
+      );
+    },
+  );
+});
+
+test("connect rejects secret-bearing argv without echoing the secret", async () => {
+  const secretArgs = [
+    "raw-positional-secret",
+    "--password",
+    "--password=",
+    "--clientSecret=",
+    "--appSecret=",
+    "--token=",
+  ];
+  const home = makeHome();
+  try {
+    for (const argument of secretArgs) {
+      const value = `${argument}${SECRET}`;
+      const result = await runClient(
+        ["connect", "dingtalk", value],
+        testEnv(home),
+      );
+      assert.notEqual(result.code, 0, `${argument} should be refused`);
+      assert.ok(!`${result.stdout}${result.stderr}`.includes(value));
+      assert.equal(jsonOutput(result).error.code, "SECRETS_NOT_ACCEPTED");
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("unknown command and platform failures do not echo untrusted input", async () => {
+  const home = makeHome();
+  try {
+    for (const { args, code } of [
+      { args: [SECRET], code: "UNKNOWN_COMMAND" },
+      { args: ["status", SECRET], code: "UNKNOWN_PLATFORM" },
+      { args: ["connect", SECRET], code: "UNKNOWN_PLATFORM" },
+    ]) {
+      const result = await runClient(args, testEnv(home));
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, code);
+      assert.ok(!`${result.stdout}${result.stderr}`.includes(SECRET));
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("explicit API overrides reject non-loopback and credential-bearing URLs", async () => {
+  const home = makeHome();
+  try {
+    for (const url of [
+      "https://127.0.0.1:3414",
+      "http://example.com:3414",
+      "http://user:password@localhost:3414",
+    ]) {
+      const result = await runClient(
+        ["list-accounts"],
+        testEnv(home, { OPENLOOMI_API_URL: url }),
+      );
+      assert.notEqual(result.code, 0);
+      assert.equal(jsonOutput(result).error.code, "INVALID_API_URL");
+      assert.ok(!`${result.stdout}${result.stderr}`.includes("user:password"));
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("plugin MCP config resolves the server from the installed plugin root", () => {
+  const manifest = JSON.parse(readFileSync(PLUGIN_MANIFEST, "utf8"));
+  const config = JSON.parse(readFileSync(MCP_CONFIG, "utf8"));
+  assert.equal(manifest.mcpServers, "./.mcp.json");
+  assert.deepEqual(Object.keys(config.mcpServers), ["openloomi"]);
+  assert.deepEqual(config.mcpServers.openloomi, {
+    command: "node",
+    args: ["scripts/openloomi-mcp-server.cjs"],
+    cwd: ".",
+  });
+  assert.ok(!readFileSync(MCP_CONFIG, "utf8").includes("${PLUGIN_ROOT}"));
+
+  const skill = readFileSync(CODEX_CONNECTOR_SKILL, "utf8");
+  for (const tool of [
+    "list_platforms",
+    "list_accounts",
+    "connector_status",
+    "connect",
+    "disconnect",
+    "query_contacts",
+    "send_reply",
+  ]) {
+    assert.match(skill, new RegExp(`mcp__openloomi__${tool}\\b`));
+  }
+});
+
+function startMcp(env) {
+  const child = spawn(process.execPath, [MCP_SERVER], {
+    env,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  let stdoutBuffer = "";
+  let stderr = "";
+  let nextId = 1;
+  const pending = new Map();
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  child.stdout.on("data", (chunk) => {
+    stdoutBuffer += chunk;
+    while (stdoutBuffer.includes("\n")) {
+      const newline = stdoutBuffer.indexOf("\n");
+      const line = stdoutBuffer.slice(0, newline).trim();
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        for (const entry of pending.values()) entry.reject(error);
+        pending.clear();
+        continue;
+      }
+      const entry = pending.get(message.id);
+      if (entry) {
+        clearTimeout(entry.timer);
+        pending.delete(message.id);
+        entry.resolve(message);
+      }
+    }
+  });
+  child.on("exit", (code, signal) => {
+    const error = new Error(
+      `MCP server exited before replying (code=${code}, signal=${signal}): ${stderr}`,
+    );
+    for (const entry of pending.values()) entry.reject(error);
+    pending.clear();
+  });
+
+  return {
+    notify(method, params = {}) {
+      child.stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`,
+      );
+    },
+    request(method, params = {}) {
+      const id = nextId;
+      nextId += 1;
+      return new Promise((resolveRequest, rejectRequest) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          rejectRequest(
+            new Error(`Timed out waiting for ${method}; stderr: ${stderr}`),
+          );
+        }, 3_000);
+        pending.set(id, {
+          resolve: resolveRequest,
+          reject: rejectRequest,
+          timer,
+        });
+        child.stdin.write(
+          `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+        );
+      });
+    },
+    async close() {
+      child.stdin.end();
+      await new Promise((resolveExit) => {
+        if (child.exitCode !== null) resolveExit();
+        else child.once("exit", resolveExit);
+      });
+      assert.equal(stderr, "", `MCP server wrote to stderr: ${stderr}`);
+    },
+  };
+}
+
+function structuredToolContent(response) {
+  assert.equal(response.jsonrpc, "2.0");
+  assert.ok(response.result);
+  assert.ok(Array.isArray(response.result.content));
+  assert.equal(response.result.content[0].type, "text");
+  assert.deepEqual(
+    JSON.parse(response.result.content[0].text),
+    response.result.structuredContent,
+  );
+  return response.result.structuredContent;
+}
+
+test("MCP server completes a real stdio initialize, tools/list, tools/call, and confirmation flow", async () => {
+  const mutations = [];
+  await withApi(
+    async (request, response) => {
+      if (!request.headers.authorization) {
+        sendProviderIdentity(response);
+        return;
+      }
+      const body =
+        request.method === "POST" ? JSON.parse(await readBody(request)) : null;
+      mutations.push({ method: request.method, url: request.url, body });
+      sendJson(response, 200, { success: true });
+    },
+    async ({ env }) => {
+      const mcp = startMcp(env);
+      try {
+        const initialized = await mcp.request("initialize", {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "openloomi-contract-test", version: "1.0.0" },
+        });
+        assert.equal(initialized.result.protocolVersion, "2025-03-26");
+        assert.equal(
+          initialized.result.serverInfo.name,
+          "openloomi-connectors",
+        );
+        assert.deepEqual(initialized.result.capabilities, {
+          tools: { listChanged: false },
+        });
+        mcp.notify("notifications/initialized");
+
+        const listed = await mcp.request("tools/list");
+        const tools = listed.result.tools;
+        assert.deepEqual(
+          tools.map((tool) => tool.name),
+          [
+            "list_platforms",
+            "list_accounts",
+            "connector_status",
+            "connect",
+            "disconnect",
+            "query_contacts",
+            "send_reply",
+          ],
+        );
+        assert.equal(
+          tools.find((tool) => tool.name === "disconnect").annotations
+            .destructiveHint,
+          true,
+        );
+        assert.equal(
+          tools.find((tool) => tool.name === "send_reply").annotations
+            .idempotentHint,
+          false,
+        );
+
+        const platformCall = await mcp.request("tools/call", {
+          name: "list_platforms",
+          arguments: {},
+        });
+        assert.equal(platformCall.result.isError, undefined);
+        assert.equal(structuredToolContent(platformCall).total, 7);
+
+        for (const malformed of [
+          {
+            name: "connector_status",
+            arguments: { platform: 42 },
+          },
+          {
+            name: "query_contacts",
+            arguments: { page: 0 },
+          },
+          {
+            name: "query_contacts",
+            arguments: { pageSize: 101 },
+          },
+          {
+            name: "disconnect",
+            arguments: { accountId: " ", confirmed: true },
+          },
+          {
+            name: "send_reply",
+            arguments: {
+              botId: "bot-1",
+              recipients: [" "],
+              message: "hello",
+              confirmed: true,
+            },
+          },
+        ]) {
+          const refused = await mcp.request("tools/call", malformed);
+          assert.equal(refused.result.isError, true);
+          assert.equal(
+            structuredToolContent(refused).error.code,
+            "INVALID_ARGUMENT",
+          );
+        }
+
+        for (const unconfirmed of [
+          {
+            name: "disconnect",
+            arguments: { accountId: "account-1" },
+          },
+          {
+            name: "send_reply",
+            arguments: {
+              botId: "bot-1",
+              recipients: ["alice"],
+              message: "hello",
+            },
+          },
+        ]) {
+          const refused = await mcp.request("tools/call", unconfirmed);
+          assert.equal(refused.result.isError, true);
+          assert.equal(
+            structuredToolContent(refused).error.code,
+            "CONFIRMATION_REQUIRED",
+          );
+        }
+        assert.deepEqual(mutations, []);
+
+        const sent = await mcp.request("tools/call", {
+          name: "send_reply",
+          arguments: {
+            botId: "bot-1",
+            recipients: ["alice"],
+            message: "hello",
+            confirmed: true,
+          },
+        });
+        assert.equal(sent.result.isError, undefined);
+        assert.deepEqual(structuredToolContent(sent), { success: true });
+
+        const disconnected = await mcp.request("tools/call", {
+          name: "disconnect",
+          arguments: { accountId: "account-1", confirmed: true },
+        });
+        assert.equal(disconnected.result.isError, undefined);
+        assert.deepEqual(structuredToolContent(disconnected), {
+          success: true,
+        });
+      } finally {
+        await mcp.close();
+      }
+    },
+  );
+
+  assert.deepEqual(mutations, [
+    {
+      method: "POST",
+      url: "/api/messages",
+      body: {
+        botId: "bot-1",
+        recipients: ["alice"],
+        message: "hello",
+      },
+    },
+    { method: "DELETE", url: "/api/integrations/account-1", body: null },
+  ]);
+});
+
+test("MCP marks HTTP 200 operation failures as tool errors", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      sendJson(response, 200, {
+        success: false,
+        error: `foreign connector detail: ${SECRET}`,
+      });
+    },
+    async ({ env }) => {
+      const mcp = startMcp(env);
+      try {
+        const response = await mcp.request("tools/call", {
+          name: "send_reply",
+          arguments: {
+            botId: "bot-1",
+            recipients: ["alice"],
+            message: "hello",
+            confirmed: true,
+          },
+        });
+        assert.equal(response.result.isError, true);
+        const structured = structuredToolContent(response);
+        assert.equal(structured.error.code, "API_OPERATION_FAILED");
+        assert.ok(!JSON.stringify(structured).includes(SECRET));
+      } finally {
+        await mcp.close();
+      }
+    },
+  );
+});
+
+test("MCP rejects malformed HTTP 200 mutation responses", async () => {
+  await withApi(
+    (request, response) => {
+      if (!request.headers.authorization) return sendProviderIdentity(response);
+      sendJson(response, 200, { success: "true" });
+    },
+    async ({ env }) => {
+      const mcp = startMcp(env);
+      try {
+        const response = await mcp.request("tools/call", {
+          name: "disconnect",
+          arguments: { accountId: "account-1", confirmed: true },
+        });
+        assert.equal(response.result.isError, true);
+        assert.equal(
+          structuredToolContent(response).error.code,
+          "INVALID_API_RESPONSE",
+        );
+      } finally {
+        await mcp.close();
+      }
+    },
+  );
+});

--- a/skills/openloomi-connectors/SKILL.md
+++ b/skills/openloomi-connectors/SKILL.md
@@ -1,364 +1,90 @@
 ---
 name: openloomi-connectors
-description: "openloomi Connectors tools - manage platform integrations (OAuth connections, list accounts, check status). Triggers: connect platform, integration status, list accounts, disconnect. Pair with the composio skill to also list composio-linked accounts."
+description: "Manage OpenLoomi's native connector accounts: list platforms or accounts, check status, open a safe connection handoff, disconnect, query contacts, and send a reply. Trigger for native connector/account requests; pair with Composio only for Composio-managed apps."
 metadata:
   version: 0.8.4
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+# OpenLoomi Connectors
 
-# OpenLoomi Connectors Skill
+Use the bundled client for OpenLoomi's seven native connectors. It reads the
+local bearer token internally, performs a best-effort expected-response check
+before sending that token, and returns structured JSON.
 
-OpenLoomi Connectors provides access to 7 messaging and productivity platform integrations. It allows AI agents to manage OAuth connections, list connected accounts, check connection status, and disconnect platforms on behalf of the user.
+## Native platforms
 
-> **Pairing with the `composio` skill:** This skill covers openloomi's **native 7 integrations** listed below. For accounts connected through **Composio** (a broader 1000+ apps surface — e.g. X, LinkedIn, Notion, HubSpot, Linear, Jira, etc.), invoke the `composio` skill in parallel: use the `composio-cli` to list connections, or call `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with `action: "list"`. When the user asks "what am I connected to?" or "list my accounts", run both — `list-accounts` here **and** the composio connection listing — and present the union. Keep auth, OAuth, and disconnect flows native to each skill.
+| ID | Name | Aliases |
+| --- | --- | --- |
+| `telegram` | Telegram | `tg` |
+| `whatsapp` | WhatsApp | — |
+| `imessage` | iMessage | — |
+| `feishu` | Lark/Feishu | `lark`, `飞书` |
+| `dingtalk` | DingTalk | `钉钉` |
+| `qqbot` | QQ | `qq`, `qq_bot` |
+| `weixin` | WeChat | `wechat`, `微信`, `wechat_work`, `wecom`, `企业微信` |
 
----
+Slack, Gmail, Outlook, GitHub, Notion, Linear, and other non-native apps are
+handled by OpenLoomi Desktop or Composio. For an all-sources account audit,
+run `list-accounts` here and the Composio connection listing in parallel,
+then label and combine the results.
 
-## What is openloomi?
+## Security
 
-Most AI assistants function as workflow tools—users give commands, they execute tasks, with no persistent knowledge of who you are or what matters to you.
+- Never request, print, or put connector credentials or the OpenLoomi bearer
+  token in prompts or command arguments.
+- If the user pastes a real credential, do not repeat it and recommend
+  rotating it after redirecting setup to Desktop.
+- `connect` accepts only a native platform and returns a local OpenLoomi
+  Desktop handoff URL. The user completes credentials, QR, or OAuth there.
+- Get explicit approval for the exact account before disconnecting.
+- Get approval for the exact bot, recipients, and message before sending.
+- Use account `id` for disconnect and its separate `botId` for sending.
 
-**openloomi takes a fundamentally different approach: it operates as a proactive digital partner** that watches, learns, remembers, and acts on your behalf. The difference is architectural.
-
-### How It Works
-
-When users connect messaging platforms and integrations to openloomi, they sync with permission:
-- Raw messages and communications
-- Meetings and calendar events
-- Emails and tweets
-- Voice calls
-- Notes and captured ideas
-
-This aggregated data becomes "the single source of truth for openloomi's brain."
-
-### The Continuous Sync Loop
-
-openloomi runs a background agent on a continuous sync loop, actively gathering information from all connected sources. An agent without this loop can only respond based on stale context. With it, every conversation—and every moment—makes openloomi smarter and more aligned with you.
-
----
-
-## Supported Platforms (7)
-
-The CLI `list-platforms` returns these 7 platforms. Other connectable
-platforms (Slack, Discord, X, Gmail, Outlook, LinkedIn, Google Calendar,
-Google Drive, Google Docs, HubSpot, Notion, etc.) are managed via the
-desktop UI or the `composio` skill — see "Platform Connection Methods"
-below for details.
-
-| ID | Display Name | Aliases |
-|----|-------------|---------|
-| `telegram` | Telegram | tg |
-| `whatsapp` | WhatsApp | |
-| `imessage` | iMessage | |
-| `feishu` | Lark/Feishu | lark, 飞书 |
-| `dingtalk` | DingTalk | 钉钉 |
-| `qqbot` | QQ | qq, qq_bot |
-| `weixin` | WeChat | wechat, 微信, wechat_work, wecom, 企业微信 |
-
----
-
-## Authentication
-
-The CLI auto-reads your token from `~/.openloomi/token` (base64 encoded JWT).
-
-### Local API Access
-
-The local API server runs on port **3414** (fallback: **3515**). If 3414 is unavailable, try 3515.
-
----
-
-## API Endpoints
-
-### Integration Accounts
-
-#### GET `/api/integrations/accounts` - List Connected Accounts
-
-Returns all connected platform accounts for the authenticated user.
+## Commands
 
 ```bash
-curl http://localhost:3414/api/integrations/accounts \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "accounts": [
-    {
-      "id": "int_xxx",
-      "platform": "gmail",
-      "externalId": "user@gmail.com",
-      "displayName": "My Gmail",
-      "status": "active",
-      "metadata": {},
-      "createdAt": "2024-01-01T00:00:00Z",
-      "botId": "bot_xxx"
-    }
-  ]
-}
-```
-
-**Note:** Each account includes a `botId` field which is used for `send-reply` and other bot operations.
-
----
-
-### OAuth Start Endpoints
-
-#### GET `/api/integrations/slack/oauth/start?userId=<userId>` - Start Slack OAuth
-
-Returns the Slack OAuth authorization URL. The CLI opens this URL in the browser for the user to complete authorization.
-
-```bash
-curl "http://localhost:3414/api/integrations/slack/oauth/start?userId=<userId>"
-```
-
-**Response:**
-```json
-{
-  "authorizationUrl": "https://slack.com/oauth/v2/authorize?...",
-  "state": "userId:uuid"
-}
-```
-
-#### GET `/api/integrations/discord/oauth/start?userId=<userId>` - Start Discord OAuth
-
-Returns the Discord OAuth authorization URL.
-
-#### GET `/api/integrations/x/oauth/start?userId=<userId>` - Start X OAuth
-
-Returns the X/Twitter OAuth authorization URL.
-
----
-
-### OAuth Exchange Endpoints
-
-#### GET `/api/integrations/slack/oauth/exchange?code=<code>&state=<state>` - Exchange Slack Code
-
-Exchange OAuth code for Slack access.
-
-#### GET `/api/integrations/discord/oauth/exchange?code=<code>&state=<state>` - Exchange Discord Code
-
-Exchange OAuth code for Discord access.
-
----
-
-### OAuth Callbacks
-
-| Platform | Endpoint |
-|----------|----------|
-| Feishu | `POST /api/feishu/listener/init` |
-| DingTalk | `POST /api/dingtalk/listener/init` |
-| QQ Bot | `POST /api/qqbot/listener/init` |
-| WeChat | `POST /api/weixin/listener/init` |
-| Telegram | `POST /api/telegram/user-listener/init` |
-| WhatsApp | `POST /api/whatsapp/register-socket` |
-| iMessage | `POST /api/imessage/init-self-listener` |
-
----
-
-### DELETE `/api/integrations/:id` - Disconnect Account
-
-Delete a connected integration account.
-
-```bash
-curl -X DELETE http://localhost:3414/api/integrations/int_xxx \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "deletedAccountId": "int_xxx",
-  "deletedBotIds": ["bot_xxx"]
-}
-```
-
----
-
-### GET `/api/contacts` - Query Contacts
-
-Query user contacts with optional filtering and pagination.
-
-```bash
-curl "http://localhost:3414/api/contacts?name=John&page=1&pageSize=10" \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**Parameters:**
-- `name` (string, optional) - Filter contacts by name (partial match)
-- `page` (number, default 1) - Page number
-- `pageSize` (number, default 10) - Items per page (max 100)
-
-**Response:**
-```json
-{
-  "success": true,
-  "contacts": [
-    {
-      "id": "contact_xxx",
-      "name": "John Doe",
-      "type": "email",
-      "botId": "bot_xxx",
-      "platform": "gmail"
-    }
-  ],
-  "pagination": {
-    "page": 1,
-    "pageSize": 10,
-    "totalCount": 50,
-    "totalPages": 5,
-    "hasMore": true,
-    "hasPrevious": false
-  }
-}
-```
-
----
-
-### POST `/api/messages` - Send Message
-
-Send a message via a connected platform bot.
-
-```bash
-curl -X POST http://localhost:3414/api/messages \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "botId": "bot_xxx",
-    "recipients": ["John"],
-    "message": "Hello!",
-    "subject": "Optional subject"
-  }'
-```
-
-**Parameters:**
-- `botId` (string, required) - The bot ID to send from
-- `recipients` (array, required) - List of recipient names
-- `message` (string, required) - Message content
-- `subject` (string, optional) - Email subject line
-- `cc` (array, optional) - CC recipients
-- `bcc` (array, optional) - BCC recipients
-
-**Note:** `botId` is returned by `list-accounts` in the `botId` field (different from account `id`).
-
----
-
-## Platform Aliases Reference
-
-Aliases are case-insensitive and support both English and Chinese:
-
-| Alias | Platform |
-|-------|----------|
-| `tg` | telegram |
-| `wechat`, `微信` | weixin |
-| `lark`, `飞书` | feishu |
-| `钉钉` | dingtalk |
-| `qq`, `qq_bot` | qqbot |
-
----
-
-## Desktop UI
-
-Users can also authorize accounts directly through the openloomi desktop application without using CLI commands.
-
-### Adding Account Authorization via Desktop UI
-
-1. **Open openloomi desktop app** on your computer
-2. **Navigate to Settings** (gear icon in the sidebar or top-right menu)
-3. **Go to Integrations** tab/section
-4. **Click on the platform** you want to connect (e.g., Telegram, Slack, Discord, Gmail, etc.)
-5. **Follow the platform-specific authorization flow:**
-   - **OAuth platforms** (Slack, Discord, X/Twitter): Click "Connect" → you'll be redirected to the platform's authorization page in your browser → Approve the permissions → you'll be redirected back
-   - **App Password platforms** (Gmail, Outlook): Enter your email and app password
-   - **App Credentials platforms** (DingTalk, Feishu, QQ): Enter your appId and appSecret
-   - **QR/Interactive platforms** (WhatsApp, Telegram, iMessage): Scan the QR code or follow the in-app instructions
-
-6. **Verify connection** — once authorized, the platform will show as "Connected" with a green checkmark
-
-### Managing Connected Accounts
-
-- **List connected accounts**: Settings → Integrations → shows all connected platforms with status
-- **Disconnect account**: Settings → Integrations → click on connected platform → "Disconnect" or remove
-- **Check status**: Connected platforms show green "Active" badge; expired/disconnected shows red "Inactive" badge
-
----
-
-## CLI Script
-
-### Quick Start
-
-```bash
-# List all supported platforms
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-platforms
-
-# List all connected accounts (includes botId for send-reply)
 node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-
-# Cross-source audit: openloomi-native + composio-linked accounts (run together, present union)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs list-accounts
-# In parallel, invoke the `composio` skill (e.g. `composio list-connections` via composio-cli,
-# or `mcp__composio__COMPOSIO_MANAGE_CONNECTIONS` with action: "list")
-
-# Check connection status for a platform
 node $SKILL_DIR/scripts/openloomi-connectors.cjs status telegram
-
-# Connect a platform (opens browser for OAuth)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs connect slack
-
-# Disconnect an account by ID
-node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx
-
-# Query contacts
+node $SKILL_DIR/scripts/openloomi-connectors.cjs connect telegram
+node $SKILL_DIR/scripts/openloomi-connectors.cjs disconnect int_xxx --confirmed=true
 node $SKILL_DIR/scripts/openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-
-# Send a message (requires botId from list-accounts)
-node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
+node $SKILL_DIR/scripts/openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello" --confirmed=true
 ```
 
-### Commands
+Never add `--password`, `--clientSecret`, `--appSecret`, or `--token`
+to `connect`; secret-bearing options are rejected by design.
 
-| Command | Description |
-|---------|-------------|
-| `list-platforms` | List all 7 supported platforms with IDs and aliases |
-| `list-accounts` | List all connected integration accounts (includes `botId`) |
-| `status <platform>` | Check if a platform is connected (e.g., telegram, slack) |
-| `connect <platform> [options]` | Connect a platform (OAuth, App Password, or App Credentials) |
-| `disconnect <accountId>` | Disconnect a specific account by ID |
-| `query-contacts [options]` | Query contacts (--name=, --page=, --pageSize=) |
-| `send-reply --botId= --recipients= --message=` | Send a message via REST API |
+The client honors `OPENLOOMI_API_URL` or `OPENLOOMI_BASE_URL` when set to
+an explicit loopback origin. Otherwise it probes ports 3414 and 3515.
 
-### Platform Connection Methods
+## Workflow
 
-| Method | Platforms |
-|--------|-----------|
-| OAuth (auto-opens browser) | `slack`, `discord`, `x` |
-| App Password | `gmail --email=x --password=xxxx`, `outlook --email=x --password=xxxx` |
-| App Credentials | `dingtalk --clientId=x --clientSecret=x`, `feishu --appId=x --appSecret=x`, `qq --appId=x --appSecret=x` |
-| iLink Token | `wechat --token=x` |
-| Browser Required (QR/interactive) | `whatsapp`, `telegram`, `imessage` |
+- Use `list-accounts` for “what am I connected to?”
+- Use `status <platform>` only for a native ID or alias.
+- Use `connect <platform>`, return its `handoffUrl`, and verify with
+  `status` after the user completes the Desktop flow.
+- If only a platform is given for disconnect, list matching accounts and ask
+  which exact account ID to remove.
+- Query contacts before sending when the recipient is ambiguous; pass exact
+  returned contact `name` values as recipients.
+- Call a platform connected only when it has at least one `active` account.
+  Expired accounts may still be listed but are not connected.
+- Treat an empty, successful account list as empty. Never translate a
+  transport or authentication failure into “disconnected.”
 
----
+## Structured failures
 
-## AI Agent Workflow
+| Code | Response |
+| --- | --- |
+| `AUTH_TOKEN_MISSING`, `AUTH_TOKEN_INVALID`, `AUTH_FAILED` | Ask the user to sign in again in OpenLoomi Desktop. |
+| `LOCAL_API_UNREACHABLE` | Ask the user to start/restart OpenLoomi Desktop; do not claim connector state. |
+| `SANDBOX_BLOCKED` | Report that loopback was blocked in this execution environment; use a host-side connector tool if one is available. |
+| `REQUEST_OUTCOME_UNKNOWN` | A mutation may have arrived and was not retried. Verify state before retrying. |
+| `API_OPERATION_FAILED` | OpenLoomi rejected the requested mutation. Report failure; do not claim it completed. |
+| `INVALID_API_RESPONSE`, `API_HTTP_ERROR` | Report the safe code/message without printing token or raw secrets. |
 
-**Triggered when the user asks about:**
-
-1. Connecting a platform - "connect telegram", "link my slack"
-2. Listing integrations - "show my connected accounts", "what platforms am I connected to"
-3. Checking status - "is my github connected?", "telegram status"
-4. Disconnecting - "disconnect my discord", "remove whatsapp"
-5. Querying contacts - "show my contacts", "find John in contacts"
-6. Sending messages - "send email to John", "reply to that message"
-7. Cross-source account audit - "show everything I'm connected to (openloomi + composio)", "list all linked accounts across both" → run `list-accounts` here **and** the `composio` skill in parallel, then present the union
-
-**Execution Flow:**
-
-1. **Identify intent** - connect / list / status / disconnect / query-contacts / send-reply
-2. **Resolve platform** - use alias normalization (e.g., `gh` -> `github`)
-3. **Execute command** - use Bash tool
-4. **Format output** - report results naturally in user's language
-
-**Note on send-reply:** The `botId` is returned by `list-accounts` in the `botId` field.
+This client can verify an unknown disconnect through a fresh account listing.
+It cannot query message delivery history, so verify an unknown send in
+OpenLoomi Desktop or the target conversation before retrying.

--- a/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
+++ b/skills/openloomi-connectors/scripts/openloomi-connectors.cjs
@@ -1,555 +1,707 @@
 #!/usr/bin/env node
-const http = require('node:http');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
-const { execSync } = require('node:child_process');
+"use strict";
 
-const PORTS = [3515, 3415, 3414]; // dev, local fallback, prod
-const TOKEN_PATH = path.join(os.homedir(), '.openloomi', 'token');
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
 
-// Platform definitions matching connector-target.ts
-// Platforms listed here must be enabled in `platform-connectability.ts`
-// (`isIntegrationPlatformConnectable`). COMING_SOON / HIDDEN platforms
-// (e.g. github, instagram, facebook_messenger, teams, asana, jira, linear,
-// google_meet) are intentionally omitted — they cannot start a new
-// connection from the connector UI.
-// `outlook_calendar` is gated behind NEXT_PUBLIC_OUTLOOK_CALENDAR_ENABLED.
+const DEFAULT_BASE_URLS = ["http://127.0.0.1:3414", "http://127.0.0.1:3515"];
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const SAFE_PRECONNECT_ERRORS = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "ETIMEDOUT",
+]);
+
+// Keep this list aligned with the platforms that the Desktop connector UI can
+// start today. Connection setup itself intentionally remains in Desktop so an
+// agent never receives connector credentials or QR/login challenges.
 const PLATFORMS = [
-  { id: 'telegram', name: 'Telegram', aliases: ['tg'] },
-  { id: 'whatsapp', name: 'WhatsApp', aliases: [] },
-  { id: 'imessage', name: 'iMessage', aliases: [] },
-  { id: 'feishu', name: 'Lark/Feishu', aliases: ['lark', '飞书'] },
-  { id: 'dingtalk', name: 'DingTalk', aliases: ['钉钉'] },
-  { id: 'qqbot', name: 'QQ', aliases: ['qq', 'qq_bot'] },
-  { id: 'weixin', name: 'WeChat', aliases: ['wechat', '微信', 'wechat_work', 'wecom', '企业微信'] },
+  { id: "telegram", name: "Telegram", aliases: ["tg"] },
+  { id: "whatsapp", name: "WhatsApp", aliases: [] },
+  { id: "imessage", name: "iMessage", aliases: [] },
+  { id: "feishu", name: "Lark/Feishu", aliases: ["lark", "飞书"] },
+  { id: "dingtalk", name: "DingTalk", aliases: ["钉钉"] },
+  { id: "qqbot", name: "QQ", aliases: ["qq", "qq_bot"] },
+  {
+    id: "weixin",
+    name: "WeChat",
+    aliases: ["wechat", "微信", "wechat_work", "wecom", "企业微信"],
+  },
 ];
 
-// Build alias lookup map (case-insensitive)
-const ALIAS_TO_PLATFORM = {};
-for (const p of PLATFORMS) {
-  ALIAS_TO_PLATFORM[p.id] = p.id;
-  for (const alias of p.aliases) {
-    ALIAS_TO_PLATFORM[alias.toLowerCase()] = p.id;
+const ALIAS_TO_PLATFORM = new Map();
+for (const platform of PLATFORMS) {
+  ALIAS_TO_PLATFORM.set(platform.id, platform.id);
+  for (const alias of platform.aliases) {
+    ALIAS_TO_PLATFORM.set(alias.toLowerCase(), platform.id);
   }
 }
 
-// OAuth start endpoints by platform
-const OAUTH_ENDPOINTS = {
-  slack: '/api/integrations/slack/oauth/start',
-  discord: '/api/integrations/discord/oauth/start',
-  x: '/api/integrations/x/oauth/start',
-};
+class ConnectorError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ConnectorError";
+    this.code = code;
+    this.details = details;
+  }
+
+  toJSON() {
+    return { code: this.code, message: this.message, ...this.details };
+  }
+}
+
+function resolvePlatform(input) {
+  if (typeof input !== "string") return null;
+  return ALIAS_TO_PLATFORM.get(input.trim().toLowerCase()) || null;
+}
+
+function getTokenPath() {
+  return (
+    process.env.OPENLOOMI_TOKEN_PATH?.trim() ||
+    path.join(os.homedir(), ".openloomi", "token")
+  );
+}
+
+function readTokenState() {
+  let encoded;
+  try {
+    encoded = fs.readFileSync(getTokenPath(), "utf8").trim();
+  } catch (error) {
+    if (error?.code === "ENOENT") return { present: false, token: null };
+    throw new ConnectorError(
+      "AUTH_TOKEN_UNREADABLE",
+      "OpenLoomi's local authentication token could not be read.",
+      { tokenPresent: false },
+    );
+  }
+
+  if (!encoded) return { present: false, token: null };
+  try {
+    const bytes = Buffer.from(encoded, "base64");
+    const canonical = bytes.toString("base64").replace(/=+$/, "");
+    if (canonical !== encoded.replace(/=+$/, "")) {
+      return { present: true, token: null, invalid: true };
+    }
+    const decoded = Buffer.from(encoded, "base64").toString("utf8").trim();
+    if (!decoded || decoded.includes("\0")) {
+      return { present: true, token: null, invalid: true };
+    }
+    return { present: true, token: decoded, invalid: false };
+  } catch {
+    return { present: true, token: null, invalid: true };
+  }
+}
 
 function getAuthToken() {
   try {
-    const encoded = fs.readFileSync(TOKEN_PATH, 'utf8').trim();
-    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-    return decoded;
+    return readTokenState().token || null;
   } catch {
     return null;
   }
 }
 
-function apiRequest(endpoint, method = 'GET', body = null, portIndex = 0) {
-  return new Promise((resolve, reject) => {
-    if (portIndex >= PORTS.length) {
-      reject(new Error(`openloomi server not running. Tried ports: ${PORTS.join(', ')}`));
-      return;
+function requireAuthToken() {
+  const state = readTokenState();
+  if (state.invalid) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_INVALID",
+      "OpenLoomi's local authentication token is invalid. Sign in again in OpenLoomi Desktop.",
+      { tokenPresent: true },
+    );
+  }
+  if (!state.token) {
+    throw new ConnectorError(
+      "AUTH_TOKEN_MISSING",
+      "OpenLoomi's local authentication token is missing. Sign in in OpenLoomi Desktop first.",
+      { tokenPresent: false },
+    );
+  }
+  return state.token;
+}
+
+function normalizeLoopbackUrl(value, envName) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" || !LOOPBACK_HOSTS.has(url.hostname.toLowerCase())) {
+      throw new Error("must be an http loopback URL");
     }
+    if (url.username || url.password) throw new Error("must not include credentials");
+    if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+      throw new Error("must contain only an origin");
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch (error) {
+    throw new ConnectorError(
+      "INVALID_API_URL",
+      `${envName} must be an HTTP URL on localhost, 127.0.0.1, or ::1.`,
+      { env: envName, reason: error.message },
+    );
+  }
+}
 
-    const port = PORTS[portIndex];
-    const url = new URL(endpoint, `http://localhost:${port}`);
+function getBaseUrls() {
+  if (process.env.OPENLOOMI_API_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_API_URL.trim(), "OPENLOOMI_API_URL")];
+  }
+  if (process.env.OPENLOOMI_BASE_URL?.trim()) {
+    return [normalizeLoopbackUrl(process.env.OPENLOOMI_BASE_URL.trim(), "OPENLOOMI_BASE_URL")];
+  }
+  return [...DEFAULT_BASE_URLS];
+}
+
+function redact(value, depth = 0) {
+  if (depth > 4) return "[truncated]";
+  if (Array.isArray(value)) return value.slice(0, 50).map((item) => redact(item, depth + 1));
+  if (!value || typeof value !== "object") {
+    if (typeof value !== "string") return value;
     const token = getAuthToken();
+    const withoutToken = token ? value.split(token).join("[redacted]") : value;
+    const withoutBearer = withoutToken.replace(/Bearer\s+[^\s,;]+/gi, "Bearer [redacted]");
+    return withoutBearer.length > 1_000 ? `${withoutBearer.slice(0, 1_000)}…` : withoutBearer;
+  }
+  const result = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (/token|secret|password|credential|authorization|cookie/i.test(key)) {
+      result[key] = "[redacted]";
+    } else {
+      result[key] = redact(item, depth + 1);
+    }
+  }
+  return result;
+}
 
-    const options = {
-      hostname: url.hostname,
-      port: url.port,
-      path: url.pathname + url.search,
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token && { 'Authorization': `Bearer ${token}` })
-      }
-    };
+function configuredTimeout(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || !Number.isInteger(parsed) || parsed < 50 || parsed > 60_000) {
+    throw new ConnectorError(
+      "INVALID_TIMEOUT",
+      `${name} must be an integer between 50 and 60000 milliseconds.`,
+    );
+  }
+  return parsed;
+}
 
-    const req = http.request(options, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json);
-        } catch {
-          resolve(data);
-        }
+function parseResponseBody(text, context) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi returned malformed JSON.",
+      context,
+    );
+  }
+}
+
+function requestOnce(
+  baseUrl,
+  endpoint,
+  {
+    method = "GET",
+    body = null,
+    token = null,
+    timeoutMs = configuredTimeout("OPENLOOMI_API_TIMEOUT_MS", DEFAULT_REQUEST_TIMEOUT_MS),
+  } = {},
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(endpoint, `${baseUrl}/`);
+    let connected = false;
+    let settled = false;
+    const payload = body === null ? null : JSON.stringify(body);
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: {
+          Accept: "application/json",
+          ...(payload && {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(payload),
+          }),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        connected = true;
+        let responseText = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          if (responseText.length < 1_000_000) responseText += chunk;
+        });
+        res.on("end", () => {
+          if (settled) return;
+          settled = true;
+          const status = res.statusCode || 0;
+          if (status < 200 || status >= 300) {
+            let responseBody = responseText;
+            try {
+              responseBody = responseText ? JSON.parse(responseText) : null;
+            } catch {
+              // Preserve a bounded, redacted response excerpt for diagnostics.
+            }
+            const authenticationFailure = status === 401 || status === 403;
+            reject(
+              new ConnectorError(
+                authenticationFailure ? "AUTH_FAILED" : "API_HTTP_ERROR",
+                authenticationFailure
+                  ? "OpenLoomi rejected the local authentication token. Sign in again in OpenLoomi Desktop."
+                  : `OpenLoomi returned HTTP ${status}.`,
+                {
+                  status,
+                  method,
+                  endpoint: url.pathname,
+                  ...(authenticationFailure ? {} : { response: redact(responseBody) }),
+                },
+              ),
+            );
+            return;
+          }
+          let responseBody;
+          try {
+            responseBody = parseResponseBody(responseText, {
+              status,
+              method,
+              endpoint: url.pathname,
+            });
+          } catch (error) {
+            reject(error);
+            return;
+          }
+          resolve({ data: responseBody, status, baseUrl });
+        });
+        const rejectResponseFailure = (sourceError) => {
+          if (settled) return;
+          settled = true;
+          const error = sourceError instanceof Error ? sourceError : new Error("Response was aborted");
+          error.code ||= "ECONNRESET";
+          error.connected = true;
+          reject(error);
+        };
+        res.on("aborted", () => rejectResponseFailure());
+        res.on("error", rejectResponseFailure);
+      },
+    );
+
+    req.on("socket", (socket) => {
+      if (!socket.connecting) connected = true;
+      socket.once("connect", () => {
+        connected = true;
       });
     });
-
-    req.on('error', () => {
-      // Try next port on connection error
-      apiRequest(endpoint, method, body, portIndex + 1).then(resolve).catch(reject);
+    req.setTimeout(timeoutMs, () => {
+      const error = new Error(`Request timed out after ${timeoutMs}ms`);
+      error.code = "ETIMEDOUT";
+      req.destroy(error);
     });
-    if (body) req.write(JSON.stringify(body));
+    req.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      error.connected = connected;
+      reject(error);
+    });
+    if (payload) req.write(payload);
     req.end();
   });
 }
 
-function openUrl(url) {
-  const cmd = os.platform() === 'darwin' ? 'open' : os.platform() === 'win32' ? 'start' : 'xdg-open';
-  execSync(`${cmd} "${url}"`, { stdio: 'ignore' });
+function matchesOpenLoomiProviderShape(data) {
+  return Boolean(
+    data &&
+      typeof data === "object" &&
+      Array.isArray(data.agents) &&
+      typeof data.defaultAgent === "string",
+  );
 }
 
-function resolvePlatform(input) {
-  if (!input) return null;
-  const normalized = input.toLowerCase().trim();
-  return ALIAS_TO_PLATFORM[normalized] || null;
-}
-
-async function listPlatforms() {
+function attemptSummary(baseUrl, stage, error) {
   return {
-    platforms: PLATFORMS.map(p => ({
-      id: p.id,
-      name: p.name,
-      aliases: p.aliases
-    })),
-    total: PLATFORMS.length
+    baseUrl,
+    stage,
+    code: error.code || "UNKNOWN_ERROR",
+    ...(error.details?.status ? { status: error.details.status } : {}),
+    connected: Boolean(error.connected),
   };
 }
 
+function isTransportError(error) {
+  return !(error instanceof ConnectorError) && typeof error?.code === "string";
+}
+
+function unreachableError(attempts, tokenPresent) {
+  const transportAttempts = attempts.filter((attempt) =>
+    [
+      "ECONNREFUSED",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "ENETDOWN",
+      "ETIMEDOUT",
+      "ECONNRESET",
+    ].includes(attempt.code),
+  );
+  const loopbackAccessAmbiguous =
+    transportAttempts.length > 0 &&
+    transportAttempts.every((attempt) =>
+      ["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "ENETDOWN", "ETIMEDOUT", "ECONNRESET"].includes(
+        attempt.code,
+      ),
+    );
+  const sandboxDisabled = process.env.CODEX_SANDBOX_NETWORK_DISABLED === "1";
+  return new ConnectorError(
+    sandboxDisabled ? "SANDBOX_BLOCKED" : "LOCAL_API_UNREACHABLE",
+    sandboxDisabled
+      ? "Codex sandbox network access is disabled; the local OpenLoomi API cannot be reached."
+      : "The local OpenLoomi API could not be reached or identified.",
+    { attempts, tokenPresent, loopbackAccessAmbiguous },
+  );
+}
+
+async function probeCandidate(baseUrl) {
+  const response = await requestOnce(baseUrl, "/api/native/providers", {
+    timeoutMs: configuredTimeout("OPENLOOMI_API_PROBE_TIMEOUT_MS", DEFAULT_PROBE_TIMEOUT_MS),
+  });
+  if (!matchesOpenLoomiProviderShape(response.data)) {
+    throw new ConnectorError(
+      "NOT_OPENLOOMI_API",
+      "The loopback service did not match the expected OpenLoomi API response shape.",
+      { baseUrl, endpoint: "/api/native/providers" },
+    );
+  }
+  return response;
+}
+
+async function discoverOpenLoomi() {
+  const attempts = [];
+  let tokenPresent = false;
+  try {
+    tokenPresent = readTokenState().present;
+  } catch {
+    // Connection handoff does not require a token; token state is diagnostic only.
+  }
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+      return { baseUrl, attempts };
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+    }
+  }
+  throw unreachableError(attempts, tokenPresent);
+}
+
+async function apiRequest(endpoint, method = "GET", body = null) {
+  const upperMethod = method.toUpperCase();
+  const readOnly = upperMethod === "GET" || upperMethod === "HEAD";
+  const token = requireAuthToken();
+  const attempts = [];
+
+  for (const baseUrl of getBaseUrls()) {
+    try {
+      await probeCandidate(baseUrl);
+    } catch (error) {
+      attempts.push(attemptSummary(baseUrl, "probe", error));
+      continue;
+    }
+
+    try {
+      const response = await requestOnce(baseUrl, endpoint, {
+        method: upperMethod,
+        body,
+        token,
+      });
+      return response.data;
+    } catch (error) {
+      if (error instanceof ConnectorError) throw error;
+      attempts.push(attemptSummary(baseUrl, "request", error));
+      if (readOnly) continue;
+      if (!error.connected && SAFE_PRECONNECT_ERRORS.has(error.code)) continue;
+      throw new ConnectorError(
+        "REQUEST_OUTCOME_UNKNOWN",
+        `The ${upperMethod} request failed after connecting; it will not be retried automatically.`,
+        { method: upperMethod, endpoint, baseUrl, cause: error.code || "NETWORK_ERROR" },
+      );
+    }
+  }
+
+  throw unreachableError(attempts, Boolean(token));
+}
+
+function sanitizeAccount(account) {
+  if (!account || typeof account !== "object") return null;
+  const allowed = [
+    "id",
+    "platform",
+    "displayName",
+    "status",
+    "createdAt",
+    "updatedAt",
+    "botId",
+    "hasValidContextToken",
+  ];
+  return Object.fromEntries(allowed.filter((key) => account[key] !== undefined).map((key) => [key, account[key]]));
+}
+
+async function listPlatforms() {
+  return { platforms: PLATFORMS.map(({ id, name, aliases }) => ({ id, name, aliases })), total: PLATFORMS.length };
+}
+
 async function listAccounts() {
-  return apiRequest('/api/integrations/accounts');
+  const data = await apiRequest("/api/integrations/accounts");
+  const accounts = Array.isArray(data) ? data : data?.accounts;
+  if (!Array.isArray(accounts)) {
+    throw new ConnectorError(
+      "INVALID_API_RESPONSE",
+      "OpenLoomi's accounts response did not contain an accounts array.",
+    );
+  }
+  const sanitized = accounts.map(sanitizeAccount).filter(Boolean);
+  return { accounts: sanitized, total: sanitized.length };
 }
 
 async function getStatus(platform) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const data = await apiRequest('/api/integrations/accounts');
-  const accounts = data.accounts || [];
-  const matching = accounts.filter(a => a.platform === platformId);
-
-  if (matching.length === 0) {
-    return {
-      platform: platformId,
-      connected: false,
-      accounts: []
-    };
-  }
-
+  const { accounts } = await listAccounts();
+  const matching = accounts.filter((account) => account.platform === platformId);
   return {
     platform: platformId,
-    connected: true,
-    accounts: matching.map(a => ({
-      id: a.id,
-      displayName: a.displayName,
-      status: a.status,
-      connectedAt: a.createdAt
-    }))
+    connected: matching.some((account) => account.status === "active"),
+    accounts: matching.map(({ platform: _platform, ...account }) => account),
   };
 }
 
-async function getOAuthUrl(platform) {
+async function connectPlatform(platform, options = {}) {
   const platformId = resolvePlatform(platform);
   if (!platformId) {
-    throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
+    throw new ConnectorError("UNKNOWN_PLATFORM", "Unsupported native connector platform.", {
+      supportedPlatforms: PLATFORMS.map(({ id }) => id),
+    });
   }
-
-  const endpoint = OAUTH_ENDPOINTS[platformId];
-  if (!endpoint) {
-    throw new Error(`OAuth not supported for ${platformId} via CLI. Use the web UI to connect.`);
+  if (options && Object.keys(options).length > 0) {
+    throw new ConnectorError(
+      "SECRETS_NOT_ACCEPTED",
+      "Connect accepts no credentials or secrets. Complete setup in OpenLoomi Desktop.",
+    );
   }
-
-  // Get userId from token for OAuth start
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated. Please log in to openloomi first.');
-  }
-
-  // Decode JWT to get userId (payload is base64 of JSON)
-  let userId = 'local';
-  try {
-    const parts = token.split('.');
-    if (parts.length >= 2) {
-      const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
-      userId = payload.sub || payload.userId || 'local';
-    }
-  } catch {
-    // Use default
-  }
-
-  const data = await apiRequest(`${endpoint}?userId=${encodeURIComponent(userId)}`);
+  const { baseUrl } = await discoverOpenLoomi();
+  const handoff = new URL("/connectors", `${baseUrl}/`);
+  handoff.searchParams.set("addPlatform", "true");
+  handoff.searchParams.set("platform", platformId);
   return {
     platform: platformId,
-    authorizationUrl: data.authorizationUrl,
-    state: data.state,
-    instructions: 'Open the URL in your browser to authorize. The CLI will attempt to open it automatically.'
+    handoffUrl: handoff.toString(),
+    instructions: "Open this URL in the running OpenLoomi Desktop app to complete the connection.",
   };
 }
 
 async function disconnectAccount(accountId) {
-  if (!accountId) {
-    throw new Error('Account ID required: disconnect <accountId>');
+  if (typeof accountId !== "string" || !accountId.trim()) {
+    throw new ConnectorError("INVALID_ARGUMENT", "Account ID is required.");
   }
-  return apiRequest(`/api/integrations/${accountId}`, 'DELETE');
+  const result = await apiRequest(
+    `/api/integrations/${encodeURIComponent(accountId.trim())}`,
+    "DELETE",
+  );
+  return requireOperationSuccess(result, "disconnect");
 }
 
 async function queryContacts(options = {}) {
-  const { name, page = 1, pageSize = 10 } = options;
-  const params = new URLSearchParams();
-  if (name) params.set('name', name);
-  params.set('page', String(page));
-  params.set('pageSize', String(pageSize));
-  return apiRequest(`/api/contacts?${params.toString()}`);
+  const page = Number.isInteger(options.page) && options.page > 0 ? options.page : 1;
+  const pageSize = Number.isInteger(options.pageSize) && options.pageSize > 0 ? Math.min(options.pageSize, 100) : 10;
+  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+  if (typeof options.name === "string" && options.name.trim()) params.set("name", options.name.trim());
+  return apiRequest(`/api/contacts?${params}`);
 }
 
 async function sendReply(options = {}) {
   const { botId, recipients, message, subject, cc, bcc } = options;
-  if (!botId || !recipients || !message) {
-    throw new Error('botId, recipients, and message are required');
+  const validStringList = (value, { required = false } = {}) =>
+    value === undefined
+      ? !required
+      : Array.isArray(value) &&
+        (!required || value.length > 0) &&
+        value.every(
+          (item) => typeof item === "string" && item.trim().length > 0,
+        );
+  if (
+    typeof botId !== "string" ||
+    !botId.trim() ||
+    !validStringList(recipients, { required: true }) ||
+    typeof message !== "string" ||
+    !message.trim() ||
+    (subject !== undefined && typeof subject !== "string") ||
+    !validStringList(cc) ||
+    !validStringList(bcc)
+  ) {
+    throw new ConnectorError("INVALID_ARGUMENT", "botId, a non-empty recipients array, and message are required.");
   }
-  return apiRequest('/api/messages', 'POST', { botId, recipients, message, subject, cc, bcc });
+  const result = await apiRequest("/api/messages", "POST", {
+    botId: botId.trim(),
+    recipients: recipients.map((item) => item.trim()),
+    message,
+    subject,
+    cc: cc?.map((item) => item.trim()),
+    bcc: bcc?.map((item) => item.trim()),
+  });
+  return requireOperationSuccess(result, "send_reply");
 }
 
-async function connectEmailPlatform(platformId, email, appPassword) {
-  const validateEndpoint = platformId === 'gmail' ? '/api/google/validate' : '/api/outlook/validate';
-
-  // Validate credentials first
-  const validateResult = await apiRequest(validateEndpoint, 'POST', {
-    email,
-    appPassword
-  });
-
-  if (validateResult.error) {
-    throw new Error(validateResult.error);
+function requireOperationSuccess(result, operation) {
+  if (result && typeof result === "object" && result.success === true) {
+    return result;
   }
-
-  // Create the integration account
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: email,
-    displayName: validateResult.name || email.split('@')[0],
-    credentials: {
-      email,
-      appPassword
-    },
-    metadata: {
-      email,
-      name: validateResult.name || email.split('@')[0]
-    },
-    bot: {
-      name: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} · ${validateResult.name || email}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter: platformId,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    email,
-    account,
-    message: `${platformId === 'gmail' ? 'Gmail' : 'Outlook'} account connected successfully!`
-  };
-}
-
-// Platforms that use appId/appSecret credentials (no validation API needed)
-async function connectAppCredentialsPlatform(platformId, credentials, displayName) {
-  const adapterMap = {
-    dingtalk: 'dingtalk',
-    qqbot: 'qqbot',
-    feishu: 'feishu'
-  };
-
-  const adapter = adapterMap[platformId];
-  if (!adapter) {
-    throw new Error(`${platformId} does not support CLI connection with credentials`);
+  if (result && typeof result === "object" && result.success === false) {
+    throw new ConnectorError(
+      "API_OPERATION_FAILED",
+      `OpenLoomi could not complete ${operation}.`,
+      { operation },
+    );
   }
-
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: platformId,
-    externalId: credentials.clientId || credentials.appId || displayName,
-    displayName: displayName || platformId,
-    credentials,
-    metadata: {
-      name: displayName || platformId
-    },
-    bot: {
-      name: `${platformId} · ${displayName || 'Bot'}`,
-      description: `Automatically created through ${platformId} authorization`,
-      adapter,
-      enable: true
-    }
-  });
-
-  return {
-    platform: platformId,
-    account,
-    message: `${platformId} connected successfully!`
-  };
+  throw new ConnectorError(
+    "INVALID_API_RESPONSE",
+    `OpenLoomi returned an invalid ${operation} response.`,
+    { operation },
+  );
 }
 
-// WeChat iLink Token connection
-async function connectWeChat(token) {
-  const account = await apiRequest('/api/integrations', 'POST', {
-    platform: 'weixin',
-    externalId: 'wechat',
-    displayName: 'WeChat',
-    credentials: {
-      ilinkToken: token
-    },
-    metadata: {
-      type: 'wechat'
-    },
-    bot: {
-      name: 'WeChat · Bot',
-      description: 'Automatically created through iLink Token authorization',
-      adapter: 'weixin',
-      enable: true
-    }
-  });
-
-  return {
-    platform: 'weixin',
-    account,
-    message: 'WeChat connected successfully!'
-  };
+function parseNamedArgs(args) {
+  const result = {};
+  for (const arg of args) {
+    if (!arg.startsWith("--") || !arg.includes("=")) continue;
+    const separator = arg.indexOf("=");
+    result[arg.slice(2, separator)] = arg.slice(separator + 1);
+  }
+  return result;
 }
 
-const command = process.argv[2];
-const args = process.argv.slice(3);
+function printJson(value, stream = process.stdout) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
 
-async function main() {
+async function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
   try {
+    let result;
     switch (command) {
-      case 'list-platforms': {
-        const result = await listPlatforms();
-        console.log(JSON.stringify(result, null, 2));
+      case "list-platforms":
+        result = await listPlatforms();
+        break;
+      case "list-accounts":
+        result = await listAccounts();
+        break;
+      case "status":
+        result = await getStatus(args[0]);
+        break;
+      case "connect": {
+        if (!args[0]) throw new ConnectorError("INVALID_ARGUMENT", "Platform is required: connect <platform>.");
+        if (args.length > 1) {
+          throw new ConnectorError(
+            "SECRETS_NOT_ACCEPTED",
+            "Connect accepts only a platform name. Complete setup in OpenLoomi Desktop.",
+          );
+        }
+        const named = parseNamedArgs(args.slice(1));
+        result = await connectPlatform(args[0], named);
         break;
       }
-
-      case 'list-accounts': {
-        const result = await listAccounts();
-        console.log(JSON.stringify(result, null, 2));
+      case "disconnect":
+        if (parseNamedArgs(args.slice(1)).confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Disconnect requires --confirmed=true after the user approves the exact account.",
+          );
+        }
+        result = await disconnectAccount(args[0]);
         break;
-      }
-
-      case 'status': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: status <platform>');
-        const result = await getStatus(platform);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'connect': {
-        const platform = args[0];
-        if (!platform) throw new Error('Platform required: connect <platform>');
-
-        const platformId = resolvePlatform(platform);
-        if (!platformId) {
-          throw new Error(`Unknown platform: ${platform}. Use list-platforms to see available platforms.`);
-        }
-
-        // Email platforms (gmail, outlook) - require validation
-        if (platformId === 'gmail' || platformId === 'outlook') {
-          const emailArg = args.find(a => a.startsWith('--email='));
-          const passwordArg = args.find(a => a.startsWith('--password='));
-
-          if (!emailArg || !passwordArg) {
-            throw new Error(`Missing credentials. For ${platformId}, provide:\n  connect ${platformId} --email=you@example.com --password=your_app_password`);
-          }
-
-          const email = emailArg.split('=')[1];
-          const appPassword = passwordArg.split('=')[1];
-
-          if (platformId === 'gmail' && appPassword.length !== 16) {
-            throw new Error('Gmail app password must be exactly 16 characters');
-          }
-
-          const result = await connectEmailPlatform(platformId, email, appPassword);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // DingTalk (clientId + clientSecret)
-        if (platformId === 'dingtalk') {
-          const clientIdArg = args.find(a => a.startsWith('--clientId='));
-          const clientSecretArg = args.find(a => a.startsWith('--clientSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!clientIdArg || !clientSecretArg) {
-            throw new Error("Missing credentials. For DingTalk, provide:\n  connect dingtalk --clientId=your_client_id --clientSecret=your_client_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            clientId: clientIdArg.split('=')[1],
-            clientSecret: clientSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'DingTalk');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // QQ Bot (appId + appSecret)
-        if (platformId === 'qqbot') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For QQ Bot, provide:\n  connect qq --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'QQ Bot');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // Feishu (appId + appSecret)
-        if (platformId === 'feishu') {
-          const appIdArg = args.find(a => a.startsWith('--appId='));
-          const appSecretArg = args.find(a => a.startsWith('--appSecret='));
-          const nameArg = args.find(a => a.startsWith('--name='));
-
-          if (!appIdArg || !appSecretArg) {
-            throw new Error("Missing credentials. For Feishu, provide:\n  connect feishu --appId=your_app_id --appSecret=your_app_secret");
-          }
-
-          const result = await connectAppCredentialsPlatform(platformId, {
-            appId: appIdArg.split('=')[1],
-            appSecret: appSecretArg.split('=')[1]
-          }, nameArg ? nameArg.split('=')[1] : 'Feishu');
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // WeChat (iLink Token)
-        if (platformId === 'weixin') {
-          const tokenArg = args.find(a => a.startsWith('--token='));
-
-          if (!tokenArg) {
-            throw new Error("Missing iLink token. For WeChat, provide:\n  connect wechat --token=your_ilink_token");
-          }
-
-          const result = await connectWeChat(tokenArg.split('=')[1]);
-          console.log(JSON.stringify(result, null, 2));
-          break;
-        }
-
-        // OAuth platforms (auto-opens browser)
-        if (OAUTH_ENDPOINTS[platformId]) {
-          const result = await getOAuthUrl(platform);
-          console.log(JSON.stringify(result, null, 2));
-          try {
-            openUrl(result.authorizationUrl);
-          } catch {
-            // Silently ignore if open fails
-          }
-          break;
-        }
-
-        // Platforms requiring browser (WhatsApp, etc)
-        throw new Error(`${platformId} requires browser interaction. Open in browser:\n  open "http://localhost:3414/connectors?addPlatform=true&platform=${platformId}"`);
-      }
-
-      case 'disconnect': {
-        const accountId = args[0];
-        const result = await disconnectAccount(accountId);
-        console.log(JSON.stringify(result, null, 2));
-        break;
-      }
-
-      case 'query-contacts': {
-        const nameArg = args.find(a => a.startsWith('--name='));
-        const pageArg = args.find(a => a.startsWith('--page='));
-        const pageSizeArg = args.find(a => a.startsWith('--pageSize='));
-        const result = await queryContacts({
-          name: nameArg ? nameArg.split('=')[1] : undefined,
-          page: pageArg ? Number.parseInt(pageArg.split('=')[1], 10) : 1,
-          pageSize: pageSizeArg ? Number.parseInt(pageSizeArg.split('=')[1], 10) : 10
+      case "query-contacts": {
+        const named = parseNamedArgs(args);
+        result = await queryContacts({
+          name: named.name,
+          page: named.page ? Number.parseInt(named.page, 10) : 1,
+          pageSize: named.pageSize ? Number.parseInt(named.pageSize, 10) : 10,
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
-      case 'send-reply': {
-        const botIdArg = args.find(a => a.startsWith('--botId='));
-        const recipientsArg = args.find(a => a.startsWith('--recipients='));
-        const messageArg = args.find(a => a.startsWith('--message='));
-        const subjectArg = args.find(a => a.startsWith('--subject='));
-        const ccArg = args.find(a => a.startsWith('--cc='));
-        const bccArg = args.find(a => a.startsWith('--bcc='));
-        if (!botIdArg || !recipientsArg || !messageArg) {
-          throw new Error('botId, recipients, and message required');
+      case "send-reply": {
+        const named = parseNamedArgs(args);
+        if (named.confirmed !== "true") {
+          throw new ConnectorError(
+            "CONFIRMATION_REQUIRED",
+            "Sending requires --confirmed=true after the user approves the exact bot, recipients, and message.",
+          );
         }
-        const result = await sendReply({
-          botId: botIdArg.split('=')[1],
-          recipients: recipientsArg.split('=')[1].split(','),
-          message: messageArg.split('=')[1],
-          subject: subjectArg ? subjectArg.split('=')[1] : undefined,
-          cc: ccArg ? ccArg.split('=')[1].split(',') : undefined,
-          bcc: bccArg ? bccArg.split('=')[1].split(',') : undefined
+        result = await sendReply({
+          botId: named.botId,
+          recipients: named.recipients?.split(",").map((item) => item.trim()).filter(Boolean),
+          message: named.message,
+          subject: named.subject,
+          cc: named.cc?.split(",").map((item) => item.trim()).filter(Boolean),
+          bcc: named.bcc?.split(",").map((item) => item.trim()).filter(Boolean),
         });
-        console.log(JSON.stringify(result, null, 2));
         break;
       }
-
+      case undefined:
+      case "help":
+      case "--help":
+      case "-h":
+        result = {
+          usage: [
+            "list-platforms",
+            "list-accounts",
+            "status <platform>",
+            "connect <platform>",
+            "disconnect <accountId> --confirmed=true",
+            "query-contacts [--name=] [--page=] [--pageSize=]",
+            "send-reply --botId= --recipients= --message= --confirmed=true [--subject=] [--cc=] [--bcc=]",
+          ],
+        };
+        break;
       default:
-        console.log(JSON.stringify({
-          error: 'Unknown command',
-          usage: `
-Commands:
-  list-platforms                                List all supported platforms
-  list-accounts                                List all connected accounts (includes botId)
-  status <platform>                            Check connection status for a platform
-  connect <platform> [options]                  Connect a platform
-  disconnect <accountId>                        Disconnect an account by ID
-  query-contacts [options]                      Query contacts (--name=, --page=, --pageSize=)
-  send-reply --botId= --recipients= --message= Send a message
-
-Platform Connection Methods:
-  OAuth (auto-opens browser):
-    connect slack
-    connect discord
-    connect x
-
-  Email (App Password):
-    connect gmail --email=x@gmail.com --password=xxxx_xxxx_xxxx_xxxx
-    connect outlook --email=x@outlook.com --password=xxxx
-
-  App Credentials:
-    connect dingtalk --clientId=x --clientSecret=x
-    connect feishu --appId=x --appSecret=x
-    connect qq --appId=x --appSecret=x
-
-  iLink Token:
-    connect wechat --token=x
-
-  Browser Required (QR scan / interactive):
-    connect whatsapp
-    connect telegram (phone/qr/bot login)
-    connect imessage
-
-Examples:
-  node openloomi-connectors.cjs list-platforms
-  node openloomi-connectors.cjs list-accounts
-  node openloomi-connectors.cjs status telegram
-  node openloomi-connectors.cjs connect gmail --email=my@gmail.com --password=abcdefghijklnop
-  node openloomi-connectors.cjs disconnect int_xxx
-  node openloomi-connectors.cjs query-contacts --name=John --page=1 --pageSize=10
-  node openloomi-connectors.cjs send-reply --botId=bot_xxx --recipients=John --message="Hello!"
-          `.trim()
-        }, null, 2));
+        throw new ConnectorError(
+          "UNKNOWN_COMMAND",
+          "Unknown command. Run with --help for usage.",
+        );
     }
+    printJson(result);
   } catch (error) {
-    console.error(JSON.stringify({ error: error.message }, null, 2));
-    process.exit(1);
+    const structured = error instanceof ConnectorError
+      ? error.toJSON()
+      : { code: "INTERNAL_ERROR", message: error?.message || "Unexpected connector error." };
+    printJson({ error: structured }, process.stderr);
+    process.exitCode = 1;
   }
 }
 
-main();
+module.exports = {
+  ConnectorError,
+  PLATFORMS,
+  apiRequest,
+  connectPlatform,
+  disconnectAccount,
+  discoverOpenLoomi,
+  getBaseUrls,
+  getStatus,
+  listAccounts,
+  listPlatforms,
+  queryContacts,
+  readTokenState,
+  resolvePlatform,
+  sanitizeAccount,
+  sendReply,
+};
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

Fix Codex connector operations failing with `ECONNREFUSED` when the model shell sandbox cannot reach the OpenLoomi Desktop API on loopback.

- register a plugin-scoped stdio MCP server exposing only supported connector operations
- make the Codex connector skill use the host-side MCP transport instead of relying on an unavailable out-of-sandbox shell retry
- harden the shared connector client with structured errors, safe fallback behavior, strict response validation, timeouts, and secret redaction
- require explicit confirmation for destructive or externally visible operations
- authenticate contacts/messages API requests and enforce bot ownership before connector side effects
- bind the packaged Desktop API explicitly to `127.0.0.1`
- add connector, MCP protocol, authentication, ownership, and CI regression coverage

## Root cause

The connector CLI called the OpenLoomi API on loopback from the Codex model shell. Codex's default sandbox can block access to the host's loopback interface, while the embedded non-interactive runtime does not expose an approval-and-retry path outside that sandbox.

The existing skill guidance therefore described a recovery action the agent could not perform.

## Implementation

The Codex plugin now registers an `openloomi` stdio MCP server. It runs in the plugin host context and delegates only the seven supported connector operations. It does not expose a general-purpose host shell or unrestricted network primitive.

Read-only requests may fall back to the secondary Desktop port. Mutations are retried only before a connection is established. Ambiguous post-connect failures return `REQUEST_OUTCOME_UNKNOWN` and are never replayed.

Mutation responses must explicitly contain `success: true`; missing, malformed, or unsuccessful responses fail closed.

## Security

- validate loopback targets and API override URLs
- probe the expected unauthenticated API response shape before sending the bearer token
- prevent tokens and connector credentials from entering model-visible output
- require explicit confirmation for `disconnect` and `send_reply`
- cryptographically verify Bearer tokens for contacts and messages routes
- verify bot ownership before loading credentials or invoking a connector adapter
- keep the packaged Desktop API bound to `127.0.0.1`

## Test plan

- [x] Reproduced host-loopback success and sandboxed-loopback `ECONNREFUSED`
- [x] Connector and MCP regression suite: 32/32 passed
- [x] Authentication and ownership regression suite: 7/7 passed
- [x] TypeScript typecheck passed
- [x] Biome lint passed
- [x] Prettier checks for changed files passed
- [x] `cargo fmt --check` passed

## Notes

The plugin manifest remains at `0.8.4` because versions are updated through the repository release workflow. The release containing this fix must bump the plugin version so existing Codex plugin caches receive the new transport.