### PR TITLE
fix: ai provider readiness when Claude runtime probes fail

### DIFF
--- a/apps/web/app/(chat)/api/preferences/ai/route.ts
+++ b/apps/web/app/(chat)/api/preferences/ai/route.ts
@@ -10,7 +10,10 @@ import {
 } from "@/lib/db/queries";
 import { isTauriMode } from "@/lib/env/constants";
 import { getConfiguredDefaultAgentProvider } from "@/lib/ai/native-agent/provider-env";
-import { probeNativeClaudeRuntime } from "@/lib/ai/native-agent/runtime-probe";
+import {
+  probeNativeClaudeRuntime,
+  type NativeRuntimeProbe,
+} from "@/lib/ai/native-agent/runtime-probe";
 import { AppError } from "@openloomi/shared/errors";
 
 const providerTypeSchema = z.enum([
@@ -150,6 +153,21 @@ function invalidPayloadResponse() {
   ).toResponse();
 }
 
+async function probeDefaultNativeRuntime(
+  defaultAgent: string,
+): Promise<NativeRuntimeProbe | null> {
+  if (defaultAgent !== "claude") {
+    return null;
+  }
+
+  try {
+    return await probeNativeClaudeRuntime();
+  } catch (error) {
+    console.warn("[AI Preferences] Native Claude runtime probe failed", error);
+    return null;
+  }
+}
+
 export async function GET() {
   const session = await auth().catch(() => null);
   if (!session?.user?.id && !isTauriMode()) {
@@ -161,8 +179,8 @@ export async function GET() {
   // local `claude` CLI auth, not from `process.env.ANTHROPIC_*`. The plugin
   // and the GUI use this field to decide whether the user needs to run
   // `claude auth login` or configure a custom endpoint.
-  const nativeRuntime = await probeNativeClaudeRuntime();
   const defaultAgent = getConfiguredDefaultAgentProvider();
+  const nativeRuntime = await probeDefaultNativeRuntime(defaultAgent);
 
   // Tauri mode may reach this handler before the user has finished guest
   // login (the pet card webview is a separate origin from the main webview

--- a/apps/web/lib/ai/native-agent/runtime-probe.ts
+++ b/apps/web/lib/ai/native-agent/runtime-probe.ts
@@ -168,10 +168,13 @@ function runCli(
   return new Promise((resolve) => {
     let timedOut = false;
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
     const settle = (result: ProbeResult) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       resolve(result);
     };
 
@@ -203,7 +206,7 @@ function runCli(
     proc.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
     proc.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       timedOut = true;
       try {
         proc.kill("SIGKILL");

--- a/apps/web/tests/api/ai-preferences.route.test.ts
+++ b/apps/web/tests/api/ai-preferences.route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: vi.fn(async () => authState.session),
+}));
+
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: vi.fn(() => true),
+}));
+
+const providerState = vi.hoisted(() => ({
+  defaultAgent: "claude",
+}));
+
+vi.mock("@/lib/ai/native-agent/provider-env", () => ({
+  getConfiguredDefaultAgentProvider: vi.fn(() => providerState.defaultAgent),
+}));
+
+const nativeProbe = vi.hoisted(() => ({
+  probe: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/native-agent/runtime-probe", () => ({
+  probeNativeClaudeRuntime: nativeProbe.probe,
+}));
+
+const dbState = vi.hoisted(() => ({
+  settings: [] as unknown[],
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  getUserLlmApiSettings: vi.fn(async () => dbState.settings),
+  getUserLlmApiSettingWithApiKey: vi.fn(),
+  upsertUserLlmApiSetting: vi.fn(),
+  deleteUserLlmApiSetting: vi.fn(),
+}));
+
+const { GET } = await import("@/app/(chat)/api/preferences/ai/route");
+
+beforeEach(() => {
+  authState.session = { user: { id: "user-1" } };
+  providerState.defaultAgent = "claude";
+  dbState.settings = [
+    {
+      providerType: "openai_compatible",
+      baseUrl: "https://api.example.test/v1",
+      model: "test-model",
+      enabled: true,
+    },
+  ];
+  nativeProbe.probe.mockReset();
+  nativeProbe.probe.mockResolvedValue({
+    checked: true,
+    available: true,
+    authenticated: true,
+    active: true,
+    ready: true,
+    reason: "CLAUDE_CLI_AUTHENTICATED",
+    defaultAgent: "claude",
+    cliPathPresent: true,
+    cliPathSource: "PATH",
+    versionPresent: true,
+    probes: {},
+  });
+});
+
+describe("GET /api/preferences/ai", () => {
+  test("returns saved settings when the default Claude runtime probe fails", async () => {
+    nativeProbe.probe.mockRejectedValue(new Error("probe failed"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.defaultAgent).toBe("claude");
+    expect(body.nativeRuntime).toBeNull();
+    expect(body.settings).toEqual(dbState.settings);
+  });
+
+  test("keeps Claude as the default preferred runtime when probe succeeds", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.defaultAgent).toBe("claude");
+    expect(body.nativeRuntime.ready).toBe(true);
+    expect(nativeProbe.probe).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not probe Claude when an alternate native agent is configured", async () => {
+    providerState.defaultAgent = "codex";
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.defaultAgent).toBe("codex");
+    expect(body.nativeRuntime).toBeNull();
+    expect(nativeProbe.probe).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -3,8 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 const spawnMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("node:child_process")>();
+  const actual = await importOriginal<typeof import("node:child_process")>();
   return {
     ...actual,
     spawn: spawnMock,

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -41,7 +41,7 @@ describe("probeNativeClaudeRuntime", () => {
 
   afterEach(() => {
     clearNativeClaudeRuntimeCache();
-    delete process.env.CLAUDE_CODE_PATH;
+    process.env.CLAUDE_CODE_PATH = undefined;
   });
 
   test("returns a structured failure when spawning claude fails synchronously", async () => {

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn((path: string) => path === "C:\\fake\\claude.exe"),
+    readdirSync: vi.fn(() => []),
+  };
+});
+
+vi.mock("@/lib/utils/logger", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { clearNativeClaudeRuntimeCache, probeNativeClaudeRuntime } =
+  await import("@/lib/ai/native-agent/runtime-probe");
+
+describe("probeNativeClaudeRuntime", () => {
+  beforeEach(() => {
+    clearNativeClaudeRuntimeCache();
+    spawnMock.mockReset();
+    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+  });
+
+  afterEach(() => {
+    clearNativeClaudeRuntimeCache();
+    delete process.env.CLAUDE_CODE_PATH;
+  });
+
+  test("returns a structured failure when spawning claude fails synchronously", async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error("spawn boom");
+    });
+
+    const probe = await probeNativeClaudeRuntime();
+
+    expect(probe).not.toBeNull();
+    expect(probe?.ready).toBe(false);
+    expect(probe?.reason).toBe("CLAUDE_CLI_VERSION_FAILED");
+    expect(probe?.probes.version?.error).toEqual({
+      code: "SPAWN_FAILED",
+      message: "spawn boom",
+    });
+  });
+});

--- a/plugins/claude/scripts/loomi-bridge.mjs
+++ b/plugins/claude/scripts/loomi-bridge.mjs
@@ -57,10 +57,20 @@ const PLUGIN_VERSION = "0.1.0";
 const CLAUDE_NATIVE_PROVIDER = "claude";
 const DEFAULT_PROVIDER_BASE = "https://api.anthropic.com";
 const DEFAULT_PROVIDER_MODEL = "claude-opus-4-6";
+function parsePortEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return fallback;
+  }
+  return parsed;
+}
+
 // Matches the documented ports in skills/openloomi-api/SKILL.md; the
 // desktop app falls back to 3515 when 3414 is busy.
-const OPENLOOMI_PORT_DEFAULT = 3414;
-const OPENLOOMI_PORT_FALLBACK = 3515;
+const OPENLOOMI_PORT_DEFAULT = parsePortEnv("OPENLOOMI_PORT_DEFAULT", 3414);
+const OPENLOOMI_PORT_FALLBACK = parsePortEnv("OPENLOOMI_PORT_FALLBACK", 3515);
 let _resolvedPort = OPENLOOMI_PORT_DEFAULT;
 const STATE_HTTP_TIMEOUT_MS = 2000;
 const ARCHIVE_HTTP_TIMEOUT_MS = 15_000;
@@ -1447,12 +1457,18 @@ function openloomiBaseUrl() {
   return `http://127.0.0.1:${_resolvedPort}`;
 }
 
-// Probes the default then fallback port for any HTTP response from
+function openloomiProbePorts() {
+  return Array.from(
+    new Set([_resolvedPort, OPENLOOMI_PORT_DEFAULT, OPENLOOMI_PORT_FALLBACK]),
+  );
+}
+
+// Probes the cached, default, then fallback ports for any HTTP response from
 // /api/remote-auth/user, caches whichever port answered for the
 // lifetime of the process, and returns the resolved base URL. Returns
 // null if neither port responds.
 async function probeOpenLoomiBaseUrl() {
-  for (const port of [OPENLOOMI_PORT_DEFAULT, OPENLOOMI_PORT_FALLBACK]) {
+  for (const port of openloomiProbePorts()) {
     const url = `http://127.0.0.1:${port}`;
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort(), 1500);
@@ -1478,13 +1494,20 @@ async function probeOpenLoomiBaseUrl() {
   return null;
 }
 
+async function resolveOpenLoomiBaseUrl() {
+  if (process.env.OPENLOOMI_BASE_URL) return openloomiBaseUrl();
+  const probed = await probeOpenLoomiBaseUrl();
+  return probed || openloomiBaseUrl();
+}
+
 async function apiGET(path, { timeoutMs = 5000 } = {}) {
   const bearer = loadBearerToken();
   const headers = { Accept: "application/json" };
   if (bearer) headers.Authorization = `Bearer ${bearer}`;
   try {
+    const baseUrl = await resolveOpenLoomiBaseUrl();
     const res = await fetchWithRetry(
-      openloomiBaseUrl() + path,
+      baseUrl + path,
       { method: "GET", headers },
       { timeoutMs },
     );
@@ -1513,8 +1536,9 @@ async function apiPOST(path, body, { timeoutMs = 10_000 } = {}) {
   };
   if (bearer) headers.Authorization = `Bearer ${bearer}`;
   try {
+    const baseUrl = await resolveOpenLoomiBaseUrl();
     const res = await fetchWithRetry(
-      openloomiBaseUrl() + path,
+      baseUrl + path,
       {
         method: "POST",
         headers,
@@ -1550,8 +1574,9 @@ async function apiPUT(path, body, { timeoutMs = 10_000 } = {}) {
   };
   if (bearer) headers.Authorization = `Bearer ${bearer}`;
   try {
+    const baseUrl = await resolveOpenLoomiBaseUrl();
     const res = await fetchWithRetry(
-      openloomiBaseUrl() + path,
+      baseUrl + path,
       {
         method: "PUT",
         headers,

--- a/plugins/claude/tests/bridge.test.mjs
+++ b/plugins/claude/tests/bridge.test.mjs
@@ -127,7 +127,15 @@ async function withClaHomeAsync(fn, options = {}) {
   }
 }
 
-async function withPreferencesServer(payload, fn) {
+async function getUnusedPort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function withPreferencesServer(payload, fn, { port = 0 } = {}) {
   const server = createServer((req, res) => {
     if (req.url === "/api/preferences/ai") {
       res.writeHead(200, { "content-type": "application/json" });
@@ -143,10 +151,10 @@ async function withPreferencesServer(payload, fn) {
     res.end(JSON.stringify({ error: "not found" }));
   });
 
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const { port } = server.address();
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+  const address = server.address();
   try {
-    return await fn(`http://127.0.0.1:${port}`);
+    return await fn(`http://127.0.0.1:${address.port}`, address.port);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -742,6 +750,53 @@ test("setup-status treats a user-saved anthropic_compatible row as the AI provid
           CLAUDE_CODE_PATH: "",
         });
 
+        assert.equal(j.aiProviderConfigured, true);
+        assert.equal(j.executionProviderReady, true);
+        assert.equal(j.executionProviderSource, "ai_provider");
+        assert.equal(j.ready, true);
+        assert.equal(j.nextAction, "run");
+        assert.equal(j.reason, "READY");
+      },
+    );
+  });
+});
+
+test("setup-status reads the AI provider after resolving the fallback API port", async () => {
+  // Source-mode desktop runs on the documented fallback port when 3414
+  // is busy. The bridge must discover that port before reading
+  // /api/preferences/ai, otherwise it reports AI_PROVIDER_REQUIRED even
+  // though the runtime has a saved direct API provider.
+  await withClaHomeAsync(async (env) => {
+    const fakeOpenLoomi = createFakeOpenLoomiBin(join(env.HOME, "fake-bin"), {
+      name: "openloomi",
+    });
+    const unusedDefaultPort = await getUnusedPort();
+
+    await withPreferencesServer(
+      aiPreferencesPayload({
+        settings: [
+          {
+            providerType: "anthropic_compatible",
+            baseUrl: "https://example.com",
+            model: "claude-sonnet-5",
+            enabled: true,
+            hasApiKey: true,
+          },
+        ],
+      }),
+      async (_baseUrl, fallbackPort) => {
+        const j = await runJsonAsync(["setup-status"], {
+          ...env,
+          PATH: makePath(),
+          OPENLOOMI_BIN: fakeOpenLoomi.binPath,
+          OPENLOOMI_AUTH_TOKEN: "mock-bearer",
+          OPENLOOMI_BASE_URL: "",
+          OPENLOOMI_PORT_DEFAULT: String(unusedDefaultPort),
+          OPENLOOMI_PORT_FALLBACK: String(fallbackPort),
+          CLAUDE_CODE_PATH: "",
+        });
+
+        assert.equal(j.apiReachable, true);
         assert.equal(j.aiProviderConfigured, true);
         assert.equal(j.executionProviderReady, true);
         assert.equal(j.executionProviderSource, "ai_provider");


### PR DESCRIPTION
## Summary

Fixes AI provider readiness handling across the web preferences API and Claude plugin setup flow.

This prevents Claude runtime probe failures from blocking users who already have a valid AI provider configured, and ensures the Claude plugin can continue through setup/status using the runtime-reported provider state.

## Changed

- Prevent `/api/preferences/ai` from returning 500 when native Claude runtime probing fails.
- Return a non-blocking native runtime status while preserving saved AI provider configuration.
- Keep configured `anthropic_compatible` providers usable even when Claude CLI auth is unavailable or not selected.
- Update the Claude plugin bridge to resolve the reachable OpenLoomi API base before reading AI provider preferences.
- Add regression coverage for saved AI provider readiness and Claude plugin provider probing.

## Why

Previously, a failed Claude native runtime probe could make the preferences endpoint fail or make the Claude plugin report setup as blocked, even when the user had already configured a working AI provider.

That made provider readiness depend too strongly on Claude CLI/native runtime availability instead of treating native runtime detection as the preferred path that should not block direct provider configuration.

## Testing

- Verified the AI preferences API no longer fails when native runtime probing is unavailable.
- Verified Claude plugin setup/status reaches READY through the configured AI provider path.
- Ran Claude plugin bridge regression tests successfully.

```powershell
node --test plugins/claude/tests/bridge.test.mjs
```