### PR TITLE
fix(codex): preflight model compatibility and surface runtime errors

### DIFF
--- a/apps/web/components/message/error-message-display.tsx
+++ b/apps/web/components/message/error-message-display.tsx
@@ -102,6 +102,35 @@ export function ErrorMessageDisplay({
   const getErrorDetails = (error: string) => {
     const lowerError = error.toLowerCase();
 
+    // Codex CLI/model compatibility errors are already actionable at the
+    // provider boundary. Preserve that original diagnostic instead of
+    // replacing it with the generic "try again later" copy (issue #437).
+    if (
+      lowerError.includes("codex") &&
+      (lowerError.includes("requires a newer") ||
+        lowerError.includes("not available in codex cli") ||
+        lowerError.includes("not supported") ||
+        lowerError.includes("unsupported model") ||
+        lowerError.includes("upgrade codex") ||
+        lowerError.includes("codex cli executable not found") ||
+        lowerError.includes("codex cli version check"))
+    ) {
+      const suggestions = t(
+        "common.errors.codexCompatibilityError.suggestions",
+        {
+          returnObjects: true,
+        },
+      );
+      return {
+        title: t("common.errors.codexCompatibilityError.title"),
+        description: sanitizeErrorForDisplay(error),
+        suggestions: Array.isArray(suggestions) ? suggestions : [],
+        icon: "alert_triangle",
+        severity: "warning" as const,
+        showCodexDocs: true,
+      };
+    }
+
     // IMPROVED: Handle special error markers from Claude Extension
     // Process crash errors (OOM, killed) - retryable
     if (
@@ -393,13 +422,7 @@ export function ErrorMessageDisplay({
       returnObjects: true,
     });
     // Remove log file paths and other sensitive info from error message
-    const cleanError = error
-      .replace(/\/Users\/[^/]+\/\.openloomi\/logs\/[^\s]+/g, "")
-      .replace(/\/home\/[^/]+\/\.openloomi\/logs\/[^\s]+/g, "")
-      .replace(/http:\/\/[^/]+\/[^/]+\/Users\/[^/]+\/[^\s]+/g, "")
-      .replace(/__CUSTOM_API_ERROR__\|[^|]+/g, "")
-      .trim()
-      .replace(/\s+/g, " ");
+    const cleanError = sanitizeErrorForDisplay(error);
     return {
       title: t("common.errors.genericError.title"),
       description: cleanError || t("common.errors.genericError.description"),
@@ -433,8 +456,12 @@ export function ErrorMessageDisplay({
           className="shrink-0 mt-0.5"
         />
 
-        <div className="flex-1 min-w-0">
-          <h4 className="font-semibold text-sm mb-1">{errorDetails.title}</h4>
+        <div className="flex-1 min-w-0 space-y-2">
+          <h4 className="font-semibold text-sm">{errorDetails.title}</h4>
+
+          <p className="text-xs opacity-90 whitespace-pre-wrap break-words">
+            {errorDetails.description}
+          </p>
 
           {/* Suggestions */}
           {errorDetails.suggestions.length > 0 && (
@@ -449,8 +476,31 @@ export function ErrorMessageDisplay({
               </ul>
             </div>
           )}
+
+          {"showCodexDocs" in errorDetails &&
+          errorDetails.showCodexDocs === true ? (
+            <Button asChild size="sm" variant="outline">
+              <a
+                href="https://github.com/openai/codex#installation"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t("common.errors.codexCompatibilityError.docsAction")}
+              </a>
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>
   );
+}
+
+function sanitizeErrorForDisplay(error: string): string {
+  return error
+    .replace(/\/Users\/[^/]+\/\.openloomi\/logs\/[^\s]+/g, "")
+    .replace(/\/home\/[^/]+\/\.openloomi\/logs\/[^\s]+/g, "")
+    .replace(/http:\/\/[^/]+\/[^/]+\/Users\/[^/]+\/[^\s]+/g, "")
+    .replace(/__CUSTOM_API_ERROR__\|[^|]+/g, "")
+    .trim()
+    .replace(/\s+/g, " ");
 }

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -36,6 +36,7 @@ import {
   parseCodexInterruptedError,
   type CodexInterruptedContext,
 } from "./interrupt-marker";
+import { preflightCodexRuntime } from "./runtime-preflight";
 
 // Re-exported from `./interrupt-marker` so legacy import paths
 // (`@/lib/ai/extensions/agent/codex`) keep working without pulling
@@ -270,6 +271,14 @@ export class CodexAgent extends BaseAgent {
       permissionMode: options?.permissionMode,
       mode,
       providerConfig: this.config.providerConfig,
+    });
+
+    await preflightCodexRuntime({
+      command: command.command,
+      cwd,
+      model: this.config.model,
+      providerConfig,
+      signal: signal ?? options?.abortController?.signal,
     });
 
     let closeEvent: Extract<CodexCliEvent, { type: "close" }> | undefined;

--- a/apps/web/lib/ai/extensions/agent/codex/runtime-preflight.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/runtime-preflight.ts
@@ -1,0 +1,687 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { createHash } from "node:crypto";
+import { StringDecoder } from "node:string_decoder";
+
+import spawn from "cross-spawn";
+
+import {
+  appendCapturedCliOutput,
+  buildCliEnvironment,
+  MAX_CLI_PROTOCOL_LINE_CHARS,
+  shouldDetachCliProcess,
+  terminateCliProcessTree,
+} from "../cli-process";
+import {
+  CodexCommandNotFoundError,
+  runCodexCli,
+  type CodexProviderConfig,
+} from "./command";
+
+const PREFLIGHT_TIMEOUT_MS = 5_000;
+const PREFLIGHT_CACHE_TTL_MS = 60_000;
+const MAX_MODEL_PAGES = 20;
+const MAX_MODELS_IN_ERROR = 8;
+const PREFLIGHT_CLIENT_VERSION = "1.0.0";
+
+type JsonRpcId = string | number;
+
+interface JsonRpcResponse {
+  id: JsonRpcId;
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+}
+
+interface PendingRequest {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+interface ModelListEntry {
+  id?: string;
+  model?: string;
+  displayName?: string;
+}
+
+interface ModelListResult {
+  data: ModelListEntry[];
+  nextCursor?: string | null;
+}
+
+export interface CodexRuntimePreflightOptions {
+  command: string;
+  cwd: string;
+  model?: string;
+  providerConfig: CodexProviderConfig;
+  signal?: AbortSignal;
+}
+
+export interface CodexRuntimePreflightResult {
+  version: string;
+  availableModels?: string[];
+  modelCatalogChecked: boolean;
+}
+
+export class CodexRuntimePreflightError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexRuntimePreflightError";
+  }
+}
+
+export class CodexModelCompatibilityError extends Error {
+  constructor(
+    readonly model: string,
+    readonly installedVersion: string,
+    readonly availableModels: string[],
+  ) {
+    const availableSummary = availableModels
+      .slice(0, MAX_MODELS_IN_ERROR)
+      .join(", ");
+    const availableSuffix =
+      availableModels.length > MAX_MODELS_IN_ERROR ? ", …" : "";
+    const availableHint = availableSummary
+      ? ` Models available from this installation include: ${availableSummary}${availableSuffix}.`
+      : "";
+
+    super(
+      `The selected model "${model}" is not available in Codex CLI ${installedVersion}. It may require a newer Codex CLI or may not be available to this account. Upgrade Codex with \`codex update\` (or install the latest \`@openai/codex\`), restart OpenLoomi, or choose a compatible model.${availableHint}`,
+    );
+    this.name = "CodexModelCompatibilityError";
+  }
+}
+
+interface CachedPreflight {
+  expiresAt: number;
+  result: Promise<CodexRuntimePreflightResult>;
+}
+
+const preflightCache = new Map<string, CachedPreflight>();
+
+/**
+ * Validate the installed Codex binary before starting a generation request.
+ *
+ * The version probe is mandatory because a missing or broken executable cannot
+ * service the request. Model compatibility uses Codex's official app-server
+ * `model/list` capability discovery instead of an OpenLoomi-maintained version
+ * matrix that would become stale. Catalog discovery deliberately fails open:
+ * older CLIs and temporary app-server/auth failures still get a chance to run
+ * `codex exec`, whose original stderr is preserved for the user.
+ */
+export async function preflightCodexRuntime(
+  options: CodexRuntimePreflightOptions,
+): Promise<CodexRuntimePreflightResult> {
+  throwIfAborted(options.signal);
+
+  const cacheKey = createPreflightCacheKey(options);
+  const now = Date.now();
+  let cached = preflightCache.get(cacheKey);
+  if (cached && cached.expiresAt <= now) {
+    preflightCache.delete(cacheKey);
+    cached = undefined;
+  }
+
+  if (!cached) {
+    const result = runPreflight(options).catch((error) => {
+      if (!(error instanceof CodexModelCompatibilityError)) {
+        preflightCache.delete(cacheKey);
+      }
+      throw error;
+    });
+    cached = {
+      expiresAt: now + PREFLIGHT_CACHE_TTL_MS,
+      result,
+    };
+    preflightCache.set(cacheKey, cached);
+  }
+
+  const result = await awaitWithAbort(cached.result, options.signal);
+  throwIfAborted(options.signal);
+  return result;
+}
+
+export function clearCodexRuntimePreflightCache(): void {
+  preflightCache.clear();
+}
+
+export function parseCodexVersion(output: string): string | undefined {
+  const match = output.match(
+    /(?:^|\s)(?:codex(?:-cli)?\s+)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?=\s|$)/i,
+  );
+  return match?.[1];
+}
+
+async function runPreflight(
+  options: CodexRuntimePreflightOptions,
+): Promise<CodexRuntimePreflightResult> {
+  const version = await probeCodexVersion(options);
+  if (!options.model) {
+    return {
+      version,
+      modelCatalogChecked: false,
+    };
+  }
+
+  let availableModels: string[];
+  try {
+    availableModels = await probeCodexModels(options);
+  } catch {
+    return {
+      version,
+      modelCatalogChecked: false,
+    };
+  }
+
+  if (availableModels.length === 0) {
+    return {
+      version,
+      modelCatalogChecked: false,
+    };
+  }
+
+  if (!availableModels.includes(options.model)) {
+    throw new CodexModelCompatibilityError(
+      options.model,
+      version,
+      availableModels,
+    );
+  }
+
+  return {
+    version,
+    availableModels,
+    modelCatalogChecked: true,
+  };
+}
+
+async function probeCodexVersion(
+  options: CodexRuntimePreflightOptions,
+): Promise<string> {
+  let closeEvent:
+    | {
+        stdout: string;
+        stderr: string;
+        exitCode: number;
+        timedOut?: boolean;
+      }
+    | undefined;
+
+  for await (const event of runCodexCli(options.command, ["--version"], {
+    cwd: options.cwd,
+    stdin: "",
+    env: options.providerConfig.env,
+    timeoutMs: PREFLIGHT_TIMEOUT_MS,
+  })) {
+    if (event.type === "close") {
+      closeEvent = event;
+    }
+  }
+
+  if (!closeEvent) {
+    throw new CodexRuntimePreflightError(
+      "Codex CLI preflight ended before reporting its version. Run `codex --version` to verify the installation.",
+    );
+  }
+
+  const output = [closeEvent.stdout, closeEvent.stderr]
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  if (closeEvent.timedOut) {
+    throw new CodexRuntimePreflightError(
+      `Codex CLI version check timed out after ${PREFLIGHT_TIMEOUT_MS}ms. Run \`${options.command} --version\` and repair or upgrade the Codex installation.`,
+    );
+  }
+
+  if (closeEvent.exitCode !== 0) {
+    const outputSuffix = output ? `: ${output}` : "";
+    throw new CodexRuntimePreflightError(
+      `Codex CLI version check failed with code ${closeEvent.exitCode}${outputSuffix}. Run \`${options.command} --version\` and repair or upgrade the Codex installation.`,
+    );
+  }
+
+  const version = parseCodexVersion(output);
+  if (!version) {
+    throw new CodexRuntimePreflightError(
+      `OpenLoomi could not determine the installed Codex CLI version from \`${options.command} --version\`. Output: ${output || "(empty)"}. Upgrade Codex or verify providerConfig.codexPath.`,
+    );
+  }
+
+  return version;
+}
+
+async function probeCodexModels(
+  options: CodexRuntimePreflightOptions,
+): Promise<string[]> {
+  const args: string[] = [];
+  if (options.providerConfig.profile) {
+    args.push("-p", options.providerConfig.profile);
+  }
+  args.push("app-server", "--stdio");
+
+  const client = new CodexAppServerProbeClient(options.command, args, {
+    cwd: options.cwd,
+    env: options.providerConfig.env,
+    timeoutMs: PREFLIGHT_TIMEOUT_MS,
+  });
+
+  try {
+    client.start();
+    await client.request("initialize", {
+      clientInfo: {
+        name: "openloomi",
+        title: "OpenLoomi",
+        version: PREFLIGHT_CLIENT_VERSION,
+      },
+      capabilities: {},
+    });
+    client.notify("initialized", {});
+
+    const models = new Set<string>();
+    let cursor: string | undefined;
+    let catalogComplete = false;
+    for (let page = 0; page < MAX_MODEL_PAGES; page += 1) {
+      const result = parseModelListResult(
+        await client.request("model/list", {
+          limit: 100,
+          includeHidden: true,
+          ...(cursor ? { cursor } : {}),
+        }),
+      );
+      for (const entry of result.data) {
+        if (entry.id?.trim()) {
+          models.add(entry.id.trim());
+        }
+        if (entry.model?.trim()) {
+          models.add(entry.model.trim());
+        }
+      }
+
+      const nextCursor = result.nextCursor?.trim();
+      if (!nextCursor || nextCursor === cursor) {
+        catalogComplete = true;
+        break;
+      }
+      cursor = nextCursor;
+    }
+
+    if (!catalogComplete) {
+      throw new Error(
+        `Codex app-server model/list exceeded ${MAX_MODEL_PAGES} pages`,
+      );
+    }
+
+    return [...models].sort();
+  } finally {
+    await client.shutdown();
+  }
+}
+
+function parseModelListResult(value: unknown): ModelListResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Codex app-server returned an invalid model/list result");
+  }
+
+  const data = (value as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("Codex app-server model/list result is missing data");
+  }
+
+  const entries = data.filter(
+    (entry): entry is ModelListEntry =>
+      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+  );
+  const nextCursor = (value as { nextCursor?: unknown }).nextCursor;
+
+  return {
+    data: entries,
+    nextCursor:
+      typeof nextCursor === "string" || nextCursor === null
+        ? nextCursor
+        : undefined,
+  };
+}
+
+class CodexAppServerProbeClient {
+  private proc?: ChildProcessWithoutNullStreams;
+  private requestCounter = 0;
+  private stdout = "";
+  private stderr = "";
+  private stdoutBuffer = "";
+  private timeout?: ReturnType<typeof setTimeout>;
+  private timedOut = false;
+  private closed = false;
+  private pendingRequests = new Map<JsonRpcId, PendingRequest>();
+  private resolveClosed?: () => void;
+  private readonly stdoutDecoder = new StringDecoder("utf8");
+  private readonly stderrDecoder = new StringDecoder("utf8");
+  private readonly closedPromise = new Promise<void>((resolve) => {
+    this.resolveClosed = resolve;
+  });
+
+  constructor(
+    private readonly command: string,
+    private readonly args: string[],
+    private readonly options: {
+      cwd: string;
+      env?: Record<string, string>;
+      timeoutMs: number;
+    },
+  ) {}
+
+  start(): void {
+    if (this.proc) {
+      return;
+    }
+
+    let proc: ChildProcessWithoutNullStreams;
+    try {
+      proc = spawn(this.command, this.args, {
+        cwd: this.options.cwd,
+        env: buildCliEnvironment(this.options.env),
+        detached: shouldDetachCliProcess(),
+        windowsHide: true,
+      }) as ChildProcessWithoutNullStreams;
+      this.proc = proc;
+    } catch (error) {
+      throw normalizeProbeSpawnError(error, this.command);
+    }
+
+    this.timeout = setTimeout(() => {
+      this.timedOut = true;
+      this.rejectAll(this.createExitError());
+      this.kill();
+    }, this.options.timeoutMs);
+
+    proc.stdin.on("error", (error: Error) => {
+      this.rejectAll(error);
+      this.kill();
+    });
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const text = this.stdoutDecoder.write(chunk);
+      this.stdout = appendCapturedCliOutput(this.stdout, text);
+      this.stdoutBuffer += text;
+      if (this.stdoutBuffer.length > MAX_CLI_PROTOCOL_LINE_CHARS) {
+        this.rejectAll(
+          new Error(
+            `Codex app-server emitted a JSON line larger than ${MAX_CLI_PROTOCOL_LINE_CHARS} characters`,
+          ),
+        );
+        this.kill();
+        return;
+      }
+      this.flushStdoutLines();
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      this.stderr = appendCapturedCliOutput(
+        this.stderr,
+        this.stderrDecoder.write(chunk),
+      );
+    });
+
+    proc.on("error", (error: Error & { code?: string }) => {
+      this.rejectAll(normalizeProbeSpawnError(error, this.command));
+      this.finish();
+    });
+
+    proc.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      const finalStdout = this.stdoutDecoder.end();
+      if (finalStdout) {
+        this.stdout = appendCapturedCliOutput(this.stdout, finalStdout);
+        this.stdoutBuffer += finalStdout;
+      }
+      this.stderr = appendCapturedCliOutput(
+        this.stderr,
+        this.stderrDecoder.end(),
+      );
+      if (this.stdoutBuffer.trim()) {
+        this.handleLine(this.stdoutBuffer);
+        this.stdoutBuffer = "";
+      }
+
+      if (this.pendingRequests.size > 0) {
+        this.rejectAll(this.createExitError(code ?? (signal ? 130 : 0)));
+      }
+      this.finish();
+    });
+  }
+
+  request(method: string, params?: unknown): Promise<unknown> {
+    const id = ++this.requestCounter;
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { method, resolve, reject });
+      try {
+        this.write({ id, method, params });
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.write({ method, params });
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.proc) {
+      return;
+    }
+    this.kill();
+    this.cleanup();
+    await Promise.race([
+      this.closedPromise,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_000);
+      }),
+    ]);
+  }
+
+  private write(message: Record<string, unknown>): void {
+    if (!this.proc || this.closed) {
+      throw new Error("Codex app-server preflight process is not running");
+    }
+    this.proc.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private flushStdoutLines(): void {
+    const lines = this.stdoutBuffer.split(/\r?\n/);
+    this.stdoutBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) {
+        this.handleLine(line);
+      }
+    }
+  }
+
+  private handleLine(line: string): void {
+    let message: unknown;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (isIncomingJsonRpcRequest(message)) {
+      this.write({
+        id: message.id,
+        error: {
+          code: -32601,
+          message: `Unsupported OpenLoomi preflight method: ${message.method}`,
+        },
+      });
+      return;
+    }
+
+    if (!isJsonRpcResponse(message)) {
+      return;
+    }
+
+    const pending = this.pendingRequests.get(message.id);
+    if (!pending) {
+      return;
+    }
+    this.pendingRequests.delete(message.id);
+
+    if (message.error) {
+      pending.reject(
+        new Error(
+          `Codex app-server ${pending.method} failed${
+            typeof message.error.code === "number"
+              ? ` (${message.error.code})`
+              : ""
+          }: ${message.error.message || "unknown error"}`,
+        ),
+      );
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  private createExitError(exitCode?: number): Error {
+    const output = this.stderr.trim() || this.stdout.trim();
+    if (this.timedOut) {
+      return new Error(
+        output
+          ? `Codex app-server preflight timed out after ${this.options.timeoutMs}ms: ${output}`
+          : `Codex app-server preflight timed out after ${this.options.timeoutMs}ms`,
+      );
+    }
+
+    return new Error(
+      output
+        ? `Codex app-server exited before completing model discovery${
+            exitCode === undefined ? "" : ` (code ${exitCode})`
+          }: ${output}`
+        : `Codex app-server exited before completing model discovery${
+            exitCode === undefined ? "" : ` (code ${exitCode})`
+          }`,
+    );
+  }
+
+  private kill(): void {
+    if (this.proc && !this.proc.killed) {
+      terminateCliProcessTree(this.proc);
+    }
+  }
+
+  private finish(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.cleanup();
+    this.resolveClosed?.();
+  }
+
+  private cleanup(): void {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+  }
+}
+
+function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const id = (value as { id?: unknown }).id;
+  return typeof id === "string" || typeof id === "number";
+}
+
+function isIncomingJsonRpcRequest(
+  value: unknown,
+): value is { id: JsonRpcId; method: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as { id?: unknown; method?: unknown };
+  return (
+    (typeof candidate.id === "string" || typeof candidate.id === "number") &&
+    typeof candidate.method === "string"
+  );
+}
+
+function normalizeProbeSpawnError(error: unknown, command: string): Error {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  return (normalized as Error & { code?: string }).code === "ENOENT"
+    ? new CodexCommandNotFoundError(command)
+    : normalized;
+}
+
+function createPreflightCacheKey(
+  options: CodexRuntimePreflightOptions,
+): string {
+  const envFingerprint = createHash("sha256")
+    .update(
+      JSON.stringify(
+        Object.entries(options.providerConfig.env ?? {}).sort(
+          ([left], [right]) => left.localeCompare(right),
+        ),
+      ),
+    )
+    .digest("hex");
+
+  return JSON.stringify([
+    options.command,
+    options.cwd,
+    options.providerConfig.profile ?? "",
+    options.model ?? "",
+    envFingerprint,
+  ]);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("The Codex request was aborted", "AbortError");
+}
+
+function awaitWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  throwIfAborted(signal);
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new DOMException("The Codex request was aborted", "AbortError"),
+      );
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -17,11 +17,16 @@ import {
   resolveCodexSandboxMode,
 } from "@/lib/ai/extensions/agent/codex/command";
 import { parseCodexJsonLine } from "@/lib/ai/extensions/agent/codex/parser";
