### PR TITLE
fix(loop): merge native Gmail connector readiness

### DIFF
--- a/apps/web/app/api/loop/connectors/route.ts
+++ b/apps/web/app/api/loop/connectors/route.ts
@@ -5,8 +5,8 @@
  *
  * Response shape (additive — older fields preserved):
  *   {
- *     items: ConnectorEntry[],           // Loop + native chat rows merged
- *     nativeAccounts?: NativeAccount[],  // NEW: raw native chat rows
+ *     items: ConnectorEntry[],           // Loop + native connector rows merged
+ *     nativeAccounts?: NativeAccount[],  // NEW: raw native integration rows
  *     lastProbeError?: ProbeErrorInfo,
  *   }
  *
@@ -19,7 +19,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { authenticateCloudRequest } from "@/lib/auth/cloud-auth";
 import { listIntegrationAccountRecordsByUser } from "@/lib/db/queries";
-import { buildNativeChatConnectorEntries, connectors } from "@/lib/loop";
+import {
+  buildNativeChatConnectorEntries,
+  buildNativeConnectorReadinessEntries,
+  connectors,
+  mergeNativeConnectorEntries,
+} from "@/lib/loop";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -33,11 +38,9 @@ async function handleConnectors(req: NextRequest, refresh: boolean) {
   // don't mind the wait.
   const { items, lastProbeError } = await connectors({ refresh });
 
-  // Surface native chat integrations (Telegram / WeChat / WhatsApp / …) on
-  // the Loomi online card. We never write these into the on-disk
-  // connector cache (Loop doesn't pull from them), only fold them into the
-  // API response — see plan §"为什么在 route 层合并". An unauthenticated
-  // probe gets `user === null` and skips this branch entirely.
+  // Surface native integrations on the Loomi online card without writing
+  // them into the on-disk connector cache. An unauthenticated probe gets
+  // `user === null` and skips this branch entirely.
   const user = await authenticateCloudRequest(req);
   let nativeAccounts:
     | Array<{
@@ -52,9 +55,12 @@ async function handleConnectors(req: NextRequest, refresh: boolean) {
   if (user) {
     const records = await listIntegrationAccountRecordsByUser(user.id);
     nativeAccounts = records;
-    const nativeEntries = buildNativeChatConnectorEntries(records);
+    const nativeEntries = [
+      ...buildNativeConnectorReadinessEntries(records),
+      ...buildNativeChatConnectorEntries(records),
+    ];
     if (nativeEntries.length > 0) {
-      mergedItems = [...items, ...nativeEntries];
+      mergedItems = mergeNativeConnectorEntries(items, nativeEntries);
     }
   }
 

--- a/apps/web/lib/loop/connectors-pure.ts
+++ b/apps/web/lib/loop/connectors-pure.ts
@@ -13,6 +13,7 @@
  */
 
 import type {
+  ConnectorAccount,
   ConnectorCapability,
   ConnectorCapabilitySummary,
   ConnectorEntry,
@@ -211,6 +212,20 @@ export const NATIVE_CHAT_INTEGRATIONS: ReadonlySet<string> = new Set([
   "discord",
 ]);
 
+// Native integrations whose connected state can satisfy connector readiness
+// for the same platform id. Keep this separate from NATIVE_CHAT_INTEGRATIONS:
+// Gmail is Loop-monitored, so adding it to the chat-only set would recreate
+// the duplicate-row collision #435 is fixing.
+const NATIVE_READINESS_INTEGRATIONS: ReadonlySet<string> = new Set([
+  "gmail",
+  "outlook",
+]);
+
+const NATIVE_CONNECTOR_LABELS: Record<string, string> = {
+  gmail: "Gmail",
+  outlook: "Outlook",
+};
+
 /**
  * Minimal shape required to turn a native chat account into a
  * `ConnectorEntry`. Lighter than the full `IntegrationAccount` row so the
@@ -281,6 +296,135 @@ export function buildNativeChatConnectorEntries(
     );
   }
   return out;
+}
+
+/**
+ * Build native connector readiness rows for platforms whose source of truth
+ * is OpenLoomi's own integration account table rather than a Composio probe.
+ *
+ * Unlike `buildNativeChatConnectorEntries`, these rows are allowed to share an
+ * id with a Loop connector (notably Gmail). Callers should pass them through
+ * `mergeNativeConnectorEntries` so an active native account upgrades the Loop
+ * row instead of appending a duplicate.
+ */
+export function buildNativeConnectorReadinessEntries(
+  accounts: NativeAccountLike[],
+): ConnectorEntry[] {
+  const byPlatform = new Map<string, NativeAccountLike[]>();
+  for (const acc of accounts) {
+    const platform = normalizeNativePlatform(acc.platform);
+    if (!NATIVE_READINESS_INTEGRATIONS.has(platform)) continue;
+    if (!isActiveNativeAccount(acc)) continue;
+    const bucket = byPlatform.get(platform) ?? [];
+    bucket.push({ ...acc, platform });
+    byPlatform.set(platform, bucket);
+  }
+
+  const fetchedAt = new Date().toISOString();
+  const out: ConnectorEntry[] = [];
+  for (const [platform, group] of byPlatform) {
+    const accountsEntries = group.map((a) => ({
+      id: a.id,
+      label: a.displayName || a.externalId || platform,
+      healthy: true,
+    }));
+    out.push(
+      withConnectorCapability({
+        id: platform,
+        label:
+          NATIVE_CONNECTOR_LABELS[platform] ?? formatNativePlatform(platform),
+        connected: true,
+        accountCount: group.length,
+        accounts: accountsEntries,
+        probed: true,
+        fetchedAt,
+        source: "native",
+      }),
+    );
+  }
+  return out;
+}
+
+/**
+ * Merge native connector rows into Loop/Composio probe rows by id. Native
+ * active rows are authoritative for connected-state readiness, but probe
+ * diagnostics stay outside this list as `lastProbeError`.
+ */
+export function mergeNativeConnectorEntries(
+  items: ConnectorEntry[],
+  nativeEntries: ConnectorEntry[],
+): ConnectorEntry[] {
+  const byId = new Map<string, ConnectorEntry>();
+
+  for (const item of items) {
+    byId.set(item.id, withConnectorCapability(item));
+  }
+
+  for (const native of nativeEntries) {
+    const existing = byId.get(native.id);
+    if (!existing) {
+      byId.set(native.id, withConnectorCapability(native));
+      continue;
+    }
+
+    const accountList = mergeConnectorAccounts(
+      existing.accounts,
+      native.accounts,
+    );
+    const merged: ConnectorEntry = {
+      ...existing,
+      ...(native.connected ? native : {}),
+      connected: Boolean(existing.connected || native.connected),
+      accountCount: Math.max(
+        existing.accountCount ?? 0,
+        native.accountCount ?? 0,
+        accountList.length,
+      ),
+      probed:
+        existing.probed === true || native.probed === true
+          ? true
+          : (existing.probed ?? native.probed),
+      fetchedAt: native.connected
+        ? native.fetchedAt || existing.fetchedAt
+        : existing.fetchedAt || native.fetchedAt,
+      lastError: native.connected
+        ? undefined
+        : existing.lastError || native.lastError,
+      ...(accountList.length > 0 ? { accounts: accountList } : {}),
+    };
+
+    byId.set(native.id, withConnectorCapability(merged));
+  }
+
+  return [...byId.values()];
+}
+
+function normalizeNativePlatform(platform: string): string {
+  return platform.trim().toLowerCase();
+}
+
+function isActiveNativeAccount(account: NativeAccountLike): boolean {
+  return account.status.trim().toLowerCase() === "active";
+}
+
+function formatNativePlatform(platform: string): string {
+  return platform
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function mergeConnectorAccounts(
+  left: ConnectorAccount[] | undefined,
+  right: ConnectorAccount[] | undefined,
+): ConnectorAccount[] {
+  const byId = new Map<string, ConnectorAccount>();
+  for (const account of [...(left ?? []), ...(right ?? [])]) {
+    if (!account?.id) continue;
+    byId.set(account.id, account);
+  }
+  return [...byId.values()];
 }
 
 /**

--- a/apps/web/lib/loop/index.ts
+++ b/apps/web/lib/loop/index.ts
@@ -21,6 +21,8 @@ export {
   filterComposioOnlyEntries,
   NATIVE_CHAT_INTEGRATIONS,
   buildNativeChatConnectorEntries,
+  buildNativeConnectorReadinessEntries,
+  mergeNativeConnectorEntries,
 } from "./connectors-pure";
 export type { NativeAccountLike } from "./connectors-pure";
 export { listConnectors, refreshConnectors } from "./connectors";

--- a/apps/web/lib/loop/types.ts
+++ b/apps/web/lib/loop/types.ts
@@ -496,6 +496,12 @@ export interface ConnectorEntry {
   probed?: boolean;
   fetchedAt: string;
   /**
+   * Optional non-secret provenance for rows derived from an integration
+   * source instead of the Loop probe. Kept advisory so older connector
+   * snapshots without it remain valid.
+   */
+  source?: "native" | "loop" | "composio" | "mixed";
+  /**
    * #361 — Loop participation flag. `true` means scheduled ticks actively
    * pull this connector for signals. `false` (or absent for compat) means
    * the connector is authorized for chat/memory but does not contribute to

--- a/apps/web/tests/unit/loop/native-chat-connector-entries.test.ts
+++ b/apps/web/tests/unit/loop/native-chat-connector-entries.test.ts
@@ -24,7 +24,9 @@ import { describe, expect, it } from "vitest";
 import {
   NATIVE_CHAT_INTEGRATIONS,
   buildNativeChatConnectorEntries,
+  buildNativeConnectorReadinessEntries,
   filterComposioOnlyEntries,
+  mergeNativeConnectorEntries,
 } from "@/lib/loop/connectors-pure";
 import type { ConnectorEntry } from "@/lib/loop/types";
 
@@ -208,5 +210,142 @@ describe("buildNativeChatConnectorEntries", () => {
     // And the native rows themselves pass the filter unchanged (they're
     // connected + probed + id is the platform).
     expect(filterComposioOnlyEntries(out, new Set())).toEqual(out);
+  });
+});
+
+describe("buildNativeConnectorReadinessEntries", () => {
+  it("emits active native Gmail as a Loop-ready connector row", () => {
+    const out = buildNativeConnectorReadinessEntries([
+      acc({
+        id: "gmail-native-1",
+        platform: "gmail",
+        displayName: "Work Gmail",
+        externalId: "work@example.com",
+        status: "active",
+      }),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: "gmail",
+      label: "Gmail",
+      connected: true,
+      accountCount: 1,
+      probed: true,
+      source: "native",
+      capability: "decision_capable",
+      loopMonitored: true,
+      decisionCapable: true,
+    });
+    expect(out[0].accounts).toEqual([
+      { id: "gmail-native-1", label: "Work Gmail", healthy: true },
+    ]);
+  });
+
+  it("emits active native Outlook without claiming Loop monitoring", () => {
+    const out = buildNativeConnectorReadinessEntries([
+      acc({
+        id: "outlook-native-1",
+        platform: "outlook",
+        displayName: "Outlook",
+        status: "active",
+      }),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: "outlook",
+      label: "Outlook",
+      connected: true,
+      accountCount: 1,
+      probed: true,
+      source: "native",
+      capability: "needs_setup",
+      loopMonitored: false,
+      decisionCapable: false,
+    });
+  });
+
+  it("does not emit inactive native Gmail rows that could override Composio", () => {
+    const out = buildNativeConnectorReadinessEntries([
+      acc({ id: "gmail-paused", platform: "gmail", status: "paused" }),
+      acc({ id: "gmail-disabled", platform: "gmail", status: "disabled" }),
+    ]);
+
+    expect(out).toEqual([]);
+  });
+});
+
+describe("mergeNativeConnectorEntries", () => {
+  it("lets active native Gmail override a failed Loop/Composio probe row without duplicating it", () => {
+    const loopItems: ConnectorEntry[] = [
+      {
+        id: "gmail",
+        label: "Gmail",
+        connected: false,
+        accountCount: 0,
+        probed: true,
+        fetchedAt: "2026-07-23T00:00:00.000Z",
+        lastError: "composio probe failed",
+        capability: "needs_setup",
+      },
+    ];
+    const nativeEntries = buildNativeConnectorReadinessEntries([
+      acc({
+        id: "native-gmail",
+        platform: "gmail",
+        displayName: "Gmail",
+        status: "active",
+      }),
+    ]);
+
+    const out = mergeNativeConnectorEntries(loopItems, nativeEntries);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: "gmail",
+      label: "Gmail",
+      connected: true,
+      accountCount: 1,
+      probed: true,
+      source: "native",
+      capability: "decision_capable",
+      loopMonitored: true,
+      decisionCapable: true,
+    });
+    expect(out[0].lastError).toBeUndefined();
+  });
+
+  it("preserves unrelated Loop rows while appending native-only rows", () => {
+    const loopItems: ConnectorEntry[] = [
+      {
+        id: "linear",
+        label: "Linear",
+        connected: true,
+        accountCount: 1,
+        probed: true,
+        fetchedAt: "2026-07-23T00:00:00.000Z",
+        capability: "decision_capable",
+      },
+    ];
+    const nativeEntries = [
+      ...buildNativeConnectorReadinessEntries([
+        acc({ id: "native-gmail", platform: "gmail", status: "active" }),
+      ]),
+      ...buildNativeChatConnectorEntries([
+        acc({ id: "native-telegram", platform: "telegram", status: "active" }),
+      ]),
+    ];
+
+    const out = mergeNativeConnectorEntries(loopItems, nativeEntries);
+
+    expect(out.map((entry) => entry.id)).toEqual([
+      "linear",
+      "gmail",
+      "telegram",
+    ]);
+    expect(out.find((entry) => entry.id === "linear")?.connected).toBe(true);
+    expect(out.find((entry) => entry.id === "gmail")?.connected).toBe(true);
+    expect(out.find((entry) => entry.id === "telegram")?.connected).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #435.

This updates `/api/loop/connectors` so native integration account state can participate in Loop connector readiness instead of being appended as a separate, non-overriding row.

The main behavior change is that an active native Gmail account now marks the Gmail connector as connected even when the Composio/Loop probe returns a disconnected fallback row. Probe failures are still preserved as diagnostics via `lastProbeError`; they no longer overwrite native Gmail readiness.

## Details

- Adds native readiness rows for OpenLoomi-owned Gmail/Outlook accounts.
- Merges native connector rows into Loop connector rows by `id`, avoiding duplicate Gmail entries.
- Keeps Gmail in the Loop-monitored capability model, so native Gmail is still reported as `decision_capable`.
- Keeps Outlook connected-state visible without marking it as Loop-monitored.
- Preserves the existing native chat integration path for Telegram/WeChat/WhatsApp/etc.
- Adds regression coverage for native Gmail overriding a failed Loop/Composio probe row.

## Scope

This does not change Gmail send/receive execution, OAuth/app-password handling, or Composio installation behavior. The fix is limited to connector readiness reporting.

## Verification

- `pnpm --filter web exec vitest run tests/unit/loop/native-chat-connector-entries.test.ts tests/unit/loop/connector-capability.test.ts tests/unit/loop/use-loop-connectors.test.ts tests/unit/loop/composio-connector-list-filter.test.ts`
- `pnpm exec prettier --check apps/web/app/api/loop/connectors/route.ts apps/web/lib/loop/connectors-pure.ts apps/web/lib/loop/index.ts apps/web/lib/loop/types.ts apps/web/tests/unit/loop/native-chat-connector-entries.test.ts`
- `git diff --check`