### PR TITLE
fix(codex): keep WebSocket retries as transient chat status

### DIFF
--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -20,7 +20,7 @@ import {
   getTextFromMessage,
 } from "@/lib/utils";
 import { mutate } from "swr";
-import { toast } from "@/components/toast";
+import { dismissToast, toast } from "@/components/toast";
 import { streamNativeAgentResponse } from "@/lib/ai/router/index";
 import { isTauri } from "@/lib/tauri";
 import {
@@ -40,6 +40,7 @@ import {
 } from "@/lib/files/extract-artifact-paths";
 import { formatAgentStreamErrorForUser } from "@/lib/ai/runtime/format-error";
 import { parseCodexInterruptedError } from "@/lib/ai/extensions/agent/codex/interrupt-marker";
+import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/codex/transport-status";
 import { detectLifestyleImageTrigger } from "@/lib/ai/image-generation/lifestyle-trigger";
 
 // Max retry attempts for stream errors
@@ -1216,6 +1217,28 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       // Bug fix: store assistantMessageId for onDone to use instead of index
       const newMessageStartIndex = messages.length;
       const assistantMessageIdForRetry = assistantMessageId;
+      const codexTransportToastId = `codex-transport-${assistantMessageId}`;
+      const codexTransportStatus = createCodexTransportStatusController({
+        show: (status) => {
+          const description =
+            status.phase === "fallback"
+              ? t("chat.codexTransport.fallback")
+              : typeof status.attempt === "number" &&
+                  typeof status.maxAttempts === "number"
+                ? t("chat.codexTransport.retryingWithAttempt", {
+                    attempt: status.attempt,
+                    maxAttempts: status.maxAttempts,
+                  })
+                : t("chat.codexTransport.retrying");
+          toast({
+            id: codexTransportToastId,
+            type: "info",
+            description,
+            duration: Number.POSITIVE_INFINITY,
+          });
+        },
+        clear: () => dismissToast(codexTransportToastId),
+      });
 
       // Used to manage message stream order
       let parts: any[] = [];
@@ -1347,6 +1370,12 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               }
               receivedMessageIds.add(messageId);
             }