+import {
+  clearCodexRuntimePreflightCache,
+  parseCodexVersion,
+} from "@/lib/ai/extensions/agent/codex/runtime-preflight";
 import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/codex/transport-status";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  clearCodexRuntimePreflightCache();
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
     if (tempDir) {
@@ -161,6 +166,112 @@ describe("Codex command builder", () => {
     expect(
       normalizeCodexProviderConfig({ timeoutMs: "nope" }).timeoutMs,
     ).toBeUndefined();
+  });
+});
+
+describe("Codex runtime preflight", () => {
+  it("parses current and prerelease Codex CLI version output", () => {
+    expect(parseCodexVersion("codex-cli 0.145.0")).toBe("0.145.0");
+    expect(parseCodexVersion("codex 1.2.3-beta.4")).toBe("1.2.3-beta.4");
+    expect(parseCodexVersion("not a version")).toBeUndefined();
+  });
+
+  it("blocks an unavailable model before codex exec starts", async () => {
+    const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
+    await writeFakeCodexScript(
+      workDir,
+      fakeCodexAppServerScript(["gpt-compatible"]),
+      "app-server",
+    );
+    const agent = new CodexAgent({
+      provider: "codex",
+      model: "gpt-requires-newer-cli",
+      workDir,
+      providerConfig: { codexPath: process.execPath },
+    });
+
+    const messages = await collectMessages(agent.run("hello codex"));
+    const error = messages.find((message) => message.type === "error");
+
+    expect(error).toMatchObject({
+      type: "error",
+      message: expect.stringContaining(
+        'The selected model "gpt-requires-newer-cli" is not available',
+      ),
+    });
+    expect(error?.message).toContain("codex update");
+    expect(error?.message).toContain("gpt-compatible");
+    await expect(
+      readFile(join(workDir, "args.json"), "utf8"),
+    ).rejects.toThrow();
+
+    const requests = JSON.parse(
+      await readFile(join(workDir, "app-server-requests.json"), "utf8"),
+    ) as Array<{ method: string; params?: Record<string, unknown> }>;
+    expect(requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "initialized",
+      "model/list",
+    ]);
+    expect(requests.at(-1)?.params).toMatchObject({
+      limit: 100,
+      includeHidden: true,
+    });
+  });
+
+  it("starts codex exec when the selected model is in the CLI catalog", async () => {
+    const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
+    await writeFakeCodexScript(
+      workDir,
+      fakeCodexAppServerScript(["gpt-compatible"]),
+      "app-server",
+    );
+    const agent = new CodexAgent({
+      provider: "codex",
+      model: "gpt-compatible",
+      workDir,
+      providerConfig: { codexPath: process.execPath },
+    });
+
+    const messages = await collectMessages(agent.run("hello codex"));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "hello" }),
+        expect.objectContaining({ type: "result", content: "success" }),
+      ]),
+    );
+    const args = JSON.parse(
+      await readFile(join(workDir, "args.json"), "utf8"),
+    ) as string[];
+    expect(args).toContain("gpt-compatible");
+  });
+
+  it("falls back to codex exec when app-server model discovery is unavailable", async () => {
+    const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
+    await writeFakeCodexScript(
+      workDir,
+      'process.stderr.write("model/list unavailable"); process.exit(2);',
+      "app-server",
+    );
+    const agent = new CodexAgent({
+      provider: "codex",
+      model: "custom-provider/model",
+      workDir,
+      providerConfig: { codexPath: process.execPath },
+    });
+
+    const messages = await collectMessages(agent.run("hello codex"));
+
+    expect(
+      messages.find((message) => message.type === "error"),
+    ).toBeUndefined();
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", content: "hello" }),
+        expect.objectContaining({ type: "result", content: "success" }),
+      ]),
+    );
   });
 });
 
