### PR TITLE
feat: issue 321 openloomi skill bundle

### DIFF
--- a/apps/openloomi-skill/README.md
+++ b/apps/openloomi-skill/README.md
@@ -2,7 +2,19 @@
 
 This directory contains the uploadable OpenLoomi skill bundle for skill-based agent hosts such as WorkBuddy. It implements issue #321 Option B only: a Skill Bundle that routes requests to the local OpenLoomi Desktop API.
 
-## Upload
+## One-Click Package
+
+Build the WorkBuddy-ready zip from the repo root:
+
+```powershell
+node apps\openloomi-skill\scripts\package-openloomi-skill.cjs
+```
+
+The helper validates the skill metadata, runs the local tests, checks formatting, creates `apps/openloomi-skill/dist/openloomi-skill.zip`, and prints the WorkBuddy smoke prompt. Upload that zip to WorkBuddy Skills.
+
+Use `--out=<path>` to write the zip somewhere else. Use `--skip-checks` only when a prior CI or local run has already passed the same validation.
+
+## Manual Upload
 
 Upload the `apps/openloomi-skill/openloomi/` folder, or create a zip from that folder's contents:
 
@@ -69,7 +81,8 @@ $env:PYTHONUTF8='1'
 python skills\skill-creator\scripts\quick_validate.py apps\openloomi-skill\openloomi
 node --test apps\openloomi-skill\tests\bundle-structure.test.mjs
 node --test apps\openloomi-skill\tests\openloomi-script.test.mjs
-pnpm exec prettier --check apps/openloomi-skill/README.md apps/openloomi-skill/openloomi/SKILL.md apps/openloomi-skill/openloomi/agents/openai.yaml apps/openloomi-skill/openloomi/references/tool-surface.md apps/openloomi-skill/openloomi/references/examples.md apps/openloomi-skill/openloomi/scripts/openloomi.cjs apps/openloomi-skill/tests/openloomi-script.test.mjs apps/openloomi-skill/tests/bundle-structure.test.mjs
+node --test apps\openloomi-skill\tests\package-openloomi-skill.test.mjs
+pnpm exec prettier --check apps/openloomi-skill/README.md apps/openloomi-skill/openloomi/SKILL.md apps/openloomi-skill/openloomi/agents/openai.yaml apps/openloomi-skill/openloomi/references/tool-surface.md apps/openloomi-skill/openloomi/references/examples.md apps/openloomi-skill/openloomi/scripts/openloomi.cjs apps/openloomi-skill/tests/openloomi-script.test.mjs apps/openloomi-skill/tests/bundle-structure.test.mjs apps/openloomi-skill/tests/package-openloomi-skill.test.mjs apps/openloomi-skill/scripts/package-openloomi-skill.cjs
 ```
 
 Optional zip smoke on Windows:

--- a/apps/openloomi-skill/README.md
+++ b/apps/openloomi-skill/README.md
@@ -48,11 +48,16 @@ Use $openloomi to list my connected accounts.
 Use $openloomi to search memory for "project alpha".
 ```
 
+```text
+Use $openloomi to list my uploaded OpenLoomi documents.
+```
+
 Expected behavior:
 
 - `status` reports the discovered local API URL, auth availability, and provider probe status.
 - `connectors-list` returns connected accounts or a clear empty state.
 - `memory-search` returns matching OpenLoomi memory/RAG results or a clear no-results message.
+- `knowledge-list` returns uploaded document ids, filenames, and pagination details or a clear empty state.
 - If OpenLoomi Desktop is closed or setup is incomplete, the skill reports the local API or auth problem without inventing data.
 
 ## Local Validation

--- a/apps/openloomi-skill/README.md
+++ b/apps/openloomi-skill/README.md
@@ -1,0 +1,79 @@
+# OpenLoomi WorkBuddy Skill Bundle
+
+This directory contains the uploadable OpenLoomi skill bundle for skill-based agent hosts such as WorkBuddy. It implements issue #321 Option B only: a Skill Bundle that routes requests to the local OpenLoomi Desktop API.
+
+## Upload
+
+Upload the `apps/openloomi-skill/openloomi/` folder, or create a zip from that folder's contents:
+
+```powershell
+Compress-Archive -Path apps\openloomi-skill\openloomi\* -DestinationPath openloomi-skill.zip -Force
+```
+
+The zip root must contain:
+
+- `SKILL.md`
+- `agents/openai.yaml`
+- `scripts/openloomi.cjs`
+- `references/examples.md`
+- `references/tool-surface.md`
+
+Do not include `apps/openloomi-skill/tests/` or this README in the uploaded bundle.
+
+## Runtime Requirements
+
+OpenLoomi Desktop must be running locally before the skill can reach memory, connectors, or native agent workflows. The wrapper tries these local API bases in order unless overridden:
+
+1. `OPENLOOMI_API_URL`
+2. `OPENLOOMI_BASE_URL`
+3. `http://127.0.0.1:3414`
+4. `http://127.0.0.1:3515`
+5. `http://127.0.0.1:3415`
+
+Authentication is resolved from `OPENLOOMI_AUTH_TOKEN`, then from the base64 token file at `~/.openloomi/token`. Never paste tokens, OAuth secrets, API keys, or app passwords into chat.
+
+## WorkBuddy Smoke
+
+After uploading the bundle, start a WorkBuddy chat and try:
+
+```text
+Use $openloomi to check my local OpenLoomi status.
+```
+
+```text
+Use $openloomi to list my connected accounts.
+```
+
+```text
+Use $openloomi to search memory for "project alpha".
+```
+
+Expected behavior:
+
+- `status` reports the discovered local API URL, auth availability, and provider probe status.
+- `connectors-list` returns connected accounts or a clear empty state.
+- `memory-search` returns matching OpenLoomi memory/RAG results or a clear no-results message.
+- If OpenLoomi Desktop is closed or setup is incomplete, the skill reports the local API or auth problem without inventing data.
+
+## Local Validation
+
+Run these checks before packaging:
+
+```powershell
+$env:PYTHONUTF8='1'
+python skills\skill-creator\scripts\quick_validate.py apps\openloomi-skill\openloomi
+node --test apps\openloomi-skill\tests\bundle-structure.test.mjs
+node --test apps\openloomi-skill\tests\openloomi-script.test.mjs
+pnpm exec prettier --check apps/openloomi-skill/README.md apps/openloomi-skill/openloomi/SKILL.md apps/openloomi-skill/openloomi/agents/openai.yaml apps/openloomi-skill/openloomi/references/tool-surface.md apps/openloomi-skill/openloomi/references/examples.md apps/openloomi-skill/openloomi/scripts/openloomi.cjs apps/openloomi-skill/tests/openloomi-script.test.mjs apps/openloomi-skill/tests/bundle-structure.test.mjs
+```
+
+Optional zip smoke on Windows:
+
+```powershell
+$zip = Join-Path $env:TEMP ("openloomi-skill-" + [guid]::NewGuid().ToString() + ".zip")
+Compress-Archive -Path apps\openloomi-skill\openloomi\* -DestinationPath $zip -Force
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$archive = [System.IO.Compression.ZipFile]::OpenRead($zip)
+try { $archive.Entries | Select-Object FullName, Length } finally { $archive.Dispose() }
+Write-Output "ZIP_PATH=$zip"
+```

--- a/apps/openloomi-skill/README.md
+++ b/apps/openloomi-skill/README.md
@@ -68,7 +68,7 @@ Expected behavior:
 
 - `status` reports the discovered local API URL, auth availability, and provider probe status.
 - `connectors-list` returns connected accounts or a clear empty state.
-- `memory-search` returns matching OpenLoomi memory/RAG results or a clear no-results message.
+- `memory-search` returns matching OpenLoomi memory/RAG results, or local memory-file hits from `~/.openloomi/data/memory/` when the API returns no matches.
 - `knowledge-list` returns uploaded document ids, filenames, and pagination details or a clear empty state.
 - If OpenLoomi Desktop is closed or setup is incomplete, the skill reports the local API or auth problem without inventing data.
 

--- a/apps/openloomi-skill/openloomi/SKILL.md
+++ b/apps/openloomi-skill/openloomi/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when the user wants a skill-hosted agent runtime to work through 
 
 Start with a status check when the user asks to use OpenLoomi for the first time in a session, when the local runtime may be stopped, or when a command fails with a network or authentication error.
 
-The wrapper command contract is documented in [references/tool-surface.md](references/tool-surface.md). The implementation lives at `scripts/openloomi.cjs` once the wrapper phase is complete.
+The wrapper command contract is documented in [references/tool-surface.md](references/tool-surface.md). The implementation lives at `scripts/openloomi.cjs`.
 
 ## Reuse Notes
 
@@ -53,4 +53,4 @@ Read [references/examples.md](references/examples.md) for worked patterns:
 
 If the local API is unreachable, tell the user to open OpenLoomi Desktop and retry the status check. If authentication is missing, tell the user to complete OpenLoomi Desktop setup so the home directory's `.openloomi/token` file is created. Do not invent memory or connector data when OpenLoomi is unavailable.
 
-If the wrapper command is unavailable or returns `NOT_IMPLEMENTED`, report that the skill bundle skeleton is installed but the OpenLoomi wrapper implementation is pending.
+If the wrapper command is unavailable, report that the skill bundle is installed incorrectly or incompletely and ask the user to reinstall the uploaded bundle.

--- a/apps/openloomi-skill/openloomi/SKILL.md
+++ b/apps/openloomi-skill/openloomi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openloomi
-description: Use local OpenLoomi from skill-based agent runtimes such as WorkBuddy to search memory, inspect connected accounts, and trigger OpenLoomi agent workflows through the local desktop API. Use for OpenLoomi, Loomi, memory search, knowledge base search, connector status, Slack or email drafts, Notion or document summarization, and local-first personal assistant workflows.
+description: Use local OpenLoomi from skill-based agent runtimes such as WorkBuddy to search memory, search/list/read/upload knowledge base documents, inspect connected accounts, and trigger OpenLoomi agent workflows through the local desktop API. Use for OpenLoomi, Loomi, memory search, knowledge base search or upload, connector status, Slack or email drafts, Notion or document summarization, and local-first personal assistant workflows.
 ---
 
 # OpenLoomi
@@ -30,7 +30,9 @@ When you implement the wrapper, reuse the existing OpenLoomi plugin scripts and 
 
 1. Identify the requested OpenLoomi surface:
    - Memory or previous context: use `memory-search`.
-   - Uploaded documents or knowledge base: use `memory-search` first, then knowledge-base commands when available.
+   - Uploaded documents or knowledge base search: use `knowledge-search`.
+   - Knowledge base inventory or document content: use `knowledge-list` or `knowledge-get`.
+   - Knowledge base upload: confirm the exact file and intent first, then use `knowledge-upload`.
    - Connector status: use `connectors-list`.
    - Complex action, draft, summary, or cross-app task: use `agent-run`.
 
@@ -45,6 +47,7 @@ When you implement the wrapper, reuse the existing OpenLoomi plugin scripts and 
 Read [references/examples.md](references/examples.md) for worked patterns:
 
 - Search OpenLoomi memory for prior context.
+- Search, list, read, or upload OpenLoomi knowledge base documents.
 - Check whether Slack, Gmail, Notion, or other accounts are connected.
 - Draft an email without sending it.
 - Summarize a Notion page or another connected document.

