### PR TITLE
fix(rag): surface clear error when no embedding provider is configured

### DIFF
--- a/apps/web/lib/ai/rag/langchain-service.ts
+++ b/apps/web/lib/ai/rag/langchain-service.ts
@@ -20,6 +20,7 @@ import type { DocumentChunk } from "@openloomi/rag/vector-service";
 import {
   createUserEmbeddingProvider,
   getUserEmbeddingModelName,
+  hasUserEmbeddingProviderConfig,
 } from "@/lib/ai/user-embedding-settings";
 
 // Re-export for consumers of langchain-service
@@ -350,6 +351,15 @@ export async function searchSimilarChunks(
   authToken?: string, // User's JWT token for authentication in local mode
 ): Promise<SearchResult[]> {
   const { limit = 5, threshold = 0.7, documentIds } = options;
+
+  // Guard: surface a clear "no provider configured" error instead of letting
+  // the request reach OpenRouter with no/invalid credentials and surface a
+  // misleading 401 "Missing Authentication header".
+  if (!(await hasUserEmbeddingProviderConfig({ userId, authToken }))) {
+    throw new Error(
+      "Embedding provider is not configured. Set OPENROUTER_API_KEY, configure a user-level embedding provider, or switch to EMBEDDING_PROVIDER=local.",
+    );
+  }
 
   // 1. Generate embedding for query
   const embeddings = await getEmbeddings(userId, authToken);

--- a/apps/web/lib/ai/user-embedding-settings.ts
+++ b/apps/web/lib/ai/user-embedding-settings.ts
@@ -79,9 +79,18 @@ export async function getUserEmbeddingModelName(
 
 export async function hasUserEmbeddingProviderConfig({
   userId,
-  authToken,
+  authToken: _authToken,
 }: {
   userId?: string;
+  /**
+   * Kept for backward compatibility with existing callers. Intentionally
+   * ignored for the cloud check: the user's session JWT is a NextAuth token,
+   * not an OpenRouter API key, so treating it as a valid cloud credential
+   * causes requests to hit OpenRouter with an invalid Bearer and surface a
+   * misleading 401 "Missing Authentication header" instead of a clear
+   * "no provider configured" error. For local mode (which never needs a
+   * key) the check below already short-circuits.
+   */
   authToken?: string;
 }): Promise<boolean> {
   const config = await getUserEmbeddingRuntimeConfig(userId);
@@ -91,7 +100,5 @@ export async function hasUserEmbeddingProviderConfig({
     return true;
   }
 
-  return Boolean(
-    config?.cloud?.apiKey || authToken || process.env.OPENROUTER_API_KEY,
-  );
+  return Boolean(config?.cloud?.apiKey || process.env.OPENROUTER_API_KEY);
 }

--- a/apps/web/tests/unit/user-embedding-settings.test.ts
+++ b/apps/web/tests/unit/user-embedding-settings.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const queryMocks = vi.hoisted(() => ({
   getUserEmbeddingSettingWithApiKey: vi.fn(),
@@ -6,11 +6,27 @@ const queryMocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/db/queries", () => queryMocks);
 
-import { getUserEmbeddingRuntimeConfig } from "@/lib/ai/user-embedding-settings";
+import {
+  getUserEmbeddingRuntimeConfig,
+  hasUserEmbeddingProviderConfig,
+} from "@/lib/ai/user-embedding-settings";
+
+const ENV_KEYS = ["EMBEDDING_PROVIDER", "OPENROUTER_API_KEY"];
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) {
+    Reflect.deleteProperty(process.env, key);
+  }
+}
 
 describe("user embedding settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearEnv();
+  });
+
+  afterEach(() => {
+    clearEnv();
   });
 
   it("maps a local setting to local provider options", async () => {
@@ -61,5 +77,65 @@ describe("user embedding settings", () => {
     await expect(
       getUserEmbeddingRuntimeConfig("user-3"),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("hasUserEmbeddingProviderConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearEnv();
+  });
+
+  afterEach(() => {
+    clearEnv();
+  });
+
+  it("returns true for local mode even without any credentials", async () => {
+    queryMocks.getUserEmbeddingSettingWithApiKey.mockResolvedValue(null);
+    process.env.EMBEDDING_PROVIDER = "local";
+
+    await expect(
+      hasUserEmbeddingProviderConfig({ userId: "user-1", authToken: "jwt" }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns true when the user has a cloud setting with an API key", async () => {
+    queryMocks.getUserEmbeddingSettingWithApiKey.mockResolvedValue({
+      enabled: true,
+      providerType: "cloud",
+      model: "text-embedding-custom",
+      baseUrl: "https://embedding.example.test/v1",
+      apiKey: "user-key",
+    });
+
+    await expect(
+      hasUserEmbeddingProviderConfig({ userId: "user-1", authToken: "jwt" }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns true when OPENROUTER_API_KEY is set and no user override", async () => {
+    queryMocks.getUserEmbeddingSettingWithApiKey.mockResolvedValue(null);
+    process.env.OPENROUTER_API_KEY = "sk-system-key";
+
+    await expect(
+      hasUserEmbeddingProviderConfig({ userId: "user-1", authToken: "jwt" }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when no DB setting, no env key, and only authToken is provided", async () => {
+    queryMocks.getUserEmbeddingSettingWithApiKey.mockResolvedValue(null);
+
+    // The user's session JWT is NOT a valid OpenRouter credential, so the
+    // helper must not treat it as one — otherwise downstream calls hit
+    // OpenRouter with an invalid Bearer and surface a misleading 401.
+    await expect(
+      hasUserEmbeddingProviderConfig({ userId: "user-1", authToken: "jwt" }),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false when there is no userId and no env key", async () => {
+    await expect(
+      hasUserEmbeddingProviderConfig({ authToken: "jwt" }),
+    ).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
The RAG search path was forwarding a 401 "Missing Authentication header" from OpenRouter whenever no embedding provider was configured. Two underlying bugs caused this:

1. `hasUserEmbeddingProviderConfig` treated the user's NextAuth session JWT as a valid cloud credential, so it returned `true` even when no real OpenRouter key (env or per-user setting) existed. The RAG route then proceeded to call OpenRouter with that token as a Bearer and surfaced the upstream 401 verbatim.

2. `searchSimilarChunks` had no guard before invoking the embedding provider, unlike the other call sites (`unified-search`, `insights`, `feishu handler`) which already short-circuit on the same check.

Tighten the helper to ignore `authToken` for the cloud check (it is a NextAuth JWT, not an OpenRouter key) and add the missing guard in `searchSimilarChunks` so callers receive an actionable error directing them to configure a provider or switch to local mode.