### PR TITLE
fix(codex): preserve multiline conversation context on Windows

### DIFF
--- a/apps/web/lib/ai/extensions/agent/codex/command.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/command.ts
@@ -59,6 +59,13 @@ export interface CodexRunCommandOptions {
 export interface CodexRunCommand {
   command: string;
   args: string[];
+  /**
+   * Prompt payload written to the child process stdin.
+   *
+   * Keep this out of argv: on Windows, npm's `codex.cmd` shim is launched
+   * through `cmd.exe`, which truncates arguments containing literal newlines.
+   */
+  stdin: string;
 }
 
 export type CodexCliEvent =
@@ -169,9 +176,11 @@ export function resolveCodexSandboxMode(
 }
 
 /**
- * Build the `codex exec --json ...` argv. Every provider-configurable value
- * passes through normalization first so unexpected input cannot inject Codex
- * flags or override `--full-auto`/`--sandbox` policy decisions.
+ * Build the `codex exec --json ...` invocation. Every provider-configurable
+ * value passes through normalization first so unexpected input cannot inject
+ * Codex flags or override `--full-auto`/`--sandbox` policy decisions. The
+ * prompt is returned separately and written to stdin by `runCodexCli` so
+ * multiline conversation context survives Windows npm `.cmd` shims.
  */
 export function buildCodexRunCommand(
   options: CodexRunCommandOptions,
@@ -203,11 +212,10 @@ export function buildCodexRunCommand(
     args.push("--", ...providerConfig.extraArgs);
   }
 
-  args.push(options.prompt);
-
   return {
     command: providerConfig.codexPath || "codex",
     args,
+    stdin: options.prompt,
   };
 }
 
@@ -216,6 +224,7 @@ export async function* runCodexCli(
   args: string[],
   options: {
     cwd: string;
+    stdin: string;
     env?: Record<string, string>;
     signal?: AbortSignal;
     timeoutMs?: number;
@@ -231,6 +240,7 @@ export async function* runCodexCli(
   let timedOut = false;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let spawnError: Error | undefined;
+  let stdinError: Error | undefined;
   let proc: ChildProcessWithoutNullStreams;
   const stdoutDecoder = new StringDecoder("utf8");
   const stderrDecoder = new StringDecoder("utf8");
@@ -253,14 +263,15 @@ export async function* runCodexCli(
       detached: shouldDetachCliProcess(),
       windowsHide: true,
     }) as ChildProcessWithoutNullStreams;
-    // Codex CLI 0.144+ reads the prompt from argv but ALSO blocks waiting
-    // for stdin to reach EOF whenever stdin is a piped stream (e.g.
-    // `node`'s default `pipe` stdio). Without this explicit close the
-    // child process hangs in "Reading additional input from stdin..."
-    // forever and the SSE stream never receives any events. We never write
-    // to stdin ourselves (the prompt is passed positionally), so closing
-    // it immediately is safe and signals EOF to the CLI.
-    proc.stdin.end();
+    // Codex officially reads its prompt from stdin when no positional prompt
+    // is supplied. This also avoids the Windows `cmd.exe`/npm-shim path, which
+    // truncates multiline argv values at the first newline. Attach an error
+    // listener before writing so a failed prompt delivery cannot surface as
+    // an unhandled EPIPE.
+    proc.stdin.on("error", (error: Error) => {
+      stdinError = error;
+    });
+    proc.stdin.end(options.stdin, "utf8");
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     if (isCommandNotFoundError(err)) {
@@ -340,6 +351,14 @@ export async function* runCodexCli(
     if (stdoutBuffer.trim()) {
       push({ type: "line", line: stdoutBuffer });
       stdoutBuffer = "";
+    }
+    // Prefer the provider's own stderr/exit status for failed processes. If
+    // the provider nevertheless reports success after stdin delivery failed,
+    // fail the run explicitly instead of silently executing an empty prompt.
+    if (!timedOut && code === 0 && stdinError) {
+      spawnError = new Error(
+        `Failed to write Codex prompt to stdin: ${stdinError.message}`,
+      );
     }
     push({
       type: "close",

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -287,6 +287,7 @@ export class CodexAgent extends BaseAgent {
 
     for await (const event of runCodexCli(command.command, command.args, {
       cwd,
+      stdin: command.stdin,
       env: providerConfig.env,
       signal: signal ?? options?.abortController?.signal,
       timeoutMs: providerConfig.timeoutMs,

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -52,8 +52,8 @@ describe("Codex command builder", () => {
       "--sandbox",
       process.platform === "darwin" ? "danger-full-access" : "workspace-write",
       "--skip-git-repo-check",
-      "fix the failing tests",
     ]);
+    expect(command.stdin).toBe("fix the failing tests");
     expect(command.args).not.toContain("--full-auto");
   });
 
@@ -108,7 +108,7 @@ describe("Codex command builder", () => {
     });
 
     expect(command.args).toContain("--full-auto");
-    expect(command.args.at(-1)).toBe("ship it");
+    expect(command.stdin).toBe("ship it");
   });
 
   it("does not pass --full-auto for bypassPermissions without explicit opt-in", () => {
@@ -524,10 +524,13 @@ describe("CodexAgent", () => {
     // carries an approval flag.
     expect(args).not.toContain("--ask-for-approval");
     expect(args).toContain("--skip-git-repo-check");
-    expect(args.at(-1)).toBe("hello codex");
+    expect(args).not.toContain("hello codex");
+    expect(await readFile(join(workDir, "stdin.txt"), "utf8")).toBe(
+      "hello codex",
+    );
   });
 
-  it("embeds conversation context into the Codex prompt", async () => {
+  it("writes multiline conversation context to Codex stdin", async () => {
     const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
     const agent = new CodexAgent({
       provider: "codex",
@@ -538,8 +541,8 @@ describe("CodexAgent", () => {
     await collectMessages(
       agent.run("current question", {
         conversation: [
-          { role: "user", content: "earlier question" },
-          { role: "assistant", content: "earlier answer" },
+          { role: "user", content: "之前的问题\n还有第二行" },
+          { role: "assistant", content: "飞书连接于六月十五日" },
         ],
       }),
     );
@@ -547,10 +550,52 @@ describe("CodexAgent", () => {
     const args = JSON.parse(
       await readFile(join(workDir, "args.json"), "utf8"),
     ) as string[];
-    const prompt = args.at(-1) ?? "";
-    expect(prompt).toEqual(expect.stringContaining("earlier question"));
+    const prompt = await readFile(join(workDir, "stdin.txt"), "utf8");
+    expect(args).not.toContain(prompt);
+    expect(prompt).toEqual(expect.stringContaining("之前的问题\n还有第二行"));
+    expect(prompt).toEqual(expect.stringContaining("飞书连接于六月十五日"));
     expect(prompt).toEqual(expect.stringContaining("current question"));
   });
+
+  it.skipIf(process.platform !== "win32")(
+    "preserves multiline conversation context through a Windows cmd shim",
+    async () => {
+      const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
+      const shimPath = join(workDir, "fake-codex.cmd");
+      await writeFile(
+        shimPath,
+        `@ECHO off\r\n"${process.execPath}" "${join(workDir, "exec")}" %*\r\n`,
+        "utf8",
+      );
+      const agent = new CodexAgent({
+        provider: "codex",
+        workDir,
+        providerConfig: { codexPath: shimPath },
+      });
+
+      await collectMessages(
+        agent.run("飞书是什么时候连接的？", {
+          conversation: [
+            { role: "user", content: "帮我检查连接状态" },
+            {
+              role: "assistant",
+              content: "飞书连接于 2026 年 6 月 15 日。",
+            },
+          ],
+        }),
+      );
+
+      const args = JSON.parse(
+        await readFile(join(workDir, "args.json"), "utf8"),
+      ) as string[];
+      const prompt = await readFile(join(workDir, "stdin.txt"), "utf8");
+      expect(args.join(" ")).not.toContain("openloomi_conversation_history");
+      expect(prompt).toContain("飞书连接于 2026 年 6 月 15 日。");
+      expect(prompt).toContain(
+        "[current_user_request]\n飞书是什么时候连接的？",
+      );
+    },
+  );
 
   it("converts a nonzero CLI exit into an error message", async () => {
     const workDir = await createFakeCodexWorkDir(`
@@ -930,25 +975,32 @@ function defaultFakeCodexScript() {
   // thread.started -> item.started (command_execution) -> item.completed
   // (agent_message + command_execution) -> turn.completed (with usage).
   return `
+const fs = require("node:fs");
 const args = process.argv.slice(2);
-require("node:fs").writeFileSync("args.json", JSON.stringify(args));
-console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
-console.log(JSON.stringify({
-  type: "item.started",
-  item: { type: "command_execution", id: "cmd-1", command: "pwd" }
-}));
-console.log(JSON.stringify({
-  type: "item.completed",
-  item: { type: "command_execution", id: "cmd-1", command: "pwd", aggregated_output: "/workspace\\n", exit_code: 0, status: "completed" }
-}));
-console.log(JSON.stringify({
-  type: "item.completed",
-  item: { type: "agent_message", id: "msg-1", text: "hello" }
-}));
-console.log(JSON.stringify({
-  type: "turn.completed",
-  usage: { input_tokens: 9, cached_input_tokens: 4, output_tokens: 4 }
-}));
+fs.writeFileSync("args.json", JSON.stringify(args));
+let stdin = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { stdin += chunk; });
+process.stdin.on("end", () => {
+  fs.writeFileSync("stdin.txt", stdin);
+  console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
+  console.log(JSON.stringify({
+    type: "item.started",
+    item: { type: "command_execution", id: "cmd-1", command: "pwd" }
+  }));
+  console.log(JSON.stringify({
+    type: "item.completed",
+    item: { type: "command_execution", id: "cmd-1", command: "pwd", aggregated_output: "/workspace\\n", exit_code: 0, status: "completed" }
+  }));
+  console.log(JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", id: "msg-1", text: "hello" }
+  }));
+  console.log(JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 9, cached_input_tokens: 4, output_tokens: 4 }
+  }));
+});
 `;
 }
 

--- a/apps/web/tests/unit/native-agent-provider-env.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-env.test.ts
@@ -449,7 +449,8 @@ describe("native agent provider env resolver", () => {
     expect(command.args).not.toContain("--ask-for-approval");
     expect(command.args).not.toContain("--skip-git-repo-check");
     expect(command.args).toContain("--full-auto");
-    expect(command.args.at(-1)).toBe("fix the failing tests");
+    expect(command.args).not.toContain("fix the failing tests");
+    expect(command.stdin).toBe("fix the failing tests");
   });
 
   it("rejects unsupported Codex sandbox env values and silently ignores ASK_FOR_APPROVAL", () => {


### PR DESCRIPTION
## Summary

- Send Codex prompts through stdin instead of command-line arguments.
- Preserve multiline conversation history when Codex runs through the Windows npm `.cmd` shim.
- Report stdin delivery failures instead of silently running with an empty prompt.
- Add regression coverage for multiline Chinese context and the Windows `.cmd` execution path.

## Root cause

OpenLoomi injected conversation history into a multiline prompt and passed it as a positional CLI argument.

On Windows, Codex is commonly launched through `codex.cmd`. The `cross-spawn → cmd.exe → .cmd` path truncated multiline arguments at the first newline, so Codex received only the opening conversation-history tag and lost both the history and current request.

## Validation

- Targeted regression tests: 7 passed.
- Affected unit tests: 75 passed.
- TypeScript check for affected sources passed.
- Biome lint and Prettier checks passed.
- Verified through the local OpenLoomi API that Codex receives the complete conversation history and answers using the previous turn.

## Notes

This is a transport-layer fix. It does not change the conversation model, database, frontend, or Claude runtime session implementation.

Closes #429