--- a/apps/openloomi-skill/openloomi/SKILL.md
+++ b/apps/openloomi-skill/openloomi/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: openloomi
+description: Use local OpenLoomi from skill-based agent runtimes such as WorkBuddy to search memory, inspect connected accounts, and trigger OpenLoomi agent workflows through the local desktop API. Use for OpenLoomi, Loomi, memory search, knowledge base search, connector status, Slack or email drafts, Notion or document summarization, and local-first personal assistant workflows.
+---
+
+# OpenLoomi
+
+## Overview
+
+Use this skill when the user wants a skill-hosted agent runtime to work through their local OpenLoomi Desktop app. Treat OpenLoomi as the source of truth for memory, connectors, credentials, and agent execution; this skill only routes requests to the local OpenLoomi API.
+
+## First Checks
+
+Start with a status check when the user asks to use OpenLoomi for the first time in a session, when the local runtime may be stopped, or when a command fails with a network or authentication error.
+
+The wrapper command contract is documented in [references/tool-surface.md](references/tool-surface.md). The implementation lives at `scripts/openloomi.cjs` once the wrapper phase is complete.
+
+## Reuse Notes
+
+When you implement the wrapper, reuse the existing OpenLoomi plugin scripts and route docs instead of inventing a new wire protocol:
+
+- `plugins/codex/skills/openloomi-memory/scripts/openloomi-memory.cjs`
+- `plugins/codex/skills/openloomi-connectors/scripts/openloomi-connectors.cjs`
+- `apps/web/src-tauri/src/cli.rs`
+- `benchmark/beam/src/memory-adapter.ts`
+- `plugins/codex/scripts/loomi-bridge.mjs`
+- `plugins/codex/skills/openloomi-api/SKILL.md`
+
+## Workflow
+
+1. Identify the requested OpenLoomi surface:
+   - Memory or previous context: use `memory-search`.
+   - Uploaded documents or knowledge base: use `memory-search` first, then knowledge-base commands when available.
+   - Connector status: use `connectors-list`.
+   - Complex action, draft, summary, or cross-app task: use `agent-run`.
+
+2. Keep secrets inside OpenLoomi-owned surfaces. Do not ask the user to paste API keys, OAuth tokens, app passwords, OpenLoomi bearer tokens, or local secure-storage values into chat.
+
+3. Confirm before sending messages, scheduling actions, deleting data, disconnecting accounts, or making any external side effect. Drafting, summarizing, searching, and listing status are read-only unless the user explicitly asks to act.
+
+4. Return the OpenLoomi result in plain language and preserve the structured JSON result when it contains useful ids such as `botId`, `accountId`, `documentId`, `decisionId`, or `actionId`.
+
+## Common Flows
+
+Read [references/examples.md](references/examples.md) for worked patterns:
+
+- Search OpenLoomi memory for prior context.
+- Check whether Slack, Gmail, Notion, or other accounts are connected.
+- Draft an email without sending it.
+- Summarize a Notion page or another connected document.
+
+## Failure Handling
+
+If the local API is unreachable, tell the user to open OpenLoomi Desktop and retry the status check. If authentication is missing, tell the user to complete OpenLoomi Desktop setup so the home directory's `.openloomi/token` file is created. Do not invent memory or connector data when OpenLoomi is unavailable.
+
+If the wrapper command is unavailable or returns `NOT_IMPLEMENTED`, report that the skill bundle skeleton is installed but the OpenLoomi wrapper implementation is pending.

--- a/apps/openloomi-skill/openloomi/agents/openai.yaml
+++ b/apps/openloomi-skill/openloomi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OpenLoomi"
+  short_description: "Use local OpenLoomi from WorkBuddy"
+  default_prompt: "Use $openloomi to check my local OpenLoomi status and list connected accounts."

--- a/apps/openloomi-skill/openloomi/references/examples.md
+++ b/apps/openloomi-skill/openloomi/references/examples.md
@@ -1,0 +1,83 @@
+# OpenLoomi Skill Examples
+
+Use these examples as task patterns for skill-based hosts such as WorkBuddy. Prefer structured command output from the wrapper, then explain the result in plain language.
+
+## Search Memory
+
+User request:
+
+```text
+Use OpenLoomi to search my memory for "internship project".
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "internship project" --limit=5
+```
+
+Respond with the most relevant matches, cite source ids or document ids when present, and say clearly when OpenLoomi returned no matches.
+
+## Check Connectors
+
+User request:
+
+```text
+Use OpenLoomi to list my connected accounts.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" connectors-list
+```
+
+Summarize connected platforms and preserve ids such as `accountId` or `botId` when the user may need them for a later action.
+
+## Draft An Email
+
+User request:
+
+```text
+Use OpenLoomi to draft an email to Alice about tomorrow's sync. Do not send it.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" agent-run "Draft an email to Alice about tomorrow's sync. Do not send it."
+```
+
+Return the draft. Do not send the email unless the user explicitly asks and confirms.
+
+## Post To Slack
+
+User request:
+
+```text
+Use OpenLoomi to draft a Slack reply to the design channel about the timeline.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" agent-run "Draft a Slack reply to the design channel about the timeline. Do not send it without confirmation."
+```
+
+If the user asks to send, confirm the exact destination and message text before triggering any side effect.
+
+## Summarize A Notion Page
+
+User request:
+
+```text
+Use OpenLoomi to summarize the Notion page about the launch plan.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" agent-run "Summarize the Notion page about the launch plan using OpenLoomi connected context."
+```
+
+If Notion is not connected, report the connector gap and suggest opening OpenLoomi Desktop connectors.

--- a/apps/openloomi-skill/openloomi/references/examples.md
+++ b/apps/openloomi-skill/openloomi/references/examples.md
@@ -34,6 +34,70 @@ node "$SKILL_DIR/scripts/openloomi.cjs" connectors-list
 
 Summarize connected platforms and preserve ids such as `accountId` or `botId` when the user may need them for a later action.
 
+## Search Knowledge Base
+
+User request:
+
+```text
+Use OpenLoomi to search my uploaded documents for "launch plan".
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-search "launch plan" --limit=5
+```
+
+Summarize the best matching chunks and preserve document ids when the user may want to open or inspect a document.
+
+## List Knowledge Base Documents
+
+User request:
+
+```text
+Use OpenLoomi to list my uploaded documents.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-list --limit=50
+```
+
+Return filenames, ids, sizes, upload times, and pagination hints when present.
+
+## Read A Knowledge Base Document
+
+User request:
+
+```text
+Use OpenLoomi to read document doc_123.
+```
+
+Run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-get doc_123
+```
+
+Summarize the document content and cite the document id.
+
+## Upload To Knowledge Base
+
+User request:
+
+```text
+Use OpenLoomi to upload ./notes/project-alpha.md to my knowledge base.
+```
+
+First confirm the exact file path and that the user wants to upload it. After confirmation, run:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-upload ./notes/project-alpha.md
+```
+
+Report the resulting `documentId`, filename, chunk count, and any upload or embedding error. For files larger than the wrapper limit, tell the user to upload through OpenLoomi Desktop Library.
+
 ## Draft An Email
 
 User request:

--- a/apps/openloomi-skill/openloomi/references/examples.md
+++ b/apps/openloomi-skill/openloomi/references/examples.md
@@ -16,7 +16,7 @@ Run:
 node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "internship project" --limit=5
 ```
 
-Respond with the most relevant matches, cite source ids or document ids when present, and say clearly when OpenLoomi returned no matches.
+Respond with the most relevant matches, cite source ids or document ids when present, cite `local-file` paths for local memory-file hits, and say clearly when OpenLoomi returned no matches.
 
 ## Check Connectors
 

--- a/apps/openloomi-skill/openloomi/references/tool-surface.md
+++ b/apps/openloomi-skill/openloomi/references/tool-surface.md
@@ -1,0 +1,101 @@
+# OpenLoomi Skill Tool Surface
+
+This reference defines the Option B skill-bundle command contract. The wrapper implementation should stay thin and call the local OpenLoomi Desktop API; OpenLoomi remains the owner of memory, connector credentials, agent execution, and side effects.
+
+## Runtime Discovery
+
+Resolve the local API base URL in this order:
+
+1. `OPENLOOMI_API_URL`
+2. `OPENLOOMI_BASE_URL`
+3. `http://127.0.0.1:3414`
+4. `http://127.0.0.1:3515`
+5. `http://127.0.0.1:3415`
+
+Resolve auth in this order:
+
+1. `OPENLOOMI_AUTH_TOKEN`
+2. Base64-decoded home directory `.openloomi/token`
+
+Never print raw tokens, API keys, OAuth secrets, app passwords, secure-storage values, or Authorization headers.
+
+## Commands
+
+All commands should print JSON to stdout. Error responses should include `ok: false`, `code`, and `message`.
+
+### status
+
+Check whether the local OpenLoomi API is reachable and whether an auth token is available.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" status
+```
+
+Expected API probes:
+
+- `GET /api/remote-auth/user`
+- optionally `GET /api/native/providers`
+
+### memory-search
+
+Search OpenLoomi memory and knowledge surfaces for user context.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "project alpha" --limit=5
+```
+
+Preferred API path:
+
+- `POST /api/memory/search` with `{ "query": "...", "limit": 5 }`
+
+Fallback API path:
+
+- `POST /api/rag/search` with `{ "query": "...", "limit": 5 }`
+
+### connectors-list
+
+List connected accounts and return account ids, platforms, display names, statuses, and bot ids when available.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" connectors-list
+```
+
+Preferred API path:
+
+- `GET /api/integrations/accounts`
+
+### agent-run
+
+Trigger the local OpenLoomi native agent for complex cross-app work, drafts, summaries, and actions that should remain inside OpenLoomi-owned runtime logic.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" agent-run "Draft an email to Alice about tomorrow's sync. Do not send it."
+```
+
+Preferred API path:
+
+- `POST /api/native/agent`
+
+The wrapper should collect the final SSE result into a concise JSON object. It should not stream raw internal events unless a debug flag is explicitly added later.
+
+## Side-Effect Policy
+
+Treat these operations as requiring explicit user confirmation:
+
+- Send a message or email.
+- Schedule or execute a Loop action.
+- Delete or disconnect any account, memory, document, or artifact.
+- Upload a document to the knowledge base.
+- Trigger an agent task that can write to external systems.
+
+Search, status checks, summaries, drafts, and connector listing are allowed as read-only operations.
+
+## Reuse Sources
+
+Use these existing repo resources as the implementation source of truth when you build `scripts/openloomi.cjs`:
+
+- `plugins/codex/skills/openloomi-memory/scripts/openloomi-memory.cjs` for token loading, port fallback, local memory search, knowledge-base search, and search aggregation.
+- `plugins/codex/skills/openloomi-connectors/scripts/openloomi-connectors.cjs` for account listing, platform status, and connector response shaping.
+- `apps/web/src-tauri/src/cli.rs` and `benchmark/beam/src/memory-adapter.ts` for `/api/native/agent` request shape and SSE result parsing.
+- `plugins/codex/scripts/loomi-bridge.mjs` for `/api/native/providers` probing and host-side readiness fallback.
+- `plugins/codex/skills/openloomi-api/SKILL.md` for the canonical endpoint catalogue when a route needs confirmation.

--- a/apps/openloomi-skill/openloomi/references/tool-surface.md
+++ b/apps/openloomi-skill/openloomi/references/tool-surface.md
@@ -4,6 +4,18 @@ This reference defines the Option B skill-bundle command contract. The wrapper i
 
 The command implementation lives at `scripts/openloomi.cjs`.
 
+## Bundle Shape
+
+Upload the `openloomi/` folder, or a zip whose root contains these files:
+
+- `SKILL.md`
+- `agents/openai.yaml`
+- `scripts/openloomi.cjs`
+- `references/tool-surface.md`
+- `references/examples.md`
+
+Keep development-only tests outside the uploaded `openloomi/` folder.
+
 ## Runtime Discovery
 
 Resolve the local API base URL in this order:

--- a/apps/openloomi-skill/openloomi/references/tool-surface.md
+++ b/apps/openloomi-skill/openloomi/references/tool-surface.md
@@ -2,6 +2,8 @@
 
 This reference defines the Option B skill-bundle command contract. The wrapper implementation should stay thin and call the local OpenLoomi Desktop API; OpenLoomi remains the owner of memory, connector credentials, agent execution, and side effects.
 
+The command implementation lives at `scripts/openloomi.cjs`.
+
 ## Runtime Discovery
 
 Resolve the local API base URL in this order:
@@ -64,6 +66,10 @@ Preferred API path:
 
 - `GET /api/integrations/accounts`
 
+Optional filter:
+
+- `--platform=gmail` returns only matching accounts while preserving the full API result under `result`.
+
 ### agent-run
 
 Trigger the local OpenLoomi native agent for complex cross-app work, drafts, summaries, and actions that should remain inside OpenLoomi-owned runtime logic.
@@ -77,6 +83,13 @@ Preferred API path:
 - `POST /api/native/agent`
 
 The wrapper should collect the final SSE result into a concise JSON object. It should not stream raw internal events unless a debug flag is explicitly added later.
+
+Default request policy:
+
+- `platform: "workbuddy"` unless `--platform=<name>` is passed.
+- `permissionMode: "dontAsk"`.
+- `Edit`, `Write`, `Bash`, `Agent`, and `Task` are explicitly disallowed.
+- `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`, `Skill`, `LSP`, and `TodoWrite` remain allowed for read, retrieval, planning, and skill-driven draft workflows.
 
 ## Side-Effect Policy
 

--- a/apps/openloomi-skill/openloomi/references/tool-surface.md
+++ b/apps/openloomi-skill/openloomi/references/tool-surface.md
@@ -52,7 +52,7 @@ Expected API probes:
 
 ### memory-search
 
-Search OpenLoomi memory for user context. This command falls back to RAG search when the unified memory endpoint is unavailable.
+Search OpenLoomi memory for user context. This command falls back to RAG search when the unified memory endpoint is unavailable, and if the API search returns no matches it performs a read-only local scan of `~/.openloomi/data/memory/**/*.md|json`.
 
 ```bash
 node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "project alpha" --limit=5
@@ -65,6 +65,11 @@ Preferred API path:
 Fallback API path:
 
 - `POST /api/rag/search` with `{ "query": "...", "limit": 5 }`
+
+Local-file fallback:
+
+- Scans `.md` and `.json` files under `~/.openloomi/data/memory/` when the API result set is empty.
+- Returns local hits at top-level `results` with `source: "local-file"`, `file`, `line`, and `preview`.
 
 ### knowledge-search
 

--- a/apps/openloomi-skill/openloomi/references/tool-surface.md
+++ b/apps/openloomi-skill/openloomi/references/tool-surface.md
@@ -52,7 +52,7 @@ Expected API probes:
 
 ### memory-search
 
-Search OpenLoomi memory and knowledge surfaces for user context.
+Search OpenLoomi memory for user context. This command falls back to RAG search when the unified memory endpoint is unavailable.
 
 ```bash
 node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "project alpha" --limit=5
@@ -65,6 +65,66 @@ Preferred API path:
 Fallback API path:
 
 - `POST /api/rag/search` with `{ "query": "...", "limit": 5 }`