+
+            // Codex WebSocket reconnect and HTTPS fallback notices are one
+            // temporary status for this turn. Terminal result/error messages
+            // clear it before their normal chat handling continues.
+            const handledCodexTransportStatus =
+              codexTransportStatus.handle(data);
 
             // Handle streaming updates
             if (data.type === "text") {
@@ -1673,27 +1702,17 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 return updated;
               }, chatIdForMessages);
             } else if (data.type === "retry") {
-              // Codex CLI 0.144+ emits non-terminal retry/transport-fallback
-              // notices as `retry` AgentMessages (e.g. "Reconnecting... 2/5
-              // (request timed out)"). These are transient status events
-              // from a still-running turn, not terminal assistant errors.
-              // Surface a brief info toast for visibility, but do NOT push a
-              // chat part — the loading indicator stays up, the turn keeps
-              // running, and the final `turn.completed` / agent message will
-              // follow normally. Pushing a part here would leave a duplicate
-              // Agent Execution Timeout card above the eventual successful
-              // reply (issue #385).
-              const retryMessage =
-                data.content || data.message || "Codex is reconnecting…";
-              const attempt =
-                typeof data.attempt === "number" &&
-                typeof data.maxAttempts === "number"
-                  ? ` (${data.attempt}/${data.maxAttempts})`
-                  : "";
-              toast({
-                type: "info",
-                description: `${retryMessage}${attempt}`,
-              });
+              // Other providers may also emit retry messages without Codex's
+              // structured transport phase. Preserve their existing brief
+              // informational notice.
+              if (!handledCodexTransportStatus) {
+                const retryMessage =
+                  data.content || data.message || "Agent is retrying…";
+                toast({
+                  type: "info",
+                  description: retryMessage,
+                });
+              }
             } else if (data.type === "error") {
               console.error("[NativeAgent] Error:", data.message);
               const errorMessage = data.message || "Unknown error";
@@ -1858,6 +1877,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           },
           modelConfig,
           onDone: async () => {
+            codexTransportStatus.clear();
             // Clear sending lock
             setIsSending(false);
             // Cleanup native agent state - use chatIdForAbort to ensure lock is cleared for correct chat
@@ -1907,6 +1927,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             );
           },
           onError: (error) => {
+            codexTransportStatus.clear();
             // Clear sending lock
             setIsSending(false);
             console.error("[NativeAgent] Stream error:", error);
@@ -2115,6 +2136,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
 
         return Promise.resolve();
       } catch (error) {
+        codexTransportStatus.clear();
         console.error("[NativeAgent] API call failed:", error);
         const errorMessage =
           error instanceof Error ? error.message : String(error);

--- a/apps/web/components/toast.tsx
+++ b/apps/web/components/toast.tsx
@@ -9,12 +9,13 @@ const iconsByType: Record<"success" | "error" | "info", ReactNode> = {
   info: <RemixIcon name="info" size="size-4" />,
 };
 
-type ToastTriggerProps = Omit<ToastProps, "id"> & {
+type ToastTriggerProps = Omit<ToastProps, "id" | "onDismiss"> & {
+  id?: string | number;
   duration?: number;
 };
 
 export function toast(props: ToastTriggerProps) {
-  const { duration, ...rest } = props;
+  const { duration, id: requestedId, ...rest } = props;
   return sonnerToast.custom(
     (id) => (
       <Toast
@@ -24,8 +25,12 @@ export function toast(props: ToastTriggerProps) {
         onDismiss={() => sonnerToast.dismiss(id)}
       />
     ),
-    { duration },
+    { duration, id: requestedId },
   );
+}
+
+export function dismissToast(id?: string | number) {
+  sonnerToast.dismiss(id);
 }
 
 function Toast(props: ToastProps) {

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -6,6 +6,14 @@ const en = {
   chat: {
     ...baseEn.chat,
     stopGenerating: "Stop generating",
+    codexTransport: {
+      retrying:
+        "Codex WebSocket timed out. Retrying; the task is still running.",
+      retryingWithAttempt:
+        "Codex WebSocket timed out. Retrying {{attempt}}/{{maxAttempts}}; the task is still running.",
+      fallback:
+        "Codex WebSocket timed out. Switching to HTTPS; the task is still running.",
+    },
   },
   common: {
     ...baseEn.common,

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -6,6 +6,12 @@ const zh = {
   chat: {
     ...baseZh.chat,
     stopGenerating: "停止生成",
+    codexTransport: {
+      retrying: "Codex WebSocket 超时，正在重试，任务仍在运行",
+      retryingWithAttempt:
+        "Codex WebSocket 超时，正在重试 {{attempt}}/{{maxAttempts}}，任务仍在运行",
+      fallback: "Codex WebSocket 超时，正在切换到 HTTPS，任务仍在运行",
+    },
   },
   common: {
     ...baseZh.common,

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -308,7 +308,7 @@ export class CodexAgent extends BaseAgent {
             // intentionally skip this branch and fall through to the default
             // yield. They must not flip `sawRuntimeError`, which would
             // suppress the final `result` even when the run ultimately
-            // succeeds (issue #385).
+            // succeeds (issues #385 and #436).
             sawRuntimeError = true;
           }
           if (message.type === "tool_use") {

--- a/apps/web/lib/ai/extensions/agent/codex/parser.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/parser.ts
@@ -15,10 +15,10 @@ import type { AgentMessage } from "@openloomi/ai/agent/types";
  *   { "type": "turn.completed",  "usage": { "input_tokens": N, "cached_input_tokens": N, "output_tokens": N } }
  *   { "type": "error",           "message": "…" }
  *
- * Note: Codex CLI 0.144+ emits non-terminal retry/transport-fallback
- * notices using the same top-level `error` shape. We classify the message
- * text and surface those as `retry` AgentMessages instead of fatal
- * `error` AgentMessages (issue #385).
+ * Note: Codex CLI emits non-terminal retry/transport-fallback notices using
+ * both top-level `error` events and completed error items. We classify the
+ * message text and surface those as `retry` AgentMessages instead of fatal
+ * `error` AgentMessages (issues #385 and #436).
  */
 export function parseCodexJsonLine(line: string): AgentMessage[] {
   const trimmed = line.trim();
@@ -106,7 +106,11 @@ export function convertCodexEvent(event: unknown): AgentMessage[] {
 function classifyCodexErrorMessage(message: string): AgentMessage {
   const transient = classifyTransientCodexError(message);
   if (transient.kind === "retry") {
-    const retry: AgentMessage = { type: "retry", content: message };
+    const retry: AgentMessage = {
+      type: "retry",
+      content: message,
+      retryKind: transient.retryKind,
+    };
     if (typeof transient.attempt === "number") {
       retry.attempt = transient.attempt;
     }
@@ -119,7 +123,12 @@ function classifyCodexErrorMessage(message: string): AgentMessage {
 }
 
 type TransientCodexErrorClassification =
-  | { kind: "retry"; attempt?: number; maxAttempts?: number }
+  | {
+      kind: "retry";
+      retryKind: "reconnecting" | "fallback";
+      attempt?: number;
+      maxAttempts?: number;
+    }
   | { kind: "fatal" };
 
 function classifyTransientCodexError(
@@ -130,12 +139,15 @@ function classifyTransientCodexError(
   // Recognised transient shapes (case-insensitive, punctuation-tolerant):
   //   - "Reconnecting... 2/5 (request timed out)"
   //   - "stream disconnected - retrying sampling request (1/5 ...)"
-  //   - "falling back to http" / "falling back to https"
+  //   - "Reconnecting... (request timed out)" (without attempt numbers)
+  //   - "falling back to HTTP"
+  //   - "Falling back from WebSockets to HTTPS transport. request timed out"
   //   - "retrying sampling request"
   const reconnectMatch = text.match(/reconnecting[^()]*?(\d+)\s*\/\s*(\d+)/);
   if (reconnectMatch) {
     return {
       kind: "retry",
+      retryKind: "reconnecting",
       attempt: Number.parseInt(reconnectMatch[1], 10),
       maxAttempts: Number.parseInt(reconnectMatch[2], 10),
     };
@@ -147,17 +159,25 @@ function classifyTransientCodexError(
   if (samplingMatch) {
     return {
       kind: "retry",
+      retryKind: "reconnecting",
       attempt: Number.parseInt(samplingMatch[1], 10),
       maxAttempts: Number.parseInt(samplingMatch[2], 10),
     };
   }
 
+  const isHttpFallback =
+    text.includes("falling back") &&
+    (text.includes("http") || text.includes("websocket"));
+  if (isHttpFallback) {
+    return { kind: "retry", retryKind: "fallback" };
+  }
+
   if (
-    text.includes("falling back to http") ||
+    text.trimStart().startsWith("reconnecting") ||
     text.includes("stream disconnected") ||
     text.includes("retrying sampling request")
   ) {
-    return { kind: "retry" };
+    return { kind: "retry", retryKind: "reconnecting" };
   }
 
   return { kind: "fatal" };
@@ -284,30 +304,30 @@ function convertCodexItem(
     }
 
     case "error": {
-      // Codex CLI 0.144+ emits two distinct flavors of error in the
+      // Codex CLI emits two distinct flavors of error in the
       // NDJSON event stream:
       //
-      //   1. **Top-level** `{"type":"error","message":"..."}` — this means
-      //      the turn was aborted and no further events will arrive. We map
-      //      this to a fatal AgentMessage error in `convertCodexEvent` below.
+      //   1. **Top-level** `{"type":"error","message":"..."}` — either a
+      //      terminal error or a transient reconnect notice, classified by
+      //      `classifyCodexErrorMessage`.
       //   2. **Item-level** `{"type":"item.completed","item":{"type":"error",...}}`
-      //      — Codex uses this shape for *non-fatal* self-diagnostics
+      //      — Codex uses this shape for *non-fatal* self-diagnostics and for
+      //      the WebSocket-to-HTTPS fallback notice
       //      (e.g. "Model metadata for `X` not found. Defaulting to
-      //      fallback metadata" or "Skill descriptions were shortened to
-      //      fit the 2% skills context budget"). The turn continues
-      //      normally afterwards. Treating these as fatal UI errors would
-      //      surface Codex's internal logging as red error banners even
-      //      when the chat reply is delivered a moment later.
+      //      fallback metadata" or "Falling back from WebSockets to HTTPS
+      //      transport. request timed out"). The turn continues normally.
       //
-      // So for the item-level variant we only emit a non-fatal
-      // `tool_result` carrying the message. Callers can still surface
-      // the text in debug UIs via the tool result, but the chat timeline
-      // stays clean. Real fatal errors are caught by the top-level
-      // branch and by the nonzero-exit branch in CodexAgent.
+      // Promote a recognised transport fallback to the same structured
+      // `retry` event as top-level reconnect notices. Other item-level
+      // diagnostics remain non-fatal tool results so the chat stays clean.
       const message =
         readString(item.message) ||
         readString(item.error) ||
         "Codex tool error";
+      const classified = classifyCodexErrorMessage(message);
+      if (classified.type === "retry") {
+        return [classified];
+      }
       const toolUseId = itemId ?? `err_${randomSuffix()}`;
       return [
         {

--- a/apps/web/lib/ai/extensions/agent/codex/transport-status.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/transport-status.ts
@@ -1,0 +1,72 @@
+import type { AgentMessage } from "@openloomi/ai/agent/types";
+
+export interface CodexTransportStatus {
+  phase: "reconnecting" | "fallback";
+  attempt?: number;
+  maxAttempts?: number;
+}
+
+interface CodexTransportStatusPresenter {
+  show: (status: CodexTransportStatus) => void;
+  clear: () => void;
+}
+
+export interface CodexTransportStatusController {
+  /**
+   * Applies transport status side effects for one agent message.
+   *
+   * Returns true only when the message is a Codex transport retry that the
+   * controller displayed. Terminal messages are still available to their
+   * normal chat handlers after clearing the temporary status.
+   */
+  handle: (message: AgentMessage) => boolean;
+  clear: () => void;
+}
+
+/**
+ * Keeps transport recovery UI scoped to one agent turn. Repeated reconnect
+ * events update one presentation, while every terminal path clears it.
+ */
+export function createCodexTransportStatusController(
+  presenter: CodexTransportStatusPresenter,
+): CodexTransportStatusController {
+  let isVisible = false;
+
+  const clear = () => {
+    if (!isVisible) return;
+    isVisible = false;
+    presenter.clear();
+  };
+
+  return {
+    handle(message) {
+      if (
+        message.type === "retry" &&
+        (message.retryKind === "reconnecting" ||
+          message.retryKind === "fallback")
+      ) {
+        const hasAttempt =
+          typeof message.attempt === "number" &&
+          typeof message.maxAttempts === "number";
+        presenter.show({
+          phase: message.retryKind,
+          attempt: hasAttempt ? message.attempt : undefined,
+          maxAttempts: hasAttempt ? message.maxAttempts : undefined,
+        });
+        isVisible = true;
+        return true;
+      }
+
+      if (
+        message.type === "result" ||
+        message.type === "error" ||
+        message.type === "done"
+      ) {
+        clear();
+      }
+
+      return false;
+    },
+    clear,
+  };
+}

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -1018,8 +1018,11 @@ setInterval(() => {}, 1000);
         message.message.startsWith("__CODEX_INTERRUPTED__"),
     );
     expect(error).toBeDefined();
-    expect(error?.message).toContain("__CODEX_INTERRUPTED__");
-    const interruption = parseCodexInterruptedError(error?.message);
+    if (!error?.message) {
+      throw new Error("Expected a structured Codex interruption message");
+    }
+    expect(error.message).toContain("__CODEX_INTERRUPTED__");
+    const interruption = parseCodexInterruptedError(error.message);
     expect(interruption).toMatchObject({
       workspacePath: workDir,
       completedArtifacts: ["report.md"],

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentMessage, TaskPlan } from "@openloomi/ai/agent/types";
 import {
   CodexAgent,
@@ -17,6 +17,7 @@ import {
   resolveCodexSandboxMode,
 } from "@/lib/ai/extensions/agent/codex/command";
 import { parseCodexJsonLine } from "@/lib/ai/extensions/agent/codex/parser";
+import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/codex/transport-status";
 
 const tempDirs: string[] = [];
 
@@ -407,7 +408,7 @@ describe("Codex parser", () => {
   // as fatal errors (e.g. "Reconnecting... 2/5 (request timed out)"). These
   // must NOT be projected to a fatal `error` AgentMessage; they are
   // transient status from a still-running turn and the chat UI surfaces
-  // them via a brief info toast only.
+  // them through one replaceable temporary status.
   it("classifies 'Reconnecting... n/m' as a retry, not a fatal error", () => {
     const messages = parseCodexJsonLine(
       JSON.stringify({
@@ -419,8 +420,25 @@ describe("Codex parser", () => {
       {
         type: "retry",
         content: "Reconnecting... 2/5 (request timed out)",
+        retryKind: "reconnecting",
         attempt: 2,
         maxAttempts: 5,
+      },
+    ]);
+  });
+
+  it("classifies a reconnect timeout without attempt numbers as a retry", () => {
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "error",
+        message: "Reconnecting... (request timed out)",
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "retry",
+        content: "Reconnecting... (request timed out)",
+        retryKind: "reconnecting",
       },
     ]);
   });
@@ -436,6 +454,7 @@ describe("Codex parser", () => {
       {
         type: "retry",
         content: "stream disconnected - retrying sampling request (3/5 ...)",
+        retryKind: "reconnecting",
         attempt: 3,
         maxAttempts: 5,
       },
@@ -453,6 +472,29 @@ describe("Codex parser", () => {
       {
         type: "retry",
         content: "falling back to HTTP",
+        retryKind: "fallback",
+      },
+    ]);
+  });
+
+  it("classifies the real item-level WebSocket fallback as a retry", () => {
+    const messages = parseCodexJsonLine(
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: "item_0",
+          type: "error",
+          message:
+            "Falling back from WebSockets to HTTPS transport. request timed out",
+        },
+      }),
+    );
+    expect(messages).toEqual([
+      {
+        type: "retry",
+        content:
+          "Falling back from WebSockets to HTTPS transport. request timed out",
+        retryKind: "fallback",
       },
     ]);
   });
@@ -479,6 +521,77 @@ describe("Codex parser", () => {
     expect(
       parseCodexJsonLine(JSON.stringify({ type: "future.event", x: 1 })),
     ).toEqual([]);
+  });
+});
+
+describe("Codex transport status controller", () => {
+  it("updates the temporary status and clears it on successful completion", () => {
+    const show = vi.fn();
+    const clear = vi.fn();
+    const controller = createCodexTransportStatusController({ show, clear });
+
+    expect(
+      controller.handle({
+        type: "retry",
+        content: "Reconnecting... (request timed out)",
+        retryKind: "reconnecting",
+      }),
+    ).toBe(true);
+    expect(show).toHaveBeenLastCalledWith({
+      phase: "reconnecting",
+      attempt: undefined,
+      maxAttempts: undefined,
+    });
+
+    expect(
+      controller.handle({
+        type: "retry",
+        content:
+          "Falling back from WebSockets to HTTPS transport. request timed out",
+        retryKind: "fallback",
+      }),
+    ).toBe(true);
+    expect(show).toHaveBeenLastCalledWith({
+      phase: "fallback",
+      attempt: undefined,
+      maxAttempts: undefined,
+    });
+
+    expect(
+      controller.handle({ type: "result", content: "turn.completed" }),
+    ).toBe(false);
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    // onDone may call clear again; cleanup is deliberately idempotent.
+    controller.clear();
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the temporary status before a true terminal error is handled", () => {
+    const show = vi.fn();
+    const clear = vi.fn();
+    const controller = createCodexTransportStatusController({ show, clear });
+
+    controller.handle({
+      type: "retry",
+      content: "Reconnecting... 5/5 (request timed out)",
+      retryKind: "reconnecting",
+      attempt: 5,
+      maxAttempts: 5,
+    });
+    expect(
+      controller.handle({
+        type: "error",
+        message: "Codex CLI exited with code 7: connection refused",
+      }),
+    ).toBe(false);
+
+    expect(show).toHaveBeenCalledWith({
+      phase: "reconnecting",
+      attempt: 5,
+      maxAttempts: 5,
+    });
+    expect(clear).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -599,6 +712,7 @@ describe("CodexAgent", () => {
 
   it("converts a nonzero CLI exit into an error message", async () => {
     const workDir = await createFakeCodexWorkDir(`
+console.log(JSON.stringify({ type: "error", message: "Reconnecting... 5/5 (request timed out)" }));
 console.error("simulated failure");
 process.exit(7);
 `);
@@ -611,6 +725,12 @@ process.exit(7);
 
     const messages = await collectMessages(agent.run("do work"));
 
+    expect(messages.find((message) => message.type === "retry")).toMatchObject({
+      type: "retry",
+      retryKind: "reconnecting",
+      attempt: 5,
+      maxAttempts: 5,
+    });
     expect(messages.find((message) => message.type === "error")).toMatchObject({
       type: "error",
       message: expect.stringContaining("Codex CLI exited with code 7"),
@@ -618,6 +738,9 @@ process.exit(7);
     expect(
       messages.find((message) => message.type === "error")?.message,
     ).toContain("simulated failure");
+    expect(
+      messages.find((message) => message.type === "result"),
+    ).toBeUndefined();
     expect(messages.at(-1)?.type).toBe("done");
   });
 
@@ -739,11 +862,11 @@ setTimeout(() => process.stdout.write(payload.subarray(split)), 10);
     );
   });
 
-  // Issue #385 — non-terminal Codex retry/transport-fallback events must
-  // not be projected to a fatal `error` AgentMessage and must not suppress
-  // the final success `result`. The chat UI relies on this invariant to
-  // avoid rendering duplicate Agent Execution Timeout cards above a
-  // successful reply.
+  // Issues #385 and #436 — non-terminal Codex retry/transport-fallback
+  // events must not be projected to a fatal `error` AgentMessage and must
+  // not suppress the final success `result`. The chat UI relies on this
+  // invariant to avoid rendering duplicate Agent Execution Timeout cards
+  // above a successful reply.
   it("treats Codex retry events as transient and still yields a success result", async () => {
     const workDir = await createFakeCodexWorkDir(`
 require("node:fs").writeFileSync("args.json", JSON.stringify(process.argv.slice(2)));
@@ -755,7 +878,14 @@ console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }));
 console.log(JSON.stringify({ type: "error", message: "Reconnecting... 2/5 (request timed out)" }));
 console.log(JSON.stringify({ type: "error", message: "Reconnecting... 3/5 (request timed out)" }));
 console.log(JSON.stringify({ type: "error", message: "stream disconnected - retrying sampling request (4/5 ...)" }));
-console.log(JSON.stringify({ type: "error", message: "falling back to HTTP" }));
+console.log(JSON.stringify({
+  type: "item.completed",
+  item: {
+    id: "item_0",
+    type: "error",
+    message: "Falling back from WebSockets to HTTPS transport. request timed out"
+  }
+}));
 console.log(JSON.stringify({
   type: "item.completed",
   item: { type: "agent_message", id: "msg-1", text: "测试成功" }
@@ -786,25 +916,30 @@ console.log(JSON.stringify({
     expect(retries[0]).toMatchObject({
       type: "retry",
       content: "Reconnecting... 2/5 (request timed out)",
+      retryKind: "reconnecting",
       attempt: 2,
       maxAttempts: 5,
     });
     expect(retries[1]).toMatchObject({
       type: "retry",
       content: "Reconnecting... 3/5 (request timed out)",
+      retryKind: "reconnecting",
       attempt: 3,
       maxAttempts: 5,
     });
     expect(retries[2]).toMatchObject({
       type: "retry",
       content: "stream disconnected - retrying sampling request (4/5 ...)",
+      retryKind: "reconnecting",
       attempt: 4,
       maxAttempts: 5,
     });
-    // "falling back to HTTP" carries no attempt numbers.
+    // The real item-level WebSocket fallback carries no attempt numbers.
     expect(retries[3]).toMatchObject({
       type: "retry",
-      content: "falling back to HTTP",
+      content:
+        "Falling back from WebSockets to HTTPS transport. request timed out",
+      retryKind: "fallback",
     });
     expect((retries[3] as { attempt?: number }).attempt).toBeUndefined();
     expect(
@@ -884,9 +1019,12 @@ setInterval(() => {}, 1000);
     );
     expect(error).toBeDefined();
     expect(error?.message).toContain("__CODEX_INTERRUPTED__");
-    expect(error?.message).toContain(workDir);
-    expect(error?.message).toContain("report.md");
-    expect(error?.message).toMatch(/"canResume":\s*true/);
+    const interruption = parseCodexInterruptedError(error?.message);
+    expect(interruption).toMatchObject({
+      workspacePath: workDir,
+      completedArtifacts: ["report.md"],
+      canResume: true,
+    });
 
     // The agent still closes with `done` so the SSE stream terminates cleanly
     // and the chat UI does not loop waiting for a result.

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -200,6 +200,12 @@ export interface AgentMessage {
    */
   attempt?: number;
   maxAttempts?: number;
+  /**
+   * Optional structured phase for transport-level retries. Keeping this
+   * separate from the provider's human-readable message lets clients render
+   * stable, localized status without parsing CLI output a second time.
+   */
+  retryKind?: "reconnecting" | "fallback";
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the misleading timeout and reconnect experience when Codex WebSocket startup is slow while the underlying task is still running.

## Changes

- Recognize numbered and unnumbered reconnect events as non-terminal retries.
- Recognize item-level WebSocket-to-HTTPS fallback events.
- Merge retries into a single updateable status.
- Show HTTPS fallback as a temporary status.
- Clear the status after completion, failure, cancellation, or stream closure.
- Keep the existing 30-second SSE heartbeat unchanged.
- Add English and Simplified Chinese messages.

## Testing

- Added coverage for reconnect events without attempt counters.
- Added coverage for item-level fallback events.
- Covered successful completion after fallback and genuine terminal failures.
- Verified temporary status cleanup.
- Manually verified on Windows with a forced WebSocket timeout: retries and fallback updated a single status, the final `OK` appeared, and the status cleared successfully.

Fixes #436