### PR TITLE
fix: issue 454 pet screen bounds

### DIFF
--- a/apps/web/public/loomi-widget.html
+++ b/apps/web/public/loomi-widget.html
@@ -878,16 +878,17 @@
         });
 
         // ---- Drag (whole window) vs click (no drag) --------------------
-        // In Tauri: call `getCurrentWebviewWindow().startDragging()` so the
-        //   168×168 window itself follows the pointer. The native drag is
-        //   OS-mediated and survives the cursor leaving the window, so the
-        //   user can fling the pet across multiple monitors.
+        // In Tauri: use the native OS drag so the whole transparent
+        // window moves normally. Rust keeps the final position inside
+        // the visible monitor bounds and cancels the current native drag
+        // if a boundary clamp was needed.
         // In standalone: no-op drag (the page is the stage). The click
-        //   branch is silently disabled because there is nothing to open.
+        // branch is silently disabled because there is nothing to open.
         let downX = 0,
           downY = 0,
           downTime = 0;
         let dragged = false;
+        let dragPointerId = null;
         // Long-press fallback for issue #314. Some macOS / Tauri builds
         // (and any standalone browser preview that doesn't get Tauri's
         // builder-side `accept_first_mouse`) silently drop the very
@@ -923,6 +924,26 @@
           return null;
         }
 
+        function startNativeDrag(win) {
+          if (win && typeof win.startDragging === "function") {
+            try {
+              win.startDragging();
+            } catch (_) {
+              /* native drag is best-effort */
+            }
+          }
+        }
+
+        function clearPointerGesture() {
+          document.body.classList.remove("dragging");
+          document.body.classList.remove("longpress");
+          try {
+            clearTimeout(longpressTimer);
+          } catch (_) {}
+          longpressTimer = null;
+          dragPointerId = null;
+        }
+
         function onPointerDown(e) {
           // #369 — pointer events that originate inside `#pet-menu`
           // must not reach the global drag/click handlers. Otherwise
@@ -934,10 +955,11 @@
           // / Quit) so we bail before any bookkeeping happens.
           if (petMenu && petMenu.contains(e.target)) return;
           if (e.button !== 0) return; // primary button only
-          downX = e.clientX;
-          downY = e.clientY;
+          downX = e.screenX;
+          downY = e.screenY;
           downTime = Date.now();
           dragged = false;
+          dragPointerId = e.pointerId;
           longpressActive = false;
           contextmenuFiredSinceDown = false;
           document.body.classList.add("dragging");
@@ -957,30 +979,17 @@
             }
             longpressTimer = null;
           }, LONGPRESS_MS);
