### PR TITLE
feat(pet): add local context menu actions

### DIFF
--- a/apps/marketing/content/attention-agent.mdx
+++ b/apps/marketing/content/attention-agent.mdx
@@ -335,6 +335,46 @@ Yes. Loomi ships with two built-in themes (`fox` and `capybara`) and a fully fil
 - **External edits auto-apply** — the config watcher listens for changes and re-paints within ~250 ms; no app restart needed.
 - **`presenting` state** — when a decision moves to `done` and you haven't reviewed it yet, Loomi shows the `presenting` sprite + bubble ("All wrapped up — ready when you are"). Click the bubble to flip back to `happy`.
 
+### Can local integrations add right-click actions?
+
+Yes. Trusted local tools can opt in by writing `~/.openloomi/pet-actions.json`. The full flow is:
+
+1. Run your local helper on a literal loopback address, for example `http://127.0.0.1:48173`.
+2. Create or update `~/.openloomi/pet-actions.json` with `enabled: true` and one entry per menu action.
+3. Right-click Loomi. OpenLoomi renders the sanitized action labels under the `Actions` section.
+4. Click an action. The widget sends only the action ID to Rust; Rust reloads the config, validates the target, and dispatches a bounded `POST`.
+5. To change menu state, such as "Start meeting recording" to "Stop meeting recording", have the helper rewrite this file. The watcher refreshes the menu without restarting OpenLoomi.
+6. To remove the custom menu, set `enabled` to `false`, remove the action, or delete the file.
+
+```json
+{
+  "version": 1,
+  "enabled": true,
+  "actions": [
+    {
+      "id": "meeting-recorder-toggle",
+      "label": "Start meeting recording",
+      "target": "http://127.0.0.1:48173/openloomi/pet/meeting/toggle",
+      "timeoutMs": 1500
+    }
+  ]
+}
+```
+
+OpenLoomi posts this payload to the configured target:
+
+```json
+{
+  "source": "openloomi-pet",
+  "version": 1,
+  "actionId": "meeting-recorder-toggle"
+}
+```
+
+Targets must use `http://127.0.0.1:...` or `http://[::1]:...`; OpenLoomi does not execute shell commands, does not allow remote hosts, does not expose the target URL to the widget, and isolates failures from the built-in Pet menu.
+
+This boundary applies only to user-defined Pet context actions. It does not change the existing plugin bridge or agent-runtime paths: when OpenLoomi is configured with `OPENLOOMI_AGENT_PROVIDER=codex`, native agent tasks can still use the existing Codex CLI runtime (`codex exec --json`) according to the agent runtime configuration. If a custom Pet action needs to trigger Codex work, point it at a trusted local helper or OpenLoomi API route; do not put an executable command in `pet-actions.json`.
+
 ### What's the difference between the Attention Agent and Loop?
 
 - **The Attention Agent** is the **little pet on your desktop**, gently reminding you in your line of sight.

--- a/apps/web/public/loomi-widget.html
+++ b/apps/web/public/loomi-widget.html
@@ -340,6 +340,8 @@
         position: fixed;
         z-index: 9999;
         min-width: 96px;
