### PR TITLE
fix(chat): reset send button after conversation completes (#438)

### DIFF
--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -1330,8 +1330,13 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             }
           },
           onUpdate: async (data) => {
-            // Ensure state is true when receiving message
-            setIsAgentRunningFn(true);
+            // Ensure state is true when receiving message.
+            // Pass the captured chatIdForAbort so the running flag is set on the
+            // SAME chat that onDone/onError later clears. Without this, updates
+            // default to the current activeChatId, which can drift (e.g. when the
+            // user switches chats mid-stream), leaving the flag stuck true and the
+            // send button locked in the loading/stop state after completion.
+            setIsAgentRunningFn(true, chatIdForAbort ?? undefined);
 
             // Deduplicate based on messageId - avoid duplicate messages
             const messageId = (data as { messageId?: string }).messageId;


### PR DESCRIPTION
## Summary
Fixes #438 — the send button stayed stuck in the loading/stop state after a conversation completed, forcing users to click stop before they could send again.

The `isAgentRunning` flag (which drives whether the input renders the `StopButton` vs the active `SendButton`) was being **set and cleared using different chat ids**:

- `onUpdate` (`chat-context.tsx`) called `setIsAgentRunningFn(true)` with **no chatId**, so it defaulted to the current `activeChatId`.
- `onDone`/`onError` cleared the flag for the captured `chatIdForAbort` (the chat id at send time).

In the normal case these match, but when `activeChatId` drifts from `chatIdForAbort` (e.g. switching chats mid-stream, or the active id shifting during a fresh chat's creation), the running flag was set on one chat and cleared on another — leaving the active chat stuck with `isAgentRunning: true` and the send button locked in the loading/stop state.

This also explains the reported workaround: clicking stop clears `isAgentRunning` for **all** chats in `stop()`'s `finally` block, unsticking the state.

## Fix
Pass the captured `chatIdForAbort` into `onUpdate` so the `true`/`false` transitions always apply to the same conversation.

## Test plan
- [ ] Send a message and let the conversation complete — send button returns to active state automatically.
- [ ] Send a message, switch to another chat mid-stream, then let it complete — neither chat is left stuck in the loading state.
- [ ] Stop button still works to interrupt an in-progress conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)