-          // Immediately hand off to Tauri's native drag. The OS will move
-          // the window and dispatch the corresponding pointermove/up events
-          // on the new position. If the user releases without moving, the
-          // pointerup distance will be ~0 and we treat it as a click.
-          const w = getCurrentWindow();
-          if (w && typeof w.startDragging === "function") {
-            // startDragging returns a Promise; we don't await — the
-            // pointermove/up handlers will pick up the new position via
-            // the window's natural event flow.
-            try {
-              w.startDragging();
-            } catch (_) {
-              /* fall through */
-            }
-          }
+          startNativeDrag(getCurrentWindow());
           try {
             document.body.setPointerCapture(e.pointerId);
           } catch (_) {}
         }
 
         function onPointerMove(e) {
-          if (dragged) return;
+          if (dragPointerId !== e.pointerId) return;
           if (
-            Math.hypot(e.clientX - downX, e.clientY - downY) > DRAG_THRESHOLD
+            !dragged &&
+            Math.hypot(e.screenX - downX, e.screenY - downY) > DRAG_THRESHOLD
           ) {
             dragged = true;
             // A real drag breaks the long-press hold — drop the dots
@@ -1007,20 +1016,23 @@
           // `onPointerDown` returned early too — no capture was taken,
           // no body classes were added, no longpress timer was armed.
           if (petMenuOpen && petMenu && petMenu.contains(e.target)) return;
-          document.body.classList.remove("dragging");
-          document.body.classList.remove("longpress");
-          try {
-            clearTimeout(longpressTimer);
-          } catch (_) {}
-          longpressTimer = null;
+          if (dragPointerId !== e.pointerId) return;
           try {
             document.body.releasePointerCapture(e.pointerId);
           } catch (_) {}
           // Click only fires if the pointer didn't travel far — anything
           // beyond DRAG_THRESHOLD counts as a drag, not a click.
-          if (dragged) return;
-          if (Math.hypot(e.clientX - downX, e.clientY - downY) > DRAG_THRESHOLD)
+          if (dragged) {
+            clearPointerGesture();
             return;
+          }
+          if (
+            Math.hypot(e.screenX - downX, e.screenY - downY) > DRAG_THRESHOLD
+          ) {
+            clearPointerGesture();
+            return;
+          }
+          clearPointerGesture();
 
           // Long-press fallback (issue #314). If the user held the pet
           // without moving for ≥ LONGPRESS_MS, surface the in-widget
@@ -1071,6 +1083,14 @@
         document.body.addEventListener("pointermove", onPointerMove);
         document.body.addEventListener("pointerup", onPointerUp);
         document.body.addEventListener("pointercancel", onPointerUp);
+        document.body.addEventListener("lostpointercapture", function (e) {
+          if (dragPointerId === e.pointerId) {
+            clearPointerGesture();
+          }
+        });
+        window.addEventListener("blur", function () {
+          if (dragPointerId !== null) clearPointerGesture();
+        });
 
         // ---- Tauri bridge ----------------------------------------------
         // Only attach the listener when running inside Tauri. When the

--- a/apps/web/src-tauri/src/pet/aux_position.rs
+++ b/apps/web/src-tauri/src/pet/aux_position.rs
@@ -10,9 +10,10 @@
 // release, not continuously during the drag, so visual follow would
 // look like a single jump at the end of the drag. To get smooth
 // real-time following we also run a low-frequency poller (see
-// `spawn_position_poller`) that re-asserts the aux windows' position
-// at 20Hz — `set_position` is essentially a property write, so the
-// per-tick cost is negligible.
+// `spawn_position_poller`) that first keeps the pet itself in the
+// visible work area, then re-asserts the aux windows' position at 20Hz.
+// `set_position` is essentially a property write, so the per-tick cost
+// is negligible.
 //
 // All desktop coordinates are computed in *physical* pixels. The aux
 // windows still declare logical CSS sizes, so helpers convert those
@@ -300,11 +301,13 @@ pub fn reposition_card_to_pet(app: &AppHandle) {
     }
 }
 
-/// Spawn a background thread that continuously re-asserts the bubble +
-/// card positions based on the pet's current position. Necessary because
-/// Tauri's `WindowEvent::Moved` only fires on release of a native drag,
-/// not during — without polling, the aux windows would visibly jump at
-/// the end of a drag instead of following smoothly.
+/// Spawn a background thread that continuously keeps the pet in the
+/// visible work area, then re-asserts the bubble + card positions based
+/// on the pet's current position. Necessary because Tauri's
+/// `WindowEvent::Moved` only fires on release of a native drag, not
+/// during — without polling, the pet can be dragged fully off-screen
+/// and the aux windows would visibly jump at the end of a drag instead
+/// of following smoothly.
 ///
 /// Cost: `set_position` is a property write on the webview window, so
 /// 20Hz is fine. The poller exits cleanly on app shutdown (the OS
@@ -316,6 +319,7 @@ pub fn spawn_position_poller(app: AppHandle) {
         .spawn(move || {
             let _ =
                 crate::panic_guard::catch_unwind_str("loomi-pet aux position poller", || loop {
+                    super::window::keep_pet_in_visible_work_area(&app);
                     reposition_bubble_to_pet(&app);
                     reposition_card_to_pet(&app);
                     std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));

--- a/apps/web/src-tauri/src/pet/window.rs
+++ b/apps/web/src-tauri/src/pet/window.rs
@@ -16,6 +16,22 @@ const PET_W: f64 = 168.0;
 const PET_H: f64 = 168.0;
 const PET_SCREEN_MARGIN_LOGICAL: f64 = 4.0;
 
+#[cfg(windows)]
+const WM_CANCELMODE: u32 = 0x001F;
+#[cfg(windows)]
+const WM_LBUTTONUP: u32 = 0x0202;
+#[cfg(windows)]
+const WM_NCLBUTTONUP: u32 = 0x00A2;
+#[cfg(windows)]
+const HTCAPTION: usize = 2;
+
+#[cfg(windows)]
+#[link(name = "user32")]
+unsafe extern "system" {
+    fn SendMessageW(hwnd: *mut std::ffi::c_void, msg: u32, wparam: usize, lparam: isize) -> isize;
+    fn PostMessageW(hwnd: *mut std::ffi::c_void, msg: u32, wparam: usize, lparam: isize) -> i32;
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct PhysicalBounds {
     left: f64,
@@ -137,11 +153,50 @@ fn persist_pet_position(app: &AppHandle, reason: &str) {
     }
 }
 
+#[cfg(windows)]
+fn cancel_active_native_drag(window: &WebviewWindow, reason: &str) {
+    let hwnd = match window.hwnd() {
+        Ok(hwnd) => hwnd.0,
+        Err(error) => {
+            log::debug!("[loop-pet] could not get pet hwnd to cancel drag after {reason}: {error}");
+            return;
+        }
+    };
+    if hwnd.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = SendMessageW(hwnd, WM_CANCELMODE, 0, 0);
+        let _ = PostMessageW(hwnd, WM_NCLBUTTONUP, HTCAPTION, 0);
+        let _ = PostMessageW(hwnd, WM_LBUTTONUP, 0, 0);
+    }
+    log::debug!("[loop-pet] requested native drag cancel after {reason} clamp");
+}
+
+#[cfg(not(windows))]
+fn cancel_active_native_drag(_window: &WebviewWindow, _reason: &str) {}
+
 fn ensure_pet_in_visible_work_area(app: &AppHandle, reason: &str) {
+    ensure_pet_in_visible_work_area_with_options(app, reason, true, false);
+}
+
+pub(super) fn keep_pet_in_visible_work_area(app: &AppHandle) {
+    ensure_pet_in_visible_work_area_with_options(app, "poll", false, true);
+}
+
+fn ensure_pet_in_visible_work_area_with_options(
+    app: &AppHandle,
+    reason: &str,
+    persist: bool,
+    cancel_drag: bool,
+) {
     let Some(window) = app.get_webview_window(PET_LABEL) else {
         return;
     };
-    if let Err(error) = clamp_pet_window_to_visible_work_area(app, &window, reason) {
+    if let Err(error) =
+        clamp_pet_window_to_visible_work_area(app, &window, reason, persist, cancel_drag)
+    {
         log::warn!("[loop-pet] failed to clamp pet position after {reason}: {error}");
     }
 }
@@ -150,6 +205,8 @@ fn clamp_pet_window_to_visible_work_area(
     app: &AppHandle,
     window: &WebviewWindow,
     reason: &str,
+    persist: bool,
+    cancel_drag: bool,
 ) -> tauri::Result<()> {
     let pos = window.outer_position()?;
     let size = window.outer_size()?;
@@ -165,15 +222,30 @@ fn clamp_pet_window_to_visible_work_area(
     };
 
     if target != pos {
-        log::info!(
-            "[loop-pet] clamping pet position after {reason}: ({},{}) -> ({},{})",
-            pos.x,
-            pos.y,
-            target.x,
-            target.y
-        );
+        if persist {
+            log::info!(
+                "[loop-pet] clamping pet position after {reason}: ({},{}) -> ({},{})",
+                pos.x,
+                pos.y,
+                target.x,
+                target.y
+            );
+        } else {
+            log::debug!(
+                "[loop-pet] clamping pet position after {reason}: ({},{}) -> ({},{})",
+                pos.x,
+                pos.y,
+                target.x,
+                target.y
+            );
+        }
         window.set_position(target)?;
-        persist_pet_position(app, reason);
+        if cancel_drag {
+            cancel_active_native_drag(window, reason);
+        }
+        if persist {
+            persist_pet_position(app, reason);
+        }
     }
 
     Ok(())
@@ -360,7 +432,7 @@ fn wire_pet_window_events(app: &AppHandle) {
                 pos.x,
                 pos.y
             );
-            ensure_pet_in_visible_work_area(&app_handle, "move");
+            ensure_pet_in_visible_work_area_with_options(&app_handle, "move", true, true);
             on_pet_moved_reposition_aux(&app_handle);
         }
         _ => {}

--- a/apps/web/src-tauri/src/pet/window.rs
+++ b/apps/web/src-tauri/src/pet/window.rs
@@ -4,12 +4,180 @@
 
 use std::sync::{Mutex, OnceLock};
 
-use tauri::{AppHandle, LogicalSize, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{
+    AppHandle, LogicalSize, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindow,
+    WebviewWindowBuilder,
+};
+use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
 use super::PET_LABEL;
 
 const PET_W: f64 = 168.0;
 const PET_H: f64 = 168.0;
+const PET_SCREEN_MARGIN_LOGICAL: f64 = 4.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct PhysicalBounds {
+    left: f64,
+    top: f64,
+    right: f64,
+    bottom: f64,
+}
+
+fn bounds_from_monitor_work_area(monitor: &tauri::Monitor) -> PhysicalBounds {
+    let work_area = monitor.work_area();
+    PhysicalBounds {
+        left: work_area.position.x as f64,
+        top: work_area.position.y as f64,
+        right: work_area.position.x as f64 + work_area.size.width as f64,
+        bottom: work_area.position.y as f64 + work_area.size.height as f64,
+    }
+}
+
+fn push_unique_bounds(bounds: &mut Vec<PhysicalBounds>, candidate: PhysicalBounds) {
+    if !bounds.iter().any(|existing| *existing == candidate) {
+        bounds.push(candidate);
+    }
+}
+
+fn pet_candidate_bounds(window: &WebviewWindow) -> tauri::Result<Vec<PhysicalBounds>> {
+    let mut bounds = Vec::new();
+
+    if let Some(monitor) = window.current_monitor()? {
+        push_unique_bounds(&mut bounds, bounds_from_monitor_work_area(&monitor));
+    }
+    if let Some(monitor) = window.primary_monitor()? {
+        push_unique_bounds(&mut bounds, bounds_from_monitor_work_area(&monitor));
+    }
+    for monitor in window.available_monitors()? {
+        push_unique_bounds(&mut bounds, bounds_from_monitor_work_area(&monitor));
+    }
+
+    Ok(bounds)
+}
+
+fn overlap_area(
+    pos: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
+    bounds: PhysicalBounds,
+) -> f64 {
+    let left = pos.x as f64;
+    let top = pos.y as f64;
+    let right = left + size.width as f64;
+    let bottom = top + size.height as f64;
+
+    let overlap_w = right.min(bounds.right) - left.max(bounds.left);
+    let overlap_h = bottom.min(bounds.bottom) - top.max(bounds.top);
+    if overlap_w <= 0.0 || overlap_h <= 0.0 {
+        0.0
+    } else {
+        overlap_w * overlap_h
+    }
+}
+
+fn target_bounds_for_pet(
+    pos: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
+    bounds: &[PhysicalBounds],
+) -> Option<PhysicalBounds> {
+    let mut best = None;
+    let mut best_area = 0.0;
+
+    for candidate in bounds {
+        let area = overlap_area(pos, size, *candidate);
+        if area > best_area {
+            best = Some(*candidate);
+            best_area = area;
+        }
+    }
+
+    best.or_else(|| bounds.first().copied())
+}
+
+fn clamp_axis(start: f64, len: f64, min: f64, max: f64, margin: f64) -> f64 {
+    let min_start = min + margin;
+    let max_start = max - margin - len;
+    if max_start >= min_start {
+        start.clamp(min_start, max_start)
+    } else {
+        min + ((max - min) - len) / 2.0
+    }
+}
+
+fn clamp_pet_position(
+    pos: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
+    bounds: &[PhysicalBounds],
+    margin: f64,
+) -> Option<PhysicalPosition<i32>> {
+    let target = target_bounds_for_pet(pos, size, bounds)?;
+    let left = clamp_axis(
+        pos.x as f64,
+        size.width as f64,
+        target.left,
+        target.right,
+        margin,
+    );
+    let top = clamp_axis(
+        pos.y as f64,
+        size.height as f64,
+        target.top,
+        target.bottom,
+        margin,
+    );
+    Some(PhysicalPosition::new(
+        left.round() as i32,
+        top.round() as i32,
+    ))
+}
+
+fn persist_pet_position(app: &AppHandle, reason: &str) {
+    if let Err(error) = app.save_window_state(StateFlags::POSITION) {
+        log::warn!("[loop-pet] failed to persist clamped position after {reason}: {error}");
+    }
+}
+
+fn ensure_pet_in_visible_work_area(app: &AppHandle, reason: &str) {
+    let Some(window) = app.get_webview_window(PET_LABEL) else {
+        return;
+    };
+    if let Err(error) = clamp_pet_window_to_visible_work_area(app, &window, reason) {
+        log::warn!("[loop-pet] failed to clamp pet position after {reason}: {error}");
+    }
+}
+
+fn clamp_pet_window_to_visible_work_area(
+    app: &AppHandle,
+    window: &WebviewWindow,
+    reason: &str,
+) -> tauri::Result<()> {
+    let pos = window.outer_position()?;
+    let size = window.outer_size()?;
+    if size.width == 0 || size.height == 0 {
+        return Ok(());
+    }
+
+    let bounds = pet_candidate_bounds(window)?;
+    let scale = window.scale_factor().unwrap_or(1.0);
+    let margin = PET_SCREEN_MARGIN_LOGICAL * scale;
+    let Some(target) = clamp_pet_position(pos, size, &bounds, margin) else {
+        return Ok(());
+    };
+
+    if target != pos {
+        log::info!(
+            "[loop-pet] clamping pet position after {reason}: ({},{}) -> ({},{})",
+            pos.x,
+            pos.y,
+            target.x,
+            target.y
+        );
+        window.set_position(target)?;
+        persist_pet_position(app, reason);
+    }
+
+    Ok(())
+}
 
 /// AppHandle captured at `build_pet_window` time so the lifecycle
 /// shutdown path (which has no `AppHandle` argument) can still reach
@@ -106,6 +274,7 @@ pub fn build_pet_window(app: &AppHandle) -> tauri::Result<()> {
     // value already matches, so the steady-state cost is one equality
     // check.
     let _ = window.set_size(LogicalSize::new(PET_W, PET_H));
+    ensure_pet_in_visible_work_area(app, "build");
     wire_pet_window_events(app);
     Ok(())
 }
@@ -128,6 +297,7 @@ pub fn show_pet_window(app: &AppHandle) {
         // is cheap and idempotent.
         super::macos_window::configure_as_floating_panel_with(&w, true);
         super::macos_window::configure_for_all_spaces(&w);
+        ensure_pet_in_visible_work_area(app, "show");
     }
 }
 
@@ -190,6 +360,7 @@ fn wire_pet_window_events(app: &AppHandle) {
                 pos.x,
                 pos.y
             );
+            ensure_pet_in_visible_work_area(&app_handle, "move");
             on_pet_moved_reposition_aux(&app_handle);
         }
         _ => {}
@@ -209,6 +380,23 @@ pub fn on_pet_moved_reposition_aux(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn bounds(left: f64, top: f64, right: f64, bottom: f64) -> PhysicalBounds {
+        PhysicalBounds {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    fn pos(x: i32, y: i32) -> PhysicalPosition<i32> {
+        PhysicalPosition::new(x, y)
+    }
+
+    fn size(width: u32, height: u32) -> PhysicalSize<u32> {
+        PhysicalSize::new(width, height)
+    }
 
     /// Canonical Pet dimensions must match the widget sprite. This is
     /// the regression guard for issue #341: when an upgrade left an
@@ -231,6 +419,70 @@ mod tests {
         assert!(
             PET_W > 84.0,
             "Pet width must exceed the #341 half-size clip (84px)"
+        );
+    }
+
+    #[test]
+    fn pet_position_inside_work_area_is_unchanged() {
+        let display = [bounds(0.0, 0.0, 1920.0, 1040.0)];
+
+        assert_eq!(
+            clamp_pet_position(pos(120, 160), size(168, 168), &display, 4.0),
+            Some(pos(120, 160))
+        );
+    }
+
+    #[test]
+    fn pet_position_is_clamped_inside_each_edge() {
+        let display = [bounds(0.0, 0.0, 1920.0, 1040.0)];
+        let pet_size = size(168, 168);
+
+        assert_eq!(
+            clamp_pet_position(pos(-300, 100), pet_size, &display, 4.0),
+            Some(pos(4, 100))
+        );
+        assert_eq!(
+            clamp_pet_position(pos(2100, 100), pet_size, &display, 4.0),
+            Some(pos(1748, 100))
+        );
+        assert_eq!(
+            clamp_pet_position(pos(100, -80), pet_size, &display, 4.0),
+            Some(pos(100, 4))
+        );
+        assert_eq!(
+            clamp_pet_position(pos(100, 1100), pet_size, &display, 4.0),
+            Some(pos(100, 868))
+        );
+    }
+
+    #[test]
+    fn pet_position_uses_intersecting_secondary_monitor_with_negative_origin() {
+        let displays = [
+            bounds(0.0, 0.0, 1920.0, 1040.0),
+            bounds(-1280.0, 0.0, 0.0, 984.0),
+        ];
+
+        assert_eq!(
+            clamp_pet_position(pos(-1400, 120), size(168, 168), &displays, 4.0),
+            Some(pos(-1276, 120))
+        );
+    }
+
+    #[test]
+    fn pet_position_without_any_monitor_bounds_is_unchanged_by_caller() {
+        assert_eq!(
+            clamp_pet_position(pos(4000, 300), size(168, 168), &[], 4.0),
+            None
+        );
+    }
+
+    #[test]
+    fn oversized_pet_is_centered_when_full_containment_is_impossible() {
+        let tiny_display = [bounds(0.0, 0.0, 100.0, 100.0)];
+
+        assert_eq!(
+            clamp_pet_position(pos(40, 40), size(168, 168), &tiny_display, 4.0),
+            Some(pos(-34, -34))
         );
     }
 }

--- a/apps/web/tests/unit/loomi-pet-hit-test.test.ts
+++ b/apps/web/tests/unit/loomi-pet-hit-test.test.ts
@@ -49,7 +49,7 @@ describe("loomi-widget — stable drag wiring", () => {
     );
   });
 
-  it("onPointerDown adds the dragging class, records coords, captures the pointer, and calls startDragging", () => {
+  it("onPointerDown adds the dragging class, records coords, captures the pointer, and starts native dragging", () => {
     // Slice from the function header to the next function header
     // (or to the end of the IIFE). `onPointerDown` is the first
     // pointer handler in the widget, so its body is bounded by
@@ -65,8 +65,8 @@ describe("loomi-widget — stable drag wiring", () => {
     // Coordinate bookkeeping — used to classify click vs. drag in
     // onPointerUp. Without this the pointerup branch can never
     // decide whether the user dragged.
-    expect(fnBody).toMatch(/downX\s*=\s*e\.clientX/);
-    expect(fnBody).toMatch(/downY\s*=\s*e\.clientY/);
+    expect(fnBody).toMatch(/downX\s*=\s*e\.screenX/);
+    expect(fnBody).toMatch(/downY\s*=\s*e\.screenY/);
     // The dragging class is what flips the cursor from `grab` to
     // `grabbing` and gates the long-press indicator.
     expect(fnBody).toMatch(
@@ -74,7 +74,9 @@ describe("loomi-widget — stable drag wiring", () => {
     );
     // The actual drag — without this call the window never moves
     // and the whole "click anywhere and drag" promise is broken.
-    expect(fnBody).toMatch(/w\.startDragging\s*\(\s*\)/);
+    expect(fnBody).toMatch(/startNativeDrag\(getCurrentWindow\(\)\)/);
+    expect(stripped).toMatch(/function startNativeDrag\(win\)/);
+    expect(stripped).toMatch(/win\.startDragging\s*\(\s*\)/);
     // Pointer capture keeps the gesture alive when the OS cursor
     // leaves the 168×168 frame during a native drag.
     expect(fnBody).toMatch(
@@ -98,7 +100,8 @@ describe("loomi-widget — stable drag wiring", () => {
     );
     // The dragging class must be removed so the cursor reverts
     // from `grabbing` to `grab` once the gesture is over.
-    expect(fnBody).toMatch(
+    expect(fnBody).toMatch(/clearPointerGesture\(\)/);
+    expect(stripped).toMatch(
       /document\.body\.classList\.remove\(\s*["']dragging["']\s*\)/,
     );
   });

--- a/apps/web/tests/unit/pet-theme.test.ts
+++ b/apps/web/tests/unit/pet-theme.test.ts
@@ -459,8 +459,10 @@ describe("pet menu interaction (#369)", () => {
     // Search the slice AFTER the guard for the side-effecting calls so
     // the comment can't satisfy the assertion.
     const afterGuard = body.slice(guardMatch.index);
-    expect(afterGuard).toMatch(/startDragging\(\)/);
+    expect(afterGuard).toMatch(/startNativeDrag\(getCurrentWindow\(\)\)/);
     expect(afterGuard).toMatch(/setPointerCapture\(/);
+    expect(stripped).toMatch(/function startNativeDrag\(win\)/);
+    expect(stripped).toMatch(/win\.startDragging\(\)/);
   });
 
   it("onPointerUp bails when the target is inside the open menu", () => {


### PR DESCRIPTION
## Issue

Fixes #454 

## Summary

Fixes the desktop pet window escaping the visible screen area and persisting an unreachable position across app restarts.

This change constrains the Loomi pet to the active monitor work area, repairs previously saved out-of-bounds positions on startup/show, and prevents the Windows native drag loop from repeatedly pulling the window back out after a boundary correction.

## Scope

Changed files:

- `apps/web/public/loomi-widget.html`
- `apps/web/src-tauri/src/pet/window.rs`
- `apps/web/src-tauri/src/pet/aux_position.rs`

## Implementation

The fix keeps native Tauri window dragging as the primary interaction path instead of replacing it with JS-driven positioning. The widget still calls `startDragging()`, preserving normal desktop drag behavior across transparent window regions.

On the Rust side, pet positioning now runs through a shared clamp path that:

- reads monitor work-area bounds in physical pixels
- selects the best candidate monitor based on current pet overlap
- clamps the pet window inside that monitor with a small margin
- persists corrected positions when the clamp happens during build/show/move
- repairs invalid saved window-state positions before they can make the pet unreachable after restart

Because Tauri native dragging can continue while the app corrects the window position, the poller now also performs bounds enforcement during drag-time updates. On Windows, when a clamp actually happens, the app sends native window messages to cancel the current OS drag session so the pet stops at the boundary instead of visually snapping back and forth while the mouse is still held.

The previous JS-controlled drag attempt was removed. That approach was more brittle because the static widget page depends on Tauri global window APIs being available in exactly the expected shape; keeping native drag and enforcing bounds in Rust gives us a smaller and more reliable platform boundary.

## Platform Notes

The shared bounds repair applies to desktop platforms, including Windows and macOS.

The active native-drag cancellation added here is Windows-specific. macOS still benefits from startup/show/move/poll clamping and persisted-state repair; full parity for “cancel the current drag immediately after clamp” would require a separate macOS-native drag cancellation hook.

## Verification

Ran:

- `pnpm exec prettier --check apps/web/public/loomi-widget.html`
- `rustfmt --check src/pet/window.rs src/pet/aux_position.rs`
- `cargo test --bin openloomi pet::window::tests`
- `cargo check --bin openloomi`
- `git diff --check -- apps/web/public/loomi-widget.html apps/web/src-tauri/src/pet/aux_position.rs apps/web/src-tauri/src/pet/window.rs`