@@ -1118,6 +1229,10 @@ function defaultFakeCodexScript() {
   return `
 const fs = require("node:fs");
 const args = process.argv.slice(2);
+if (args.includes("--version")) {
+  console.log("codex-cli 0.145.0");
+  process.exit(0);
+}
 fs.writeFileSync("args.json", JSON.stringify(args));
 let stdin = "";
 process.stdin.setEncoding("utf8");
@@ -1141,6 +1256,38 @@ process.stdin.on("end", () => {
     type: "turn.completed",
     usage: { input_tokens: 9, cached_input_tokens: 4, output_tokens: 4 }
   }));
+});
+`;
+}
+
+function fakeCodexAppServerScript(models: string[]) {
+  return `
+const fs = require("node:fs");
+const models = ${JSON.stringify(models)};
+const requests = [];
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split(/\\r?\\n/);
+  buffer = lines.pop() || "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    requests.push(message);
+    fs.writeFileSync("app-server-requests.json", JSON.stringify(requests));
+    if (message.method === "initialize") {
+      console.log(JSON.stringify({ id: message.id, result: { userAgent: "fake-codex" } }));
+    } else if (message.method === "model/list") {
+      console.log(JSON.stringify({
+        id: message.id,
+        result: {
+          data: models.map((model) => ({ id: model, model, displayName: model })),
+          nextCursor: null
+        }
+      }));
+    }
+  }
 });
 `;
 }

