### PR TITLE
fix: issue 447 digest card bugfix

### DIFF
--- a/apps/web/components/loop/decision-card.tsx
+++ b/apps/web/components/loop/decision-card.tsx
@@ -631,6 +631,15 @@ export function DecisionCard({
   const nextStep =
     decision.nextStep ??
     t("loop.nextStep.tapRun", "Tap Run to let the agent handle this decision.");
+  const quietDigestModule =
+    (decision.action?.params as Record<string, unknown> | undefined)?.module ??
+    (decision.context as Record<string, unknown> | undefined)?.module;
+  const quietDigestItems = Array.isArray(decision.context?.items)
+    ? (decision.context.items as Array<Record<string, unknown>>).slice(0, 20)
+    : [];
+  const isGithubQuietDigest =
+    quietDigestModule === "github-notifications" ||
+    /github notification|github has/i.test(`${decision.title} ${dialogue}`);
 
   // #363 — pre-resolve the decision context. RSVP renders the
   // time/organizer/attendance/location/conflict block; other types return
@@ -1106,89 +1115,105 @@ export function DecisionCard({
               mirrors the pet bubble's grouped GitHub summary. Each item
               shows repo, title, and (when derivable) a validated HTTPS
               link to the thread. */}
-          {Array.isArray(decision.context?.items) &&
-            (decision.context?.items as Array<Record<string, unknown>>).length >
-              0 && (
-              <ul className="flex flex-col gap-1.5 text-xs">
-                {(decision.context?.items as Array<Record<string, unknown>>)
-                  .slice(0, 20)
-                  .map((it, idx) => {
-                    const title =
-                      typeof it.title === "string" ? it.title : "GitHub update";
-                    const repo =
-                      typeof it.repo === "string" ? it.repo : "unknown";
-                    const summary =
-                      typeof it.summary === "string" ? it.summary : "";
-                    const url =
-                      typeof it.url === "string" &&
-                      it.url.startsWith("https://")
-                        ? it.url
-                        : null;
-                    const kindLabel = url
-                      ? /\/(issues|pull)\/\d+$/.test(url)
-                        ? t("loop.quietDigest.openIssue", "Open on GitHub")
-                        : t("loop.quietDigest.openIssue", "Open on GitHub")
-                      : null;
-                    return (
-                      <li
-                        key={`${repo}-${idx}-${title}`}
-                        className="flex flex-col gap-0.5 rounded-md border bg-muted/30 px-2 py-1.5"
-                      >
-                        <div className="flex flex-wrap items-baseline gap-2">
-                          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                            {repo}
-                          </span>
-                          <span className="text-sm font-medium leading-snug">
-                            {title}
-                          </span>
-                          {url && (
-                            <a
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="ml-auto text-[10px] font-medium text-primary hover:underline"
-                            >
-                              {kindLabel} ↗
-                            </a>
-                          )}
-                        </div>
-                        {summary && (
-                          <span className="text-xs text-muted-foreground">
-                            {summary}
-                          </span>
-                        )}
-                      </li>
-                    );
-                  })}
-              </ul>
-            )}
+          {quietDigestItems.length > 0 ? (
+            <ul className="flex flex-col gap-1.5 text-xs">
+              {quietDigestItems.map((it, idx) => {
+                const title =
+                  typeof it.title === "string" ? it.title : "GitHub update";
+                const repo = typeof it.repo === "string" ? it.repo : "unknown";
+                const summary =
+                  typeof it.summary === "string" ? it.summary : "";
+                const rawUrl =
+                  typeof it.url === "string" && it.url.startsWith("https://")
+                    ? it.url
+                    : null;
+                const githubUrl = rawUrl?.startsWith("https://github.com/")
+                  ? rawUrl
+                  : null;
+                const href =
+                  githubUrl ??
+                  (isGithubQuietDigest
+                    ? "https://github.com/notifications"
+                    : rawUrl);
+                const kindLabel = githubUrl
+                  ? t("loop.quietDigest.openIssue", "Open on GitHub")
+                  : isGithubQuietDigest
+                    ? t(
+                        "loop.quietDigest.openNotifications",
+                        "Open notifications",
+                      )
+                    : t("loop.quietDigest.openLink", "Open");
+                return (
+                  <li
+                    key={`${repo}-${idx}-${title}`}
+                    className="flex flex-col gap-0.5 rounded-md border bg-muted/30 px-2 py-1.5"
+                  >
+                    <div className="flex flex-wrap items-baseline gap-2">
+                      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        {repo}
+                      </span>
+                      <span className="text-sm font-medium leading-snug">
+                        {title}
+                      </span>
+                      {href && (
+                        <a
+                          href={href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ml-auto text-[10px] font-medium text-primary hover:underline"
+                        >
+                          {kindLabel} ↗
+                        </a>
+                      )}
+                    </div>
+                    {summary && (
+                      <span className="text-xs text-muted-foreground">
+                        {summary}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : isGithubQuietDigest ? (
+            <div className="flex flex-col gap-1 rounded-md border bg-muted/30 px-2 py-1.5 text-xs">
+              <span className="text-sm font-medium leading-snug">
+                {t(
+                  "loop.quietDigest.githubDetailsUnavailable",
+                  "GitHub notification details unavailable",
+                )}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {t(
+                  "loop.quietDigest.githubDetailsUnavailableBody",
+                  "OpenLoomi saw unread GitHub notifications, but this card did not receive the item details.",
+                )}
+              </span>
+              <a
+                href="https://github.com/notifications"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-medium text-primary hover:underline"
+              >
+                {t("loop.quietDigest.openNotifications", "Open notifications")}
+              </a>
+            </div>
+          ) : null}
           <div className="flex flex-wrap items-center justify-end gap-2">
             {/* #378 — github-notifications digest relabels Dismiss → "Mark
                 as read". Other quiet_digest modules keep the legacy
                 "Dismiss" label since the existing copy still fits. */}
-            {(() => {
-              const module =
-                (decision.action?.params as Record<string, unknown> | undefined)
-                  ?.module ??
-                (decision.context as Record<string, unknown> | undefined)
-                  ?.module;
-              const isGithub =
-                module === "github-notifications" ||
-                String(module ?? "") === "github-notifications";
-              return (
-                <ActionButton
-                  icon="ri-check-line"
-                  label={
-                    isGithub
-                      ? t("loop.quietDigest.markAsRead", "Mark as read")
-                      : t("loop.dismiss", "Dismiss")
-                  }
-                  variant="default"
-                  onClick={() => act("dismiss")}
-                  pending={pendingAction === "dismiss"}
-                />
-              );
-            })()}
+            <ActionButton
+              icon="ri-check-line"
+              label={
+                isGithubQuietDigest
+                  ? t("loop.quietDigest.markAsRead", "Mark as read")
+                  : t("loop.dismiss", "Dismiss")
+              }
+              variant="default"
+              onClick={() => act("dismiss")}
+              pending={pendingAction === "dismiss"}
+            />
           </div>
         </footer>
       )}

--- a/apps/web/components/loop/loop-detail-workspace.tsx
+++ b/apps/web/components/loop/loop-detail-workspace.tsx
@@ -195,6 +195,9 @@ export function LoopDetailWorkspace({
   const state = readinessState(decision);
   const stateMeta = stateLabel(state);
   const executable = canExecute(readiness);
+  const isQuietDigest =
+    decision.type === "quiet_digest" ||
+    decision.action?.kind === "quiet_digest";
   const dryRunText =
     typeof decision.context?.dry_run === "string"
       ? decision.context.dry_run
@@ -429,7 +432,7 @@ export function LoopDetailWorkspace({
         )}
 
         {/* Status-dependent action block */}
-        {status === "pending" && (
+        {status === "pending" && !isQuietDigest && (
           <div className="flex flex-col gap-3">
             <DryRunPreview
               decisionId={decision.id}

--- a/apps/web/lib/loop/readiness.ts
+++ b/apps/web/lib/loop/readiness.ts
@@ -134,6 +134,8 @@ export function deriveReadiness(decision: ReadableDecision): DecisionReadiness {
       }
       return { status: "ready" };
     }
+    case "quiet_digest":
+      return { status: "not_actionable" };
     default:
       return { status: "ready" };
   }

--- a/apps/web/public/loomi-card.html
+++ b/apps/web/public/loomi-card.html
@@ -3219,6 +3219,53 @@
         }
 
         // ---------- Helpers ----------
+        function getTauriInvoke() {
+          const t = window.__TAURI__;
+          if (!t) return null;
+          if (t.core && typeof t.core.invoke === "function") {
+            return t.core.invoke.bind(t.core);
+          }
+          if (t.tauri && typeof t.tauri.invoke === "function") {
+            return t.tauri.invoke.bind(t.tauri);
+          }
+          if (typeof t.invoke === "function") {
+            return t.invoke.bind(t);
+          }
+          return null;
+        }
+
+        function safeHttpsUrl(rawUrl) {
+          if (typeof rawUrl !== "string" || !rawUrl.trim()) return null;
+          try {
+            const url = new URL(rawUrl.trim());
+            if (url.protocol !== "https:") return null;
+            return url.href;
+          } catch (_) {
+            return null;
+          }
+        }
+
+        async function openExternalUrl(rawUrl) {
+          const url = safeHttpsUrl(rawUrl);
+          if (!url) {
+            showToast("Can't open an invalid link.", true);
+            return;
+          }
+          const invoke = getTauriInvoke();
+          if (invoke) {
+            try {
+              await invoke("open_url_custom", { url });
+              return;
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              showToast(`Open failed: ${msg}`, true);
+              return;
+            }
+          }
+          const opened = window.open(url, "_blank", "noopener,noreferrer");
+          if (!opened) window.location.href = url;
+        }
+
         function fmtTs(ts) {
           if (!ts) return "—";
           try {
@@ -5035,11 +5082,20 @@
           }
         }
 
-        // Lives on the card root (same delegation pattern as the rest
-        // of the card) and matches `[data-editor-action]`. Kept
-        // separate from the main click handler so the dispatch is
-        // trivial — no risk of the schedule-fall-through eating an
-        // editor click.
+        // Pet card webviews do not reliably hand target=_blank anchors
+        // to the OS browser. Route trusted external links through the
+        // same Tauri command the main window uses.
+        card.addEventListener("click", (e) => {
+          const link = e.target.closest("[data-external-url]");
+          if (!link) return;
+          e.preventDefault();
+          e.stopPropagation();
+          openExternalUrl(link.dataset.externalUrl || link.href);
+        });
+
+        // Lives on the card root and matches `[data-editor-action]`.
+        // Kept separate from the main action handler so editor clicks
+        // cannot fall through into scheduling.
         card.addEventListener("click", (e) => {
           const btn = e.target.closest("[data-editor-action]");
           if (!btn) return;
@@ -5727,7 +5783,7 @@
                 '<span class="brief-priority p2">·</span>' +
                 '<div><div class="bi-title">GitHub notification details unavailable</div>' +
                 '<div class="bi-sub">OpenLoomi saw unread GitHub notifications, but this card did not receive the item details.</div></div>' +
-                '<span class="bi-link-cell"><a class="bi-link" href="https://github.com/notifications" target="_blank" rel="noopener noreferrer">Open notifications</a></span>';
+                '<span class="bi-link-cell"><a class="bi-link" href="https://github.com/notifications" data-external-url="https://github.com/notifications" target="_blank" rel="noopener noreferrer">Open notifications</a></span>';
             } else {
               empty.innerHTML =
                 '<span class="brief-priority p2">·</span><div><div class="bi-title">Nothing to read</div><div class="bi-sub">The filler ran but had nothing to surface.</div></div><span></span>';
@@ -5760,6 +5816,8 @@
               const linkText = url ? "Open on GitHub" : "Open notifications";
               const linkHtml =
                 '<a class="bi-link" href="' +
+                esc(href) +
+                '" data-external-url="' +
                 esc(href) +
                 '" target="_blank" rel="noopener noreferrer">' +
                 linkText +

--- a/apps/web/public/loomi-card.html
+++ b/apps/web/public/loomi-card.html
@@ -5684,7 +5684,13 @@
             (decision.action &&
               decision.action.params &&
               decision.action.params.module) ||
+            (decision.context && decision.context.module) ||
             null;
+          const isGithubDigest =
+            moduleId === "github-notifications" ||
+            /github notification|github has/i.test(
+              [decision.title, decision.dialogue].filter(Boolean).join(" "),
+            );
           const moduleLabel =
             moduleId === "ai-news-digest"
               ? "Last 24h in AI / tech"
@@ -5692,7 +5698,7 @@
                 ? "Weather + meetings"
                 : moduleId === "memory-resurface"
                   ? "From your memory"
-                  : moduleId === "github-notifications"
+                  : isGithubDigest
                     ? "GitHub updates"
                     : "Quiet day filler";
           tagEl.textContent = moduleLabel;
@@ -5702,8 +5708,7 @@
           // not an actionable ask. Other quiet_digest modules keep the
           // existing "Got it" copy that fits them.
           if (dismissBtn) {
-            dismissBtn.textContent =
-              moduleId === "github-notifications" ? "Mark as read" : "Got it";
+            dismissBtn.textContent = isGithubDigest ? "Mark as read" : "Got it";
           }
 
           // Bullets. The contract is `context.items: { title, summary, ref?, url? }[]`.
@@ -5717,8 +5722,16 @@
           if (items.length === 0) {
             const empty = document.createElement("div");
             empty.className = "brief-item";
-            empty.innerHTML =
-              '<span class="brief-priority p2">·</span><div><div class="bi-title">Nothing to read</div><div class="bi-sub">The filler ran but had nothing to surface.</div></div><span></span>';
+            if (isGithubDigest) {
+              empty.innerHTML =
+                '<span class="brief-priority p2">·</span>' +
+                '<div><div class="bi-title">GitHub notification details unavailable</div>' +
+                '<div class="bi-sub">OpenLoomi saw unread GitHub notifications, but this card did not receive the item details.</div></div>' +
+                '<span class="bi-link-cell"><a class="bi-link" href="https://github.com/notifications" target="_blank" rel="noopener noreferrer">Open notifications</a></span>';
+            } else {
+              empty.innerHTML =
+                '<span class="brief-priority p2">·</span><div><div class="bi-title">Nothing to read</div><div class="bi-sub">The filler ran but had nothing to surface.</div></div><span></span>';
+            }
             listEl.appendChild(empty);
             return;
           }
@@ -5730,7 +5743,7 @@
           // produces an executable `<a href="…">` for an unverified
           // origin. Other quiet_digest modules fall through to the
           // legacy generic rendering.
-          if (moduleId === "github-notifications") {
+          if (isGithubDigest) {
             for (const it of items) {
               const row = document.createElement("div");
               row.className = "brief-item";
@@ -5743,11 +5756,14 @@
                 urlRaw.startsWith("https://github.com/")
                   ? urlRaw
                   : null;
-              const linkHtml = url
-                ? '<a class="bi-link" href="' +
-                  esc(url) +
-                  '" target="_blank" rel="noopener noreferrer">Open on GitHub ↗</a>'
-                : "";
+              const href = url || "https://github.com/notifications";
+              const linkText = url ? "Open on GitHub" : "Open notifications";
+              const linkHtml =
+                '<a class="bi-link" href="' +
+                esc(href) +
+                '" target="_blank" rel="noopener noreferrer">' +
+                linkText +
+                "</a>";
               row.innerHTML =
                 '<span class="brief-priority p2">·</span>' +
                 '<div class="gh-row">' +

--- a/apps/web/src-tauri/capabilities/loomi-pet.json
+++ b/apps/web/src-tauri/capabilities/loomi-pet.json
@@ -22,6 +22,7 @@
     "core:window:allow-set-ignore-cursor-events",
     "core:window:allow-close",
     "core:window:allow-start-dragging",
+    "allow-open-url-custom",
     "allow-emit-dev-state",
     "allow-get-pet-config",
     "allow-set-active-theme"

--- a/apps/web/src-tauri/src/pet/watcher.rs
+++ b/apps/web/src-tauri/src/pet/watcher.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use std::fs;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Listener, Manager};
 
 use super::{
@@ -463,6 +463,8 @@ fn build_decision_payload(d: &DecItem) -> serde_json::Value {
         "source": source,
         "source_type": source_type,
         "source_ts": source_ts,
+        "action": d.action,
+        "context": d.context,
         "why": d.context.as_ref().and_then(|c| c.why.clone()).unwrap_or_default(),
         "status": "pending",
     })
@@ -917,6 +919,8 @@ pub struct DecItem {
     #[serde(default)]
     pub source_signal: Option<SourceSignal>,
     #[serde(default)]
+    pub action: Option<DecAction>,
+    #[serde(default)]
     pub context: Option<DecContext>,
     #[serde(default)]
     pub created_at: Option<String>,
@@ -929,7 +933,7 @@ pub struct DecItem {
     pub needs_user: Option<bool>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct SourceSignal {
     #[serde(default)]
     pub source: String,
@@ -939,10 +943,20 @@ pub struct SourceSignal {
     pub ts: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
+pub struct DecAction {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct DecContext {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub why: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Map a decision snapshot to `(pet_state, optional_monologue_hint)`.
@@ -1240,6 +1254,7 @@ mod tests {
                     dialogue: None,
                     confidence: Some(0.8),
                     source_signal: None,
+                    action: None,
                     context: None,
                     created_at: Some(format!("2026-01-01T00:00:0{i}Z")),
                     completed_at: None,
@@ -1254,6 +1269,7 @@ mod tests {
                     dialogue: None,
                     confidence: Some(0.8),
                     source_signal: None,
+                    action: None,
                     context: None,
                     created_at: None,
                     completed_at: Some(format!("2026-01-01T00:00:0{i}Z")),
@@ -1268,6 +1284,7 @@ mod tests {
                     dialogue: None,
                     confidence: Some(0.8),
                     source_signal: None,
+                    action: None,
                     context: None,
                     created_at: Some(format!("2026-01-01T00:00:0{i}Z")),
                     completed_at: None,
@@ -1336,6 +1353,7 @@ mod tests {
                     dialogue: None,
                     confidence: Some(0.8),
                     source_signal: None,
+                    action: None,
                     context: None,
                     created_at: None,
                     completed_at: Some(completed_at.into()),
@@ -1437,6 +1455,7 @@ mod tests {
             dialogue: Some("hello".into()),
             confidence: Some(0.8),
             source_signal: None,
+            action: None,
             context: None,
             created_at: None,
             completed_at: Some("2026-01-01T00:00:00Z".into()),
@@ -1493,6 +1512,69 @@ mod tests {
             "p2"
         };
         assert_eq!(p, expected, "priority must match confidence bucket");
+    }
+
+    #[test]
+    fn build_decision_payload_preserves_quiet_digest_action_and_items() {
+        let mut extra = serde_json::Map::new();
+        extra.insert("module".into(), serde_json::json!("github-notifications"));
+        extra.insert(
+            "items".into(),
+            serde_json::json!([
+                {
+                    "repo": "melandlabs/openloomi",
+                    "title": "Issue 447 repro",
+                    "summary": "You were mentioned",
+                    "url": "https://github.com/melandlabs/openloomi/issues/447"
+                }
+            ]),
+        );
+        let d = DecItem {
+            id: Some("gh_digest_repro".into()),
+            r#type: Some("quiet_digest".into()),
+            title: Some("GitHub has 1 update".into()),
+            dialogue: Some(
+                "1 unread GitHub notification across 1 repo: melandlabs/openloomi.".into(),
+            ),
+            confidence: Some(0.9),
+            source_signal: None,
+            action: Some(DecAction {
+                kind: Some("quiet_digest".into()),
+                params: Some(serde_json::json!({
+                    "module": "github-notifications"
+                })),
+            }),
+            context: Some(DecContext {
+                why: Some(vec![
+                    "Grouped 1 passive GitHub notification into one read-only summary".into(),
+                ]),
+                extra,
+            }),
+            created_at: None,
+            completed_at: None,
+            needs_user: None,
+        };
+
+        let v = build_decision_payload(&d);
+        assert_eq!(
+            v.pointer("/action/params/module").and_then(|m| m.as_str()),
+            Some("github-notifications"),
+            "pet card payload must keep the quiet digest module"
+        );
+        assert_eq!(
+            v.pointer("/context/items/0/url").and_then(|u| u.as_str()),
+            Some("https://github.com/melandlabs/openloomi/issues/447"),
+            "pet card payload must keep GitHub digest items for navigation"
+        );
+        assert_eq!(
+            v.pointer("/context/items/0/title").and_then(|t| t.as_str()),
+            Some("Issue 447 repro")
+        );
+        assert_eq!(
+            v.get("why").and_then(|w| w.as_array()).map(|w| w.len()),
+            Some(1),
+            "legacy top-level why remains populated for old card code"
+        );
     }
 
     #[test]

--- a/apps/web/tests/unit/loop/readiness.test.ts
+++ b/apps/web/tests/unit/loop/readiness.test.ts
@@ -157,6 +157,15 @@ describe("deriveReadiness — email_reply", () => {
 });
 
 describe("deriveReadiness — fallback for unknown / custom types", () => {
+  it("marks quiet_digest cards as not_actionable", () => {
+    const r = deriveReadiness({
+      type: "quiet_digest",
+      action: { params: { module: "github-notifications" } },
+    });
+    expect(r.status).toBe("not_actionable");
+    expect(canExecute(r)).toBe(false);
+  });
+
   it("defaults to ready for unknown types so custom cards keep working", () => {
     const r = deriveReadiness({
       type: "my_custom_thing",


### PR DESCRIPTION
## Summary

Fixes #447.

This PR fixes the GitHub quiet digest card so unread GitHub notifications are rendered as real notification items instead of falling back to the empty “Nothing to read” state.

## Changed

- Preserved the full `quiet_digest` payload emitted from the Tauri pet watcher, including `action` and `context.items`.
- Updated the pet card GitHub digest renderer to show repository, title, reason, and GitHub links.
- Added a GitHub fallback state for digest cards that are missing item details.
- Updated the web Loop decision card to render GitHub quiet digest items consistently.
- Marked `quiet_digest` decisions as read-only / not actionable so generic Run, Dry run, and Edit controls are not shown.
- Allowed the pet card window to open external GitHub URLs through the Tauri `open_url_custom` command.

## Verification

- Verified a GitHub unread notification digest displays correctly in the pet card.
- Verified the card shows the repository, notification title, and reason.
- Verified the card no longer shows `Nothing to read` or `The filler ran but had nothing to surface`.
- Verified the card uses `Mark as read` for the primary acknowledge action.
- Verified `Open on GitHub` opens the notification URL in the system browser.
- Ran targeted unit tests:
  - `pnpm -C apps/web exec vitest run tests/unit/loop/github-notifications.test.ts tests/unit/loop/readiness.test.ts`
- Ran Rust watcher regression tests:
  - `cargo test build_decision_payload --manifest-path apps\web\src-tauri\Cargo.toml`
- Ran lint/checks:
  - `pnpm -C apps/web exec biome lint components/loop/decision-card.tsx components/loop/loop-detail-workspace.tsx lib/loop/readiness.ts tests/unit/loop/readiness.test.ts`
  - `git diff --check`
  - `cargo check --manifest-path apps/web/src-tauri/Cargo.toml`

 ## Pet Card Verification Screenshot

The screenshot below shows the fixed GitHub digest rendered in the Loomi pet card, including the repository, notification title, mention reason, `Open on GitHub` link, and `Mark as read` action.

<img width="685" height="556" alt="test_card" src="https://github.com/user-attachments/assets/cc175ff8-0682-4655-8c2d-fedddeb1b960" />