+
+### knowledge-search
+
+Search uploaded knowledge base documents explicitly through RAG.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-search "project alpha" --limit=5
+```
+
+Preferred API path:
+
+- `POST /api/rag/search` with `{ "query": "...", "limit": 5 }`
+
+### knowledge-list
+
+List uploaded knowledge base documents.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-list --limit=50
+```
+
+Preferred API path:
+
+- `GET /api/rag/documents?pageSize=<limit>`
+
+Optional cursor:
+
+- `--cursor=<timestamp>` forwards cursor-based pagination as `cursor`.
+
+### knowledge-get
+
+Read a single uploaded knowledge base document and its chunks.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-get doc_xxx
+```
+
+Preferred API path:
+
+- `GET /api/rag/documents/[documentId]`
+
+### knowledge-upload
+
+Upload a small local file into the OpenLoomi knowledge base. This is a write operation and requires explicit user confirmation before running.
+
+```bash
+node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-upload ./notes/project-alpha.md
+```
+
+Preferred API path:
+
+- `POST /api/rag/upload` with multipart field `file`.
+
+Default upload policy:
+
+- Files are limited to 8 MB by default. For larger files, tell the user to upload through OpenLoomi Desktop Library.
+- `--skip-embeddings` stores the document without generating embeddings when the local OpenLoomi runtime supports that mode.
+- `--file-name=<name>` overrides the uploaded filename.
+- `--content-type=<mime>` overrides the default `application/octet-stream`; OpenLoomi infers common types from the filename when possible.
+- The wrapper may pass the decoded local auth token to the local API as `cloudAuthToken`, but must never print it.
 
 ### connectors-list
 

--- a/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
+++ b/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
@@ -15,6 +15,7 @@ const DEFAULT_AGENT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_UPLOAD_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_UPLOAD_MAX_BYTES = 8 * 1024 * 1024;
 const TOKEN_PATH = path.join(os.homedir(), ".openloomi", "token");
+const MEMORY_DIR = path.join(os.homedir(), ".openloomi", "data", "memory");
 
 const SAFE_AGENT_ALLOWED_TOOLS = [
   "Read",
@@ -493,6 +494,154 @@ function shouldFallbackToRag(error) {
   return error?.code === "not_found" || error?.code === "method_not_allowed";
 }
 
+function resolveMemoryDir(env = process.env) {
+  return path.resolve(env.OPENLOOMI_MEMORY_DIR || MEMORY_DIR);
+}
+
+function fileSystemMethod(fileSystem, name) {
+  return typeof fileSystem?.[name] === "function"
+    ? fileSystem[name].bind(fileSystem)
+    : fs[name].bind(fs);
+}
+
+function normalizeRelativePath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function buildLocalMemoryPreview(lines, index) {
+  const snippets = [];
+  for (
+    let cursor = index;
+    cursor < lines.length && snippets.join(" ").length < 200;
+    cursor += 1
+  ) {
+    const text = lines[cursor].trim();
+    if (text) {
+      snippets.push(text);
+    }
+  }
+  return snippets.join(" ").replace(/\s+/g, " ").slice(0, 200);
+}
+
+function extractSearchResults(body) {
+  const containers = [
+    body,
+    body?.data,
+    body?.result,
+    body?.memory,
+    body?.rag,
+  ].filter((value) => value && typeof value === "object");
+  const keys = ["results", "items", "documents", "matches", "memories"];
+
+  for (const container of containers) {
+    for (const key of keys) {
+      if (Array.isArray(container[key])) {
+        return container[key];
+      }
+    }
+  }
+  return [];
+}
+
+function hasSearchResults(body) {
+  if (extractSearchResults(body).length > 0) {
+    return true;
+  }
+
+  const counts = [
+    body?.count,
+    body?.total,
+    body?.data?.count,
+    body?.data?.total,
+    body?.result?.count,
+    body?.result?.total,
+  ];
+  return counts.some((value) => Number.isFinite(value) && Number(value) > 0);
+}
+
+function searchLocalMemoryFiles(query, options = {}) {
+  const {
+    env = process.env,
+    fileSystem = fs,
+    limit = 5,
+    maxDepth = 8,
+  } = options;
+  const memoryDir = resolveMemoryDir(env);
+  const existsSync = fileSystemMethod(fileSystem, "existsSync");
+  const readdirSync = fileSystemMethod(fileSystem, "readdirSync");
+  const readFileSync = fileSystemMethod(fileSystem, "readFileSync");
+
+  const localFiles = {
+    source: "local-files",
+    memoryDir,
+    results: [],
+    total: 0,
+  };
+
+  if (!existsSync(memoryDir)) {
+    localFiles.message = `Memory directory not found: ${memoryDir}`;
+    return localFiles;
+  }
+
+  const queryLower = query.toLocaleLowerCase();
+  const extensions = new Set([".md", ".json"]);
+
+  function walk(dir, depth = 0) {
+    if (depth > maxDepth || localFiles.results.length >= limit) {
+      return;
+    }
+
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (localFiles.results.length >= limit) {
+        return;
+      }
+
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath, depth + 1);
+        continue;
+      }
+      if (!entry.isFile() || !extensions.has(path.extname(entry.name))) {
+        continue;
+      }
+
+      let content;
+      try {
+        content = readFileSync(fullPath, "utf8");
+      } catch {
+        continue;
+      }
+
+      const lines = content.split(/\r?\n/);
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line.toLocaleLowerCase().includes(queryLower)) {
+          continue;
+        }
+        localFiles.results.push({
+          source: "local-file",
+          file: normalizeRelativePath(path.relative(memoryDir, fullPath)),
+          line: index + 1,
+          preview: buildLocalMemoryPreview(lines, index),
+        });
+        break;
+      }
+    }
+  }
+
+  walk(memoryDir);
+  localFiles.total = localFiles.results.length;
+  return localFiles;
+}
+
 async function memorySearchCommand(args, context) {
   const { flags, positionals } = parseCommandArgs(args);
   const query = positionals.join(" ").trim();
@@ -533,6 +682,22 @@ async function memorySearchCommand(args, context) {
     });
   }
 
+  const apiResults = extractSearchResults(response.body);
+  const localFiles = hasSearchResults(response.body)
+    ? {
+        source: "local-files",
+        memoryDir: resolveMemoryDir(context.env),
+        results: [],
+        total: 0,
+        skipped: "api-returned-results",
+      }
+    : searchLocalMemoryFiles(query, {
+        env: context.env,
+        fileSystem: context.fs,
+        limit,
+      });
+  const results = apiResults.length > 0 ? apiResults : localFiles.results;
+
   return {
     ok: true,
     command: "memory-search",
@@ -541,6 +706,10 @@ async function memorySearchCommand(args, context) {
     query,
     limit,
     result: response.body,
+    results,
+    total: results.length,
+    sources: localFiles.total > 0 ? ["api", "local-files"] : ["api"],
+    localFiles,
   };
 }
 

--- a/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
+++ b/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
@@ -1,0 +1,857 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const DEFAULT_BASE_URLS = [
+  "http://127.0.0.1:3414",
+  "http://127.0.0.1:3515",
+  "http://127.0.0.1:3415",
+];
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_AGENT_TIMEOUT_MS = 30 * 60 * 1000;
+const TOKEN_PATH = path.join(os.homedir(), ".openloomi", "token");
+
+const SAFE_AGENT_ALLOWED_TOOLS = [
+  "Read",
+  "Glob",
+  "Grep",
+  "WebSearch",
+  "WebFetch",
+  "Skill",
+  "LSP",
+  "TodoWrite",
+];
+const SAFE_AGENT_DISALLOWED_TOOLS = ["Edit", "Write", "Bash", "Agent", "Task"];
+
+class OpenLoomiError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "OpenLoomiError";
+    this.code = code;
+    this.details = details;
+    if (details.status) {
+      this.status = details.status;
+    }
+  }
+}
+
+function normalizeBaseUrl(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new OpenLoomiError(
+      "invalid_config",
+      `Invalid OpenLoomi base URL: ${value}`,
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new OpenLoomiError(
+      "invalid_config",
+      `OpenLoomi base URL must use http or https: ${value}`,
+    );
+  }
+  return url.toString().replace(/\/+$/, "");
+}
+
+function resolveBaseUrls(env = process.env) {
+  const values = [
+    env.OPENLOOMI_API_URL,
+    env.OPENLOOMI_BASE_URL,
+    ...DEFAULT_BASE_URLS,
+  ];
+  const seen = new Set();
+  const urls = [];
+  for (const value of values) {
+    const normalized = normalizeBaseUrl(value);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    urls.push(normalized);
+  }
+  return urls;
+}
+
+function looksLikeJwt(value) {
+  return /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?$/.test(value);
+}
+
+function maybeDecodeToken(raw) {
+  const trimmed = String(raw || "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (looksLikeJwt(trimmed)) {
+    return { token: trimmed, encoded: false };
+  }
+
+  const decoded = Buffer.from(trimmed, "base64").toString("utf8").trim();
+  if (decoded && looksLikeJwt(decoded)) {
+    return { token: decoded, encoded: true };
+  }
+  return { token: trimmed, encoded: false };
+}
+
+function readAuthToken(env = process.env, fileSystem = fs) {
+  const envToken = maybeDecodeToken(env.OPENLOOMI_AUTH_TOKEN);
+  if (envToken?.token) {
+    return {
+      available: true,
+      source: "env:OPENLOOMI_AUTH_TOKEN",
+      token: envToken.token,
+      encoded: envToken.encoded,
+    };
+  }
+
+  const tokenPath = env.OPENLOOMI_TOKEN_PATH || TOKEN_PATH;
+  try {
+    const token = maybeDecodeToken(fileSystem.readFileSync(tokenPath, "utf8"));
+    if (token?.token) {
+      return {
+        available: true,
+        source: "file",
+        tokenPath,
+        token: token.token,
+        encoded: token.encoded,
+      };
+    }
+  } catch {
+    // Missing local OpenLoomi token is a normal first-run state.
+  }
+
+  return {
+    available: false,
+    source: "none",
+    token: null,
+  };
+}
+
+function publicAuthInfo(auth) {
+  return {
+    available: auth.available === true,
+    source: auth.source,
+    encoded: auth.encoded === true,
+    tokenPath: auth.tokenPath,
+  };
+}
+
+function parseCommandArgs(args) {
+  const flags = {};
+  const positionals = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const withoutPrefix = arg.slice(2);
+    const eqIndex = withoutPrefix.indexOf("=");
+    if (eqIndex >= 0) {
+      const key = withoutPrefix.slice(0, eqIndex);
+      flags[key] = withoutPrefix.slice(eqIndex + 1);
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags[withoutPrefix] = next;
+      i += 1;
+    } else {
+      flags[withoutPrefix] = true;
+    }
+  }
+
+  return { flags, positionals };
+}
+
+function parsePositiveInteger(value, fallback, name) {
+  if (value === undefined || value === null || value === true || value === "") {
+    return fallback;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new OpenLoomiError("usage", `${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseOptionalNumber(value, name) {
+  if (value === undefined || value === null || value === true || value === "") {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new OpenLoomiError("usage", `${name} must be a number.`);
+  }
+  return parsed;
+}
+
+function extractMessage(body, fallbackText) {
+  if (body && typeof body === "object") {
+    if (typeof body.message === "string") {
+      return body.message;
+    }
+    if (typeof body.error === "string") {
+      return body.error;
+    }
+    if (body.error && typeof body.error.message === "string") {
+      return body.error.message;
+    }
+    if (typeof body.code === "string") {
+      return body.code;
+    }
+  }
+  const text = String(fallbackText || "").trim();
+  return text || null;
+}
+
+function httpErrorCode(status) {
+  if (status === 401 || status === 403) return "not_authenticated";
+  if (status === 404) return "not_found";
+  if (status === 405) return "method_not_allowed";
+  if (status === 408 || status === 504) return "timeout";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "service_unavailable";
+  if (status >= 400) return "bad_request";
+  return "http_error";
+}
+
+function parseJsonMaybe(text) {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWithTimeout(url, options, timeoutMs) {
+  if (typeof fetch !== "function") {
+    throw new OpenLoomiError(
+      "unsupported_runtime",
+      "This skill wrapper requires Node.js 18 or newer with global fetch support.",
+    );
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new OpenLoomiError("timeout", `Request timed out: ${url}`);
+    }
+    throw new OpenLoomiError(
+      "network",
+      `Could not connect to OpenLoomi at ${url}: ${error?.message || error}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function apiRequest(baseUrl, endpoint, options = {}) {
+  const {
+    method = "GET",
+    body,
+    auth,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    accept = "application/json",
+  } = options;
+  const url = new URL(endpoint, baseUrl).toString();
+  const headers = {
+    Accept: accept,
+  };
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (auth?.token) {
+    headers.Authorization = `Bearer ${auth.token}`;
+  }
+
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    timeoutMs,
+  );
+  const text = await response.text();
+  const parsed = parseJsonMaybe(text);
+
+  if (!response.ok) {
+    const message =
+      extractMessage(parsed, text) ||
+      `${method} ${endpoint} returned HTTP ${response.status}`;
+    throw new OpenLoomiError(httpErrorCode(response.status), message, {
+      status: response.status,
+      endpoint,
+      baseUrl,
+      body: parsed ?? text,
+    });
+  }
+
+  return {
+    baseUrl,
+    endpoint,
+    status: response.status,
+    body: parsed ?? text,
+    text,
+  };
+}
+
+function unwrapData(body) {
+  if (body && typeof body === "object" && "data" in body) {
+    return body.data;
+  }
+  return body;
+}
+
+function formatAttempt(baseUrl, error) {
+  return {
+    baseUrl,
+    ok: false,
+    code: error.code || "unknown",
+    message: error.message,
+    status: error.status,
+  };
+}
+
+async function locateBaseUrl(env, auth, timeoutMs = 5000) {
+  const attempts = [];
+  for (const baseUrl of resolveBaseUrls(env)) {
+    try {
+      const probe = await apiRequest(baseUrl, "/api/remote-auth/user", {
+        auth,
+        timeoutMs,
+      });
+      return { baseUrl, probe, attempts };
+    } catch (error) {
+      attempts.push(formatAttempt(baseUrl, error));
+    }
+  }
+
+  throw new OpenLoomiError(
+    "service_unavailable",
+    "OpenLoomi local API is unreachable. Open OpenLoomi Desktop and retry.",
+    { attempts },
+  );
+}
+
+function sanitizeUser(user) {
+  if (!user || typeof user !== "object") {
+    return user;
+  }
+  return {
+    id: user.id ?? null,
+    email: user.email ?? null,
+    name: user.name ?? null,
+    authenticated: user.authenticated === true,
+  };
+}
+
+async function statusCommand(args, context) {
+  const { flags } = parseCommandArgs(args);
+  const timeoutMs = parsePositiveInteger(
+    flags["timeout-ms"],
+    DEFAULT_TIMEOUT_MS,
+    "--timeout-ms",
+  );
+  const auth = readAuthToken(context.env, context.fs);
+  const attempts = [];
+
+  for (const baseUrl of resolveBaseUrls(context.env)) {
+    try {
+      const userProbe = await apiRequest(baseUrl, "/api/remote-auth/user", {
+        auth,
+        timeoutMs,
+      });
+      let providersProbe;
+      try {
+        providersProbe = await apiRequest(baseUrl, "/api/native/providers", {
+          auth,
+          timeoutMs,
+        });
+      } catch (error) {
+        providersProbe = { error };
+      }
+
+      const user = unwrapData(userProbe.body);
+      const providerBody =
+        providersProbe && !providersProbe.error
+          ? unwrapData(providersProbe.body)
+          : null;
+
+      return {
+        ok: true,
+        command: "status",
+        baseUrl,
+        auth: publicAuthInfo(auth),
+        probes: {
+          user: {
+            ok: true,
+            status: userProbe.status,
+            authenticated: user?.authenticated === true,
+            user: sanitizeUser(user),
+          },
+          providers: providersProbe.error
+            ? {
+                ok: false,
+                code: providersProbe.error.code,
+                message: providersProbe.error.message,
+                status: providersProbe.error.status,
+              }
+            : {
+                ok: true,
+                status: providersProbe.status,
+                defaultAgent: providerBody?.defaultAgent ?? null,
+                agents: Array.isArray(providerBody?.agents)
+                  ? providerBody.agents
+                  : [],
+              },
+        },
+        attempts,
+      };
+    } catch (error) {
+      attempts.push(formatAttempt(baseUrl, error));
+    }
+  }
+
+  throw new OpenLoomiError(
+    "service_unavailable",
+    "OpenLoomi local API is unreachable. Open OpenLoomi Desktop and retry.",
+    { attempts, auth: publicAuthInfo(auth) },
+  );
+}
+
+function shouldFallbackToRag(error) {
+  return error?.code === "not_found" || error?.code === "method_not_allowed";
+}
+
+async function memorySearchCommand(args, context) {
+  const { flags, positionals } = parseCommandArgs(args);
+  const query = positionals.join(" ").trim();
+  if (!query) {
+    throw new OpenLoomiError(
+      "usage",
+      'Query required: memory-search "your query" [--limit=5]',
+    );
+  }
+
+  const limit = parsePositiveInteger(flags.limit, 5, "--limit");
+  const threshold = parseOptionalNumber(flags.threshold, "--threshold");
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+
+  const body = { query, limit };
+  if (threshold !== undefined) {
+    body.threshold = threshold;
+  }
+
+  let endpoint = "/api/memory/search";
+  let response;
+  try {
+    response = await apiRequest(located.baseUrl, endpoint, {
+      method: "POST",
+      auth,
+      body,
+    });
+  } catch (error) {
+    if (!shouldFallbackToRag(error)) {
+      throw error;
+    }
+    endpoint = "/api/rag/search";
+    response = await apiRequest(located.baseUrl, endpoint, {
+      method: "POST",
+      auth,
+      body,
+    });
+  }
+
+  return {
+    ok: true,
+    command: "memory-search",
+    baseUrl: located.baseUrl,
+    endpoint,
+    query,
+    limit,
+    result: response.body,
+  };
+}
+
+async function connectorsListCommand(args, context) {
+  const { flags } = parseCommandArgs(args);
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const response = await apiRequest(
+    located.baseUrl,
+    "/api/integrations/accounts",
+    { auth },
+  );
+  const body = unwrapData(response.body);
+  const accounts = Array.isArray(body?.accounts) ? body.accounts : [];
+  const platform =
+    typeof flags.platform === "string" ? flags.platform.trim() : null;
+  const filteredAccounts = platform
+    ? accounts.filter((account) => account.platform === platform)
+    : accounts;
+
+  return {
+    ok: true,
+    command: "connectors-list",
+    baseUrl: located.baseUrl,
+    endpoint: "/api/integrations/accounts",
+    platform: platform || undefined,
+    accounts: filteredAccounts,
+    total: filteredAccounts.length,
+    result: response.body,
+  };
+}
+
+function addUnique(values, value) {
+  if (value && !values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function extractSkillName(input) {
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    return trimmed || null;
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return null;
+  }
+  for (const key of ["skill", "skillName", "skill_name", "name", "command"]) {
+    if (typeof input[key] === "string" && input[key].trim()) {
+      return input[key].trim();
+    }
+  }
+  return null;
+}
+
+function recordAgentEvent(result, event) {
+  result.eventCount += 1;
+  const type = typeof event.type === "string" ? event.type : "";
+
+  if (type === "text" || type === "direct_answer") {
+    if (typeof event.content === "string") {
+      result.response += event.content;
+      result.textEventCount += 1;
+    }
+    return;
+  }
+
+  if (type === "session") {
+    result.sessionId = event.sessionId || event.session_id || result.sessionId;
+    return;
+  }
+
+  if (type === "tool_use") {
+    if (typeof event.name === "string") {
+      result.toolCalls.push(event.name);
+      addUnique(result.tools, event.name);
+      if (event.name === "Skill") {
+        addUnique(result.skills, extractSkillName(event.input));
+      }
+    }
+    return;
+  }
+
+  if (type === "permission_request") {
+    result.permissionRequests += 1;
+    return;
+  }
+
+  if (type === "result") {
+    result.cost = typeof event.cost === "number" ? event.cost : result.cost;
+    result.durationMs =
+      typeof event.duration === "number" ? event.duration : result.durationMs;
+    result.usage = event.usage || result.usage;
+    if (!result.response && typeof event.content === "string") {
+      result.response = event.content;
+    }
+    return;
+  }
+
+  if (type === "error") {
+    result.error =
+      event.message ||
+      event.content ||
+      result.error ||
+      "agent returned an error event";
+  }
+}
+
+function resultFromPlainJson(value) {
+  const response =
+    typeof value?.text === "string"
+      ? value.text
+      : typeof value?.content === "string"
+        ? value.content
+        : typeof value?.message === "string"
+          ? value.message
+          : typeof value?.result === "string"
+            ? value.result
+            : "";
+  return {
+    response,
+    eventCount: 0,
+    textEventCount: response ? 1 : 0,
+    toolCalls: [],
+    tools: [],
+    skills: [],
+    permissionRequests: 0,
+    cost: typeof value?.cost === "number" ? value.cost : null,
+    durationMs: typeof value?.duration === "number" ? value.duration : null,
+    usage: value?.usage,
+    sessionId: value?.sessionId || value?.session_id || null,
+    error:
+      typeof value?.error === "string"
+        ? value.error
+        : typeof value?.error?.message === "string"
+          ? value.error.message
+          : null,
+  };
+}
+
+function parseAgentSse(raw) {
+  const result = {
+    response: "",
+    eventCount: 0,
+    textEventCount: 0,
+    toolCalls: [],
+    tools: [],
+    skills: [],
+    permissionRequests: 0,
+    cost: null,
+    durationMs: null,
+    usage: undefined,
+    sessionId: null,
+    error: null,
+  };
+
+  for (const line of String(raw || "").split(/\r?\n/)) {
+    if (!line.startsWith("data:")) {
+      continue;
+    }
+    const data = line.slice("data:".length).trim();
+    if (!data || data === "[DONE]") {
+      continue;
+    }
+    let event;
+    try {
+      event = JSON.parse(data);
+    } catch (error) {
+      throw new OpenLoomiError(
+        "agent_response",
+        `Failed to parse agent SSE event: ${error.message}`,
+      );
+    }
+    recordAgentEvent(result, event);
+  }
+
+  if (result.eventCount > 0) {
+    return result;
+  }
+
+  const json = parseJsonMaybe(raw);
+  if (json && typeof json === "object") {
+    return resultFromPlainJson(json);
+  }
+
+  const response = String(raw || "").trim();
+  if (response) {
+    return {
+      ...result,
+      response,
+      textEventCount: 1,
+    };
+  }
+
+  throw new OpenLoomiError(
+    "agent_response",
+    "Agent API response did not contain SSE data events.",
+  );
+}
+
+function buildAgentRequest(prompt, auth, flags = {}) {
+  const body = {
+    prompt,
+    platform:
+      typeof flags.platform === "string" && flags.platform.trim()
+        ? flags.platform.trim()
+        : "workbuddy",
+    workDir: process.cwd(),
+    useProvidedWorkDir: true,
+    permissionMode: "dontAsk",
+    allowedTools: SAFE_AGENT_ALLOWED_TOOLS,
+    disallowedTools: SAFE_AGENT_DISALLOWED_TOOLS,
+    excludeTools: [],
+    skillsConfig: {
+      enabled: true,
+      userDirEnabled: true,
+      appDirEnabled: true,
+    },
+    mcpConfig: {
+      enabled: true,
+      userDirEnabled: true,
+      appDirEnabled: true,
+    },
+  };
+
+  if (typeof flags["session-id"] === "string" && flags["session-id"].trim()) {
+    body.sessionId = flags["session-id"].trim();
+  }
+  if (
+    typeof flags["memory-retrieval-mode"] === "string" &&
+    flags["memory-retrieval-mode"].trim()
+  ) {
+    body.memoryRetrievalMode = flags["memory-retrieval-mode"].trim();
+  }
+  if (auth?.token) {
+    body.authToken = auth.token;
+  }
+  return body;
+}
+
+async function agentRunCommand(args, context) {
+  const { flags, positionals } = parseCommandArgs(args);
+  const prompt = positionals.join(" ").trim();
+  if (!prompt) {
+    throw new OpenLoomiError(
+      "usage",
+      'Prompt required: agent-run "Draft an email. Do not send it."',
+    );
+  }
+
+  const timeoutMs = parsePositiveInteger(
+    flags["timeout-ms"],
+    DEFAULT_AGENT_TIMEOUT_MS,
+    "--timeout-ms",
+  );
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const response = await apiRequest(located.baseUrl, "/api/native/agent", {
+    method: "POST",
+    auth,
+    body: buildAgentRequest(prompt, auth, flags),
+    timeoutMs,
+    accept: "text/event-stream",
+  });
+  const result = parseAgentSse(response.text);
+
+  if (result.error) {
+    throw new OpenLoomiError("agent_error", result.error, { result });
+  }
+
+  return {
+    ok: true,
+    command: "agent-run",
+    baseUrl: located.baseUrl,
+    endpoint: "/api/native/agent",
+    response: result.response,
+    result,
+  };
+}
+
+function helpResult() {
+  return {
+    ok: true,
+    commands: {
+      status: 'node "$SKILL_DIR/scripts/openloomi.cjs" status',
+      "memory-search":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "query" --limit=5',
+      "connectors-list":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" connectors-list [--platform=gmail]',
+      "agent-run":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" agent-run "Prompt. Do not perform side effects without confirmation."',
+    },
+  };
+}
+
+async function runCommand(argv, context = { env: process.env, fs }) {
+  const [command, ...args] = argv;
+
+  switch (command) {
+    case "help":
+    case "--help":
+    case "-h":
+    case undefined:
+      return helpResult();
+    case "status":
+      return statusCommand(args, context);
+    case "memory-search":
+      return memorySearchCommand(args, context);
+    case "connectors-list":
+      return connectorsListCommand(args, context);
+    case "agent-run":
+      return agentRunCommand(args, context);
+    default:
+      throw new OpenLoomiError(
+        "usage",
+        `Unknown command: ${command}. Run openloomi.cjs help.`,
+      );
+  }
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function errorToJson(error) {
+  if (error instanceof OpenLoomiError) {
+    return {
+      ok: false,
+      code: error.code,
+      message: error.message,
+      ...error.details,
+    };
+  }
+  return {
+    ok: false,
+    code: "unknown",
+    message: error?.message || String(error),
+  };
+}
+
+async function main() {
+  try {
+    printJson(
+      await runCommand(process.argv.slice(2), { env: process.env, fs }),
+    );
+  } catch (error) {
+    printJson(errorToJson(error));
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  void main();
+}
+
+module.exports = {
+  OpenLoomiError,
+  buildAgentRequest,
+  errorToJson,
+  parseAgentSse,
+  readAuthToken,
+  resolveBaseUrls,
+  runCommand,
+};

--- a/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
+++ b/apps/openloomi-skill/openloomi/scripts/openloomi.cjs
@@ -12,6 +12,8 @@ const DEFAULT_BASE_URLS = [
 ];
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_AGENT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_UPLOAD_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_UPLOAD_MAX_BYTES = 8 * 1024 * 1024;
 const TOKEN_PATH = path.join(os.homedir(), ".openloomi", "token");
 
 const SAFE_AGENT_ALLOWED_TOOLS = [
@@ -195,6 +197,10 @@ function parseOptionalNumber(value, name) {
   return parsed;
 }
 
+function isTruthyFlag(value) {
+  return value === true || value === "true" || value === "1" || value === "yes";
+}
+
 function extractMessage(body, fallbackText) {
   if (body && typeof body === "object") {
     if (typeof body.message === "string") {
@@ -299,6 +305,49 @@ async function apiRequest(baseUrl, endpoint, options = {}) {
     const message =
       extractMessage(parsed, text) ||
       `${method} ${endpoint} returned HTTP ${response.status}`;
+    throw new OpenLoomiError(httpErrorCode(response.status), message, {
+      status: response.status,
+      endpoint,
+      baseUrl,
+      body: parsed ?? text,
+    });
+  }
+
+  return {
+    baseUrl,
+    endpoint,
+    status: response.status,
+    body: parsed ?? text,
+    text,
+  };
+}
+
+async function apiFormDataRequest(baseUrl, endpoint, formData, options = {}) {
+  const { auth, timeoutMs = DEFAULT_UPLOAD_TIMEOUT_MS } = options;
+  const url = new URL(endpoint, baseUrl).toString();
+  const headers = {
+    Accept: "application/json",
+  };
+  if (auth?.token) {
+    headers.Authorization = `Bearer ${auth.token}`;
+  }
+
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method: "POST",
+      headers,
+      body: formData,
+    },
+    timeoutMs,
+  );
+  const text = await response.text();
+  const parsed = parseJsonMaybe(text);
+
+  if (!response.ok) {
+    const message =
+      extractMessage(parsed, text) ||
+      `POST ${endpoint} returned HTTP ${response.status}`;
     throw new OpenLoomiError(httpErrorCode(response.status), message, {
       status: response.status,
       endpoint,
@@ -491,6 +540,176 @@ async function memorySearchCommand(args, context) {
     endpoint,
     query,
     limit,
+    result: response.body,
+  };
+}
+
+async function knowledgeSearchCommand(args, context) {
+  const { flags, positionals } = parseCommandArgs(args);
+  const query = positionals.join(" ").trim();
+  if (!query) {
+    throw new OpenLoomiError(
+      "usage",
+      'Query required: knowledge-search "your query" [--limit=5]',
+    );
+  }
+
+  const limit = parsePositiveInteger(flags.limit, 5, "--limit");
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const body = { query, limit };
+  const response = await apiRequest(located.baseUrl, "/api/rag/search", {
+    method: "POST",
+    auth,
+    body,
+  });
+
+  return {
+    ok: true,
+    command: "knowledge-search",
+    baseUrl: located.baseUrl,
+    endpoint: "/api/rag/search",
+    query,
+    limit,
+    result: response.body,
+  };
+}
+
+async function knowledgeListCommand(args, context) {
+  const { flags } = parseCommandArgs(args);
+  const pageSize = parsePositiveInteger(flags.limit, 50, "--limit");
+  const params = new URLSearchParams({ pageSize: String(pageSize) });
+  if (typeof flags.cursor === "string" && flags.cursor.trim()) {
+    params.set("cursor", flags.cursor.trim());
+  }
+
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const endpoint = `/api/rag/documents?${params.toString()}`;
+  const response = await apiRequest(located.baseUrl, endpoint, { auth });
+
+  return {
+    ok: true,
+    command: "knowledge-list",
+    baseUrl: located.baseUrl,
+    endpoint,
+    limit: pageSize,
+    cursor: params.get("cursor") || undefined,
+    result: response.body,
+  };
+}
+
+async function knowledgeGetCommand(args, context) {
+  const { positionals } = parseCommandArgs(args);
+  const documentId = positionals.join(" ").trim();
+  if (!documentId) {
+    throw new OpenLoomiError(
+      "usage",
+      "Document id required: knowledge-get <documentId>",
+    );
+  }
+
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const encodedId = encodeURIComponent(documentId);
+  const endpoint = `/api/rag/documents/${encodedId}`;
+  const response = await apiRequest(located.baseUrl, endpoint, { auth });
+
+  return {
+    ok: true,
+    command: "knowledge-get",
+    baseUrl: located.baseUrl,
+    endpoint,
+    documentId,
+    result: response.body,
+  };
+}
+
+function assertFormDataRuntime() {
+  if (typeof FormData !== "function" || typeof Blob !== "function") {
+    throw new OpenLoomiError(
+      "unsupported_runtime",
+      "knowledge-upload requires Node.js 18 or newer with FormData and Blob support.",
+    );
+  }
+}
+
+async function knowledgeUploadCommand(args, context) {
+  const { flags, positionals } = parseCommandArgs(args);
+  const filePath = positionals.join(" ").trim();
+  if (!filePath) {
+    throw new OpenLoomiError(
+      "usage",
+      "File path required: knowledge-upload <path> [--file-name=name.md] [--skip-embeddings]",
+    );
+  }
+
+  assertFormDataRuntime();
+  const timeoutMs = parsePositiveInteger(
+    flags["timeout-ms"],
+    DEFAULT_UPLOAD_TIMEOUT_MS,
+    "--timeout-ms",
+  );
+  const maxBytes = parsePositiveInteger(
+    flags["max-bytes"],
+    DEFAULT_UPLOAD_MAX_BYTES,
+    "--max-bytes",
+  );
+  const resolvedPath = path.resolve(filePath);
+  let buffer;
+  try {
+    buffer = context.fs.readFileSync(resolvedPath);
+  } catch (error) {
+    throw new OpenLoomiError(
+      "file_read",
+      `Could not read file for knowledge upload: ${resolvedPath}`,
+      { cause: error?.message },
+    );
+  }
+  if (!Buffer.isBuffer(buffer)) {
+    buffer = Buffer.from(buffer);
+  }
+  if (buffer.byteLength > maxBytes) {
+    throw new OpenLoomiError(
+      "file_too_large",
+      `knowledge-upload supports files up to ${maxBytes} bytes. Use OpenLoomi Desktop Library for larger files.`,
+      { filePath: resolvedPath, sizeBytes: buffer.byteLength, maxBytes },
+    );
+  }
+
+  const auth = readAuthToken(context.env, context.fs);
+  const located = await locateBaseUrl(context.env, auth);
+  const fileName =
+    typeof flags["file-name"] === "string" && flags["file-name"].trim()
+      ? flags["file-name"].trim()
+      : path.basename(resolvedPath);
+  const contentType =
+    typeof flags["content-type"] === "string" && flags["content-type"].trim()
+      ? flags["content-type"].trim()
+      : "application/octet-stream";
+  const formData = new FormData();
+  formData.append("file", new Blob([buffer], { type: contentType }), fileName);
+  if (isTruthyFlag(flags["skip-embeddings"])) {
+    formData.append("skipEmbeddings", "true");
+  }
+  if (auth?.token && !isTruthyFlag(flags["no-cloud-auth-token"])) {
+    formData.append("cloudAuthToken", auth.token);
+  }
+
+  const response = await apiFormDataRequest(
+    located.baseUrl,
+    "/api/rag/upload",
+    formData,
+    { auth, timeoutMs },
+  );
+
+  return {
+    ok: true,
+    command: "knowledge-upload",
+    baseUrl: located.baseUrl,
+    endpoint: "/api/rag/upload",
+    fileName,
+    sizeBytes: buffer.byteLength,
     result: response.body,
   };
 }
@@ -778,6 +997,14 @@ function helpResult() {
       status: 'node "$SKILL_DIR/scripts/openloomi.cjs" status',
       "memory-search":
         'node "$SKILL_DIR/scripts/openloomi.cjs" memory-search "query" --limit=5',
+      "knowledge-search":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-search "query" --limit=5',
+      "knowledge-list":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-list [--limit=50]',
+      "knowledge-get":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-get <documentId>',
+      "knowledge-upload":
+        'node "$SKILL_DIR/scripts/openloomi.cjs" knowledge-upload <path> [--skip-embeddings]',
       "connectors-list":
         'node "$SKILL_DIR/scripts/openloomi.cjs" connectors-list [--platform=gmail]',
       "agent-run":
@@ -799,6 +1026,14 @@ async function runCommand(argv, context = { env: process.env, fs }) {
       return statusCommand(args, context);
     case "memory-search":
       return memorySearchCommand(args, context);
+    case "knowledge-search":
+      return knowledgeSearchCommand(args, context);
+    case "knowledge-list":
+      return knowledgeListCommand(args, context);
+    case "knowledge-get":
+      return knowledgeGetCommand(args, context);
+    case "knowledge-upload":
+      return knowledgeUploadCommand(args, context);
     case "connectors-list":
       return connectorsListCommand(args, context);
     case "agent-run":

--- a/apps/openloomi-skill/scripts/package-openloomi-skill.cjs
+++ b/apps/openloomi-skill/scripts/package-openloomi-skill.cjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "../../..");
+const skillDir = path.resolve(repoRoot, "apps/openloomi-skill/openloomi");
+const distDir = path.resolve(repoRoot, "apps/openloomi-skill/dist");
+const defaultZipPath = path.resolve(distDir, "openloomi-skill.zip");
+
+const EXPECTED_BUNDLE_FILES = [
+  "SKILL.md",
+  "agents/openai.yaml",
+  "references/examples.md",
+  "references/tool-surface.md",
+  "scripts/openloomi.cjs",
+];
+
+const PRETTIER_FILES = [
+  "apps/openloomi-skill/README.md",
+  "apps/openloomi-skill/openloomi/SKILL.md",
+  "apps/openloomi-skill/openloomi/agents/openai.yaml",
+  "apps/openloomi-skill/openloomi/references/tool-surface.md",
+  "apps/openloomi-skill/openloomi/references/examples.md",
+  "apps/openloomi-skill/openloomi/scripts/openloomi.cjs",
+  "apps/openloomi-skill/tests/openloomi-script.test.mjs",
+  "apps/openloomi-skill/tests/bundle-structure.test.mjs",
+  "apps/openloomi-skill/tests/package-openloomi-skill.test.mjs",
+  "apps/openloomi-skill/scripts/package-openloomi-skill.cjs",
+];
+
+let crcTable;
+
+function makeCrcTable() {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i += 1) {
+    let value = i;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[i] = value >>> 0;
+  }
+  return table;
+}
+
+function crc32(buffer) {
+  crcTable ||= makeCrcTable();
+  let value = 0xffffffff;
+  for (const byte of buffer) {
+    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(date = new Date()) {
+  const year = Math.max(date.getFullYear(), 1980);
+  const dosTime =
+    (date.getHours() << 11) |
+    (date.getMinutes() << 5) |
+    Math.floor(date.getSeconds() / 2);
+  const dosDate =
+    ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+  return { dosDate, dosTime };
+}
+
+function listFilesRecursive(rootDir, dir = rootDir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir)) {
+    const fullPath = path.resolve(dir, entry);
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...listFilesRecursive(rootDir, fullPath));
+      continue;
+    }
+    if (stat.isFile()) {
+      files.push(path.relative(rootDir, fullPath).split(path.sep).join("/"));
+    }
+  }
+  return files.sort();
+}
+
+function listBundleFiles(rootDir = skillDir) {
+  return listFilesRecursive(rootDir);
+}
+
+function assertBundleShape(files) {
+  const expected = [...EXPECTED_BUNDLE_FILES].sort();
+  const actual = [...files].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      [
+        "OpenLoomi skill bundle contains unexpected files.",
+        `Expected: ${expected.join(", ")}`,
+        `Actual: ${actual.join(", ")}`,
+      ].join("\n"),
+    );
+  }
+}
+
+function writeUInt16(value) {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value, 0);
+  return buffer;
+}
+
+function writeUInt32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value >>> 0, 0);
+  return buffer;
+}
+
+function createZipBuffer(rootDir, files) {
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const fullPath = path.resolve(rootDir, file);
+    const data = fs.readFileSync(fullPath);
+    const name = Buffer.from(file, "utf8");
+    const stat = fs.statSync(fullPath);
+    const { dosDate, dosTime } = dosDateTime(stat.mtime);
+    const checksum = crc32(data);
+
+    const localHeader = Buffer.concat([
+      writeUInt32(0x04034b50),
+      writeUInt16(20),
+      writeUInt16(0),
+      writeUInt16(0),
+      writeUInt16(dosTime),
+      writeUInt16(dosDate),
+      writeUInt32(checksum),
+      writeUInt32(data.length),
+      writeUInt32(data.length),
+      writeUInt16(name.length),
+      writeUInt16(0),
+      name,
+    ]);
+    localParts.push(localHeader, data);
+
+    const centralHeader = Buffer.concat([
+      writeUInt32(0x02014b50),
+      writeUInt16(20),
+      writeUInt16(20),
+      writeUInt16(0),
+      writeUInt16(0),
+      writeUInt16(dosTime),
+      writeUInt16(dosDate),
+      writeUInt32(checksum),
+      writeUInt32(data.length),
+      writeUInt32(data.length),
+      writeUInt16(name.length),
+      writeUInt16(0),
+      writeUInt16(0),
+      writeUInt16(0),
+      writeUInt16(0),
+      writeUInt32(0),
+      writeUInt32(offset),
+      name,
+    ]);
+    centralParts.push(centralHeader);
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const endRecord = Buffer.concat([
+    writeUInt32(0x06054b50),
+    writeUInt16(0),
+    writeUInt16(0),
+    writeUInt16(files.length),
+    writeUInt16(files.length),
+    writeUInt32(centralDirectory.length),
+    writeUInt32(offset),
+    writeUInt16(0),
+  ]);
+
+  return Buffer.concat([...localParts, centralDirectory, endRecord]);
+}
+
+function createZipArchive(options = {}) {
+  const rootDir = path.resolve(options.rootDir || skillDir);
+  const outPath = path.resolve(options.outPath || defaultZipPath);
+  const files = listBundleFiles(rootDir);
+  assertBundleShape(files);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, createZipBuffer(rootDir, files));
+  return { outPath, files };
+}
+
+function runStep(label, command, args, options = {}) {
+  process.stdout.write(`\n> ${label}\n`);
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+    shell: process.platform === "win32",
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${result.status}`);
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    outPath: defaultZipPath,
+    skipChecks: false,
+  };
+  for (const arg of argv) {
+    if (arg === "--skip-checks") {
+      options.skipChecks = true;
+      continue;
+    }
+    if (arg.startsWith("--out=")) {
+      options.outPath = path.resolve(repoRoot, arg.slice("--out=".length));
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function runChecks() {
+  runStep("Validate skill metadata", "python", [
+    "skills/skill-creator/scripts/quick_validate.py",
+    "apps/openloomi-skill/openloomi",
+  ]);
+  runStep("Run bundle structure tests", "node", [
+    "--test",
+    "apps/openloomi-skill/tests/bundle-structure.test.mjs",
+  ]);
+  runStep("Run wrapper tests", "node", [
+    "--test",
+    "apps/openloomi-skill/tests/openloomi-script.test.mjs",
+  ]);
+  runStep("Run package helper tests", "node", [
+    "--test",
+    "apps/openloomi-skill/tests/package-openloomi-skill.test.mjs",
+  ]);
+  runStep("Check formatting", "pnpm", [
+    "exec",
+    "prettier",
+    "--check",
+    ...PRETTIER_FILES,
+  ]);
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (!options.skipChecks) {
+    runChecks();
+  }
+  const { outPath, files } = createZipArchive({ outPath: options.outPath });
+  process.stdout.write(
+    [
+      "",
+      "OpenLoomi WorkBuddy skill bundle is ready.",
+      `Zip: ${outPath}`,
+      "Zip root entries:",
+      ...files.map((file) => `- ${file}`),
+      "",
+      "Upload this zip to WorkBuddy Skills, then run:",
+      "Use $openloomi to check my local OpenLoomi status and list connected accounts.",
+      "",
+    ].join("\n"),
+  );
+  return { outPath, files };
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`\n${error.message || error}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  EXPECTED_BUNDLE_FILES,
+  assertBundleShape,
+  createZipArchive,
+  createZipBuffer,
+  listBundleFiles,
+  main,
+  parseArgs,
+};

--- a/apps/openloomi-skill/tests/bundle-structure.test.mjs
+++ b/apps/openloomi-skill/tests/bundle-structure.test.mjs
@@ -48,6 +48,11 @@ test("WorkBuddy packaging docs keep development files outside the upload root", 
 
   assert.match(
     readme,
+    /node apps\\openloomi-skill\\scripts\\package-openloomi-skill\.cjs/,
+  );
+  assert.match(readme, /apps\/openloomi-skill\/dist\/openloomi-skill\.zip/);
+  assert.match(
+    readme,
     /Upload the `apps\/openloomi-skill\/openloomi\/` folder/,
   );
   assert.match(

--- a/apps/openloomi-skill/tests/bundle-structure.test.mjs
+++ b/apps/openloomi-skill/tests/bundle-structure.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const skillDir = resolve(testDir, "../openloomi");
+const docsDir = resolve(testDir, "..");
 
 function listFiles(dir) {
   const files = [];
@@ -25,6 +26,10 @@ function readSkillFile(path) {
   return readFileSync(resolve(skillDir, path), "utf8");
 }
 
+function readDocsFile(path) {
+  return readFileSync(resolve(docsDir, path), "utf8");
+}
+
 test("WorkBuddy upload bundle has the required root skill files", () => {
   const files = listFiles(skillDir);
 
@@ -35,6 +40,25 @@ test("WorkBuddy upload bundle has the required root skill files", () => {
     "references/tool-surface.md",
     "scripts/openloomi.cjs",
   ]);
+});
+
+test("WorkBuddy packaging docs keep development files outside the upload root", () => {
+  const readme = readDocsFile("README.md");
+  const files = listFiles(skillDir);
+
+  assert.match(
+    readme,
+    /Upload the `apps\/openloomi-skill\/openloomi\/` folder/,
+  );
+  assert.match(
+    readme,
+    /Compress-Archive -Path apps\\openloomi-skill\\openloomi\\\*/,
+  );
+  assert.match(readme, /Do not include `apps\/openloomi-skill\/tests\/`/);
+  assert.equal(
+    files.some((file) => file === "README.md" || file.startsWith("tests/")),
+    false,
+  );
 });
 
 test("SKILL.md exposes a valid OpenLoomi skill trigger", () => {

--- a/apps/openloomi-skill/tests/bundle-structure.test.mjs
+++ b/apps/openloomi-skill/tests/bundle-structure.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const skillDir = resolve(testDir, "../openloomi");
+
+function listFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = resolve(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...listFiles(fullPath));
+    } else if (stat.isFile()) {
+      files.push(relative(skillDir, fullPath).split(sep).join("/"));
+    }
+  }
+  return files.sort();
+}
+
+function readSkillFile(path) {
+  return readFileSync(resolve(skillDir, path), "utf8");
+}
+
+test("WorkBuddy upload bundle has the required root skill files", () => {
+  const files = listFiles(skillDir);
+
+  assert.deepEqual(files, [
+    "SKILL.md",
+    "agents/openai.yaml",
+    "references/examples.md",
+    "references/tool-surface.md",
+    "scripts/openloomi.cjs",
+  ]);
+});
+
+test("SKILL.md exposes a valid OpenLoomi skill trigger", () => {
+  const skillMd = readSkillFile("SKILL.md");
+
+  assert.match(skillMd, /^---\n/m);
+  assert.match(skillMd, /^name: openloomi$/m);
+  assert.match(skillMd, /^description: .+OpenLoomi.+WorkBuddy.+$/m);
+  assert.doesNotMatch(skillMd, /TODO|NOT_IMPLEMENTED|pending/i);
+});
+
+test("agents/openai.yaml contains UI metadata and explicit skill invocation", () => {
+  const openaiYaml = readSkillFile("agents/openai.yaml");
+
+  assert.match(openaiYaml, /^interface:\r?\n/m);
+  assert.match(openaiYaml, /display_name: "OpenLoomi"/);
+  assert.match(
+    openaiYaml,
+    /short_description: "Use local OpenLoomi from WorkBuddy"/,
+  );
+  assert.match(openaiYaml, /default_prompt: "Use \$openloomi /);
+});

--- a/apps/openloomi-skill/tests/openloomi-script.test.mjs
+++ b/apps/openloomi-skill/tests/openloomi-script.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
@@ -164,6 +172,57 @@ test("memory-search falls back from unified memory to RAG search", async () => {
       assert.equal(result.json.result.results[0].documentId, "doc_1");
     },
   );
+});
+
+test("memory-search falls back to local memory files when API returns no results", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "openloomi-memory-"));
+  const notesDir = join(tempDir, "cloud_test", "notes");
+  mkdirSync(notesDir, { recursive: true });
+  writeFileSync(
+    join(notesDir, "roadmap.md"),
+    "# Roadmap\n\nThe roadmap priority is high.\n",
+    "utf8",
+  );
+
+  try {
+    await withMockServer(
+      async (req, res, body) => {
+        if (defaultProbeHandler(req, res)) return;
+        if (req.url === "/api/memory/search") {
+          assert.deepEqual(body, { query: "roadmap", limit: 5 });
+          sendJson(res, 200, {
+            query: body.query,
+            sources: ["memory", "insights", "knowledge"],
+            results: [],
+            count: 0,
+          });
+          return;
+        }
+        sendJson(res, 404, { error: "not found" });
+      },
+      async ({ baseUrl }) => {
+        const result = await runCli(
+          baseUrl,
+          ["memory-search", "roadmap", "--limit=5"],
+          { OPENLOOMI_MEMORY_DIR: tempDir },
+          { existsSync, readdirSync, readFileSync },
+        );
+
+        assert.equal(result.status, 0);
+        assert.equal(result.json.ok, true);
+        assert.equal(result.json.endpoint, "/api/memory/search");
+        assert.deepEqual(result.json.sources, ["api", "local-files"]);
+        assert.equal(result.json.total, 1);
+        assert.equal(result.json.localFiles.total, 1);
+        assert.equal(result.json.results[0].source, "local-file");
+        assert.equal(result.json.results[0].file, "cloud_test/notes/roadmap.md");
+        assert.equal(result.json.results[0].line, 1);
+        assert.match(result.json.results[0].preview, /high/);
+      },
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("knowledge commands use explicit RAG document APIs", async () => {

--- a/apps/openloomi-skill/tests/openloomi-script.test.mjs
+++ b/apps/openloomi-skill/tests/openloomi-script.test.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -70,7 +72,7 @@ async function withMockServer(handler, fn) {
   }
 }
 
-async function runCli(baseUrl, args, env = {}) {
+async function runCli(baseUrl, args, env = {}, fsOverride) {
   const json = await runCommand(args, {
     env: {
       OPENLOOMI_API_URL: baseUrl,
@@ -78,7 +80,7 @@ async function runCli(baseUrl, args, env = {}) {
       OPENLOOMI_AUTH_TOKEN: "test.jwt.token",
       ...env,
     },
-    fs: {
+    fs: fsOverride || {
       readFileSync() {
         throw new Error("token file should not be read when env token exists");
       },
@@ -162,6 +164,123 @@ test("memory-search falls back from unified memory to RAG search", async () => {
       assert.equal(result.json.result.results[0].documentId, "doc_1");
     },
   );
+});
+
+test("knowledge commands use explicit RAG document APIs", async () => {
+  await withMockServer(
+    async (req, res, body) => {
+      if (defaultProbeHandler(req, res)) return;
+      if (req.url === "/api/rag/search") {
+        assert.deepEqual(body, { query: "launch plan", limit: 3 });
+        sendJson(res, 200, {
+          results: [{ documentId: "doc_1", content: "launch result" }],
+        });
+        return;
+      }
+      if (req.url === "/api/rag/documents?pageSize=2&cursor=1700000000000") {
+        sendJson(res, 200, {
+          documents: [{ id: "doc_1", fileName: "launch.md" }],
+          hasMore: false,
+          nextCursor: null,
+          total: 1,
+        });
+        return;
+      }
+      if (req.url === "/api/rag/documents/doc_1") {
+        sendJson(res, 200, {
+          document: {
+            id: "doc_1",
+            fileName: "launch.md",
+            chunks: [{ id: "chunk_1", content: "Launch notes" }],
+          },
+        });
+        return;
+      }
+      sendJson(res, 404, { error: "not found" });
+    },
+    async ({ baseUrl }) => {
+      const search = await runCli(baseUrl, [
+        "knowledge-search",
+        "launch",
+        "plan",
+        "--limit=3",
+      ]);
+      assert.equal(search.json.ok, true);
+      assert.equal(search.json.endpoint, "/api/rag/search");
+      assert.equal(search.json.result.results[0].documentId, "doc_1");
+
+      const list = await runCli(baseUrl, [
+        "knowledge-list",
+        "--limit=2",
+        "--cursor=1700000000000",
+      ]);
+      assert.equal(list.json.ok, true);
+      assert.equal(
+        list.json.endpoint,
+        "/api/rag/documents?pageSize=2&cursor=1700000000000",
+      );
+      assert.equal(list.json.result.documents[0].fileName, "launch.md");
+
+      const get = await runCli(baseUrl, ["knowledge-get", "doc_1"]);
+      assert.equal(get.json.ok, true);
+      assert.equal(get.json.endpoint, "/api/rag/documents/doc_1");
+      assert.equal(get.json.result.document.chunks[0].content, "Launch notes");
+    },
+  );
+});
+
+test("knowledge-upload posts a small file as multipart form data", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "openloomi-skill-"));
+  const filePath = join(tempDir, "phase-five.md");
+  writeFileSync(filePath, "# Phase five\n\nUpload me.", "utf8");
+
+  try {
+    await withMockServer(
+      async (req, res, body) => {
+        if (defaultProbeHandler(req, res)) return;
+        if (req.url === "/api/rag/upload") {
+          assert.equal(req.method, "POST");
+          assert.equal(req.headers.authorization, "Bearer test.jwt.token");
+          assert.match(
+            req.headers["content-type"],
+            /^multipart\/form-data; boundary=/,
+          );
+          assert.match(body, /name="file"; filename="phase-five.md"/);
+          assert.match(body, /# Phase five/);
+          assert.match(body, /name="skipEmbeddings"/);
+          assert.match(body, /true/);
+          assert.match(body, /name="cloudAuthToken"/);
+          sendJson(res, 200, {
+            success: true,
+            documentId: "doc_uploaded",
+            fileName: "phase-five.md",
+          });
+          return;
+        }
+        sendJson(res, 404, { error: "not found" });
+      },
+      async ({ baseUrl }) => {
+        const result = await runCli(
+          baseUrl,
+          [
+            "knowledge-upload",
+            filePath,
+            "--skip-embeddings",
+            "--timeout-ms=2000",
+          ],
+          {},
+          { readFileSync },
+        );
+        assert.equal(result.json.ok, true);
+        assert.equal(result.json.endpoint, "/api/rag/upload");
+        assert.equal(result.json.fileName, "phase-five.md");
+        assert.equal(result.json.result.documentId, "doc_uploaded");
+        assert.doesNotMatch(JSON.stringify(result.json), /test\.jwt\.token/);
+      },
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("connectors-list returns accounts and supports platform filtering", async () => {

--- a/apps/openloomi-skill/tests/openloomi-script.test.mjs
+++ b/apps/openloomi-skill/tests/openloomi-script.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const scriptPath = resolve(testDir, "../openloomi/scripts/openloomi.cjs");
+const require = createRequire(import.meta.url);
+const { runCommand } = require(scriptPath);
+
+function readRequestBody(req) {
+  return new Promise((resolveBody) => {
+    let text = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      text += chunk;
+    });
+    req.on("end", () => {
+      if (!text) {
+        resolveBody(undefined);
+        return;
+      }
+      try {
+        resolveBody(JSON.parse(text));
+      } catch {
+        resolveBody(text);
+      }
+    });
+  });
+}
+
+function sendJson(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function sendSse(res, frames) {
+  res.writeHead(200, { "content-type": "text/event-stream" });
+  for (const frame of frames) {
+    res.write(`data: ${JSON.stringify(frame)}\n\n`);
+  }
+  res.end();
+}
+
+async function withMockServer(handler, fn) {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const body = await readRequestBody(req);
+    requests.push({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body,
+    });
+    await handler(req, res, body, requests);
+  });
+
+  await new Promise((resolveListen) =>
+    server.listen(0, "127.0.0.1", resolveListen),
+  );
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    return await fn({ baseUrl, requests });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+}
+
+async function runCli(baseUrl, args, env = {}) {
+  const json = await runCommand(args, {
+    env: {
+      OPENLOOMI_API_URL: baseUrl,
+      OPENLOOMI_BASE_URL: "",
+      OPENLOOMI_AUTH_TOKEN: "test.jwt.token",
+      ...env,
+    },
+    fs: {
+      readFileSync() {
+        throw new Error("token file should not be read when env token exists");
+      },
+    },
+  });
+  return {
+    status: 0,
+    json,
+  };
+}
+
+function defaultProbeHandler(req, res) {
+  if (req.url === "/api/remote-auth/user") {
+    sendJson(res, 200, {
+      success: true,
+      data: {
+        id: "user_1",
+        email: "user@example.test",
+        name: "Test User",
+        authenticated: true,
+      },
+    });
+    return true;
+  }
+  return false;
+}
+
+test("status probes the user and native provider endpoints", async () => {
+  await withMockServer(
+    async (req, res) => {
+      if (defaultProbeHandler(req, res)) return;
+      if (req.url === "/api/native/providers") {
+        sendJson(res, 200, {
+          defaultAgent: "codex",
+          agents: [{ type: "codex", displayName: "Codex" }],
+        });
+        return;
+      }
+      sendJson(res, 404, { error: "not found" });
+    },
+    async ({ baseUrl }) => {
+      const result = await runCli(baseUrl, ["status"]);
+      assert.equal(result.status, 0);
+      assert.equal(result.json.ok, true);
+      assert.equal(result.json.baseUrl, baseUrl);
+      assert.equal(result.json.auth.available, true);
+      assert.equal(result.json.probes.user.authenticated, true);
+      assert.equal(result.json.probes.providers.defaultAgent, "codex");
+    },
+  );
+});
+
+test("memory-search falls back from unified memory to RAG search", async () => {
+  await withMockServer(
+    async (req, res, body) => {
+      if (defaultProbeHandler(req, res)) return;
+      if (req.url === "/api/memory/search") {
+        sendJson(res, 404, { error: "missing route" });
+        return;
+      }
+      if (req.url === "/api/rag/search") {
+        assert.deepEqual(body, { query: "alpha project", limit: 7 });
+        sendJson(res, 200, {
+          query: body.query,
+          results: [{ documentId: "doc_1", content: "alpha result" }],
+        });
+        return;
+      }
+      sendJson(res, 404, { error: "not found" });
+    },
+    async ({ baseUrl }) => {
+      const result = await runCli(baseUrl, [
+        "memory-search",
+        "alpha",
+        "project",
+        "--limit=7",
+      ]);
+      assert.equal(result.status, 0);
+      assert.equal(result.json.ok, true);
+      assert.equal(result.json.endpoint, "/api/rag/search");
+      assert.equal(result.json.result.results[0].documentId, "doc_1");
+    },
+  );
+});
+
+test("connectors-list returns accounts and supports platform filtering", async () => {
+  await withMockServer(
+    async (req, res) => {
+      if (defaultProbeHandler(req, res)) return;
+      if (req.url === "/api/integrations/accounts") {
+        sendJson(res, 200, {
+          accounts: [
+            {
+              id: "int_gmail",
+              platform: "gmail",
+              displayName: "Gmail",
+              status: "active",
+              botId: "bot_gmail",
+            },
+            {
+              id: "int_slack",
+              platform: "slack",
+              displayName: "Slack",
+              status: "active",
+              botId: "bot_slack",
+            },
+          ],
+        });
+        return;
+      }
+      sendJson(res, 404, { error: "not found" });
+    },
+    async ({ baseUrl }) => {
+      const result = await runCli(baseUrl, [
+        "connectors-list",
+        "--platform=gmail",
+      ]);
+      assert.equal(result.status, 0);
+      assert.equal(result.json.ok, true);
+      assert.equal(result.json.total, 1);
+      assert.equal(result.json.accounts[0].id, "int_gmail");
+      assert.equal(result.json.accounts[0].botId, "bot_gmail");
+    },
+  );
+});
+
+test("agent-run posts a safe native-agent request and parses SSE output", async () => {
+  await withMockServer(
+    async (req, res, body) => {
+      if (defaultProbeHandler(req, res)) return;
+      if (req.url === "/api/native/agent") {
+        assert.equal(req.headers.authorization, "Bearer test.jwt.token");
+        assert.equal(body.prompt, "Draft reply");
+        assert.equal(body.platform, "workbuddy-test");
+        assert.equal(body.permissionMode, "dontAsk");
+        assert.equal(body.authToken, "test.jwt.token");
+        assert.ok(body.allowedTools.includes("Read"));
+        assert.ok(!body.allowedTools.includes("Bash"));
+        assert.ok(body.disallowedTools.includes("Bash"));
+        sendSse(res, [
+          { type: "session", sessionId: "session_1" },
+          { type: "text", content: "Hello" },
+          { type: "tool_use", name: "Skill", input: { skill: "openloomi" } },
+          { type: "text", content: " world" },
+          { type: "result", cost: 0.12, duration: 345 },
+        ]);
+        return;
+      }
+      sendJson(res, 404, { error: "not found" });
+    },
+    async ({ baseUrl }) => {
+      const result = await runCli(baseUrl, [
+        "agent-run",
+        "Draft",
+        "reply",
+        "--platform=workbuddy-test",
+        "--timeout-ms=2000",
+      ]);
+      assert.equal(result.status, 0);
+      assert.equal(result.json.ok, true);
+      assert.equal(result.json.response, "Hello world");
+      assert.equal(result.json.result.sessionId, "session_1");
+      assert.deepEqual(result.json.result.tools, ["Skill"]);
+      assert.deepEqual(result.json.result.skills, ["openloomi"]);
+      assert.equal(result.json.result.cost, 0.12);
+      assert.equal(result.json.result.durationMs, 345);
+    },
+  );
+});

--- a/apps/openloomi-skill/tests/package-openloomi-skill.test.mjs
+++ b/apps/openloomi-skill/tests/package-openloomi-skill.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const packageScript = require(
+  resolve(testDir, "../scripts/package-openloomi-skill.cjs"),
+);
+
+function readZipEntryNames(zipPath) {
+  const buffer = readFileSync(zipPath);
+  const names = [];
+  let offset = 0;
+  while (offset < buffer.length - 4) {
+    const signature = buffer.readUInt32LE(offset);
+    if (signature !== 0x02014b50) {
+      offset += 1;
+      continue;
+    }
+    const nameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const nameStart = offset + 46;
+    names.push(buffer.subarray(nameStart, nameStart + nameLength).toString());
+    offset = nameStart + nameLength + extraLength + commentLength;
+  }
+  return names.sort();
+}
+
+test("package helper lists the exact WorkBuddy upload bundle files", () => {
+  assert.deepEqual(
+    packageScript.listBundleFiles(resolve(testDir, "../openloomi")),
+    packageScript.EXPECTED_BUNDLE_FILES,
+  );
+});
+
+test("package helper rejects extra files in the upload root", () => {
+  assert.throws(
+    () => packageScript.assertBundleShape(["SKILL.md", "README.md"]),
+    /unexpected files/,
+  );
+});
+
+test("package helper creates a zip whose root is the skill bundle", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "openloomi-skill-package-"));
+  const outPath = join(tempDir, "openloomi-skill.zip");
+
+  try {
+    packageScript.createZipArchive({
+      rootDir: resolve(testDir, "../openloomi"),
+      outPath,
+    });
+
+    assert.equal(existsSync(outPath), true);
+    assert.deepEqual(readZipEntryNames(outPath), [
+      "SKILL.md",
+      "agents/openai.yaml",
+      "references/examples.md",
+      "references/tool-surface.md",
+      "scripts/openloomi.cjs",
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("package helper can override the output path", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "openloomi-skill-args-"));
+
+  try {
+    assert.equal(
+      packageScript.parseArgs([`--out=${join(tempDir, "bundle.zip")}`]).outPath,
+      resolve(tempDir, "bundle.zip"),
+    );
+    assert.equal(packageScript.parseArgs(["--skip-checks"]).skipChecks, true);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #321.

This PR implements the Option B WorkBuddy Skill Bundle path for OpenLoomi. It provides an uploadable `$openloomi` skill bundle that routes WorkBuddy requests to the local OpenLoomi Desktop API, plus packaging, docs, and regression tests.

## Usage Flow

1. Build the uploadable skill bundle:

   ```powershell
   node apps\openloomi-skill\scripts\package-openloomi-skill.cjs
   ```

2. Upload the generated zip to WorkBuddy Skills:

   ```text
   apps\openloomi-skill\dist\openloomi-skill.zip
   ```

3. Make sure OpenLoomi Desktop is running locally.

4. In WorkBuddy, invoke the skill for common OpenLoomi tasks such as status checks, memory search, connector listing, knowledge-base lookup, or agent execution.

   ```text
   Use $openloomi to search memory for "project status".
   ```

5. WorkBuddy runs the bundled wrapper script from the installed skill directory, for example:

   ```powershell
   node "%USERPROFILE%\.workbuddy\skills\openloomi\scripts\openloomi.cjs" memory-search "project status" --limit=5
   ```

## Changed

- Added the uploadable OpenLoomi WorkBuddy skill bundle under `apps/openloomi-skill/openloomi/`.
- Added WorkBuddy-facing skill metadata and examples.
- Added `scripts/openloomi.cjs` wrapper commands:
  - `status`
  - `memory-search`
  - `knowledge-search`
  - `knowledge-list`
  - `knowledge-get`
  - `knowledge-upload`
  - `connectors-list`
  - `agent-run`
- Added bundle packaging helper:
  - `apps/openloomi-skill/scripts/package-openloomi-skill.cjs`
- Added validation and wrapper tests.
- Added local-memory fallback for `memory-search`:
  - first calls `/api/memory/search`
  - falls back to `/api/rag/search` when unified memory API is unavailable
  - if API search returns no matches, performs read-only local scan of `~/.openloomi/data/memory/**/*.md|json`
  - returns local hits at top-level `results` with `source`, `file`, `line`, and `preview`

## Real Test Results

Validated wrapper tests:

```powershell
node --test apps\openloomi-skill\tests\openloomi-script.test.mjs
```

Result: 7 tests passed.

Validated full packaging flow:

```powershell
node apps\openloomi-skill\scripts\package-openloomi-skill.cjs
```

Result:

- skill metadata validation passed
- bundle structure tests passed
- wrapper tests passed
- package helper tests passed
- Prettier check passed
- generated `apps\openloomi-skill\dist\openloomi-skill.zip`

Also verified the bundle with core flows covering memory search, connectors, knowledge-base commands.

## Notes

The generated zip is intentionally not committed. It should be rebuilt locally with the package script and uploaded to WorkBuddy.