--- a/apps/web/tests/unit/error-message-display.test.ts
+++ b/apps/web/tests/unit/error-message-display.test.ts
@@ -1,0 +1,74 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { returnObjects?: boolean }) => {
+      if (options?.returnObjects) {
+        if (key === "common.errors.codexCompatibilityError.suggestions") {
+          return ["Upgrade Codex", "Choose a compatible model"];
+        }
+        if (key === "common.errors.genericError.suggestions") {
+          return ["Please try again later"];
+        }
+        return [];
+      }
+
+      const messages: Record<string, string> = {
+        "common.errors.codexCompatibilityError.title":
+          "Codex setup needs attention",
+        "common.errors.codexCompatibilityError.docsAction":
+          "Open Codex installation guide",
+        "common.errors.genericError.title": "An Error Occurred",
+        "common.errors.genericError.description":
+          "There was a problem processing your request.",
+      };
+      return messages[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock("@/components/remix-icon", () => ({
+  RemixIcon: () => null,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: unknown }) => children,
+}));
+
+import { ErrorMessageDisplay } from "@/components/message/error-message-display";
+
+describe("ErrorMessageDisplay", () => {
+  it("renders the original backend detail for an otherwise generic error", () => {
+    const html = renderToStaticMarkup(
+      createElement(ErrorMessageDisplay, {
+        errorContent:
+          "Error: The provider rejected this exact request for account policy ABC-123.",
+      }),
+    );
+
+    expect(html).toContain(
+      "The provider rejected this exact request for account policy ABC-123.",
+    );
+    expect(html).toContain("An Error Occurred");
+  });
+
+  it("renders actionable Codex compatibility detail and the upgrade guide", () => {
+    const html = renderToStaticMarkup(
+      createElement(ErrorMessageDisplay, {
+        errorContent:
+          'The selected model "gpt-new" is not available in Codex CLI 0.100.0. Upgrade Codex or choose a compatible model.',
+      }),
+    );
+
+    expect(html).toContain("Codex setup needs attention");
+    expect(html).toContain("gpt-new");
+    expect(html).toContain("Codex CLI 0.100.0");
+    expect(html).toContain("Upgrade Codex");
+    expect(html).toContain("Choose a compatible model");
+    expect(html).toContain(
+      'href="https://github.com/openai/codex#installation"',
+    );
+  });
+});

