### PR TITLE
fix(plugins): prevent tour memory help probes

### DIFF
--- a/plugins/claude/skills/openloomi-tour/SKILL.md
+++ b/plugins/claude/skills/openloomi-tour/SKILL.md
@@ -292,6 +292,10 @@ grounding. The [Library / Knowledge Base](https://openloomi.ai/docs/library) sit
 ```bash
 MEM="${CLAUDE_PLUGIN_ROOT}/skills/openloomi-memory/scripts/openloomi-memory.cjs"
 
+# The required Memory commands are known. Do not run discovery/help probes
+# such as `node "$MEM" --help`, `node "$MEM" -h`, or `node "$MEM" help`
+# before this phase; go directly to add-memory and search-all.
+
 # 1. People / me
 node "$MEM" add-memory "About me: <one-line role + timezone + how I prefer to work>" \
   --file=people/me.md

--- a/plugins/codex/skills/openloomi-tour/SKILL.md
+++ b/plugins/codex/skills/openloomi-tour/SKILL.md
@@ -287,6 +287,10 @@ grounding. The [Library / Knowledge Base](https://openloomi.ai/docs/library) sit
 ```bash
 MEM="$SKILL_DIR/../openloomi-memory/scripts/openloomi-memory.cjs"
 
+# The required Memory commands are known. Do not run discovery/help probes
+# such as `node "$MEM" --help`, `node "$MEM" -h`, or `node "$MEM" help`
+# before this phase; go directly to add-memory and search-all.
+
 # 1. People / me
 node "$MEM" add-memory "About me: <one-line role + timezone + how I prefer to work>" \
   --file=people/me.md

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -415,6 +415,27 @@ test("Codex memory and connector helpers stay in parity with Claude", () => {
   }
 });
 
+test("tour Memory phase uses known commands without help discovery", () => {
+  for (const pluginName of ["codex", "claude"]) {
+    const tourPath = join(
+      PLUGIN_DIR,
+      "..",
+      pluginName,
+      "skills",
+      "openloomi-tour",
+      "SKILL.md",
+    );
+    const source = readFileSync(tourPath, "utf8");
+    assert.match(source, /Do not run discovery\/help probes/);
+    assert.match(source, /node "\$MEM" add-memory/);
+    assert.match(source, /node "\$MEM" search-all/);
+    const memoryHelpCommandLines = source
+      .split(/\r?\n/)
+      .filter((line) => /^\s*node "\$MEM" (--help|-h|help)\b/.test(line));
+    assert.deepEqual(memoryHelpCommandLines, []);
+  }
+});
+
 // -----------------------------------------------------------------------------
 // setup-status shape contract
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Issue
Fixes #433

## Summary
- Constrain the Codex and Claude OpenLoomi tour Memory phase to use known `add-memory` and `search-all` commands directly.
- Avoid `--help` / `-h` / `help` discovery probes before Memory seeding.
- Add a regression test to ensure the tour Memory phase keeps this no-help-probe contract.

## Tests
- PASS: `git diff --check`
- PASS: `node --test --test-name-pattern "tour Memory phase uses known commands without help discovery" plugins\codex\tests\bridge.test.mjs`