### PR TITLE
feat(loop): unify decision priority, add email burst digest, throttle notifications

### DIFF
--- a/apps/web/lib/loop/email-bursts.ts
+++ b/apps/web/lib/loop/email-bursts.ts
@@ -1,0 +1,521 @@
+/**
+ * Email burst aggregator (SP-3).
+ *
+ * Direct `email` signals can arrive in short bursts from a single
+ * sender — mailing-list traffic, status-page notifications, an
+ * autoresponder loop, etc. Left to the per-signal classify path,
+ * each email becomes its own `email_reply` decision and the pet
+ * bubble fans out N copies of a near-identical card.
+ *
+ * This module turns a burst into ONE read-only `email_burst_digest`
+ * card:
+ *   - recognises `email` signals arriving via the built-in `gmail`
+ *     pull or a custom `email` channel;
+ *   - groups by lowercase sender address (the canonical
+ *     `mutes.ts::muteKeyFor({ type: "email", from })` shape — the
+ *     existing mutes pipeline already key-dedupes on this exact
+ *     normalised value, so a digest dismissed now will block the
+ *     next burst from the same sender for the natural re-mute
+ *     window);
+ *   - applies a 5-emails / 15-min threshold; below that, the
+ *     per-signal path still wins (a single important reply is more
+ *     valuable than a digest);
+ *   - excludes threadIds already represented by a typed `email_reply`
+ *     decision or a prior burst digest, so repeated ticks do not
+ *     re-pester;
+ *   - merges freshly-unseen items into an existing pending digest
+ *     instead of creating a second summary card.
+ *
+ * Mirrors `github-notifications.ts` deliberately — the
+ * `classify → digest → decide` shape is identical so the agentic
+ * tick wiring in `tick.ts` can compose them the same way. No URL
+ * derivation here (email `threadId` is enough identity).
+ *
+ * Everything here is PURE and READ-ONLY. It never sends mail and
+ * never mutates external resources — it only reshapes signals the
+ * tick already pulled into a decision the store can persist.
+ */
+
+import type { LoopDecision, LoopSignal } from "./types";
+
+/** `action.params.module` value that marks an email-burst digest. */
+export const EMAIL_BURSTS_MODULE = "email-bursts";
+
+/** Signal sources that can carry `email` records for this digest.
+ *  Mirrors `GITHUB_NOTIFICATION_SOURCES` — kept narrow on purpose:
+ *  we only aggregate signals that arrived through Loop's canonical
+ *  pull, not arbitrary `manual` / `insights` injects (those carry
+ *  user intent and should be surfaced individually). */
+const EMAIL_SIGNAL_SOURCES = new Set(["gmail", "email"]);
+
+/** Hard cap on how many items one burst card lists. Keeps the
+ *  read-only summary bounded even if a sender firehoses. Newest
+ *  win. */
+export const MAX_EMAIL_BURST_ITEMS = 10;
+
+/** Minimum number of emails in the window before we aggregate. Below
+ *  this the per-signal `email_reply` cards are more useful — a
+ *  single important reply beats a digest of one item. */
+export const BURST_THRESHOLD = 5;
+
+/** Lookback window for the burst (ms). Combined with the threshold:
+ *  5 emails in 15 min → digest. Spaced-out sends remain per-signal. */
+export const BURST_WINDOW_MS = 15 * 60_000;
+
+// ---------------------------------------------------------------------------
+// Item shape
+// ---------------------------------------------------------------------------
+
+export interface EmailBurstItem {
+  /** Canonical, source-independent dedupe key. */
+  key: string;
+  /** Lowercased sender address — the burst grouping axis. */
+  from: string;
+  /** Optional display name (preserved for the card render). */
+  fromName?: string;
+  /** Subject (best-effort, truncated). */
+  title: string;
+  /** Short preview snippet (best-effort, truncated). */
+  snippet?: string;
+  /** ISO timestamp the signal arrived. */
+  ts: string;
+  /** Thread id — used to suppress overlap with typed `email_reply`
+   *  decisions. */
+  threadId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Small payload accessors
+// ---------------------------------------------------------------------------
+
+function payloadOf(signal: LoopSignal): Record<string, unknown> {
+  const p = signal.payload;
+  return p && typeof p === "object" ? (p as Record<string, unknown>) : {};
+}
+
+function firstString(...vals: unknown[]): string | null {
+  for (const v of vals) {
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+/** Lowercased sender email. Same extraction as `mutes.ts::muteKeyFor`
+ *  so digest dismissal lines up with future per-sender mutes. */
+function fromAddress(p: Record<string, unknown>): string {
+  const raw = firstString(p.from, p.sender) ?? "";
+  const m = raw.match(/<([^>]+)>/);
+  const addr = m ? m[1] : raw;
+  return addr.toLowerCase().trim();
+}
+
+/** Display name (everything before the angle bracket, or empty). */
+function fromNameOf(p: Record<string, unknown>): string | undefined {
+  const raw = firstString(p.from, p.sender) ?? "";
+  const m = raw.match(/^"?([^"<]*?)"?\s*<[^>]+>/);
+  const name = m ? m[1].trim() : "";
+  return name || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Recognition + canonicalization
+// ---------------------------------------------------------------------------
+
+/** True when a signal is an email arriving via the built-in `gmail`
+ *  pull or a custom `email` channel. */
+export function isEmailBurstSignal(
+  signal: LoopSignal | null | undefined,
+): boolean {
+  if (!signal || typeof signal !== "object") return false;
+  if (signal.type !== "email") return false;
+  return EMAIL_SIGNAL_SOURCES.has(String(signal.source));
+}
+
+/** Derive a source-independent canonical key for an email signal.
+ *  Prefers the email messageId (stable across `gmail` and `email`
+ *  surfaces), then `threadId` + from, then subject + from. The
+ *  per-burst coverage collector in `collectCoveredEmailBurstKeys`
+ *  uses the same shape so a typed `email_reply` decision keyed by
+ *  threadId suppresses the matching digest item. */
+export function emailBurstKey(
+  signal: LoopSignal | null | undefined,
+): string | null {
+  if (!signal || typeof signal !== "object") return null;
+  const p = payloadOf(signal);
+  const msgId = firstString(p.messageId, p.id, p.message_id);
+  if (msgId) return `email:msg:${msgId}`;
+  const threadId = firstString(p.threadId, p.thread_id);
+  const from = fromAddress(p);
+  if (threadId && from) return `email:thread:${from}:${threadId}`;
+  const subject = firstString(p.subject);
+  if (from && subject)
+    return `email:from-subject:${from}:${subject.toLowerCase()}`;
+  return null;
+}
+
+/** Build a normalised item from a single email signal, or null when
+ *  the signal lacks a stable identity. */
+function toEmailItem(signal: LoopSignal): EmailBurstItem | null {
+  const key = emailBurstKey(signal);
+  if (!key) return null;
+  const p = payloadOf(signal);
+  const from = fromAddress(p);
+  if (!from) return null;
+  const title = firstString(p.subject) ?? "(no subject)";
+  const snippet = firstString(p.snippet, p.body) ?? undefined;
+  const ts = signal.ts || new Date().toISOString();
+  const threadId = firstString(p.threadId, p.thread_id) ?? undefined;
+  const name = fromNameOf(p);
+  return {
+    key,
+    from,
+    ...(name ? { fromName: name } : {}),
+    title: title.slice(0, 160),
+    ...(snippet ? { snippet: snippet.slice(0, 280) } : {}),
+    ts,
+    ...(threadId ? { threadId } : {}),
+  };
+}
+
+/** Normalize + cross-source deduplicate a batch of signals into
+ *  items. Non-email signals are ignored; signals with the same key
+ *  collapse (newest ts wins on collision). */
+export function normalizeEmailBursts(signals: LoopSignal[]): EmailBurstItem[] {
+  const map = new Map<string, EmailBurstItem>();
+  for (const s of signals) {
+    if (!isEmailBurstSignal(s)) continue;
+    const item = toEmailItem(s);
+    if (!item) continue;
+    const existing = map.get(item.key);
+    if (!existing) {
+      map.set(item.key, item);
+      continue;
+    }
+    // Newest ts wins on collision.
+    if (item.ts > existing.ts) {
+      map.set(item.key, item);
+    } else {
+      // Merge snippet / fromName if the new one has them and the
+      // existing doesn't.
+      map.set(item.key, {
+        ...existing,
+        ...(item.snippet && !existing.snippet ? { snippet: item.snippet } : {}),
+        ...(item.fromName && !existing.fromName
+          ? { fromName: item.fromName }
+          : {}),
+      });
+    }
+  }
+  return [...map.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Burst grouping + coverage
+// ---------------------------------------------------------------------------
+
+interface SenderBucket {
+  from: string;
+  items: EmailBurstItem[];
+}
+
+/** Group items by lowercase sender. Items with the same `from`
+ *  collapse into one bucket; the bucket is then evaluated against
+ *  BURST_THRESHOLD + BURST_WINDOW_MS. */
+function groupBySender(items: EmailBurstItem[]): SenderBucket[] {
+  const map = new Map<string, SenderBucket>();
+  for (const it of items) {
+    let bucket = map.get(it.from);
+    if (!bucket) {
+      bucket = { from: it.from, items: [] };
+      map.set(it.from, bucket);
+    }
+    bucket.items.push(it);
+  }
+  return [...map.values()];
+}
+
+/** True when a bucket qualifies as a burst: at least BURST_THRESHOLD
+ *  items, and the spread between oldest and newest is within
+ *  BURST_WINDOW_MS. */
+function isBurst(bucket: SenderBucket, now: number): boolean {
+  if (bucket.items.length < BURST_THRESHOLD) return false;
+  const sorted = bucket.items.slice().sort((a, b) => a.ts.localeCompare(b.ts));
+  const oldest = Date.parse(sorted[0].ts);
+  const newest = Date.parse(sorted[sorted.length - 1].ts);
+  if (Number.isNaN(oldest) || Number.isNaN(newest)) {
+    // Unparseable timestamps: fall through to the size-only check
+    // — if we have BURST_THRESHOLD items from the same sender, that's
+    // still a burst worth surfacing.
+    return true;
+  }
+  return newest - oldest <= BURST_WINDOW_MS;
+}
+
+/** True when a decision is an email-burst `email_burst_digest` card. */
+export function isEmailBurstDecision(dec: LoopDecision): boolean {
+  if (!dec || dec.type !== "email_burst_digest") return false;
+  const params = dec.action?.params as Record<string, unknown> | undefined;
+  const module =
+    params?.module ??
+    (dec.context && (dec.context as Record<string, unknown>).module);
+  return module === EMAIL_BURSTS_MODULE;
+}
+
+/** Read the persisted items array off an email-burst digest
+ *  decision. */
+function readBurstItems(dec: LoopDecision): EmailBurstItem[] {
+  const raw = (dec.context as Record<string, unknown> | undefined)?.items;
+  if (!Array.isArray(raw)) return [];
+  const out: EmailBurstItem[] = [];
+  for (const it of raw) {
+    if (!it || typeof it !== "object") continue;
+    const o = it as Record<string, unknown>;
+    const key = firstString(o.key);
+    if (!key) continue;
+    out.push({
+      key,
+      from: firstString(o.from) ?? "unknown",
+      ...(firstString(o.fromName) ? { fromName: String(o.fromName) } : {}),
+      title: firstString(o.title) ?? "(no subject)",
+      ...(firstString(o.snippet) ? { snippet: String(o.snippet) } : {}),
+      ts: firstString(o.ts) ?? new Date().toISOString(),
+      ...(firstString(o.threadId) ? { threadId: String(o.threadId) } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * Collect the email thread keys already represented by existing
+ * decisions:
+ *   - threadIds listed on any prior email-burst digest
+ *     (`context.burst_keys`);
+ *   - the `threadId` of any typed, NON-unknown `email_reply` decision
+ *     whose `source_signal` is an email.
+ *
+ * Untyped `unknown` records are intentionally NOT treated as
+ * summarized — they carry no real coverage and should not suppress
+ * the burst.
+ */
+export function collectCoveredEmailBurstKeys(
+  decisions: LoopDecision[],
+): Set<string> {
+  const set = new Set<string>();
+  for (const d of decisions) {
+    if (isEmailBurstDecision(d)) {
+      const keys = (d.context as Record<string, unknown> | undefined)
+        ?.burst_keys;
+      if (Array.isArray(keys)) {
+        for (const k of keys) if (typeof k === "string") set.add(k);
+      }
+      continue;
+    }
+    if (d.type === "unknown") continue;
+    if (d.type !== "email_reply") continue;
+    const src = d.source_signal;
+    if (src && isEmailBurstSignal(src)) {
+      const k = emailBurstKey(src);
+      if (k) set.add(k);
+    }
+  }
+  return set;
+}
+
+/** Find the first pending email-burst digest, or null. */
+export function findPendingEmailBurst(
+  decisions: LoopDecision[],
+): LoopDecision | null {
+  return (
+    decisions.find((d) => d.status === "pending" && isEmailBurstDecision(d)) ??
+    null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Digest builder
+// ---------------------------------------------------------------------------
+
+function burstId(): string {
+  return `email_burst_${Date.now().toString(36)}${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+}
+
+interface BuildDigestOpts {
+  /** Reuse an existing decision id when merging into a pending digest. */
+  id?: string;
+  /** Timestamp for the (re)built digest. Defaults to now. */
+  ts?: string;
+  /** Original creation timestamp, preserved across merges for provenance. */
+  createdTs?: string;
+}
+
+/** Build a bounded, read-only `email_burst_digest` decision from
+ *  items. The decision carries NO executable action — `action.kind`
+ *  is `email_burst_digest` and `params.module` marks it as the
+ *  email-bursts summary, which the web card and pet card render
+ *  read-only with a local "Mark as read". */
+export function buildEmailBurstDigest(
+  from: string,
+  fromName: string | undefined,
+  items: EmailBurstItem[],
+  opts: BuildDigestOpts = {},
+): LoopDecision {
+  const bounded = items.slice(-MAX_EMAIL_BURST_ITEMS);
+  const count = bounded.length;
+  const ts = opts.ts ?? new Date().toISOString();
+  const sender = fromName ? `${fromName} <${from}>` : from;
+  const title = `${count} email${count === 1 ? "" : "s"} from ${sender}`;
+  const dialogue = `${count} email${count === 1 ? "" : "s"} from ${sender} in the last ${Math.round(
+    BURST_WINDOW_MS / 60_000,
+  )} minutes.`;
+
+  return {
+    id: opts.id ?? burstId(),
+    ts,
+    status: "pending",
+    type: "email_burst_digest",
+    title,
+    action: {
+      kind: "email_burst_digest",
+      params: { module: EMAIL_BURSTS_MODULE, from },
+    },
+    dialogue,
+    nextStep: "Mark as read once you've caught up.",
+    context: {
+      module: EMAIL_BURSTS_MODULE,
+      from,
+      ...(fromName ? { fromName } : {}),
+      count,
+      burst_keys: bounded.map((i) => i.key),
+      thread_ids: bounded
+        .map((i) => i.threadId)
+        .filter((v): v is string => typeof v === "string"),
+      items: bounded.map((i) => ({
+        key: i.key,
+        from: i.from,
+        ...(i.fromName ? { fromName: i.fromName } : {}),
+        title: i.title,
+        ...(i.snippet ? { snippet: i.snippet } : {}),
+        ts: i.ts,
+        ...(i.threadId ? { threadId: i.threadId } : {}),
+      })),
+      why: [
+        `Grouped ${count} email${count === 1 ? "" : "s"} from ${from} into one read-only summary`,
+      ],
+      ...(opts.createdTs ? { created_ts: opts.createdTs } : {}),
+    },
+    confidence: 0.85,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation entry point
+// ---------------------------------------------------------------------------
+
+export interface EmailBurstInput {
+  /** Recent signal window (the tick already pulled these). */
+  signals: LoopSignal[];
+  /** All decisions across pending / done / dismissed buckets. */
+  decisions: LoopDecision[];
+  /** Injectable clock for deterministic tests. */
+  now?: number;
+}
+
+export interface EmailBurstAggregationResult {
+  /**
+   *  - "create" → no pending digest existed; `decision` is a fresh
+   *    card to persist via `decisions.add()`.
+   *  - "merge"  → a pending digest existed; `decision` (same id)
+   *    carries the merged items and should be written via
+   *    `decisions.update()`.
+   *  - "noop"   → nothing new to surface; `decision` is null.
+   */
+  kind: "create" | "merge" | "noop";
+  decision: LoopDecision | null;
+  /** Keys added by this aggregation pass (empty for noop). */
+  newKeys: string[];
+}
+
+/**
+ * Aggregate email bursts (>= BURST_THRESHOLD from same sender within
+ * BURST_WINDOW_MS) into a single read-only digest per sender.
+ *
+ * Pure: reads signals + existing decisions, returns an instruction
+ * for the caller to persist. Never touches the store, mail servers,
+ * or any external resource itself.
+ */
+export function aggregateEmailBursts(
+  input: EmailBurstInput,
+): EmailBurstAggregationResult {
+  const items = normalizeEmailBursts(input.signals);
+  if (items.length === 0) {
+    return { kind: "noop", decision: null, newKeys: [] };
+  }
+  const now = input.now ?? Date.now();
+  const buckets = groupBySender(items).filter((b) => isBurst(b, now));
+  if (buckets.length === 0) {
+    return { kind: "noop", decision: null, newKeys: [] };
+  }
+  // Coverage from everything EXCEPT the pending digests we'll merge
+  // into (their own keys are preserved separately below).
+  const pendingDigests = input.decisions
+    .filter((d) => d.status === "pending" && isEmailBurstDecision(d))
+    .map((d) => ({ from: fromOfDigest(d), dec: d }));
+  const others = input.decisions.filter(
+    (d) => !pendingDigests.some((p) => p.dec === d),
+  );
+  const covered = collectCoveredEmailBurstKeys(others);
+
+  // Pick the largest burst from this tick. Multi-sender bursts at
+  // once are rare; if they do happen, surfacing the largest first
+  // matches "show me the loudest signal" without flooding the user.
+  const candidate = buckets
+    .slice()
+    .sort((a, b) => b.items.length - a.items.length)[0];
+
+  const pendingDigest = pendingDigests.find(
+    (p) => p.from === candidate.from,
+  )?.dec;
+
+  const existingItems = pendingDigest ? readBurstItems(pendingDigest) : [];
+  const existingKeys = new Set(existingItems.map((i) => i.key));
+  const fresh = candidate.items.filter(
+    (i) => !covered.has(i.key) && !existingKeys.has(i.key),
+  );
+  if (fresh.length === 0 && !pendingDigest) {
+    return { kind: "noop", decision: null, newKeys: [] };
+  }
+  // If a pending digest exists but no fresh items, leave it alone.
+  if (fresh.length === 0) {
+    return { kind: "noop", decision: null, newKeys: [] };
+  }
+  const merged = pendingDigest ? [...existingItems, ...fresh] : fresh;
+  const newKeys = fresh.map((i) => i.key);
+  // Pick a friendly fromName from any item (first one wins).
+  const fromName = candidate.items.find((i) => i.fromName)?.fromName;
+
+  if (pendingDigest) {
+    const decision = buildEmailBurstDigest(candidate.from, fromName, merged, {
+      id: pendingDigest.id,
+      ts: new Date(now).toISOString(),
+      createdTs:
+        ((pendingDigest.context as Record<string, unknown> | undefined)
+          ?.created_ts as string | undefined) ?? pendingDigest.ts,
+    });
+    return { kind: "merge", decision, newKeys };
+  }
+  const decision = buildEmailBurstDigest(candidate.from, fromName, merged, {
+    ts: new Date(now).toISOString(),
+  });
+  return { kind: "create", decision, newKeys };
+}
+
+function fromOfDigest(dec: LoopDecision): string {
+  const ctx = dec.context as Record<string, unknown> | undefined;
+  const fromParam = (dec.action?.params as Record<string, unknown> | undefined)
+    ?.from;
+  if (typeof fromParam === "string" && fromParam) return fromParam;
+  if (ctx && typeof ctx.from === "string") return ctx.from;
+  return "";
+}

--- a/apps/web/lib/loop/notifications.ts
+++ b/apps/web/lib/loop/notifications.ts
@@ -1,5 +1,5 @@
 /**
- * Loop desktop-notification helper (#288).
+ * Loop desktop-notification helper (#288, SP-4).
  *
  * Filters out non-actionable records (noop, tick_summary, "0 new decisions"
  * titles, context.noop === true, context.source === "loop_tick") and only
@@ -12,9 +12,23 @@
  * handleWrap do NOT call it today; the pet watcher
  * (apps/web/src-tauri/src/pet/watcher.rs) is the canonical fan-out for
  * fresh decisions.
+ *
+ * SP-4 throttling:
+ *   - `attentionBudget.daily` (default 3) caps notifications per
+ *     user-local day. Counter persisted to `~/.openloomi/loop/attention.json`
+ *     so a server restart / config PUT doesn't lose the running count.
+ *   - P0-priority decisions bypass the budget by default; toggle via
+ *     `attentionBudget.p0BypassBudget = false`.
+ *   - `cooldown.windowSec` (default 1800 = 30 min) suppresses repeats
+ *     from the same source after a dismiss. Backed by `MuteRule.cooldown_until`
+ *     so the existing dismiss-write path produces cooldowns for free.
+ *   - Bubble is unaffected — the pet still surfaces every pending
+ *     decision via the watcher; only the OS notification is throttled.
  */
 
-import { isNoopDecision } from "./store";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { ensureDirs, ensureParent, LOOP_PATHS } from "./paths";
+import { isNoopDecision, mutes } from "./store";
 import { readPreferences } from "./preferences";
 import { sendNotification } from "@/lib/tauri";
 import type { LoopDecision } from "./types";
@@ -24,6 +38,12 @@ export interface NotificationsResult {
   sent: number;
   filtered: number;
   skippedOptOut: boolean;
+  /** P0 notifications that bypassed the daily budget. */
+  sentP0Bypass: number;
+  /** Notifications the budget suppressed (over daily cap, P0 bypass off). */
+  budgetSuppressed: number;
+  /** Notifications the per-source cooldown suppressed. */
+  cooldownSuppressed: number;
   errors: number;
 }
 
@@ -32,10 +52,144 @@ export function filterActionable(decisions: LoopDecision[]): LoopDecision[] {
   return decisions.filter((d) => !isNoopDecision(d));
 }
 
+// ---------------------------------------------------------------------------
+// Daily attention counter (SP-4)
+// ---------------------------------------------------------------------------
+
+interface AttentionState {
+  /** User-local YYYY-MM-DD the counter is anchored to. */
+  day: string;
+  count: number;
+}
+
+function readAttentionState(): AttentionState {
+  try {
+    if (!existsSync(LOOP_PATHS.attention)) return { day: "", count: 0 };
+    const raw = JSON.parse(readFileSync(LOOP_PATHS.attention, "utf8"));
+    if (
+      raw &&
+      typeof raw === "object" &&
+      typeof raw.day === "string" &&
+      typeof raw.count === "number"
+    ) {
+      return { day: raw.day, count: Math.max(0, Math.floor(raw.count)) };
+    }
+  } catch {
+    /* fall through */
+  }
+  return { day: "", count: 0 };
+}
+
+function writeAttentionState(state: AttentionState): void {
+  ensureParent(LOOP_PATHS.attention);
+  ensureDirs();
+  try {
+    writeFileSync(LOOP_PATHS.attention, JSON.stringify(state, null, 2));
+  } catch {
+    /* best effort — the budget is advisory, never block the fan-out */
+  }
+}
+
+/** Format `now` as YYYY-MM-DD in the user-local timezone (or UTC
+ *  fallback when the runtime has no Intl data). */
+export function localDayKey(now: Date = new Date()): string {
+  try {
+    // Mirror the same shape `briefTimeToCron` uses so the budget
+    // rolls over at the same wall-clock midnight the brief/wrap
+    // schedules do. Falling back to UTC keeps tests deterministic
+    // when the env has no locale data.
+    const fmt = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+    return fmt.format(now); // en-CA → YYYY-MM-DD
+  } catch {
+    return now.toISOString().slice(0, 10);
+  }
+}
+
+/** Read the current count for `today`, resetting when the stored
+ *  day doesn't match. Exported for tests. */
+export function getAttentionCount(now: Date = new Date()): number {
+  const today = localDayKey(now);
+  const state = readAttentionState();
+  if (state.day !== today) return 0;
+  return state.count;
+}
+
+/** True iff the daily cap has been reached. Pure of any side
+ *  effect; does NOT bump the counter. */
+export function isOverBudget(
+  prefs: { attentionBudget?: { daily: number; p0BypassBudget?: boolean } },
+  now: Date = new Date(),
+): boolean {
+  const budget = prefs.attentionBudget ?? { daily: 3, p0BypassBudget: true };
+  const today = localDayKey(now);
+  const state = readAttentionState();
+  if (state.day !== today) return false; // fresh day → always under
+  return state.count >= Math.max(0, Math.floor(budget.daily));
+}
+
+/** Increment the daily counter and persist. Resets the day when the
+ *  stored day doesn't match `now`. Exported for tests. */
+export function bumpAttentionCount(now: Date = new Date()): AttentionState {
+  const today = localDayKey(now);
+  const state = readAttentionState();
+  const next: AttentionState =
+    state.day === today
+      ? { day: today, count: state.count + 1 }
+      : { day: today, count: 1 };
+  writeAttentionState(next);
+  return next;
+}
+
+/** Compute the per-source mute key for a decision's notification
+ *  path. The shape mirrors `mutes.ts::muteKeyFor` for the supported
+ *  types; the bubble + card surface don't need this — the cooldown
+ *  is purely an OS-notification suppression. Returns `null` when
+ *  the decision's signal type has no stable identity (a cooldown
+ *  on "unknown" is a no-op anyway, so we just skip the gate). */
+function cooldownKeyFor(decision: LoopDecision): string | null {
+  const src = decision.source_signal;
+  if (!src) return null;
+  // The full muteKeyFor lives in store.ts and would import-cycle;
+  // replicate the email branch inline because email_burst_digest
+  // (the SP-3 hot path) is the only place we actually need it.
+  if (src.type === "email") {
+    const p = src.payload as Record<string, unknown>;
+    const raw = String(p.from ?? p.sender ?? "").trim();
+    const m = raw.match(/<([^>]+)>/);
+    const addr = (m ? m[1] : raw).toLowerCase().trim();
+    return addr ? `email:${addr}` : null;
+  }
+  return null;
+}
+
+/** True when the decision's source is in a per-source cooldown
+ *  window. Pure of any side effect; the underlying `mutes` cache
+ *  is invalidated on every dismiss write so this is always
+ *  current. */
+export function isInCooldown(
+  decision: LoopDecision,
+  now: Date = new Date(),
+): boolean {
+  const key = cooldownKeyFor(decision);
+  if (!key) return false;
+  return mutes.cooldownActive(key, now);
+}
+
 /**
  * Send desktop notifications for a batch of decisions. No-op when:
  *   - prefs.desktopNotifications is false (default), OR
  *   - all records are filtered out by isNoopDecision.
+ *
+ * SP-4: each individual send is gated by the daily budget
+ * (LoopPreferences.attentionBudget) and the per-source cooldown
+ * (MuteRule.cooldown_until). P0 priority bypasses the budget by
+ * default. The bubble is unaffected.
+ *
  * Never throws — best-effort delivery, errors are logged.
  */
 export async function notifyForDecisions(
@@ -48,21 +202,45 @@ export async function notifyForDecisions(
     sent: 0,
     filtered: decisions.length - actionable.length,
     skippedOptOut: false,
+    sentP0Bypass: 0,
+    budgetSuppressed: 0,
+    cooldownSuppressed: 0,
     errors: 0,
   };
   if (prefs.desktopNotifications === false) {
     result.skippedOptOut = true;
     return result;
   }
+  // Pre-compute the budget gate so a batch of P0+don't-care items
+  // doesn't spam the user. We snapshot once: by the time the
+  // P0-bypass branch fires, the counter has already been bumped
+  // for prior sends in this loop, so the cap is enforced
+  // cumulatively.
+  const budget = prefs.attentionBudget ?? {
+    daily: 3,
+    p0BypassBudget: true,
+  };
   for (const d of actionable) {
     try {
+      if (isInCooldown(d)) {
+        result.cooldownSuppressed++;
+        continue;
+      }
+      const isP0 = d.priority === "P0";
+      const bypass = isP0 && (budget.p0BypassBudget ?? true);
+      if (!bypass && isOverBudget(prefs)) {
+        result.budgetSuppressed++;
+        continue;
+      }
       const title = `openloomi-loop: ${d.title}`;
       const body =
         typeof d.dialogue === "string" && d.dialogue
           ? d.dialogue
           : `New pending decision (${d.type})`;
       await sendNotification(title, body);
+      bumpAttentionCount();
       result.sent++;
+      if (bypass && isP0) result.sentP0Bypass++;
     } catch (e) {
       result.errors++;
       console.error("[loop.notifications] send failed:", e);

--- a/apps/web/lib/loop/paths.ts
+++ b/apps/web/lib/loop/paths.ts
@@ -70,6 +70,15 @@ export const LOOP_PATHS = {
    * round-trip back into the Next.js server.
    */
   activationState: join(LOOP_HOME, "activation_state.json"),
+  /**
+   * SP-4 — daily OS-notification counter. Persisted separately from
+   * `config.json` so the budget write path doesn't race with
+   * `writePreferences`. Holds `{ day, count }` keyed by the
+   * user-local YYYY-MM-DD string (matches `briefTimeToCron` so the
+   * budget rolls over at the same wall-clock midnight the briefs do).
+   * Missing file → treated as `{ day: "", count: 0 }`.
+   */
+  attention: join(LOOP_HOME, "attention.json"),
 } as const;
 
 export function ensureDirs(): void {

--- a/apps/web/lib/loop/readiness.ts
+++ b/apps/web/lib/loop/readiness.ts
@@ -239,6 +239,99 @@ export function derivePriority(
 }
 
 // ---------------------------------------------------------------------------
+// Ranking (SP-1) — pure projector over a list of decisions
+// ---------------------------------------------------------------------------
+//
+// `derivePriority` is a per-decision bucketing function. The pet bubble
+// and the pet card need a *list* projection: given the current pending
+// bucket, return the same decisions in priority order so the user sees
+// the most urgent card first, not the oldest. The order is:
+//
+//   1. P0 > P1 > P2
+//   2. Ties broken by `action.params.deadlineAt` (or `start` for
+//      RSVPs) ascending — sooner deadlines float up. Missing timestamp
+//      sorts last within its bucket.
+//   3. Final tie-break by `ts` ascending — older arrivals surface first
+//      among equally-deadlined cards (stable for the FIFO-sensitive
+//      dismiss → re-surface flow).
+//
+// Pure: no clock, no IO, no store. The caller injects `now` so the
+// same projector works for the pet watcher poll loop and for unit
+// tests with a frozen clock.
+
+/** Narrow decision shape that the ranker needs to sort a pending
+ *  list. Mirrors the structural subset of `LoopDecision` the
+ *  projector actually reads. */
+export interface RankableDecision {
+  ts: string;
+  type: string;
+  action?: Pick<LoopAction, "params"> | null;
+  /** Pre-computed priority (set by `normalizeDecision`). When absent
+   *  the ranker derives it on the fly using `derivePriority(decision, now)`. */
+  priority?: LoopPriority;
+}
+
+function rankParams(d: RankableDecision): Record<string, unknown> {
+  return d.action?.params ?? {};
+}
+
+function readDeadlineMs(d: RankableDecision): number | null {
+  const p = rankParams(d);
+  const when = parseTimestamp(p.deadlineAt) ?? parseTimestamp(p.start);
+  return when?.getTime() ?? null;
+}
+
+function toRank(p: LoopPriority | undefined): number {
+  if (p === "P0") return 0;
+  if (p === "P1") return 1;
+  return 2;
+}
+
+/**
+ * Project a list of decisions into priority order. The original list
+ * is NOT mutated — the projector returns a new array. Caller-supplied
+ * `now` is forwarded to `derivePriority` for any decisions that
+ * haven't been pre-classified (legacy `priority` field absent).
+ *
+ * Sort order:
+ *   1. P0 > P1 > P2
+ *   2. Ties broken by `action.params.deadlineAt` (or `start` for
+ *      RSVPs) ascending — sooner deadlines float up. Missing
+ *      timestamp sorts last within its bucket.
+ *   3. Final tie-break by `ts` ascending — older arrivals surface
+ *      first among equally-deadlined cards.
+ */
+export function rankByPriority<T extends RankableDecision>(
+  decisions: T[],
+  now: Date = new Date(),
+): T[] {
+  const indexed = decisions.map((d) => {
+    const p = d.priority ?? derivePriority(d, now);
+    const deadline = readDeadlineMs(d);
+    return { d, p, deadline };
+  });
+  indexed.sort((a, b) => {
+    const pa = toRank(a.p);
+    const pb = toRank(b.p);
+    if (pa !== pb) return pa - pb;
+    // P0/P1/P2 tie — sooner deadline first. `null` deadline sorts
+    // AFTER a non-null deadline (so a typed-but-undated decision
+    // doesn't out-shove a dated one).
+    if (a.deadline !== b.deadline) {
+      if (a.deadline === null) return 1;
+      if (b.deadline === null) return -1;
+      return a.deadline - b.deadline;
+    }
+    // Final tie-break: `ts` ascending. Older arrivals surface first
+    // among equally-deadlined cards. ISO-8601 strings sort
+    // chronologically with plain `localeCompare`, no need to parse.
+    if (a.d.ts !== b.d.ts) return a.d.ts.localeCompare(b.d.ts);
+    return 0;
+  });
+  return indexed.map((x) => x.d);
+}
+
+// ---------------------------------------------------------------------------
 // Plain-language state for the card surface
 // ---------------------------------------------------------------------------
 

--- a/apps/web/lib/loop/store.ts
+++ b/apps/web/lib/loop/store.ts
@@ -13,6 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { ensureDirs, ensureParent, LOOP_PATHS } from "./paths";
+import { derivePriority, rankByPriority } from "./readiness";
 import type {
   DecisionStatus,
   DecisionType,
@@ -89,8 +90,15 @@ function appendJsonl(p: string, obj: unknown): void {
 // payload, run-prompt builder, web UI) sees one consistent shape regardless
 // of how the decision was originally emitted. Mutates and returns the same
 // object — callers can chain or assign. Idempotent: no-op when already nested.
+//
+// SP-1: also stamps `context.priority` (and the top-level `dec.priority`
+// mirror) via `readiness.ts::derivePriority`. The Rust watcher reads
+// `context.priority` verbatim to render the chip; the TS side reads
+// either field, preferring the top-level when present. `dec.priority`
+// is set whenever `derivePriority` runs, so the two stay in lockstep.
 function normalizeDecision(
   dec: LoopDecision | null | undefined,
+  now: Date = new Date(),
 ): LoopDecision | null | undefined {
   if (!dec || typeof dec !== "object") return dec;
   if (!dec.context || typeof dec.context !== "object") dec.context = {};
@@ -107,6 +115,25 @@ function normalizeDecision(
       ctx[k] = bucket;
       delete (dec as unknown as Record<string, unknown>)[k];
     }
+  }
+  // SP-1: compute the priority once and persist it under `context.priority`
+  // (Rust source of truth) AND mirror at the top level (TS consumers).
+  // The Rust watcher reads `context.priority` via `dec_priority(d)`; the
+  // pet bubble + dashboard both rely on the persisted value, so a record
+  // missing it would silently fall back to "p2" — which is the safer
+  // default but masks the real ranking. The dual-write keeps both worlds
+  // happy without recomputing on every read.
+  if (ctx.priority === undefined) {
+    const computed = derivePriority(
+      dec as unknown as { type: string; action: LoopDecision["action"] },
+      now,
+    );
+    ctx.priority = computed;
+    (dec as unknown as Record<string, unknown>).priority = computed;
+  } else if (dec.priority === undefined) {
+    // Legacy record that already has `context.priority` (written by an
+    // earlier patch or the migration) but no top-level mirror. Sync up.
+    dec.priority = ctx.priority as LoopDecision["priority"];
   }
   return dec;
 }
@@ -218,7 +245,15 @@ export function isNoopDecision(input: {
 
 function readDecisions(): LoopDecisionBuckets {
   ensureDirs();
-  const d = readJson<LoopDecisionBuckets>(LOOP_PATHS.decisions, emptyBuckets());
+  const raw = readJson<LoopDecisionBuckets & { version?: number }>(
+    LOOP_PATHS.decisions,
+    emptyBuckets(),
+  );
+  const d: LoopDecisionBuckets = {
+    pending: Array.isArray(raw.pending) ? raw.pending : [],
+    done: Array.isArray(raw.done) ? raw.done : [],
+    dismissed: Array.isArray(raw.dismissed) ? raw.dismissed : [],
+  };
   for (const bucket of ["pending", "done", "dismissed"] as const) {
     if (!Array.isArray(d[bucket])) d[bucket] = [];
     for (const dec of d[bucket]) normalizeDecision(dec);
@@ -252,16 +287,39 @@ function readDecisions(): LoopDecisionBuckets {
     d.pending = survivors;
     d.dismissed = [...migrated, ...d.dismissed];
     trimBucket(d.dismissed);
-    writeDecisions(d);
     log(
       `[decisions.read] migrated ${migrated.length} non-actionable pending card(s) → dismissed`,
+    );
+  }
+  // SP-1 — one-shot backfill of `context.priority` (and top-level
+  // `dec.priority` mirror) for legacy rows. `normalizeDecision` above
+  // already stamped priority for every record on the first read
+  // after this gate fires; the only question is whether to persist
+  // the backfill or rely on the read-time computation.
+  //
+  // Persist once, gate by `version: 2`. Without the gate, every poll
+  // would re-write the file (mtime churn → watcher wakes → re-write)
+  // because `normalizeDecision` mutates in place. The Rust watcher
+  // depends on mtime/contents-based transition diffs to drive its
+  // `loop:state` / `loop:decision` emissions; if the backfill re-wrote
+  // the file indefinitely, the bubble would re-fire on every poll.
+  // Once `version: 2` lands, future reads see the gate and no-op.
+  if ((raw as { version?: number }).version !== 2) {
+    writeDecisions(d);
+    log(
+      `[decisions.read] stamped version:2 — SP-1 priority backfill persisted`,
     );
   }
   return d;
 }
 
 function writeDecisions(d: LoopDecisionBuckets): void {
-  writeJsonAtomic(LOOP_PATHS.decisions, d);
+  // SP-1 — stamp `version: 2` on every write so the readDecisions
+  // migration gate is sticky. The migration fires once on the first
+  // read after upgrade; every subsequent write keeps the flag set,
+  // so the gate is idempotent.
+  const stamped = { version: 2 as const, ...d };
+  writeJsonAtomic(LOOP_PATHS.decisions, stamped);
 }
 
 function trimBucket(
@@ -465,21 +523,25 @@ const MAX_MUTES = 1000;
 /** Decision types eligible for auto-muting on dismiss. brief / wrap are
  *  explicitly excluded — those are scheduled and must resurface each day.
  *  `quiet_digest` (#316) is INCLUDED — a digest the user dismisses should
- *  not auto-resurface on the next tick. */
-export const MUTABLE_DECISION_TYPES: ReadonlySet<DecisionType> = new Set([
-  "rsvp",
-  "email_reply",
-  "im_reply",
-  "review_pr",
-  "todo",
-  "deadline_reminder",
-  "release_plan",
-  "requirement_synthesis",
-  "linear_review",
-  "contact_update",
-  "doc_update",
-  "quiet_digest",
-]);
+ *  not auto-resurface on the next tick. `email_burst_digest` (SP-3) is
+ *  also INCLUDED — a burst digest the user dismisses should suppress the
+ *  next burst from the same sender, paired with the SP-4 cooldown. */
+export const MUTABLE_DECISION_TYPES: ReadonlySet<DecisionType> =
+  new Set<DecisionType>([
+    "rsvp",
+    "email_reply",
+    "im_reply",
+    "review_pr",
+    "todo",
+    "deadline_reminder",
+    "release_plan",
+    "requirement_synthesis",
+    "linear_review",
+    "contact_update",
+    "doc_update",
+    "quiet_digest",
+    "email_burst_digest",
+  ]);
 
 function emptyMutes(): LoopMutes {
   return { version: 1, rules: [], keys: [] };
@@ -631,19 +693,69 @@ export const mutes = {
   has(key: string): boolean {
     return readMutes().keys.includes(key);
   },
+  /**
+   * SP-4 — true when the rule for `key` carries a `cooldown_until`
+   * strictly in the future. Returns `false` for rules without
+   * `cooldown_until` (so the existing mute behaviour is preserved
+   * bit-for-bit — cooldowns are additive, not replacement).
+   *
+   * Used by `notifyForDecisions` to suppress the OS-notification
+   * fan-out for a source the user just dismissed, while still
+   * letting the bubble surface the underlying decision.
+   */
+  cooldownActive(key: string, now: Date = new Date()): boolean {
+    const rule = readMutes().rules.find((r) => r.key === key);
+    if (!rule || !rule.cooldown_until) return false;
+    const until = Date.parse(rule.cooldown_until);
+    if (Number.isNaN(until)) return false;
+    return until > now.getTime();
+  },
   /** List rules, newest first. */
   list(): MuteRule[] {
     return [...readMutes().rules].sort((a, b) =>
       b.createdAt.localeCompare(a.createdAt),
     );
   },
-  /** Idempotent add — same key returns the existing rule unchanged.
-   *  Caps `rules.length` at `MAX_MUTES` by dropping the oldest half of
-   *  unique-key entries when the limit is exceeded. */
+  /**
+   * Idempotent add — same key returns the existing rule unchanged.
+   * Caps `rules.length` at `MAX_MUTES` by dropping the oldest half of
+   * unique-key entries when the limit is exceeded.
+   *
+   * SP-4: accepts an optional `cooldown_until` ISO string. When set,
+   * the rule is persisted with the cooldown timestamp and the
+   * `notifyForDecisions` fan-out consults `cooldownActive` to
+   * throttle the OS-notification path. A rule carrying a past
+   * `cooldown_until` degrades to a regular mute (still blocks per
+   * `mutes.has`). Callers should pass an ISO timestamp strictly in
+   * the future — the function does not validate that the value is
+   * sensible, so a misconfigured cooldown_until that's already past
+   * simply no-ops.
+   */
   add(rule: Omit<MuteRule, "createdAt"> & { createdAt?: string }): MuteRule {
     const cur = readMutes();
     const existing = cur.rules.find((r) => r.key === rule.key);
     if (existing) {
+      // Refresh the cooldown_until if the caller is bumping an
+      // existing rule. This is the "second dismiss within an hour
+      // extends the window" semantics — without the refresh, a
+      // second dismiss would land on the same already-existing rule
+      // and the cooldown wouldn't extend.
+      if (
+        rule.cooldown_until &&
+        rule.cooldown_until !== existing.cooldown_until
+      ) {
+        const updated: MuteRule = {
+          ...existing,
+          cooldown_until: rule.cooldown_until,
+        };
+        const rules = cur.rules.map((r) => (r.key === rule.key ? updated : r));
+        writeMutes({
+          version: 1,
+          rules,
+          keys: rules.map((r) => r.key),
+        });
+        return updated;
+      }
       mutesCache = null;
       return existing;
     }
@@ -653,6 +765,7 @@ export const mutes = {
       scope: rule.scope,
       createdAt,
       ...(rule.source ? { source: rule.source } : {}),
+      ...(rule.cooldown_until ? { cooldown_until: rule.cooldown_until } : {}),
     };
     const rules = [...cur.rules, next];
     if (rules.length > MAX_MUTES) {

--- a/apps/web/lib/loop/store.ts
+++ b/apps/web/lib/loop/store.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { ensureDirs, ensureParent, LOOP_PATHS } from "./paths";
-import { derivePriority, rankByPriority } from "./readiness";
+import { derivePriority } from "./readiness";
 import type {
   DecisionStatus,
   DecisionType,

--- a/apps/web/lib/loop/tick.ts
+++ b/apps/web/lib/loop/tick.ts
@@ -264,6 +264,53 @@ async function runAgentic(opts: TickOptions): Promise<LoopTickResult> {
     );
   }
 
+  // SP-3 — aggregate email bursts from the same sender into ONE
+  // read-only `email_burst_digest` per tick. Runs over the same
+  // recent signal window + current decision buckets as the GitHub
+  // digest above so it can dedupe cross-source, skip threadIds
+  // already covered by a typed `email_reply` decision or a prior
+  // digest, and merge new items into an existing pending digest
+  // instead of spawning a second summary card. Best-effort: a
+  // failure here must not poison the tick.
+  try {
+    const { signals } = await import("./store");
+    const { aggregateEmailBursts } = await import("./email-bursts");
+    const sinceIso = new Date(
+      Date.now() - (opts.sinceMs ?? TICK_LOOKBACK_MS),
+    ).toISOString();
+    const recentSignals = signals.list({ since: sinceIso, limit: 500 });
+    const allDecisions = decisions.list();
+    const agg = aggregateEmailBursts({
+      signals: recentSignals,
+      decisions: allDecisions,
+    });
+    if (agg.kind === "create" && agg.decision) {
+      const added = decisions.add(agg.decision);
+      if (added) {
+        log(
+          `tick (agentic): created email burst digest ${added.id} (${agg.newKeys.length} item(s))`,
+        );
+      }
+    } else if (agg.kind === "merge" && agg.decision) {
+      decisions.update(agg.decision.id, {
+        title: agg.decision.title,
+        dialogue: agg.decision.dialogue,
+        nextStep: agg.decision.nextStep,
+        context: agg.decision.context,
+        ts: agg.decision.ts,
+      });
+      log(
+        `tick (agentic): merged ${agg.newKeys.length} item(s) into email burst digest ${agg.decision.id}`,
+      );
+    }
+  } catch (e) {
+    log(
+      `tick (agentic): email burst aggregation failed: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+
   // Derive the surfaced count + returned decisions from ACTUAL persisted
   // pending state (post-aggregation) so rejected `unknown` records are not
   // reported as surfaced and the freshly-created digest is included.

--- a/apps/web/lib/loop/types.ts
+++ b/apps/web/lib/loop/types.ts
@@ -28,6 +28,7 @@ export type DecisionType =
   | "noop" // NEW — non-actionable; filtered at decisions.add()
   | "tick_summary" // NEW — explicit per-tick summary; filtered at decisions.add()
   | "quiet_digest" // NEW — filler content for empty brief/wrap days; read-only
+  | "email_burst_digest" // NEW (SP-3) — burst of N emails from same sender
   | "unknown";
 
 export type DecisionStatus = "pending" | "done" | "dismissed";
@@ -47,6 +48,7 @@ export type ActionKind =
   | "brief"
   | "wrap"
   | "quiet_digest" // NEW — filler content for empty brief/wrap days
+  | "email_burst_digest" // NEW (SP-3) — burst digest action kind
   | string; // open form for agent-emitted kinds
 
 export interface LoopAction {
@@ -200,6 +202,22 @@ export interface LoopDecision {
    */
   relationship?: DecisionRelationship;
   source_signal?: LoopSignal;
+  /**
+   * SP-1 — pre-computed card-display priority, set by
+   * `store.ts::normalizeDecision` via `readiness.ts::derivePriority`.
+   * Independent of `confidence` (per #359) and independent of
+   * `readiness.status` — a `not_actionable` decision is P2 regardless
+   * of how urgent its source signal looked. Persisted under
+   * `context.priority` for the Rust watcher to read verbatim, and
+   * mirrored at the top level for clean TS consumers. When absent
+   * (legacy rows pre-SP-1) consumers should re-derive via
+   * `readiness.ts::derivePriority(decision, now)`.
+   *
+   * Typed inline (not as `LoopPriority` from `./readiness`) to avoid
+   * the `types ↔ readiness` circular import — the union is identical
+   * and structurally compatible.
+   */
+  priority?: "P0" | "P1" | "P2";
   result?: unknown;
   completed_at?: string;
   /** Card-flavored dialogue/next step for the pet and web UI. */
@@ -351,6 +369,47 @@ export interface LoopPreferences {
    */
   cronCompletionPetNotify?: boolean;
   /**
+   * SP-4 — daily OS-notification budget. Caps the number of native
+   * desktop notifications fired by `notifyForDecisions` per
+   * user-local day, so a slack flood can't bury the user.
+   *
+   * `daily`         — max notifications per day. Default `3`.
+   * `p0BypassBudget`— when `true` (default), P0-priority decisions
+   *                   always notify regardless of the daily count.
+   *                   Set to `false` to enforce the budget
+   *                   uniformly.
+   *
+   * Lives on `LoopPreferences` (next to `desktopNotifications`,
+   * which gates the same fan-out) rather than as a new top-level
+   * setting, so the same PUT body that opts the user in also
+   * shapes how often they want to be pestered. The counter itself
+   * is persisted to `~/.openloomi/loop/attention.json` (NOT
+   * `config.json`) to avoid a write-race on the preferences path.
+   */
+  attentionBudget?: {
+    daily: number;
+    p0BypassBudget?: boolean;
+  };
+  /**
+   * SP-4 — per-source cooldown. When a user dismisses a notification,
+   * the dismiss writes a `cooldown_until` onto the matching mute
+   * rule. `notifyForDecisions` consults this window before firing
+   * another OS notification for the same source, suppressing
+   * repeated pings of an action the user already swiped away.
+   *
+   * `windowSec` — seconds to suppress after a dismiss. Default
+   *               `1800` (30 min). Set to `0` to disable.
+   *
+   * Shared storage with `MuteRule` so dismiss-driven cooldowns
+   * inherit the existing on-disk shape + cache-invalidation
+   * discipline. Cooldown is additive: it does NOT replace
+   * `mutes.has()` — a muted rule still blocks; a cooldown-only
+   * rule just throttles the next nudge.
+   */
+  cooldown?: {
+    windowSec: number;
+  };
+  /**
    * When the brief or wrap snapshot is empty (no surfaced items /
    * highlights), skip the templated "nothing to do" card entirely.
    * Snapshot still gets persisted to `~/.openloomi/loop/{brief,wrap}.json`
@@ -398,6 +457,16 @@ export interface MuteRule {
   createdAt: string;
   /** Provenance — which dismiss produced this rule. */
   source?: { decisionId?: string; signalType?: SignalType };
+  /**
+   * SP-4 — optional ISO timestamp until which the rule is treated
+   * as "in cooldown" by `mutes.cooldownActive(key, now)`. Distinct
+   * from the rule being absent: a rule with `cooldown_until` in
+   * the future still allows the decision to land in `pending` (the
+   * pet bubble surfaces it) but suppresses the OS-notification
+   * fan-out for the same source. After `cooldown_until` passes the
+   * rule degrades to a regular mute (still blocks per `mutes.has`).
+   */
+  cooldown_until?: string;
 }
 
 export interface LoopMutes {
@@ -419,6 +488,20 @@ export const DEFAULT_LOOP_PREFERENCES: LoopPreferences = {
   cronCompletionPetNotify: false, // NEW — opt-in transient pet bubble
   quietWhenEmpty: true, // NEW (#316) — opt-out via prefs
   quietDayFiller: "none", // NEW (#316) — opt into a module
+  // SP-4 — daily OS-notification budget. Three notifications per
+  // user-local day is enough for a typical "morning brief + a
+  // urgent PR + an evening wrap" flow; anything beyond that almost
+  // always indicates either a stuck watcher or a sender that
+  // shouldn't have hit Loop at all. P0 still bypasses by default
+  // so a real urgent signal (RSVP in <1h, hard deadline) never
+  // gets dropped.
+  attentionBudget: { daily: 3, p0BypassBudget: true },
+  // SP-4 — 30-minute per-source cooldown after a dismiss. Long
+  // enough to ride out a "boss said something, then said it again
+  // in a thread reply" pattern, short enough that an actually
+  // distinct follow-up from the same sender still reaches the
+  // user before EOD.
+  cooldown: { windowSec: 1800 },
 };
 
 /**

--- a/apps/web/src-tauri/src/pet/watcher.rs
+++ b/apps/web/src-tauri/src/pet/watcher.rs
@@ -225,7 +225,15 @@ fn watch_loop(app: &AppHandle, setup_emitted: std::sync::Arc<std::sync::Mutex<bo
             .filter_map(|d| d.completed_at.clone().or(d.created_at.clone()))
             .max();
         let needs_user = snap.pending.iter().any(|d| d.needs_user.unwrap_or(false));
-        let top_pending_id = snap.pending.first().and_then(|d| d.id.clone());
+        // SP-1 — project `pending` through `rank_pending` once so the
+        // bubble/card surfaces the most-urgent card, not the FIFO
+        // first. The same ranked slice backs the top-id snapshot, the
+        // `loop:decision` emit, and the top-5 pending list. We clone
+        // to a `Vec<&DecItem>` (cheap — pointer array) because the
+        // rest of the watch loop needs to keep using `snap` for the
+        // terminal-transition diff and other reads.
+        let ranked = rank_pending(&snap.pending);
+        let top_pending_id = ranked.first().and_then(|d| d.id.clone());
         // Snapshot the current pending ids so the transition-diff below
         // can compare against the previous poll. We clone rather than
         // borrow because `snap.pending` is moved through several helpers
@@ -310,7 +318,7 @@ fn watch_loop(app: &AppHandle, setup_emitted: std::sync::Arc<std::sync::Mutex<bo
         // (so the user immediately sees the decision + connector dots)
         // and otherwise leave its visibility alone (the × / click
         // handlers drive subsequent toggles).
-        if let Some(top) = snap.pending.first() {
+        if let Some(top) = ranked.first() {
             let decision_payload = build_decision_payload(top);
             let _ = app.emit_to(PET_BUBBLE_LABEL, "loop:decision", decision_payload.clone());
             let _ = app.emit_to(PET_CARD_LABEL, "loop:decision", decision_payload);
@@ -400,8 +408,11 @@ fn watch_loop(app: &AppHandle, setup_emitted: std::sync::Arc<std::sync::Mutex<bo
         // (Form 1) and any layout that wants to render a queue can
         // subscribe. Top 5 entries is plenty for a 360×420 window —
         // the user can dismiss / open to see more in the dashboard.
+        // SP-1 — slice the *ranked* projection, not the raw FIFO
+        // `snap.pending`, so the top-5 list mirrors the bubble's
+        // #1 (P0 surfaces first).
         let pending_list = serde_json::json!({
-            "items": snap.pending.iter().take(5).map(|d| {
+            "items": ranked.iter().take(5).map(|d| {
                 serde_json::json!({
                     "id": d.id,
                     "type": d.r#type,
@@ -431,6 +442,63 @@ fn should_emit_update(
     data_changed || review_changed || last_state != Some(next_state)
 }
 
+/// Resolve the card-display priority for a single decision.
+///
+/// SP-2 contract: priority is TS-precomputed and persisted at
+/// `context.priority` (set by `lib/loop/store.ts::normalizeDecision`
+/// using `readiness.ts::derivePriority`). The pet/bubble/card chip
+/// reads that precomputed value, NOT `confidence` — the historical
+/// `confidence → priority` mapping in this file violated the
+/// `derivePriority — never derived from confidence` invariant and
+/// made `quiet_digest` (confidence 0.9) surface as p0. The TS layer
+/// is the single source of truth; Rust is a pure reader.
+///
+/// Returns the literal "p0" | "p1" | "p2" string for direct
+/// `serde_json::json!({...})` interpolation. Falls back to "p2"
+/// when the field is missing, malformed, or carries an unknown
+/// value — under-prioritising a card the TS layer never classified
+/// is the safer failure mode (the user can still open the card and
+/// see it in the queue).
+fn dec_priority(d: &DecItem) -> &'static str {
+    let raw = d
+        .context
+        .as_ref()
+        .and_then(|c| c.extra.get("priority"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_ascii_lowercase());
+    match raw.as_deref() {
+        Some("p0") => "p0",
+        Some("p1") => "p1",
+        _ => "p2",
+    }
+}
+
+/// Numeric rank used by the `rank_pending` projector: p0=0 (top),
+/// p1=1, p2=2 (default fallback). The watcher sorts by this rank
+/// so the bubble surfaces the most urgent card, not the oldest
+/// arrival — see SP-1.
+fn priority_rank(d: &DecItem) -> u8 {
+    match dec_priority(d) {
+        "p0" => 0,
+        "p1" => 1,
+        _ => 2,
+    }
+}
+
+/// Project `snap.pending` into priority order. SP-1 contract: the
+/// pet bubble + card must show the most-urgent pending card, not
+/// the FIFO first. TS pre-computes the priority and persists it;
+/// Rust re-projects the snapshot on every poll (2 s, cheap — just
+/// pointer Vec<u8>+&DecItem). Returns borrowed references so the
+/// caller can keep using `snap` for the rest of the watch loop
+/// without cloning every item.
+fn rank_pending(items: &[DecItem]) -> Vec<&DecItem> {
+    let mut indexed: Vec<(u8, &DecItem)> =
+        items.iter().map(|d| (priority_rank(d), d)).collect();
+    indexed.sort_by_key(|(rank, _)| *rank);
+    indexed.into_iter().map(|(_, d)| d).collect()
+}
+
 /// Build the `loop:decision` payload that the bubble + card webviews
 /// listen for. Mirrors the shape consumed by `loomi-bubble.html` /
 /// `loomi-card.html` (id, type, title, dialogue, priority, confidence,
@@ -441,14 +509,11 @@ fn should_emit_update(
 /// "no payload yet" from "still pending". Note: `confidence` is
 /// emitted as-is (`Option<f32>` → `null` if missing) so the card's
 /// meta-node row can render `Math.round(c * 100) + "%"` directly;
-/// priority is derived from the same value upstream so card and
-/// payload stay consistent.
+/// priority comes from `context.priority` (TS-precomputed via
+/// `readiness.ts::derivePriority`) so the chip and the dashboard's
+/// `derivePriority(decision)` always render the same bucket.
 fn build_decision_payload(d: &DecItem) -> serde_json::Value {
-    let priority = match d.confidence {
-        Some(c) if c >= 0.85 => "p0",
-        Some(c) if c >= 0.75 => "p1",
-        _ => "p2",
-    };
+    let priority = dec_priority(d);
     let (source, source_type, source_ts) = match d.source_signal.as_ref() {
         Some(s) => (Some(s.source.clone()), Some(s.r#type.clone()), s.ts.clone()),
         None => (None, None, None),
@@ -1483,10 +1548,11 @@ mod tests {
         // The card's meta-node row renders `Math.round(confidence * 100) +
         // "%"`. The top-pending emit (`loop:decision`) is the only event
         // that drives that row, so it must carry confidence too — the
-        // priority chip is derived from the same value upstream so the
-        // raw number on the card matches the chip. Without this test the
-        // field was forgotten and the card rendered "—" even for a
-        // decision with confidence=0.92 (bug surfaced via the
+        // priority chip is TS-precomputed (see `readiness.ts::derivePriority`)
+        // and stored at `context.priority`, so the raw number on the card
+        // matches the chip independently. Without this test the
+        // `confidence` field was forgotten and the card rendered "—"
+        // even for a decision with confidence=0.92 (bug surfaced via the
         // birthday_wish demo screenshot, 2026-07-14).
         let d = dec_with_id("dec_y");
         let v = build_decision_payload(&d);
@@ -1501,17 +1567,193 @@ mod tests {
             (0.0..=1.0).contains(&conf),
             "confidence must be in [0,1]; got {conf}"
         );
-        // The priority field is derived from confidence upstream, so the
-        // two values must agree on the chip bucket (0.92 → p0).
+        // SP-2: priority is TS-precomputed and persisted at
+        // `context.priority`. `build_decision_payload` reads that
+        // value verbatim, so a decision with no priority on disk
+        // falls back to p2 (the safer default — under-prioritising a
+        // card the TS layer never classified is preferable to the
+        // historical confidence-bucket mapping, which labelled
+        // `quiet_digest` (confidence 0.9, readiness=not_actionable)
+        // as p0). The dec_with_id helper above doesn't stamp
+        // `context.priority`, so the expected bucket is the p2
+        // fallback.
         let p = v.get("priority").and_then(|s| s.as_str()).unwrap_or("");
-        let expected = if conf >= 0.85 {
-            "p0"
-        } else if conf >= 0.75 {
-            "p1"
-        } else {
-            "p2"
+        assert_eq!(
+            p, "p2",
+            "priority must derive from context.priority (defaulting to p2 when absent)"
+        );
+    }
+
+    #[test]
+    fn build_decision_payload_reads_priority_from_context() {
+        // SP-2 contract: the chip on the pet/bubble/card always
+        // matches the TS-computed `derivePriority(decision)`. A
+        // decision with a high-confidence `quiet_digest` (which
+        // `readiness.ts` would resolve to P2 because readiness is
+        // `not_actionable`) MUST surface as p2 even though
+        // `confidence: 0.92` would have hit the old confidence
+        // bucket. This is the regression test for the priority
+        // invariant the old `match d.confidence` block violated.
+        let mut extra = serde_json::Map::new();
+        extra.insert("priority".into(), serde_json::json!("p0"));
+        extra.insert(
+            "deadlineAt".into(),
+            serde_json::json!("2030-01-01T00:00:00Z"),
+        );
+        let d_low_conf_p0 = DecItem {
+            id: Some("dec_low_conf_p0".into()),
+            r#type: Some("deadline_reminder".into()),
+            title: Some("Low confidence but urgent".into()),
+            dialogue: None,
+            // confidence 0.5 would have hit the p2 bucket under the
+            // old code; with context.priority = "p0" the new code
+            // honours the TS-computed value.
+            confidence: Some(0.5),
+            source_signal: None,
+            action: None,
+            context: Some(DecContext {
+                why: None,
+                extra,
+            }),
+            created_at: None,
+            completed_at: None,
+            needs_user: None,
         };
-        assert_eq!(p, expected, "priority must match confidence bucket");
+        let v = build_decision_payload(&d_low_conf_p0);
+        assert_eq!(
+            v.get("priority").and_then(|s| s.as_str()),
+            Some("p0"),
+            "context.priority must override any confidence-based bucket"
+        );
+
+        // Symmetric case: a high-confidence quiet_digest with
+        // context.priority = "p2" (readiness=not_actionable →
+        // derivePriority always P2) must surface as p2.
+        let mut extra2 = serde_json::Map::new();
+        extra2.insert("priority".into(), serde_json::json!("p2"));
+        let d_high_conf_p2 = DecItem {
+            id: Some("dec_quiet_digest".into()),
+            r#type: Some("quiet_digest".into()),
+            title: Some("AI news digest".into()),
+            dialogue: None,
+            confidence: Some(0.92),
+            source_signal: None,
+            action: None,
+            context: Some(DecContext {
+                why: None,
+                extra: extra2,
+            }),
+            created_at: None,
+            completed_at: None,
+            needs_user: None,
+        };
+        let v2 = build_decision_payload(&d_high_conf_p2);
+        assert_eq!(
+            v2.get("priority").and_then(|s| s.as_str()),
+            Some("p2"),
+            "quiet_digest (readiness=not_actionable) must always be p2"
+        );
+
+        // Garbage / missing values fall back to p2.
+        let mut extra3 = serde_json::Map::new();
+        extra3.insert("priority".into(), serde_json::json!("banana"));
+        let d_garbage = DecItem {
+            id: Some("dec_garbage".into()),
+            r#type: Some("todo".into()),
+            title: Some("garbage".into()),
+            dialogue: None,
+            confidence: Some(0.9),
+            source_signal: None,
+            action: None,
+            context: Some(DecContext {
+                why: None,
+                extra: extra3,
+            }),
+            created_at: None,
+            completed_at: None,
+            needs_user: None,
+        };
+        assert_eq!(
+            build_decision_payload(&d_garbage)
+                .get("priority")
+                .and_then(|s| s.as_str()),
+            Some("p2"),
+            "unknown priority values must fall back to p2"
+        );
+    }
+
+    #[test]
+    fn rank_pending_orders_by_priority_then_keeps_diversity() {
+        // SP-1 contract: the bubble + card must surface the most
+        // urgent pending card, not the FIFO first. `rank_pending`
+        // is the only sanctioned projection — every read of
+        // `snap.pending.first()` / `snap.pending.iter().take(5)`
+        // funnels through this helper.
+        let mk = |id: &str, prio: &str, conf: f32| DecItem {
+            id: Some(id.into()),
+            r#type: Some("todo".into()),
+            title: Some(id.into()),
+            dialogue: None,
+            confidence: Some(conf),
+            source_signal: None,
+            action: None,
+            context: Some(DecContext {
+                why: None,
+                extra: {
+                    let mut m = serde_json::Map::new();
+                    m.insert("priority".into(), serde_json::json!(prio));
+                    m
+                },
+            }),
+            created_at: None,
+            completed_at: None,
+            needs_user: None,
+        };
+        // P2 oldest, P1 middle, P0 newest — rank should put P0 first.
+        let items = vec![
+            mk("dec_p2", "p2", 0.9),
+            mk("dec_p1", "p1", 0.8),
+            mk("dec_p0", "p0", 0.7),
+        ];
+        let ranked = rank_pending(&items);
+        let ids: Vec<&str> = ranked.iter().filter_map(|d| d.id.as_deref()).collect();
+        assert_eq!(ids, vec!["dec_p0", "dec_p1", "dec_p2"]);
+
+        // Two P0 + one P2: P0s first (stable order preserved among
+        // the tied bucket), P2 last.
+        let items2 = vec![
+            mk("dec_p2_again", "p2", 0.9),
+            mk("dec_p0_a", "p0", 0.7),
+            mk("dec_p0_b", "p0", 0.7),
+        ];
+        let ranked2 = rank_pending(&items2);
+        let ids2: Vec<&str> = ranked2.iter().filter_map(|d| d.id.as_deref()).collect();
+        assert_eq!(ids2, vec!["dec_p0_a", "dec_p0_b", "dec_p2_again"]);
+
+        // Missing / invalid priority falls back to p2.
+        let items3 = vec![
+            DecItem {
+                id: Some("dec_unclassified".into()),
+                r#type: Some("todo".into()),
+                title: Some("unclassified".into()),
+                dialogue: None,
+                confidence: Some(0.5),
+                source_signal: None,
+                action: None,
+                context: None,
+                created_at: None,
+                completed_at: None,
+                needs_user: None,
+            },
+            mk("dec_p0_only", "p0", 0.7),
+        ];
+        let ranked3 = rank_pending(&items3);
+        let ids3: Vec<&str> = ranked3.iter().filter_map(|d| d.id.as_deref()).collect();
+        assert_eq!(ids3, vec!["dec_p0_only", "dec_unclassified"]);
+
+        // Empty input → empty output.
+        let empty: Vec<DecItem> = vec![];
+        assert!(rank_pending(&empty).is_empty());
     }
 
     #[test]

--- a/apps/web/tests/unit/loop/email-bursts.test.ts
+++ b/apps/web/tests/unit/loop/email-bursts.test.ts
@@ -21,7 +21,6 @@
 import { describe, expect, it } from "vitest";
 import {
   BURST_THRESHOLD,
-  BURST_WINDOW_MS,
   EMAIL_BURSTS_MODULE,
   MAX_EMAIL_BURST_ITEMS,
   aggregateEmailBursts,
@@ -227,8 +226,11 @@ describe("isEmailBurstDecision + collectCoveredEmailBurstKeys", () => {
     });
     const typed = typedDecision(sig1);
     const covered = collectCoveredEmailBurstKeys([typed]);
-    expect(covered.has(emailBurstKey(sig1)!)).toBe(true);
-    expect(covered.has(emailBurstKey(sig2)!)).toBe(false);
+    const k1 = emailBurstKey(sig1);
+    const k2 = emailBurstKey(sig2);
+    if (!k1 || !k2) throw new Error("expected non-null keys");
+    expect(covered.has(k1)).toBe(true);
+    expect(covered.has(k2)).toBe(false);
   });
 
   it("does not treat unknown decisions as covered", () => {
@@ -243,7 +245,9 @@ describe("isEmailBurstDecision + collectCoveredEmailBurstKeys", () => {
       source_signal: sig1,
     };
     const covered = collectCoveredEmailBurstKeys([unknown]);
-    expect(covered.has(emailBurstKey(sig1)!)).toBe(false);
+    const k = emailBurstKey(sig1);
+    if (!k) throw new Error("expected non-null key");
+    expect(covered.has(k)).toBe(false);
   });
 });
 
@@ -331,18 +335,17 @@ describe("aggregateEmailBursts", () => {
       now: NOW,
     });
     expect(res.kind).toBe("create");
-    expect(res.decision).not.toBeNull();
-    expect(res.decision!.type).toBe("email_burst_digest");
-    expect(res.decision!.title).toMatch(/^5 emails from /);
-    expect((res.decision!.context as { from: string }).from).toBe(
+    if (res.kind !== "create" || !res.decision) {
+      throw new Error("expected create kind with non-null decision");
+    }
+    const digest = res.decision;
+    expect(digest.type).toBe("email_burst_digest");
+    expect(digest.title).toMatch(/^5 emails from /);
+    expect((digest.context as { from: string }).from).toBe(
       "alice@example.com",
     );
-    expect((res.decision!.context as { fromName: string }).fromName).toBe(
-      "Alice",
-    );
-    expect((res.decision!.context as { count: number }).count).toBe(
-      BURST_THRESHOLD,
-    );
+    expect((digest.context as { fromName: string }).fromName).toBe("Alice");
+    expect((digest.context as { count: number }).count).toBe(BURST_THRESHOLD);
     expect(res.newKeys).toHaveLength(BURST_THRESHOLD);
   });
 
@@ -385,7 +388,10 @@ describe("aggregateEmailBursts", () => {
       now: NOW,
     });
     expect(res.kind).toBe("create");
-    expect(res.decision!.title).toMatch(/alice/);
+    if (res.kind !== "create" || !res.decision) {
+      throw new Error("expected create kind with non-null decision");
+    }
+    expect(res.decision.title).toMatch(/alice/);
   });
 
   it("excludes keys already covered by a typed email_reply decision", () => {
@@ -398,7 +404,10 @@ describe("aggregateEmailBursts", () => {
       now: NOW,
     });
     expect(res.kind).toBe("create");
-    expect((res.decision!.context as { count: number }).count).toBe(
+    if (res.kind !== "create" || !res.decision) {
+      throw new Error("expected create kind with non-null decision");
+    }
+    expect((res.decision.context as { count: number }).count).toBe(
       BURST_THRESHOLD - 2,
     );
     expect(res.newKeys).toHaveLength(BURST_THRESHOLD - 2);
@@ -409,6 +418,7 @@ describe("aggregateEmailBursts", () => {
       "alice@example.com",
       "Alice",
       fiveFromAlice().map((s) => ({
+        // biome-ignore lint/style/noNonNullAssertion: test fixture has valid keys
         key: emailBurstKey(s)!,
         from: "alice@example.com",
         title: "old",
@@ -437,8 +447,11 @@ describe("aggregateEmailBursts", () => {
       now: NOW,
     });
     expect(res.kind).toBe("merge");
-    expect(res.decision!.id).toBe(pending.id);
-    expect((res.decision!.context as { count: number }).count).toBe(
+    if (res.kind !== "merge" || !res.decision) {
+      throw new Error("expected merge kind with non-null decision");
+    }
+    expect(res.decision.id).toBe(pending.id);
+    expect((res.decision.context as { count: number }).count).toBe(
       BURST_THRESHOLD + BURST_THRESHOLD,
     );
   });
@@ -449,6 +462,7 @@ describe("aggregateEmailBursts", () => {
       "alice@example.com",
       undefined,
       sigs.map((s) => ({
+        // biome-ignore lint/style/noNonNullAssertion: test fixture has valid keys
         key: emailBurstKey(s)!,
         from: "alice@example.com",
         title: "old",

--- a/apps/web/tests/unit/loop/email-bursts.test.ts
+++ b/apps/web/tests/unit/loop/email-bursts.test.ts
@@ -1,0 +1,484 @@
+/**
+ * SP-3 — email burst aggregator regression tests.
+ *
+ * Mirrors `github-notifications.test.ts` deliberately. Pins:
+ *   - canonical-key derivation prefers `messageId`, falls back to
+ *     `threadId:from`, then `from:subject`;
+ *   - cross-source dedupe collapses `gmail` / `email` records of the
+ *     same message to one item;
+ *   - sender extraction lowercases + strips display name;
+ *   - aggregation threshold: >= 5 emails in <= 15 min from the same
+ *     sender → digest. Below threshold, the per-signal path wins.
+ *   - aggregator excludes threadIds already covered by a typed
+ *     `email_reply` decision or a prior pending digest;
+ *   - aggregator merges new items into an existing pending digest
+ *     instead of creating a second summary card;
+ *   - bounded digest caps at MAX_EMAIL_BURST_ITEMS items.
+ *   - `unknown` decisions are NEVER treated as having already
+ *     summarized emails (otherwise they'd suppress the digest they
+ *     couldn't cover).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BURST_THRESHOLD,
+  BURST_WINDOW_MS,
+  EMAIL_BURSTS_MODULE,
+  MAX_EMAIL_BURST_ITEMS,
+  aggregateEmailBursts,
+  buildEmailBurstDigest,
+  collectCoveredEmailBurstKeys,
+  emailBurstKey,
+  findPendingEmailBurst,
+  isEmailBurstDecision,
+  isEmailBurstSignal,
+  normalizeEmailBursts,
+} from "@/lib/loop/email-bursts";
+import type { LoopDecision, LoopSignal } from "@/lib/loop/types";
+
+// Anchor all `now`-relative math at this point.
+const NOW = new Date("2026-07-17T12:00:00.000Z").getTime();
+
+function sig(
+  id: string,
+  payload: Record<string, unknown>,
+  opts: {
+    source?: "gmail" | "email";
+    ts?: string;
+  } = {},
+): LoopSignal {
+  return {
+    id,
+    ts: opts.ts ?? "2026-07-17T11:55:00.000Z",
+    source: opts.source ?? "gmail",
+    type: "email",
+    payload,
+  };
+}
+
+function typedDecision(
+  source: LoopSignal,
+  type: LoopDecision["type"] = "email_reply",
+): LoopDecision {
+  return {
+    id: `dec_${source.id}`,
+    ts: "2026-07-17T00:00:00.000Z",
+    status: "pending",
+    type,
+    title: "typed",
+    action: { kind: "email_reply", params: {} },
+    source_signal: source,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recognition + canonicalization
+// ---------------------------------------------------------------------------
+
+describe("isEmailBurstSignal", () => {
+  it("accepts gmail + email sources with type email", () => {
+    expect(isEmailBurstSignal(sig("s1", { from: "a@x.com" }))).toBe(true);
+    expect(
+      isEmailBurstSignal(sig("s2", { from: "a@x.com" }, { source: "email" })),
+    ).toBe(true);
+  });
+
+  it("rejects wrong type / wrong source / null", () => {
+    expect(isEmailBurstSignal(null)).toBe(false);
+    expect(
+      isEmailBurstSignal({
+        id: "s3",
+        ts: "x",
+        source: "gmail",
+        type: "calendar_event",
+        payload: {},
+      }),
+    ).toBe(false);
+    expect(
+      isEmailBurstSignal({
+        id: "s4",
+        ts: "x",
+        source: "manual",
+        type: "email",
+        payload: {},
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("emailBurstKey", () => {
+  it("prefers the messageId", () => {
+    const k = emailBurstKey(
+      sig("s1", { messageId: "msg_abc", from: "a@x.com" }),
+    );
+    expect(k).toBe("email:msg:msg_abc");
+  });
+
+  it("falls back to threadId + from when messageId missing", () => {
+    const k = emailBurstKey(sig("s1", { threadId: "thr_1", from: "a@x.com" }));
+    expect(k).toBe("email:thread:a@x.com:thr_1");
+  });
+
+  it("falls back to from + subject when messageId + threadId missing", () => {
+    const k = emailBurstKey(
+      sig("s1", { from: "a@x.com", subject: "Hi there" }),
+    );
+    expect(k).toBe("email:from-subject:a@x.com:hi there");
+  });
+
+  it("returns null when nothing usable is present", () => {
+    expect(emailBurstKey(sig("s1", {}))).toBeNull();
+  });
+});
+
+describe("normalizeEmailBursts", () => {
+  it("collapses cross-source duplicates by canonical key", () => {
+    const items = normalizeEmailBursts([
+      sig(
+        "s1",
+        { messageId: "m1", from: "a@x.com", subject: "S" },
+        { source: "gmail" },
+      ),
+      sig(
+        "s2",
+        { messageId: "m1", from: "a@x.com", subject: "S" },
+        { source: "email" },
+      ),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0].key).toBe("email:msg:m1");
+  });
+
+  it("lower-cases the from address", () => {
+    const items = normalizeEmailBursts([
+      sig("s1", { from: "Alice@Example.COM", subject: "S" }),
+    ]);
+    expect(items[0].from).toBe("alice@example.com");
+  });
+
+  it("strips the display name from `from`", () => {
+    const items = normalizeEmailBursts([
+      sig("s1", { from: '"Alice" <alice@x.com>', subject: "S" }),
+    ]);
+    expect(items[0].from).toBe("alice@x.com");
+    expect(items[0].fromName).toBe("Alice");
+  });
+
+  it("ignores signals that are not email typed", () => {
+    const items = normalizeEmailBursts([
+      {
+        id: "s1",
+        ts: "2026-07-17T11:55:00.000Z",
+        source: "gmail",
+        type: "calendar_event",
+        payload: { from: "a@x.com" },
+      },
+    ]);
+    expect(items).toHaveLength(0);
+  });
+
+  it("skips signals with no canonical key", () => {
+    const items = normalizeEmailBursts([sig("s1", { from: "" })]);
+    expect(items).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Digest recognition + covered-key collection
+// ---------------------------------------------------------------------------
+
+describe("isEmailBurstDecision + collectCoveredEmailBurstKeys", () => {
+  it("identifies email_burst_digest decisions with the right module", () => {
+    const dec = buildEmailBurstDigest("a@x.com", undefined, [
+      {
+        key: "email:msg:m1",
+        from: "a@x.com",
+        title: "S1",
+        ts: "2026-07-17T11:50:00.000Z",
+      },
+    ]);
+    expect(isEmailBurstDecision(dec)).toBe(true);
+  });
+
+  it("rejects other quiet_digest / unknown modules", () => {
+    const other = {
+      id: "x",
+      ts: "x",
+      status: "pending",
+      type: "quiet_digest",
+      title: "x",
+      action: {
+        kind: "quiet_digest",
+        params: { module: "github-notifications" },
+      },
+    } as LoopDecision;
+    expect(isEmailBurstDecision(other)).toBe(false);
+  });
+
+  it("collects burst_keys + threadIds from typed email_reply decisions", () => {
+    const sig1 = sig("s1", {
+      messageId: "m1",
+      threadId: "thr1",
+      from: "a@x.com",
+    });
+    const sig2 = sig("s2", {
+      messageId: "m2",
+      threadId: "thr2",
+      from: "a@x.com",
+    });
+    const typed = typedDecision(sig1);
+    const covered = collectCoveredEmailBurstKeys([typed]);
+    expect(covered.has(emailBurstKey(sig1)!)).toBe(true);
+    expect(covered.has(emailBurstKey(sig2)!)).toBe(false);
+  });
+
+  it("does not treat unknown decisions as covered", () => {
+    const sig1 = sig("s1", { messageId: "m1", from: "a@x.com" });
+    const unknown: LoopDecision = {
+      id: "u1",
+      ts: "x",
+      status: "pending",
+      type: "unknown",
+      title: "x",
+      action: { kind: "noop", params: {} },
+      source_signal: sig1,
+    };
+    const covered = collectCoveredEmailBurstKeys([unknown]);
+    expect(covered.has(emailBurstKey(sig1)!)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Digest builder
+// ---------------------------------------------------------------------------
+
+describe("buildEmailBurstDigest", () => {
+  it("produces a read-only email_burst_digest with bounded items", () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({
+      key: `k${i}`,
+      from: "a@x.com",
+      title: `S${i}`,
+      ts: new Date(NOW - i * 60_000).toISOString(),
+    }));
+    const dec = buildEmailBurstDigest("a@x.com", "Alice", items);
+    expect(dec.type).toBe("email_burst_digest");
+    expect((dec.action.params as { module: string }).module).toBe(
+      EMAIL_BURSTS_MODULE,
+    );
+    expect(dec.context?.count).toBe(MAX_EMAIL_BURST_ITEMS);
+    expect((dec.context?.items as unknown[]).length).toBe(
+      MAX_EMAIL_BURST_ITEMS,
+    );
+  });
+
+  it("uses singular phrasing for one item", () => {
+    const dec = buildEmailBurstDigest("a@x.com", undefined, [
+      {
+        key: "k1",
+        from: "a@x.com",
+        title: "S1",
+        ts: "2026-07-17T11:50:00.000Z",
+      },
+    ]);
+    expect(dec.title).toMatch(/^1 email from /);
+    expect(dec.dialogue).toMatch(/^1 email from /);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+describe("aggregateEmailBursts", () => {
+  function fiveFromAlice(opts: { startMinAgo?: number } = {}): LoopSignal[] {
+    const start = NOW - (opts.startMinAgo ?? 10) * 60_000;
+    return Array.from({ length: BURST_THRESHOLD }, (_, i) => ({
+      id: `sig_a_${i}`,
+      ts: new Date(start + i * 30_000).toISOString(),
+      source: "gmail",
+      type: "email",
+      payload: {
+        messageId: `m_a_${i}`,
+        threadId: "thr_alice",
+        from: '"Alice" <alice@example.com>',
+        subject: `Hello ${i}`,
+        snippet: `Snippet ${i}`,
+      },
+    }));
+  }
+
+  it("returns noop when there are no email signals", () => {
+    const res = aggregateEmailBursts({
+      signals: [],
+      decisions: [],
+      now: NOW,
+    });
+    expect(res.kind).toBe("noop");
+  });
+
+  it("returns noop when fewer than BURST_THRESHOLD emails from one sender", () => {
+    const res = aggregateEmailBursts({
+      signals: fiveFromAlice().slice(0, BURST_THRESHOLD - 1),
+      decisions: [],
+      now: NOW,
+    });
+    expect(res.kind).toBe("noop");
+  });
+
+  it("creates a digest when BURST_THRESHOLD emails land in the window", () => {
+    const res = aggregateEmailBursts({
+      signals: fiveFromAlice(),
+      decisions: [],
+      now: NOW,
+    });
+    expect(res.kind).toBe("create");
+    expect(res.decision).not.toBeNull();
+    expect(res.decision!.type).toBe("email_burst_digest");
+    expect(res.decision!.title).toMatch(/^5 emails from /);
+    expect((res.decision!.context as { from: string }).from).toBe(
+      "alice@example.com",
+    );
+    expect((res.decision!.context as { fromName: string }).fromName).toBe(
+      "Alice",
+    );
+    expect((res.decision!.context as { count: number }).count).toBe(
+      BURST_THRESHOLD,
+    );
+    expect(res.newKeys).toHaveLength(BURST_THRESHOLD);
+  });
+
+  it("returns noop when the spread is wider than BURST_WINDOW_MS", () => {
+    // 5 emails spread over 30 minutes (> 15 min window).
+    const sigs = Array.from({ length: BURST_THRESHOLD }, (_, i) => ({
+      id: `sig_spread_${i}`,
+      ts: new Date(NOW - (30 - i * 6) * 60_000).toISOString(),
+      source: "gmail",
+      type: "email",
+      payload: {
+        messageId: `m_spread_${i}`,
+        from: "a@x.com",
+      },
+    }));
+    const res = aggregateEmailBursts({
+      signals: sigs,
+      decisions: [],
+      now: NOW,
+    });
+    expect(res.kind).toBe("noop");
+  });
+
+  it("does not aggregate bursts across different senders in one tick", () => {
+    // 5 from alice + 3 from bob → alice bursts; bob stays per-signal.
+    const alice = fiveFromAlice();
+    const bob = Array.from({ length: 3 }, (_, i) => ({
+      id: `sig_b_${i}`,
+      ts: new Date(NOW - 5 * 60_000 + i * 30_000).toISOString(),
+      source: "gmail",
+      type: "email",
+      payload: {
+        messageId: `m_b_${i}`,
+        from: "bob@example.com",
+      },
+    }));
+    const res = aggregateEmailBursts({
+      signals: [...alice, ...bob],
+      decisions: [],
+      now: NOW,
+    });
+    expect(res.kind).toBe("create");
+    expect(res.decision!.title).toMatch(/alice/);
+  });
+
+  it("excludes keys already covered by a typed email_reply decision", () => {
+    const sigs = fiveFromAlice();
+    // First two are already covered by typed decisions.
+    const typed = sigs.slice(0, 2).map((s) => typedDecision(s));
+    const res = aggregateEmailBursts({
+      signals: sigs,
+      decisions: typed,
+      now: NOW,
+    });
+    expect(res.kind).toBe("create");
+    expect((res.decision!.context as { count: number }).count).toBe(
+      BURST_THRESHOLD - 2,
+    );
+    expect(res.newKeys).toHaveLength(BURST_THRESHOLD - 2);
+  });
+
+  it("merges new items into an existing pending digest", () => {
+    const pending = buildEmailBurstDigest(
+      "alice@example.com",
+      "Alice",
+      fiveFromAlice().map((s) => ({
+        key: emailBurstKey(s)!,
+        from: "alice@example.com",
+        title: "old",
+        ts: s.ts,
+      })),
+      { ts: "2026-07-17T11:50:00.000Z" },
+    );
+    pending.status = "pending";
+    // New batch — different messageIds, same sender, BURST_THRESHOLD
+    // signals so `isBurst` qualifies them. The merge should add them
+    // to the existing pending digest, not spawn a second card.
+    const newSigs = Array.from({ length: BURST_THRESHOLD }, (_, i) => ({
+      id: `sig_new_${i}`,
+      ts: new Date(NOW - 5 * 60_000 + i * 30_000).toISOString(),
+      source: "gmail",
+      type: "email",
+      payload: {
+        messageId: `m_new_${i}`,
+        from: "alice@example.com",
+        subject: "fresh",
+      },
+    }));
+    const res = aggregateEmailBursts({
+      signals: newSigs,
+      decisions: [pending],
+      now: NOW,
+    });
+    expect(res.kind).toBe("merge");
+    expect(res.decision!.id).toBe(pending.id);
+    expect((res.decision!.context as { count: number }).count).toBe(
+      BURST_THRESHOLD + BURST_THRESHOLD,
+    );
+  });
+
+  it("returns noop when the existing digest already covers all new keys", () => {
+    const sigs = fiveFromAlice();
+    const pending = buildEmailBurstDigest(
+      "alice@example.com",
+      undefined,
+      sigs.map((s) => ({
+        key: emailBurstKey(s)!,
+        from: "alice@example.com",
+        title: "old",
+        ts: s.ts,
+      })),
+    );
+    pending.status = "pending";
+    const res = aggregateEmailBursts({
+      signals: sigs, // same signals
+      decisions: [pending],
+      now: NOW,
+    });
+    expect(res.kind).toBe("noop");
+  });
+});
+
+describe("findPendingEmailBurst", () => {
+  it("finds the first pending email-burst digest", () => {
+    const dec = buildEmailBurstDigest("a@x.com", undefined, [
+      {
+        key: "k1",
+        from: "a@x.com",
+        title: "S1",
+        ts: NOW.toString(),
+      },
+    ]);
+    dec.status = "pending";
+    expect(findPendingEmailBurst([dec])).toBe(dec);
+  });
+  it("returns null when no pending burst exists", () => {
+    expect(findPendingEmailBurst([])).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/loop/email-bursts.test.ts
+++ b/apps/web/tests/unit/loop/email-bursts.test.ts
@@ -341,9 +341,7 @@ describe("aggregateEmailBursts", () => {
     const digest = res.decision;
     expect(digest.type).toBe("email_burst_digest");
     expect(digest.title).toMatch(/^5 emails from /);
-    expect((digest.context as { from: string }).from).toBe(
-      "alice@example.com",
-    );
+    expect((digest.context as { from: string }).from).toBe("alice@example.com");
     expect((digest.context as { fromName: string }).fromName).toBe("Alice");
     expect((digest.context as { count: number }).count).toBe(BURST_THRESHOLD);
     expect(res.newKeys).toHaveLength(BURST_THRESHOLD);

--- a/apps/web/tests/unit/loop/notifications.test.ts
+++ b/apps/web/tests/unit/loop/notifications.test.ts
@@ -30,6 +30,8 @@ vi.mock("@/lib/loop/paths", async () => {
     log: join(LOOP_HOME, "loop.log"),
     inbox: join(LOOP_HOME, "inbox"),
     syncState: join(LOOP_HOME, "sync-state.json"),
+    // SP-4 — daily attention counter
+    attention: join(LOOP_HOME, "attention.json"),
   });
   const pathsProxy = new Proxy(
     {},
@@ -54,11 +56,18 @@ vi.mock("@/lib/loop/paths", async () => {
   };
 });
 
-const { filterActionable, notifyForDecisions } =
-  await import("@/lib/loop/notifications");
+const {
+  filterActionable,
+  notifyForDecisions,
+  getAttentionCount,
+  bumpAttentionCount,
+  isOverBudget,
+  localDayKey,
+} = await import("@/lib/loop/notifications");
 const { sendNotification } = await import("@/lib/tauri");
 const { writePreferences, readPreferences } =
   await import("@/lib/loop/preferences");
+const { mutes } = await import("@/lib/loop/store");
 
 let tmp: string;
 
@@ -143,5 +152,165 @@ describe("notifyForDecisions", () => {
       expect.stringContaining("Reply to Alice"),
       expect.anything(),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SP-4 — daily attention budget + per-source cooldown
+// ---------------------------------------------------------------------------
+
+const p0Dec = {
+  id: "p0_1",
+  ts: new Date().toISOString(),
+  status: "pending" as const,
+  type: "rsvp" as const,
+  title: "P0 RSVP",
+  action: { kind: "rsvp" as const, params: {} },
+  priority: "P0" as const,
+};
+
+const p1Dec = {
+  id: "p1_1",
+  ts: new Date().toISOString(),
+  status: "pending" as const,
+  type: "todo" as const,
+  title: "P1 todo",
+  action: { kind: "todo" as const, params: {} },
+  priority: "P1" as const,
+};
+
+describe("localDayKey", () => {
+  it("returns YYYY-MM-DD for a Date in the user's locale", () => {
+    const k = localDayKey(new Date("2026-07-17T12:34:56Z"));
+    expect(k).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("bumpAttentionCount / getAttentionCount", () => {
+  it("starts at 0 when no file exists", () => {
+    expect(getAttentionCount()).toBe(0);
+  });
+  it("increments monotonically within the same day", () => {
+    bumpAttentionCount();
+    bumpAttentionCount();
+    expect(getAttentionCount()).toBe(2);
+  });
+  it("resets when the day rolls over", () => {
+    bumpAttentionCount(new Date("2026-07-16T12:00:00Z"));
+    bumpAttentionCount(new Date("2026-07-17T12:00:00Z"));
+    expect(getAttentionCount(new Date("2026-07-17T12:00:00Z"))).toBe(1);
+    expect(getAttentionCount(new Date("2026-07-16T12:00:00Z"))).toBe(0);
+  });
+});
+
+describe("isOverBudget", () => {
+  it("returns false when under the cap", () => {
+    expect(isOverBudget({ attentionBudget: { daily: 3 } })).toBe(false);
+  });
+  it("returns true once the cap is reached", () => {
+    bumpAttentionCount();
+    bumpAttentionCount();
+    bumpAttentionCount();
+    expect(isOverBudget({ attentionBudget: { daily: 3 } })).toBe(true);
+  });
+  it("uses the default daily=3 when no budget is supplied", () => {
+    bumpAttentionCount();
+    bumpAttentionCount();
+    bumpAttentionCount();
+    expect(isOverBudget({})).toBe(true);
+  });
+});
+
+describe("notifyForDecisions — SP-4 budget + cooldown", () => {
+  beforeEach(() => {
+    // Reset mutes between tests so cooldowns don't leak.
+    mutes.invalidate();
+  });
+  it("respects the daily cap, dropping P1+ after the threshold", async () => {
+    writePreferences({
+      desktopNotifications: true,
+      attentionBudget: { daily: 2, p0BypassBudget: false },
+    });
+    const a = { ...p1Dec, id: "a" };
+    const b = { ...p1Dec, id: "b" };
+    const c = { ...p1Dec, id: "c" };
+    const r = await notifyForDecisions([a, b, c]);
+    expect(r.sent).toBe(2);
+    expect(r.budgetSuppressed).toBe(1);
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+  it("lets P0 bypass the budget by default", async () => {
+    writePreferences({
+      desktopNotifications: true,
+      attentionBudget: { daily: 1, p0BypassBudget: true },
+    });
+    // Burn the one P1 slot, then a P0 must still go through.
+    const r1 = await notifyForDecisions([{ ...p1Dec, id: "x" }]);
+    expect(r1.sent).toBe(1);
+    const r2 = await notifyForDecisions([{ ...p0Dec, id: "y" }]);
+    expect(r2.sent).toBe(1);
+    expect(r2.sentP0Bypass).toBe(1);
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+  it("p0BypassBudget=false also caps P0", async () => {
+    writePreferences({
+      desktopNotifications: true,
+      attentionBudget: { daily: 1, p0BypassBudget: false },
+    });
+    const r = await notifyForDecisions([
+      { ...p1Dec, id: "x" },
+      { ...p0Dec, id: "y" },
+    ]);
+    expect(r.sent).toBe(1);
+    expect(r.budgetSuppressed).toBe(1);
+    expect(r.sentP0Bypass).toBe(0);
+  });
+  it("suppresses notifications when the source is in cooldown", async () => {
+    writePreferences({ desktopNotifications: true });
+    // Arm a cooldown for the same email sender.
+    mutes.add({
+      key: "email:alice@example.com",
+      scope: { kind: "email", from: "alice@example.com" },
+      createdAt: new Date().toISOString(),
+      cooldown_until: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const decWithSource = {
+      ...p1Dec,
+      id: "z",
+      source_signal: {
+        id: "sig1",
+        ts: new Date().toISOString(),
+        source: "gmail",
+        type: "email" as const,
+        payload: { from: "alice@example.com" },
+      },
+    };
+    const r = await notifyForDecisions([decWithSource]);
+    expect(r.sent).toBe(0);
+    expect(r.cooldownSuppressed).toBe(1);
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+  it("cooldown does not block when the source is different", async () => {
+    writePreferences({ desktopNotifications: true });
+    mutes.add({
+      key: "email:bob@example.com",
+      scope: { kind: "email", from: "bob@example.com" },
+      createdAt: new Date().toISOString(),
+      cooldown_until: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const decWithSource = {
+      ...p1Dec,
+      id: "z",
+      source_signal: {
+        id: "sig1",
+        ts: new Date().toISOString(),
+        source: "gmail",
+        type: "email" as const,
+        payload: { from: "alice@example.com" },
+      },
+    };
+    const r = await notifyForDecisions([decWithSource]);
+    expect(r.sent).toBe(1);
+    expect(r.cooldownSuppressed).toBe(0);
   });
 });

--- a/apps/web/tests/unit/loop/readiness.test.ts
+++ b/apps/web/tests/unit/loop/readiness.test.ts
@@ -24,8 +24,10 @@ import {
   deriveReadiness,
   deriveRelationship,
   deriveUrgency,
+  rankByPriority,
   readinessState,
   stateLabel,
+  type RankableDecision,
 } from "@/lib/loop/readiness";
 
 beforeEach(() => {
@@ -495,5 +497,139 @@ describe("stateLabel", () => {
       key: "loop.readiness.confirm",
       fallback: "Confirm carefully",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rankByPriority — SP-1 projector
+// ---------------------------------------------------------------------------
+//
+// Pin the ranking contract that backs the pet bubble + card "most-urgent
+// first" behaviour. The projector must:
+//   1. Order P0 → P1 → P2
+//   2. Break ties by `action.params.deadlineAt` (or `start`) ascending
+//   3. Break remaining ties by `ts` ascending (older arrivals first)
+//   4. Treat missing deadlines as "after a non-null deadline" within
+//      the same priority bucket
+//   5. Honour pre-computed `priority` field when present (TS source of
+//      truth; the projector must not re-derive on top of a stored value)
+
+function mk(
+  id: string,
+  type: string,
+  ts: string,
+  params: Record<string, unknown> = {},
+  priority?: "P0" | "P1" | "P2",
+): RankableDecision & { id: string } {
+  return {
+    id,
+    ts,
+    type,
+    action: { params },
+    ...(priority ? { priority } : {}),
+  };
+}
+
+describe("rankByPriority — SP-1", () => {
+  it("orders P0 before P1 before P2", () => {
+    // Use plain `todo` with explicit priorities via pre-computed field
+    // so the test doesn't depend on the rsvp read-side readiness
+    // semantics (which require attendees / my_response to be set).
+    const ranked = rankByPriority([
+      mk("p2", "todo", "2026-07-16T10:00:00Z", {}, "P2"),
+      mk("p0", "todo", "2026-07-16T11:00:00Z", {}, "P0"),
+      mk("p1", "todo", "2026-07-16T11:30:00Z", {}, "P1"),
+    ]);
+    expect(ranked.map((d) => d.id)).toEqual(["p0", "p1", "p2"]);
+  });
+
+  it("breaks priority ties by deadline ascending", () => {
+    const ranked = rankByPriority([
+      mk("late", "rsvp", "2026-07-16T11:00:00Z", {
+        start: "2026-07-18T12:00:00Z", // later deadline
+      }),
+      mk("early", "rsvp", "2026-07-16T11:00:00Z", {
+        start: "2026-07-17T12:00:00Z", // sooner deadline
+      }),
+    ]);
+    expect(ranked.map((d) => d.id)).toEqual(["early", "late"]);
+  });
+
+  it("places missing-deadline decisions last within their priority bucket", () => {
+    const ranked = rankByPriority([
+      mk("no-date", "todo", "2026-07-16T08:00:00Z"), // no params
+      mk("with-date", "todo", "2026-07-16T11:00:00Z", {
+        deadlineAt: "2026-07-18T12:00:00Z",
+      }),
+    ]);
+    expect(ranked.map((d) => d.id)).toEqual(["with-date", "no-date"]);
+  });
+
+  it("breaks remaining ties by ts ascending (older first)", () => {
+    // Same priority, same deadline — only ts differs.
+    const ranked = rankByPriority([
+      mk("newer", "rsvp", "2026-07-16T11:00:00Z", {
+        start: "2026-07-17T12:00:00Z",
+      }),
+      mk("older", "rsvp", "2026-07-16T08:00:00Z", {
+        start: "2026-07-17T12:00:00Z",
+      }),
+    ]);
+    expect(ranked.map((d) => d.id)).toEqual(["older", "newer"]);
+  });
+
+  it("honours pre-computed priority field without re-deriving", () => {
+    // Pre-computed P2 wins over what `derivePriority` would have
+    // produced (the rsvp has `start` in <24h → would normally be
+    // P0). The pre-computed value is the TS source of truth — the
+    // projector trusts it verbatim so the pet bubble stays in
+    // lockstep with the dashboard.
+    const now = new Date("2026-07-16T12:00:00Z");
+    const ranked = rankByPriority(
+      [
+        mk(
+          "stamped-p2",
+          "rsvp",
+          "2026-07-16T10:00:00Z",
+          {
+            start: "2026-07-16T18:00:00Z", // <24h → would derive P0
+            organizer: "alice@x.com",
+          },
+          "P2",
+        ),
+        mk(
+          "stamped-p0",
+          "todo",
+          "2026-07-16T10:00:00Z",
+          {
+            deadlineAt: "2026-07-20T12:00:00Z", // >72h → would derive P2
+          },
+          "P0",
+        ),
+      ],
+      now,
+    );
+    // The pre-computed values invert the natural derivation order:
+    // stamped-p2 (urgent source, but explicitly demoted to P2) lands
+    // LAST; stamped-p0 (stale source, but explicitly promoted to P0)
+    // lands FIRST. This is the SP-1 contract: TS is source of truth,
+    // the projector doesn't second-guess it.
+    expect(ranked.map((d) => d.id)).toEqual(["stamped-p0", "stamped-p2"]);
+  });
+
+  it("returns the same array reference count for an empty list", () => {
+    expect(rankByPriority([])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      mk("p2", "todo", "2026-07-16T10:00:00Z"),
+      mk("p0", "rsvp", "2026-07-16T11:00:00Z", {
+        start: "2026-07-16T18:00:00Z",
+      }),
+    ];
+    const before = input.map((d) => d.id);
+    rankByPriority(input);
+    expect(input.map((d) => d.id)).toEqual(before);
   });
 });

--- a/apps/web/tests/unit/loop/store.test.ts
+++ b/apps/web/tests/unit/loop/store.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Regression coverage for `lib/loop/store.ts` — the JSON-backed decision
+ * store. These tests pin:
+ *
+ *   1. SP-1 — `decisions.add` stamps `context.priority` + top-level
+ *      `dec.priority` via `normalizeDecision`, using
+ *      `readiness.ts::derivePriority` (NOT confidence).
+ *   2. SP-1 — the `version: 2` migration fires exactly once on the
+ *      first read of a legacy (pre-SP-1) decisions.json, persists
+ *      the backfilled priorities, and stays silent on subsequent
+ *      reads (so the watcher's mtime-based transition diff doesn't
+ *      churn).
+ *   3. SP-1 — `decisions.add` retains FIFO storage order (insertion
+ *      order); ranking is a *read-time* projection, not a sort on
+ *      insert. The Rust watcher projects via `rank_pending`.
+ *
+ * The store writes to `~/.openloomi/loop/decisions.json`; these tests
+ * override `LOOP_PATHS.home` via the test-only hook in
+ * `lib/loop/paths.ts` so they run in a sandboxed temp dir.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+// `vi.mock` is hoisted above top-level statements, so the temp dir
+// must be created inside `vi.hoisted` to avoid a TDZ error. The
+// hoisted callback runs in a sandbox that pre-resolves ESM imports,
+// so we use `require` for the fs/path calls.
+const { tempHome } = vi.hoisted(() => {
+  const fs = require("node:fs") as typeof import("node:fs");
+  const path = require("node:path") as typeof import("node:path");
+  const os = require("node:os") as typeof import("node:os");
+  return {
+    tempHome: fs.mkdtempSync(path.join(os.tmpdir(), "openloomi-store-test-")),
+  };
+});
+
+// Override the loop home BEFORE importing the store so `LOOP_PATHS`
+// resolves to the temp dir on first read.
+vi.mock("@/lib/loop/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/loop/paths")>(
+      "@/lib/loop/paths",
+    );
+  return {
+    ...actual,
+    LOOP_PATHS: {
+      ...actual.LOOP_PATHS,
+      home: tempHome,
+      decisions: join(tempHome, "decisions.json"),
+      mutes: join(tempHome, "mutes.json"),
+      log: join(tempHome, "loop.log"),
+    },
+    ensureDirs: () => {
+      // no-op — tempHome already exists
+    },
+  };
+});
+
+import { decisions, log as _log } from "@/lib/loop/store";
+import { LOOP_PATHS } from "@/lib/loop/paths";
+
+beforeEach(() => {
+  // Fresh file per test so migration + version-stamping can be
+  // observed in isolation.
+  if (existsSync(LOOP_PATHS.decisions)) {
+    rmSync(LOOP_PATHS.decisions);
+  }
+  if (existsSync(LOOP_PATHS.mutes)) {
+    rmSync(LOOP_PATHS.mutes);
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// SP-1 — priority stamp on add
+// ---------------------------------------------------------------------------
+
+describe("decisions.add — SP-1 priority stamp", () => {
+  it("writes context.priority and top-level priority for an urgent rsvp", () => {
+    // Frozen `now` so the deadline is <24h and `derivePriority` returns P0.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T12:00:00Z"));
+    try {
+      const dec = decisions.add({
+        type: "rsvp",
+        title: "RSVP — project sync",
+        action: {
+          kind: "calendar_rsvp",
+          params: {
+            start: "2026-07-16T18:00:00Z", // 6h
+            organizer: "alice@example.com",
+            attendeesCount: 2,
+          },
+        },
+      });
+      expect(dec).not.toBeNull();
+      expect(dec!.priority).toBe("P0");
+      expect(dec!.context?.priority).toBe("P0");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("writes P2 for a not_actionable decision regardless of confidence", () => {
+    // quiet_digest always resolves to readiness=not_actionable per
+    // readiness.ts → derivePriority always returns P2. The confidence
+    // 0.9 is irrelevant (and is what the old Rust `match confidence`
+    // would have wrongly bucketed as P0).
+    const dec = decisions.add({
+      type: "quiet_digest",
+      title: "AI news digest",
+      action: {
+        kind: "quiet_digest",
+        params: { module: "ai-news-digest" },
+      },
+      confidence: 0.9,
+    });
+    expect(dec).not.toBeNull();
+    expect(dec!.priority).toBe("P2");
+    expect(dec!.context?.priority).toBe("P2");
+  });
+
+  it("retains FIFO insertion order — the priority is on the record, not the order", () => {
+    // Insert P1 first, P0 second. The pending array should still be
+    // [P0, P1] (insertion order = reverse of insertion because
+    // `unshift` puts the new row at the head). The rank projection
+    // is the consumer's job (Rust `rank_pending` / TS `rankByPriority`).
+    const p1 = decisions.add({
+      type: "todo",
+      title: "Pick up issue #1",
+      action: {
+        kind: "todo",
+        params: { title: "stale task" },
+      },
+    });
+    const p0 = decisions.add({
+      type: "rsvp",
+      title: "RSVP — urgent",
+      action: {
+        kind: "calendar_rsvp",
+        params: {
+          start: new Date(Date.now() + 6 * 3600 * 1000).toISOString(),
+          organizer: "alice@example.com",
+        },
+      },
+    });
+    expect(p1).not.toBeNull();
+    expect(p0).not.toBeNull();
+    const list = decisions.pending();
+    expect(list.map((d) => d.id)).toEqual([p0!.id, p1!.id]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SP-1 — version: 2 migration gate
+// ---------------------------------------------------------------------------
+
+describe("decisions — SP-1 version: 2 migration", () => {
+  it("backfills priority for legacy rows on the first read", () => {
+    // Write a pre-SP-1 decisions.json: no `version`, no `priority` field.
+    const legacy = {
+      pending: [
+        {
+          id: "dec_legacy_p0",
+          ts: "2026-07-16T10:00:00Z",
+          status: "pending",
+          type: "rsvp",
+          title: "Legacy urgent RSVP",
+          action: {
+            kind: "calendar_rsvp",
+            params: {
+              start: "2026-07-16T18:00:00Z",
+              organizer: "alice@example.com",
+            },
+          },
+        },
+        {
+          id: "dec_legacy_p2",
+          ts: "2026-07-16T10:00:00Z",
+          status: "pending",
+          type: "todo",
+          title: "Legacy todo",
+          action: { kind: "todo", params: { title: "task" } },
+        },
+      ],
+      done: [],
+      dismissed: [],
+    };
+    writeFileSync(LOOP_PATHS.decisions, JSON.stringify(legacy));
+
+    // First read triggers the migration. The pending list comes back
+    // stamped with priority AND the file is rewritten with `version: 2`.
+    const first = decisions.list("pending");
+    expect(first).toHaveLength(2);
+    for (const d of first) {
+      expect(d.priority).toMatch(/^P[012]$/);
+      expect(d.context?.priority).toBe(d.priority);
+    }
+
+    // File on disk now carries the version gate.
+    const onDisk = JSON.parse(readFileSync(LOOP_PATHS.decisions, "utf8"));
+    expect(onDisk.version).toBe(2);
+  });
+
+  it("does not re-write the file when the version is already 2 (idempotent)", () => {
+    // Write a v2 file with priorities already present. Read it twice
+    // and observe that the mtime does not change on the second read
+    // (no needless churn → watcher's mtime-based transition diff
+    // stays stable).
+    const v2 = {
+      version: 2,
+      pending: [
+        {
+          id: "dec_v2",
+          ts: "2026-07-16T10:00:00Z",
+          status: "pending",
+          type: "todo",
+          title: "v2",
+          action: { kind: "todo", params: { title: "task" } },
+          priority: "P1",
+          context: { priority: "P1" },
+        },
+      ],
+      done: [],
+      dismissed: [],
+    };
+    writeFileSync(LOOP_PATHS.decisions, JSON.stringify(v2));
+    const mtimeBefore = require("node:fs").statSync(
+      LOOP_PATHS.decisions,
+    ).mtimeMs;
+
+    // Sleep so any spurious write would be observable as an mtime bump.
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    return sleep(20).then(() => {
+      decisions.list("pending");
+      const mtimeAfter = require("node:fs").statSync(
+        LOOP_PATHS.decisions,
+      ).mtimeMs;
+      expect(mtimeAfter).toBe(mtimeBefore);
+    });
+  });
+});

--- a/apps/web/tests/unit/loop/store.test.ts
+++ b/apps/web/tests/unit/loop/store.test.ts
@@ -20,8 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
@@ -60,7 +59,7 @@ vi.mock("@/lib/loop/paths", async () => {
   };
 });
 
-import { decisions, log as _log } from "@/lib/loop/store";
+import { decisions } from "@/lib/loop/store";
 import { LOOP_PATHS } from "@/lib/loop/paths";
 
 beforeEach(() => {
@@ -101,8 +100,9 @@ describe("decisions.add — SP-1 priority stamp", () => {
         },
       });
       expect(dec).not.toBeNull();
-      expect(dec!.priority).toBe("P0");
-      expect(dec!.context?.priority).toBe("P0");
+      if (!dec) throw new Error("dec is null");
+      expect(dec.priority).toBe("P0");
+      expect(dec.context?.priority).toBe("P0");
     } finally {
       vi.useRealTimers();
     }
@@ -123,8 +123,9 @@ describe("decisions.add — SP-1 priority stamp", () => {
       confidence: 0.9,
     });
     expect(dec).not.toBeNull();
-    expect(dec!.priority).toBe("P2");
-    expect(dec!.context?.priority).toBe("P2");
+    if (!dec) throw new Error("dec is null");
+    expect(dec.priority).toBe("P2");
+    expect(dec.context?.priority).toBe("P2");
   });
 
   it("retains FIFO insertion order — the priority is on the record, not the order", () => {
@@ -153,8 +154,9 @@ describe("decisions.add — SP-1 priority stamp", () => {
     });
     expect(p1).not.toBeNull();
     expect(p0).not.toBeNull();
+    if (!p0 || !p1) throw new Error("p0 or p1 is null");
     const list = decisions.pending();
-    expect(list.map((d) => d.id)).toEqual([p0!.id, p1!.id]);
+    expect(list.map((d) => d.id)).toEqual([p0.id, p1.id]);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the priority mis-classification bug, adds a digest for email floods, and adds a budget + cooldown so the desktop notification fan-out can't bury the user.

| Track | What | Why |
|---|---|---|
| **SP-1** | TS becomes the single source of truth for `priority`; Rust is a pure reader + projector | `confidence >= 0.85 -> p0` made `quiet_digest` (confidence 0.9) surface as urgent. `readiness.ts::derivePriority` knows about `readiness.status` and demotes `not_actionable` cards regardless of confidence. |
| **SP-2** | New regression tests pin the priority invariant in both TS and Rust | A future refactor that re-introduces confidence bucketing will break `build_decision_payload_reads_priority_from_context` and the `rankByPriority` ordering tests. |
| **SP-3** | New `lib/loop/email-bursts.ts` collapses >=5 emails from the same sender in 15 min into ONE read-only `email_burst_digest` card | A mailing-list burst or autoresponder loop used to spawn N near-identical `email_reply` cards and N OS notifications. |
| **SP-4** | New `attentionBudget` (default 3/day) + `cooldown` (default 30 min/source) prefs; backed by `attention.json` + `MuteRule.cooldown_until` | Even with bursts digested, a stuck watcher could still fire 50 notifications in an afternoon. The cap is per user-local day; P0 bypasses by default. |

## Changes

- `apps/web/lib/loop/types.ts` — `priority` field on `LoopDecision`; `email_burst_digest` decision/action kind; `attentionBudget` + `cooldown` prefs; `MuteRule.cooldown_until`
- `apps/web/lib/loop/paths.ts` — `LOOP_PATHS.attention` (separate file, no write race with `config.json`)
- `apps/web/lib/loop/readiness.ts` — new `rankByPriority` pure projector (P0>P1>P2, deadline ascending, ts ascending, no mutation)
- `apps/web/lib/loop/store.ts` — `normalizeDecision` double-writes `context.priority` + `dec.priority`; one-shot `version: 2` migration; `mutes.cooldownActive`; `MUTABLE_DECISION_TYPES` includes `email_burst_digest`; `mutes.add` refreshes `cooldown_until` on repeat dismiss
- `apps/web/lib/loop/tick.ts` — wires `aggregateEmailBursts` into the agentic tick (try/catch so a failure can't poison the tick)
- `apps/web/lib/loop/notifications.ts` — daily attention counter, per-source cooldown gate, P0-bypass logic; bubble unaffected
- `apps/web/lib/loop/email-bursts.ts` *(new)* — pure aggregator with `create` / `merge` discriminated return; mirrors `github-notifications.ts` shape
- `apps/web/src-tauri/src/pet/watcher.rs` — `dec_priority` / `priority_rank` / `rank_pending`; `build_decision_payload` reads `context.priority`; `snap.pending.first()` and `snap.pending.iter().take(5)` now flow through the ranked projection
- Tests — new `email-bursts.test.ts`, new `store.test.ts`; `readiness.test.ts` adds 5 `rankByPriority` cases; `notifications.test.ts` adds 5 SP-4 describes; `watcher.rs` adds 3 unit tests

## Test plan

- [x] `pnpm tsc` — exit 0
- [x] `pnpm test` — 1945 passed / 17 skipped / 0 failed (157 test files)
- [x] `pnpm format` — all `unchanged`
- [ ] Manual: trigger a 6+ email burst from a single sender, confirm one digest card lands
- [ ] Manual: dismiss a digest, confirm subsequent bursts from the same sender are muted + on 30 min cooldown
- [ ] Manual: hit the daily 3-notification cap with P1 cards, confirm P0 still goes through
- [ ] Manual: open the bubble on a `quiet_digest` (or any `not_actionable`) decision, confirm priority chip shows P2 even if `confidence` is 0.9

## Migration / risk

- `decisions.json` gets a one-shot `version: 2` stamp on first read. The gate is sticky: every subsequent write keeps the flag, so the read-time backfill runs exactly once. After that, the watcher sees no mtime churn.
- `~/.openloomi/loop/attention.json` is created on the first notification fan-out; missing file is treated as `{ day: "", count: 0 }`.
- No top-level schema shape change on `LoopDecision` / `LoopAction` / `MuteRule` — all additions are optional fields. Legacy rows continue to work; the priority is re-derived on read when `context.priority` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)