--- a/packages/i18n/src/locales/en-US.ts
+++ b/packages/i18n/src/locales/en-US.ts
@@ -723,6 +723,14 @@ const enUS = {
           "Contact support if the problem persists",
         ],
       },
+      codexCompatibilityError: {
+        title: "Codex setup needs attention",
+        suggestions: [
+          "Upgrade Codex, then restart OpenLoomi",
+          "Or choose a model supported by the installed Codex CLI",
+        ],
+        docsAction: "Open Codex installation guide",
+      },
       fileNotFoundError: {
         title: "File Not Found",
         description: "The specified file could not be found.",

--- a/packages/i18n/src/locales/zh-Hans.ts
+++ b/packages/i18n/src/locales/zh-Hans.ts
@@ -680,6 +680,14 @@ const zhHans = {
         description: "处理请求时遇到问题。",
         suggestions: ["稍后重试", "如果问题持续存在，请联系支持"],
       },
+      codexCompatibilityError: {
+        title: "Codex 配置需要处理",
+        suggestions: [
+          "升级 Codex，然后重启 OpenLoomi",
+          "或选择当前 Codex CLI 支持的模型",
+        ],
+        docsAction: "打开 Codex 安装指南",
+      },
       fileNotFoundError: {
         title: "文件未找到",
         description: "找不到指定的文件。",


### PR DESCRIPTION
## Summary

Fixes #437.

OpenLoomi now checks the local Codex CLI and selected model before starting a request, while preserving actionable runtime errors in the desktop UI.

## Root cause

Two issues were combined:

1. `CodexAgent` launched `codex exec` without checking whether the installed CLI supported the selected model.
2. The error UI received the original provider error as `description`, but never rendered that field. Users only saw the generic “An Error Occurred” card.

## Changes

- Run `codex --version` before starting Codex requests.
- Discover supported models through the official Codex app-server `model/list` API.
- Prevent `codex exec` from starting when the selected model is confirmed unavailable.
- Include the installed CLI version and available models in compatibility errors.
- Tell users to upgrade Codex or select a compatible model.
- Fail open when model discovery itself is unavailable, allowing `codex exec` to return its authoritative error.
- Cache preflight results for 60 seconds.
- Render original backend error details in the desktop error card.
- Add a Codex-specific upgrade guide action.
- Add English and Simplified Chinese copy.

## Validation

- Added coverage for:
  - Codex version parsing
  - incompatible models being blocked before `codex exec`
  - compatible models executing normally
  - app-server discovery failure fallback
  - original backend error rendering
  - Codex upgrade guidance
- Verified against a real Codex CLI 0.145.0 `model/list` response.

## Screenshots

Not included. The updated error card now displays the original compatibility error, upgrade guidance, and Codex installation link.