+        max-width: calc(100vw - 8px);
+        box-sizing: border-box;
         /* The pet window is 168×168 but the menu (theme picker + a
            few shortcuts) is ~250px tall, so we cap the height and let
            it scroll rather than clip the Quit button. `calc(100vh -
@@ -396,6 +398,8 @@
         border-radius: 6px;
         cursor: pointer;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       #pet-menu button:hover,
       #pet-menu button:focus-visible {
@@ -458,6 +462,10 @@
     <div id="pet-menu" role="menu" aria-hidden="true">
       <button type="button" data-op="open" role="menuitem">Open Loomi</button>
       <button type="button" data-op="settings" role="menuitem">Settings</button>
+      <div id="pet-actions-section" hidden>
+        <div class="menu-separator">Actions</div>
+        <div id="pet-actions"></div>
+      </div>
       <hr />
       <div class="menu-separator">Theme</div>
       <button type="button" data-op="theme-fox" role="menuitem">
@@ -534,6 +542,9 @@
         // `~/.openloomi/pet-custom/` directory. Refreshed on every
         // config event. The widget renders one menu button per entry.
         let customThemes = [];
+        // User-defined context actions. Rendered separately from the
+        // theme picker and hidden entirely when the action config is off.
+        let petContextActions = [];
 
         const fox = document.getElementById("fox");
         const pendingBadge = document.getElementById("pending-badge");
@@ -654,6 +665,54 @@
         }
 
         // Toggle the ✓ indicator on the active theme's button.
+        function rebuildActionButtons() {
+          const section = document.getElementById("pet-actions-section");
+          const container = document.getElementById("pet-actions");
+          if (!section || !container) return;
+          container.replaceChildren();
+          if (!petContextActions.length) {
+            section.hidden = true;
+            return;
+          }
+          section.hidden = false;
+          for (const action of petContextActions) {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.setAttribute("role", "menuitem");
+            btn.dataset.op = "action";
+            btn.dataset.actionId = action.id;
+            btn.textContent = action.label;
+            container.appendChild(btn);
+          }
+        }
+
+        function applyActions(view) {
+          if (
+            !view ||
+            typeof view !== "object" ||
+            view.enabled !== true ||
+            !Array.isArray(view.actions)
+          ) {
+            petContextActions = [];
+            rebuildActionButtons();
+            return;
+          }
+          petContextActions = view.actions
+            .map((action) => {
+              if (!action || typeof action !== "object") return null;
+              if (typeof action.id !== "string" || !action.id) return null;
+              if (typeof action.label !== "string" || !action.label) {
+                return null;
+              }
+              return {
+                id: action.id,
+                label: action.label,
+              };
+            })
+            .filter(Boolean);
+          rebuildActionButtons();
+        }
+
         function updateThemeTicks() {
           document.querySelectorAll("[data-theme-tick]").forEach((el) => {
             el.classList.toggle(
@@ -867,6 +926,27 @@
                 })
                 .catch((err) => {
                   console.warn("[loomi] set_active_theme failed", err);
+                });
+            }
+            return;
+          }
+          if (op === "action") {
+            const actionId =
+              button && button.dataset ? button.dataset.actionId : null;
+            if (!actionId) return;
+            if (t.core && t.core.invoke) {
+              t.core
+                .invoke("dispatch_pet_context_action", { actionId: actionId })
+                .then((result) => {
+                  if (result && result.ok === false) {
+                    console.warn(
+                      "[loomi] dispatch_pet_context_action returned non-success",
+                      result,
+                    );
+                  }
+                })
+                .catch((err) => {
+                  console.warn("[loomi] dispatch_pet_context_action failed", err);
                 });
             }
             return;
@@ -1173,6 +1253,10 @@
             const p = (e && e.payload) || null;
             if (p) applyConfig(p);
           });
+          t.event.listen("pet:actions-changed", (e) => {
+            const p = (e && e.payload) || null;
+            applyActions(p);
+          });
         }
 
         // ---- Boot -------------------------------------------------------
@@ -1190,6 +1274,14 @@
             })
             .catch((err) => {
               console.warn("[loomi] get_pet_config failed", err);
+            });
+          t.core
+            .invoke("get_pet_context_actions")
+            .then((view) => {
+              applyActions(view);
+            })
+            .catch((err) => {
+              console.warn("[loomi] get_pet_context_actions failed", err);
             });
         }
       })();

--- a/apps/web/public/loomi-widget.html
+++ b/apps/web/public/loomi-widget.html
@@ -946,7 +946,10 @@
                   }
                 })
                 .catch((err) => {
-                  console.warn("[loomi] dispatch_pet_context_action failed", err);
+                  console.warn(
+                    "[loomi] dispatch_pet_context_action failed",
+                    err,
+                  );
                 });
             }
             return;

--- a/apps/web/src-tauri/capabilities/loomi-pet.json
+++ b/apps/web/src-tauri/capabilities/loomi-pet.json
@@ -25,6 +25,8 @@
     "allow-open-url-custom",
     "allow-emit-dev-state",
     "allow-get-pet-config",
+    "allow-get-pet-context-actions",
+    "allow-dispatch-pet-context-action",
     "allow-set-active-theme"
   ],
   "remote": {

--- a/apps/web/src-tauri/permissions/commands.toml
+++ b/apps/web/src-tauri/permissions/commands.toml
@@ -274,6 +274,16 @@ description = "Allow the get_pet_config command (read theme + overrides)"
 commands.allow = ["get_pet_config"]
 
 [[permission]]
+identifier = "allow-get-pet-context-actions"
+description = "Allow the get_pet_context_actions command (read sanitized Pet context actions)"
+commands.allow = ["get_pet_context_actions"]
+
+[[permission]]
+identifier = "allow-dispatch-pet-context-action"
+description = "Allow the dispatch_pet_context_action command (bounded loopback Pet context action)"
+commands.allow = ["dispatch_pet_context_action"]
+
+[[permission]]
 identifier = "allow-set-active-theme"
 description = "Allow the set_active_theme command (right-click theme switcher)"
 commands.allow = ["set_active_theme"]

--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -467,6 +467,8 @@ fn main() {
             // shortcuts. Registered unconditionally so the widget
             // always has a way to discover its theme on cold boot.
             pet::get_pet_config,
+            pet::get_pet_context_actions,
+            pet::dispatch_pet_context_action,
             pet::set_active_theme,
         ])
         .setup(|app| {

--- a/apps/web/src-tauri/src/pet/actions.rs
+++ b/apps/web/src-tauri/src/pet/actions.rs
@@ -1,0 +1,488 @@
+// Loomi Pet context actions.
+//
+// User-defined menu actions are intentionally narrow: OpenLoomi reads a
+// versioned config file from `~/.openloomi/pet-actions.json`, renders only
+// sanitized labels in the pet menu, and dispatches clicks as bounded POSTs to
+// literal loopback URLs. The target URL never crosses into the widget.
+
+use std::collections::HashSet;
+use std::io::Read;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use url::{Host, Url};
+
+use super::theme;
+
+pub const ACTIONS_CONFIG_FILENAME: &str = "pet-actions.json";
+
+const SUPPORTED_VERSION: u32 = 1;
+const DEFAULT_TIMEOUT_MS: u64 = 1500;
+const MIN_TIMEOUT_MS: u64 = 100;
+const MAX_TIMEOUT_MS: u64 = 5000;
+const MAX_RESPONSE_BYTES: usize = 8 * 1024;
+const MAX_ACTIONS: usize = 24;
+const MAX_ID_LEN: usize = 64;
+const MAX_LABEL_LEN: usize = 80;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PetActionsConfig {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub actions: Vec<PetActionDefinition>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+impl Default for PetActionsConfig {
+    fn default() -> Self {
+        Self {
+            version: SUPPORTED_VERSION,
+            enabled: false,
+            actions: Vec::new(),
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PetActionDefinition {
+    pub id: String,
+    pub label: String,
+    pub target: String,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PetContextActionsView {
+    pub version: u32,
+    pub enabled: bool,
+    pub actions: Vec<PetContextActionView>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PetContextActionView {
+    pub id: String,
+    pub label: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PetActionDispatchResult {
+    pub action_id: String,
+    pub ok: bool,
+    pub status: Option<u16>,
+    pub response: Option<String>,
+    pub truncated: bool,
+}
+
+fn default_version() -> u32 {
+    SUPPORTED_VERSION
+}
+
+pub fn actions_config_path(app: &AppHandle) -> PathBuf {
+    theme::config_path(app).with_file_name(ACTIONS_CONFIG_FILENAME)
+}
+
+pub fn read_config(app: &AppHandle) -> PetActionsConfig {
+    read_config_at(&actions_config_path(app))
+}
+
+fn read_config_at(path: &Path) -> PetActionsConfig {
+    match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<PetActionsConfig>(&bytes) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                eprintln!(
+                    "[loomi-pet/actions] failed to parse {}: {e}; using defaults",
+                    path.display()
+                );
+                PetActionsConfig::default()
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => PetActionsConfig::default(),
+        Err(e) => {
+            eprintln!(
+                "[loomi-pet/actions] failed to read {}: {e}; using defaults",
+                path.display()
+            );
+            PetActionsConfig::default()
+        }
+    }
+}
+
+pub fn build_view(cfg: &PetActionsConfig) -> PetContextActionsView {
+    let supported = cfg.version == SUPPORTED_VERSION;
+    let enabled = supported && cfg.enabled;
+    let actions = if enabled {
+        sanitized_actions(cfg)
+            .into_iter()
+            .filter(|action| action.enabled)
+            .map(|action| PetContextActionView {
+                id: action.id,
+                label: action.label,
+                enabled: action.enabled,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    PetContextActionsView {
+        version: cfg.version,
+        enabled,
+        actions,
+        updated_at: cfg.updated_at.clone(),
+    }
+}
+
+pub fn dispatch_action(
+    app: &AppHandle,
+    action_id: &str,
+) -> Result<PetActionDispatchResult, String> {
+    let cfg = read_config(app);
+    dispatch_action_from_config(&cfg, action_id)
+}
+
+fn dispatch_action_from_config(
+    cfg: &PetActionsConfig,
+    action_id: &str,
+) -> Result<PetActionDispatchResult, String> {
+    if cfg.version != SUPPORTED_VERSION {
+        return Err(format!("unsupported pet actions version: {}", cfg.version));
+    }
+    if !cfg.enabled {
+        return Err("pet context actions are disabled".into());
+    }
+
+    let action = sanitized_actions(cfg)
+        .into_iter()
+        .find(|action| action.id == action_id)
+        .ok_or_else(|| "pet context action not found".to_string())?;
+    if !action.enabled {
+        return Err("pet context action is disabled".into());
+    }
+
+    let target = validate_loopback_target(&action.target)?;
+    let timeout = effective_timeout(action.timeout_ms);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("build HTTP client: {e}"))?;
+    let payload = dispatch_payload(&action.id);
+    let response = client
+        .post(target)
+        .json(&payload)
+        .send()
+        .map_err(|e| format!("dispatch pet context action: {e}"))?;
+
+    let status = response.status();
+    let mut limited = response.take((MAX_RESPONSE_BYTES + 1) as u64);
+    let mut bytes = Vec::new();
+    limited
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("read pet context action response: {e}"))?;
+    let truncated = bytes.len() > MAX_RESPONSE_BYTES;
+    if truncated {
+        bytes.truncate(MAX_RESPONSE_BYTES);
+    }
+    let response = if bytes.is_empty() {
+        None
+    } else {
+        Some(String::from_utf8_lossy(&bytes).to_string())
+    };
+
+    Ok(PetActionDispatchResult {
+        action_id: action.id,
+        ok: status.is_success(),
+        status: Some(status.as_u16()),
+        response,
+        truncated,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct SanitizedAction {
+    id: String,
+    label: String,
+    target: String,
+    enabled: bool,
+    timeout_ms: Option<u64>,
+}
+
+fn sanitized_actions(cfg: &PetActionsConfig) -> Vec<SanitizedAction> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for action in cfg.actions.iter().take(MAX_ACTIONS) {
+        let Some(id) = sanitize_id(&action.id) else {
+            continue;
+        };
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let Some(label) = sanitize_label(&action.label) else {
+            continue;
+        };
+        if validate_loopback_target(&action.target).is_err() {
+            continue;
+        }
+        out.push(SanitizedAction {
+            id,
+            label,
+            target: action.target.trim().to_string(),
+            enabled: action.enabled.unwrap_or(true),
+            timeout_ms: action.timeout_ms,
+        });
+    }
+    out
+}
+
+fn sanitize_id(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_ID_LEN {
+        return None;
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':'))
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn sanitize_label(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.chars().count() > MAX_LABEL_LEN {
+        return None;
+    }
+    if trimmed.chars().any(|c| c.is_control()) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn effective_timeout(raw: Option<u64>) -> Duration {
+    let ms = raw
+        .unwrap_or(DEFAULT_TIMEOUT_MS)
+        .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+    Duration::from_millis(ms)
+}
+
+fn validate_loopback_target(raw: &str) -> Result<Url, String> {
+    let url = Url::parse(raw.trim()).map_err(|e| format!("invalid action target URL: {e}"))?;
+    if url.scheme() != "http" {
+        return Err("pet context action target must use http".into());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("pet context action target must not include credentials".into());
+    }
+    if url.fragment().is_some() {
+        return Err("pet context action target must not include a fragment".into());
+    }
+    match url.host() {
+        Some(Host::Ipv4(addr)) if addr == Ipv4Addr::LOCALHOST => Ok(url),
+        Some(Host::Ipv6(addr)) if addr == Ipv6Addr::LOCALHOST => Ok(url),
+        _ => Err("pet context action target must be a literal loopback address".into()),
+    }
+}
+
+fn dispatch_payload(action_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "source": "openloomi-pet",
+        "version": SUPPORTED_VERSION,
+        "actionId": action_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn sample_action(target: String) -> PetActionDefinition {
+        PetActionDefinition {
+            id: "meeting-recorder-toggle".into(),
+            label: "Start meeting recording".into(),
+            target,
+            enabled: None,
+            timeout_ms: Some(2000),
+        }
+    }
+
+    #[test]
+    fn default_config_is_disabled_and_empty() {
+        let cfg = PetActionsConfig::default();
+        let view = build_view(&cfg);
+        assert!(!view.enabled);
+        assert!(view.actions.is_empty());
+    }
+
+    #[test]
+    fn build_view_exposes_only_sanitized_action_fields() {
+        let cfg = PetActionsConfig {
+            version: 1,
+            enabled: true,
+            actions: vec![
+                sample_action("http://127.0.0.1:48173/openloomi/pet/toggle".into()),
+                PetActionDefinition {
+                    id: "bad action".into(),
+                    label: "Bad".into(),
+                    target: "http://127.0.0.1:48173/bad".into(),
+                    enabled: None,
+                    timeout_ms: None,
+                },
+                PetActionDefinition {
+                    id: "remote".into(),
+                    label: "Remote".into(),
+                    target: "https://example.com/pet".into(),
+                    enabled: None,
+                    timeout_ms: None,
+                },
+                PetActionDefinition {
+                    id: "control-label".into(),
+                    label: "Line\nBreak".into(),
+                    target: "http://127.0.0.1:48173/control-label".into(),
+                    enabled: None,
+                    timeout_ms: None,
+                },
+                PetActionDefinition {
+                    id: "disabled".into(),
+                    label: "Disabled".into(),
+                    target: "http://127.0.0.1:48173/disabled".into(),
+                    enabled: Some(false),
+                    timeout_ms: None,
+                },
+            ],
+            updated_at: Some("2026-07-27T00:00:00Z".into()),
+        };
+
+        let view = build_view(&cfg);
+        assert!(view.enabled);
+        assert_eq!(view.actions.len(), 1);
+        assert_eq!(view.actions[0].id, "meeting-recorder-toggle");
+        assert_eq!(view.actions[0].label, "Start meeting recording");
+        assert!(view.actions[0].enabled);
+    }
+
+    #[test]
+    fn validates_literal_loopback_targets_only() {
+        assert!(validate_loopback_target("http://127.0.0.1:48173/action").is_ok());
+        assert!(validate_loopback_target("http://[::1]:48173/action").is_ok());
+        assert!(validate_loopback_target("http://localhost:48173/action").is_err());
+        assert!(validate_loopback_target("http://127.0.0.2:48173/action").is_err());
+        assert!(validate_loopback_target("https://127.0.0.1:48173/action").is_err());
+        assert!(validate_loopback_target("http://192.168.1.10:48173/action").is_err());
+        assert!(validate_loopback_target("http://user:pw@127.0.0.1:48173/action").is_err());
+        assert!(validate_loopback_target("http://127.0.0.1:48173/action#frag").is_err());
+    }
+
+    #[test]
+    fn reads_malformed_config_as_default() {
+        let dir =
+            std::env::temp_dir().join(format!("loomi-pet-actions-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("pet-actions.json");
+        std::fs::write(&path, b"{ nope").unwrap();
+
+        let cfg = read_config_at(&path);
+        assert!(!cfg.enabled);
+        assert!(cfg.actions.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dispatch_payload_identifies_pet_source_and_action_id() {
+        let payload = dispatch_payload("meeting-recorder-toggle");
+        assert_eq!(payload["source"], "openloomi-pet");
+        assert_eq!(payload["version"], 1);
+        assert_eq!(payload["actionId"], "meeting-recorder-toggle");
+    }
+
+    #[test]
+    fn dispatch_posts_bounded_payload_to_loopback() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .unwrap();
+            let mut buf = [0_u8; 2048];
+            let mut bytes = Vec::new();
+            let mut expected_len = None;
+            loop {
+                let n = stream.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&buf[..n]);
+                if expected_len.is_none() {
+                    if let Some(header_end) = find_header_end(&bytes) {
+                        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+                        let content_len = headers
+                            .lines()
+                            .find_map(|line| {
+                                line.strip_prefix("Content-Length:")
+                                    .or_else(|| line.strip_prefix("content-length:"))
+                                    .and_then(|v| v.trim().parse::<usize>().ok())
+                            })
+                            .unwrap_or(0);
+                        expected_len = Some(header_end + 4 + content_len);
+                    }
+                }
+                if let Some(total) = expected_len {
+                    if bytes.len() >= total {
+                        break;
+                    }
+                }
+            }
+            let req = String::from_utf8_lossy(&bytes).to_string();
+            stream
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
+            req
+        });
+
+        let cfg = PetActionsConfig {
+            version: 1,
+            enabled: true,
+            actions: vec![sample_action(format!(
+                "http://127.0.0.1:{}/openloomi/pet/toggle",
+                addr.port()
+            ))],
+            updated_at: None,
+        };
+
+        let result = dispatch_action_from_config(&cfg, "meeting-recorder-toggle").unwrap();
+        assert!(result.ok, "expected success, got {result:?}");
+        assert_eq!(result.status, Some(204));
+        assert_eq!(result.response, None);
+        let req = handle.join().unwrap();
+        assert!(req.starts_with("POST /openloomi/pet/toggle HTTP/1.1"));
+    }
+
+    fn find_header_end(bytes: &[u8]) -> Option<usize> {
+        bytes.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+}

--- a/apps/web/src-tauri/src/pet/config_watcher.rs
+++ b/apps/web/src-tauri/src/pet/config_watcher.rs
@@ -6,7 +6,8 @@
 // and emit `pet:config-changed` so the widget can swap sprites
 // without a restart.
 //
-// Two watches:
+// Watches:
+//   * `pet-actions.json` (non-recursive) - user-defined context actions.
 //   * `pet-config.json` (non-recursive) — the single config file.
 //   * `pet-custom/`      (recursive)    — every subdirectory the
 //                                         user might drop a custom
@@ -24,6 +25,7 @@ use std::time::{Duration, Instant};
 use notify::{EventKind, RecursiveMode, Watcher};
 use tauri::{AppHandle, Emitter};
 
+use super::actions;
 use super::theme;
 use super::PET_LABEL;
 
@@ -46,6 +48,7 @@ pub fn spawn_config_watcher(app: AppHandle) {
 
 fn watch_loop(app: &AppHandle) {
     let config_path = theme::config_path(app);
+    let actions_path = actions::actions_config_path(app);
     let config_dir = config_path
         .parent()
         .map(|p| p.to_path_buf())
@@ -74,6 +77,13 @@ fn watch_loop(app: &AppHandle) {
         eprintln!(
             "[loomi-pet/config-watcher] failed to watch config {}: {e}",
             config_path.display()
+        );
+    }
+
+    if let Err(e) = watcher.watch(&actions_path, RecursiveMode::NonRecursive) {
+        eprintln!(
+            "[loomi-pet/config-watcher] failed to watch actions config {}: {e}",
+            actions_path.display()
         );
     }
 
@@ -127,6 +137,7 @@ fn watch_loop(app: &AppHandle) {
                 if !primed {
                     primed = true;
                     emit_config_changed(app, &cfg);
+                    emit_actions_changed(app);
                     last_emit = Instant::now();
                 }
                 continue;
@@ -153,16 +164,16 @@ fn watch_loop(app: &AppHandle) {
         // the modify/create/remove filter below pass them through
         // after the transition. Anything else is dropped here so the
         // debounced emit isn't drowned by unrelated directory churn.
-        let touches_config_file = event.paths.iter().any(|p| {
-            p.file_name()
-                .zip(config_path.file_name())
-                .map(|(a, b)| a == b)
-                .unwrap_or(false)
-        });
-        if !touches_config_file {
+        let touches_config_file = event_touches_file(&event, &config_path);
+        let touches_actions_file = event_touches_file(&event, &actions_path);
+        let touches_theme_dir = current_themes_dir
+            .as_ref()
+            .map(|dir| event_touches_dir(&event, dir))
+            .unwrap_or(false);
+        if !touches_config_file && !touches_actions_file && !touches_theme_dir {
             continue;
         }
-        if matches!(event.kind, EventKind::Create(_)) {
+        if matches!(event.kind, EventKind::Create(_)) && touches_config_file {
             // Transition to a direct file watch — subsequent edits
             // hit the file watcher (no per-inode churn through the
             // directory). If `pet-config.json` is then removed, the
@@ -175,14 +186,43 @@ fn watch_loop(app: &AppHandle) {
                 );
             }
         }
+        if matches!(event.kind, EventKind::Create(_)) && touches_actions_file {
+            if let Err(e) = watcher.watch(&actions_path, RecursiveMode::NonRecursive) {
+                eprintln!(
+                    "[loomi-pet/config-watcher] failed to (re-)watch actions config {}: {e}",
+                    actions_path.display()
+                );
+            }
+        }
         // Debounce: skip events that arrive within 250 ms of the
         // previous emit so a single editor save fires one event.
         if last_emit.elapsed() < Duration::from_millis(DEBOUNCE_MS) {
             continue;
         }
         last_emit = Instant::now();
-        emit_config_changed(app, &theme::read_config(app));
+        if touches_config_file || touches_theme_dir {
+            emit_config_changed(app, &theme::read_config(app));
+        }
+        if touches_actions_file {
+            emit_actions_changed(app);
+        }
     }
+}
+
+fn event_touches_file(event: &notify::Event, target: &PathBuf) -> bool {
+    event.paths.iter().any(|p| {
+        p == target
+            || p.parent()
+                .zip(target.parent())
+                .filter(|(a, b)| a == b)
+                .and_then(|_| p.file_name().zip(target.file_name()))
+                .map(|(a, b)| a == b)
+                .unwrap_or(false)
+    })
+}
+
+fn event_touches_dir(event: &notify::Event, dir: &PathBuf) -> bool {
+    event.paths.iter().any(|p| p.starts_with(dir))
 }
 
 fn emit_config_changed(app: &AppHandle, cfg: &theme::PetConfig) {
@@ -196,6 +236,19 @@ fn emit_config_changed(app: &AppHandle, cfg: &theme::PetConfig) {
         }
     };
     let _ = app.emit_to(PET_LABEL, "pet:config-changed", payload);
+}
+
+fn emit_actions_changed(app: &AppHandle) {
+    let cfg = actions::read_config(app);
+    let view = actions::build_view(&cfg);
+    let payload = match serde_json::to_value(&view) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[loomi-pet/config-watcher] failed to serialize PetContextActionsView: {e}");
+            return;
+        }
+    };
+    let _ = app.emit_to(PET_LABEL, "pet:actions-changed", payload);
 }
 
 // Real coverage for the parent-dir watch + create-transition path

--- a/apps/web/src-tauri/src/pet/mod.rs
+++ b/apps/web/src-tauri/src/pet/mod.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use tauri::Emitter;
 use tauri::Manager;
 
+pub mod actions;
 mod aux_position;
 mod bubble;
 mod card;
@@ -22,6 +23,7 @@ pub mod theme;
 mod watcher;
 mod window;
 
+pub use actions::{PetActionDispatchResult, PetContextActionsView};
 pub use aux_position::{
     clear_card_manual_position, reposition_bubble_to_pet, reposition_card_to_pet,
     set_card_manual_position, spawn_position_poller,
@@ -185,6 +187,26 @@ pub fn get_pet_config(app: tauri::AppHandle) -> PetConfigView {
     let cfg = theme::read_config(&app);
     let custom = theme::list_custom_themes(&cfg);
     theme::build_view(cfg, custom)
+}
+
+/// Returns sanitized, user-defined context actions for the Pet menu.
+/// The widget only receives IDs + labels; loopback targets remain
+/// host-side and are re-read on dispatch.
+#[tauri::command]
+pub fn get_pet_context_actions(app: tauri::AppHandle) -> PetContextActionsView {
+    let cfg = actions::read_config(&app);
+    actions::build_view(&cfg)
+}
+
+/// Dispatches one configured Pet context action by ID. The target URL
+/// never comes from the widget; Rust reloads the config, validates the
+/// ID and target, then performs a bounded loopback POST.
+#[tauri::command(rename_all = "camelCase")]
+pub fn dispatch_pet_context_action(
+    app: tauri::AppHandle,
+    action_id: String,
+) -> Result<PetActionDispatchResult, String> {
+    actions::dispatch_action(&app, &action_id)
 }
 
 /// Updates only `activeTheme` (called by the right-click menu).

--- a/apps/web/tests/unit/pet-theme.test.ts
+++ b/apps/web/tests/unit/pet-theme.test.ts
@@ -200,9 +200,7 @@ describe("widget source sanity", () => {
   });
 
   it("widget boots via get_pet_context_actions", () => {
-    expect(widgetHtml).toMatch(
-      /invoke\(\s*["']get_pet_context_actions["']/,
-    );
+    expect(widgetHtml).toMatch(/invoke\(\s*["']get_pet_context_actions["']/);
   });
 
   it("widget listens for pet:config-changed", () => {
@@ -509,9 +507,7 @@ describe("pet menu interaction (#369)", () => {
     expect(handler).toMatch(/emit\(\s*["']pet:open-settings["']/);
     expect(handler).toMatch(/emit\(\s*["']pet:quit["']/);
     expect(handler).toMatch(/invoke\(\s*["']set_active_theme["']/);
-    expect(handler).toMatch(
-      /invoke\(\s*["']dispatch_pet_context_action["']/,
-    );
+    expect(handler).toMatch(/invoke\(\s*["']dispatch_pet_context_action["']/);
     expect(handler).toMatch(/actionId:\s*actionId/);
     expect(handler).toMatch(
       /theme-\$\{|op\.slice\(\s*["']theme-["']\.length\s*\)/,

--- a/apps/web/tests/unit/pet-theme.test.ts
+++ b/apps/web/tests/unit/pet-theme.test.ts
@@ -199,8 +199,18 @@ describe("widget source sanity", () => {
     expect(widgetHtml).toMatch(/invoke\(\s*["']get_pet_config["']/);
   });
 
+  it("widget boots via get_pet_context_actions", () => {
+    expect(widgetHtml).toMatch(
+      /invoke\(\s*["']get_pet_context_actions["']/,
+    );
+  });
+
   it("widget listens for pet:config-changed", () => {
     expect(widgetHtml).toMatch(/listen\(\s*["']pet:config-changed["']/);
+  });
+
+  it("widget listens for pet:actions-changed", () => {
+    expect(widgetHtml).toMatch(/listen\(\s*["']pet:actions-changed["']/);
   });
 
   it("widget listens for pending-count badge updates", () => {
@@ -491,17 +501,29 @@ describe("pet menu interaction (#369)", () => {
     expect(handler).toMatch(/button\.dataset\.op/);
   });
 
-  it("menu wires every operation (open / settings / theme-* / quit)", () => {
+  it("menu wires every operation (open / settings / action / theme-* / quit)", () => {
     const handler = petMenuClickHandler();
     // Event-emit operations are dispatched on the host bridge; theme
-    // switches go through `invoke("set_active_theme", ...)`.
+    // switches and custom context actions go through `core.invoke`.
     expect(handler).toMatch(/emit\(\s*["']pet:open-dashboard["']/);
     expect(handler).toMatch(/emit\(\s*["']pet:open-settings["']/);
     expect(handler).toMatch(/emit\(\s*["']pet:quit["']/);
     expect(handler).toMatch(/invoke\(\s*["']set_active_theme["']/);
     expect(handler).toMatch(
+      /invoke\(\s*["']dispatch_pet_context_action["']/,
+    );
+    expect(handler).toMatch(/actionId:\s*actionId/);
+    expect(handler).toMatch(
       /theme-\$\{|op\.slice\(\s*["']theme-["']\.length\s*\)/,
     );
+  });
+
+  it("custom action buttons render text labels and carry only action ids", () => {
+    expect(stripped).toMatch(/id="pet-actions-section"/);
+    expect(stripped).toMatch(/id="pet-actions"/);
+    expect(stripped).toMatch(/btn\.dataset\.op\s*=\s*["']action["']/);
+    expect(stripped).toMatch(/btn\.dataset\.actionId\s*=\s*action\.id/);
+    expect(stripped).toMatch(/btn\.textContent\s*=\s*action\.label/);
   });
 
   it("theme buttons expose data-op so closest() can find them", () => {


### PR DESCRIPTION
## Summary

Adds a small, config-driven extension point for trusted local integrations to add actions to the Loomi Pet right-click menu.

Custom actions are loaded from `~/.openloomi/pet-actions.json`, rendered under a separate `Actions` section in the Pet menu, and dispatched through bounded `POST` requests to literal loopback targets only. This lets local tools, such as a meeting recorder or developer helper, integrate with the Pet without patching `loomi-widget.html` after every OpenLoomi upgrade.

Fixes #444.

## Changes

### Pet action configuration and dispatch

- Added a new Rust module for Pet context actions:
  - reads `~/.openloomi/pet-actions.json`
  - defaults to disabled when the file is missing, malformed, or unsupported
  - validates a versioned config shape
  - sanitizes action IDs and labels
  - filters disabled or invalid actions
  - exposes only `id`, `label`, and `enabled` to the widget
  - dispatches by re-reading the config on click instead of trusting widget-provided targets

### Tauri command surface

- Added `get_pet_context_actions`
- Added `dispatch_pet_context_action`
- Registered both commands in the main Tauri invoke handler
- Added explicit permissions and included them in the `loomi-pet` capability

### Pet widget UI

- Added a dedicated `Actions` section to the right-click menu
- Loads configured actions on widget boot
- Listens for `pet:actions-changed`
- Renders labels using `textContent`
- Sends only `actionId` back to Rust on click
- Keeps custom actions separate from built-in Pet menu items and theme controls

### Config watcher

- Extended the Pet config watcher to also watch `pet-actions.json`
- Emits `pet:actions-changed` when action config changes
- Keeps existing `pet:config-changed` behavior for theme/config updates
- Refreshes the action menu without requiring an app restart

### Documentation

- Documented the user configuration flow in the Attention Agent docs
- Added a complete `pet-actions.json` example
- Documented the POST payload sent to local integrations
- Clarified security boundaries and compatibility with existing Codex plugin/runtime paths

## User Configuration Flow

Trusted local integrations configure Pet actions by writing:

```text
~/.openloomi/pet-actions.json
```

Example:

```json
{
  "version": 1,
  "enabled": true,
  "actions": [
    {
      "id": "meeting-recorder-toggle",
      "label": "Start meeting recording",
      "target": "http://127.0.0.1:48173/openloomi/pet/meeting/toggle",
      "timeoutMs": 1500
    }
  ]
}
```

Runtime flow:

1. The integration runs a trusted local helper on a literal loopback address.
2. The helper or user writes `~/.openloomi/pet-actions.json`.
3. The Pet config watcher detects the file and refreshes the menu.
4. Loomi renders the sanitized action label under `Actions`.
5. When clicked, the widget sends only `actionId` to Rust.
6. Rust reloads the config, validates the target, and sends a bounded `POST`.
7. Integrations can update labels such as `Start` / `Stop` by rewriting the config file.
8. Users can disable the menu by setting `enabled: false`, removing actions, or deleting the file.

OpenLoomi sends this payload to the configured target:

```json
{
  "source": "openloomi-pet",
  "version": 1,
  "actionId": "meeting-recorder-toggle"
}
```

## Security Boundaries

This intentionally does not add arbitrary command execution to OpenLoomi core.

The first version is limited to:

- `POST` only
- literal loopback targets only:
  - `http://127.0.0.1:...`
  - `http://[::1]:...`
- no `localhost` DNS resolution
- no remote hosts
- no HTTPS targets
- no credentials in URLs
- no URL fragments
- no redirects
- no proxy usage
- bounded timeout
- bounded response body
- labels treated as untrusted display text
- target URLs never exposed to the widget
- broken configs or failing helpers do not affect built-in Pet menu actions

This boundary applies only to user-defined Pet context actions. It does not change the existing plugin bridge or agent runtime paths. In particular, `OPENLOOMI_AGENT_PROVIDER=codex` and the existing Codex CLI runtime continue to work through the established runtime configuration.

If a Pet action needs to trigger Codex work, the intended pattern is:

```text
Pet menu click -> local helper / OpenLoomi API -> existing Codex runtime path
```

not:

```text
pet-actions.json -> shell command
```

## Out of Scope

This PR does not add:

- a general plugin registry
- shell-command actions
- unrestricted headers
- remote webhooks
- a bundled meeting recorder
- first-use confirmation UI
- app-level settings UI for editing actions

Those can be considered later if maintainers want a broader capability model.

## Testing

Manual E2E:

- Started a local Node helper on `127.0.0.1:48173`
- Wrote `~/.openloomi/pet-actions.json`
- Launched the Tauri dev app
- Verified the Pet right-click menu shows an `Actions` section
- Clicked the custom action
- Confirmed the helper received:

```text
POST /openloomi/pet/meeting/toggle
```

with payload:

```json
{
  "actionId": "meeting-recorder-toggle",
  "source": "openloomi-pet",
  "version": 1
}
```

- Confirmed the helper could rewrite `pet-actions.json` and the menu label refreshed from `Start` to `Stop` without restarting OpenLoomi.