### PR TITLE
feat(agent): add Claude goal lifecycle and replacement semantics

### DIFF
--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -1961,8 +1961,13 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
         };
       }
     } finally {
-      goalRuntimeRegistration?.release();
-      await claudeRuntime.close();
+      try {
+        await claudeRuntime.close();
+      } finally {
+        // Keep a closing Query registered until it can no longer accept Goal
+        // commands or emit old-epoch events.
+        goalRuntimeRegistration?.release();
+      }
       this.sessions.delete(session.id);
       // Windows cleanup prevents skill files generated for this session from
       // leaking into the next Claude Code run.

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
@@ -25,6 +25,35 @@ export class ClaudeGoalRuntimeRegistrationError extends Error {
   }
 }
 
+export class ClaudeGoalRuntimeEpochMismatchError extends Error {
+  readonly code = "run_epoch_mismatch";
+
+  constructor(
+    public readonly runtimeSessionId: string,
+    public readonly expectedRunEpoch: number,
+    public readonly actualRunEpoch: number,
+  ) {
+    super(
+      `Cannot register Claude Runtime Session ${runtimeSessionId} at runEpoch ${actualRunEpoch}; OpenLoomi expects ${expectedRunEpoch}`,
+    );
+    this.name = "ClaudeGoalRuntimeEpochMismatchError";
+  }
+}
+
+export class ClaudeGoalRuntimeRecoveryRequiredError extends Error {
+  readonly code = "run_epoch_recovery_required";
+
+  constructor(
+    public readonly runtimeSessionId: string,
+    public readonly runEpoch: number,
+  ) {
+    super(
+      `Claude Runtime Session ${runtimeSessionId} requires runEpoch ${runEpoch} recovery, which is not available before durable restart recovery is implemented`,
+    );
+    this.name = "ClaudeGoalRuntimeRecoveryRequiredError";
+  }
+}
+
 /**
  * Reserves the owner-scoped runtime identity, starts the Claude SDK Query, then
  * replays its pending instruction outbox. Registration is synchronous, so no
@@ -45,6 +74,23 @@ export async function startClaudeGoalRuntimeSession(
   const goalRuntime = input.goalRuntime ?? getAgentGoalRuntime();
   let registration: RuntimeSessionRegistration | undefined;
   try {
+    const expectedRunEpoch = await goalRuntime.goals.getRuntimeSessionRunEpoch(
+      ownerId,
+      input.runtime.runtimeSessionId,
+    );
+    if (input.runtime.runEpoch !== expectedRunEpoch) {
+      throw new ClaudeGoalRuntimeEpochMismatchError(
+        input.runtime.runtimeSessionId,
+        expectedRunEpoch,
+        input.runtime.runEpoch,
+      );
+    }
+    if (expectedRunEpoch > 0) {
+      throw new ClaudeGoalRuntimeRecoveryRequiredError(
+        input.runtime.runtimeSessionId,
+        expectedRunEpoch,
+      );
+    }
     registration = goalRuntime.sessions.register({
       ownerId,
       transport: input.runtime,
@@ -59,8 +105,11 @@ export async function startClaudeGoalRuntimeSession(
     }
     return registration;
   } catch (error) {
-    registration?.release();
-    await input.runtime.close();
+    try {
+      await input.runtime.close();
+    } finally {
+      registration?.release();
+    }
     throw error;
   }
 }

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
@@ -8,16 +8,23 @@ import { assertRuntimeSessionStateTransition } from "@openloomi/ai/agent/runtime
 import type {
   RuntimeDeliveryReceipt,
   RuntimeInstruction,
-  RuntimeInstructionTransportPort,
+  RuntimeRunEpochAdvanceResult,
+  RuntimeSessionLifecycleControlPort,
   RuntimeSessionState,
+  RuntimeTerminalInputHold,
+  RuntimeTurnBoundary,
+  RuntimeTurnBoundaryInputHold,
+  RuntimeTurnTerminal,
 } from "@openloomi/ai/agent/runtime-instructions";
 import { AgentOutputEventBus } from "@openloomi/ai/agent/runtime";
 import {
   AgentSupplementalInputQueue,
   SupplementalInputRuntimeInstructionTransport,
+  type AgentSupplementalInputHold,
 } from "@openloomi/ai/agent/supplemental-input";
 import type {
   AgentMessage,
+  AgentSupplementalInput,
   AgentSupplementalInputSource,
 } from "@openloomi/ai/agent/types";
 
@@ -35,11 +42,20 @@ export interface ClaudeRuntimeSessionOptions {
   supplementalInput?: AgentSupplementalInputSource;
 }
 
+interface TerminalWaiter {
+  expectedRunEpoch: number;
+  afterTerminalSequence: number;
+  resolve: (terminal: RuntimeTurnTerminal) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
 /**
  * Owns one Claude SDK Query and exposes an OpenLoomi runtime-session boundary.
  * Goal lifecycle and persistence intentionally remain outside this class.
  */
-export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
+export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort {
   readonly runtimeSessionId: string;
 
   private readonly sdkTransport: ClaudeSdkTransport;
@@ -55,12 +71,17 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
   private currentState: RuntimeSessionState = "starting";
   private processedSdkMessages = 0;
   private closing = false;
+  private providerOutputEpoch: number;
+  private terminalSequence = 0;
+  private readonly terminalHistory: RuntimeTurnTerminal[] = [];
+  private readonly terminalWaiters = new Set<TerminalWaiter>();
 
   claudeSessionId?: string;
 
   constructor(options: ClaudeRuntimeSessionOptions) {
     assertRunEpoch(options.runEpoch);
     this.runtimeSessionId = options.runtimeSessionId;
+    this.providerOutputEpoch = options.runEpoch;
     this.sdkTransport = options.sdkTransport;
     this.logger = options.logger;
     this.output = new AgentOutputEventBus<AgentMessage>();
@@ -112,6 +133,9 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
       );
     }
 
+    this.inputQueue.setHandoffHandler((supplementalInput) => {
+      this.observeSupplementalInputHandoff(supplementalInput);
+    });
     const multiplexer = new ClaudeInputMultiplexer(
       input.initialPrompt,
       this.runtimeSessionId,
@@ -148,9 +172,29 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
   async deliver(
     instruction: RuntimeInstruction,
   ): Promise<RuntimeDeliveryReceipt> {
-    const receipt = await this.instructionTransport.deliver(instruction);
-    if (receipt.state === "queued" && this.query) {
-      this.transition("running");
+    const idle = this.currentState === "idle";
+    const receipt = await this.instructionTransport.deliver(instruction, {
+      interruptControl: !idle,
+      interruptSteer: !idle,
+    });
+    if (receipt.state !== "queued" || !this.query) return receipt;
+
+    if (
+      instruction.kind === "control.interrupt" ||
+      instruction.kind === "goal.pause" ||
+      instruction.kind === "goal.cancel"
+    ) {
+      if (
+        this.runEpoch === instruction.payload.expectedRunEpoch &&
+        (this.currentState === "running" || this.currentState === "evaluating")
+      ) {
+        this.transition("interrupted");
+      }
+      return receipt;
+    }
+
+    if (instruction.deliveryMode === "next_boundary" && idle) {
+      this.inputQueue.releasePendingInform();
     }
     return receipt;
   }
@@ -170,11 +214,149 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
       );
     }
     await this.instructionTransport.interrupt(request);
-    this.transition("interrupted");
+    if (this.runEpoch !== request.expectedRunEpoch) {
+      throw new ClaudeRuntimeSessionError(
+        "invalid_run_epoch",
+        `Run epoch advanced while interrupt ${request.expectedRunEpoch} was in flight`,
+      );
+    }
+    if (this.currentState === "running" || this.currentState === "evaluating") {
+      this.transition("interrupted");
+    }
   }
 
-  advanceRunEpoch(nextRunEpoch: number): void {
-    this.instructionTransport.advanceRunEpoch(nextRunEpoch);
+  captureTurnBoundary(): RuntimeTurnBoundary {
+    return {
+      runtimeSessionId: this.runtimeSessionId,
+      runEpoch: this.runEpoch,
+      terminalSequence: this.terminalSequence,
+      state: this.currentState,
+    };
+  }
+
+  captureTurnBoundaryAndHoldPendingInput(
+    expectedRunEpoch: number,
+  ): RuntimeTurnBoundaryInputHold {
+    assertRunEpoch(expectedRunEpoch);
+    if (this.runEpoch !== expectedRunEpoch) {
+      throw new ClaudeRuntimeSessionError(
+        "invalid_run_epoch",
+        `Expected run epoch ${expectedRunEpoch}, active epoch is ${this.runEpoch}`,
+      );
+    }
+
+    const queueHold =
+      this.inputQueue.holdPendingInputForRunEpoch(expectedRunEpoch);
+    try {
+      const boundary = this.captureTurnBoundary();
+      if (boundary.runEpoch !== expectedRunEpoch) {
+        throw new ClaudeRuntimeSessionError(
+          "invalid_run_epoch",
+          `Expected run epoch ${expectedRunEpoch}, active epoch is ${boundary.runEpoch}`,
+        );
+      }
+      return {
+        boundary,
+        hold: this.createTerminalInputHold(queueHold),
+      };
+    } catch (error) {
+      queueHold.release();
+      throw error;
+    }
+  }
+
+  private createTerminalInputHold(
+    hold: AgentSupplementalInputHold,
+  ): RuntimeTerminalInputHold {
+    return {
+      runEpoch: hold.runEpoch,
+      release: (options = {}) => {
+        hold.release();
+        if (
+          options.releasePendingIfIdle === true &&
+          this.currentState === "idle" &&
+          this.runEpoch === hold.runEpoch
+        ) {
+          this.inputQueue.releasePendingInform();
+        }
+      },
+    };
+  }
+
+  waitForTurnTerminal(input: {
+    expectedRunEpoch: number;
+    afterTerminalSequence: number;
+    signal?: AbortSignal;
+  }): Promise<RuntimeTurnTerminal> {
+    assertRunEpoch(input.expectedRunEpoch);
+    if (
+      !Number.isInteger(input.afterTerminalSequence) ||
+      input.afterTerminalSequence < 0
+    ) {
+      throw new ClaudeRuntimeSessionError(
+        "invalid_terminal_boundary",
+        "afterTerminalSequence must be a non-negative integer",
+      );
+    }
+    if (input.signal?.aborted) {
+      return Promise.reject(this.terminalWaitAborted());
+    }
+
+    const observed = this.terminalHistory.find(
+      (terminal) =>
+        terminal.runEpoch === input.expectedRunEpoch &&
+        terminal.terminalSequence > input.afterTerminalSequence,
+    );
+    if (observed) return Promise.resolve(structuredClone(observed));
+
+    if (this.runEpoch !== input.expectedRunEpoch) {
+      return Promise.reject(
+        new ClaudeRuntimeSessionError(
+          "invalid_run_epoch",
+          `Expected run epoch ${input.expectedRunEpoch}, active epoch is ${this.runEpoch}`,
+        ),
+      );
+    }
+    if (this.currentState === "closed" || this.currentState === "failed") {
+      return Promise.reject(this.terminalUnavailable(this.currentState));
+    }
+
+    return new Promise<RuntimeTurnTerminal>((resolve, reject) => {
+      const waiter: TerminalWaiter = {
+        expectedRunEpoch: input.expectedRunEpoch,
+        afterTerminalSequence: input.afterTerminalSequence,
+        resolve,
+        reject,
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
+      };
+      if (input.signal) {
+        waiter.onAbort = () => {
+          if (!this.terminalWaiters.delete(waiter)) return;
+          this.removeWaiterAbortListener(waiter);
+          reject(this.terminalWaitAborted());
+        };
+        input.signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      this.terminalWaiters.add(waiter);
+    });
+  }
+
+  advanceRunEpoch(input: {
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+  }): RuntimeRunEpochAdvanceResult {
+    if (this.currentState !== "idle") {
+      throw new ClaudeRuntimeSessionError(
+        "turn_not_terminal",
+        `Cannot advance runEpoch while Runtime Session is ${this.currentState}`,
+      );
+    }
+    const discarded = this.instructionTransport.advanceRunEpoch(input);
+    return {
+      previousRunEpoch: input.expectedRunEpoch,
+      runEpoch: input.nextRunEpoch,
+      discardedInputIds: discarded.map((entry) => entry.id),
+    };
   }
 
   async close(): Promise<void> {
@@ -182,6 +364,7 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
     this.closing = true;
 
     this.inputQueue.setInterruptHandler(null);
+    this.inputQueue.setHandoffHandler(null);
     try {
       this.query?.close();
     } catch (error) {
@@ -200,6 +383,7 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
       );
     }
     this.output.close();
+    this.rejectTerminalWaiters(this.terminalUnavailable("closed"));
     if (this.currentState !== "closed" && this.currentState !== "failed") {
       this.transition("closed");
     }
@@ -211,20 +395,27 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
     let failed = false;
     try {
       for await (const message of query) {
+        const observedRunEpoch = this.providerOutputEpoch;
         this.processedSdkMessages++;
-        this.observeSdkMessage(message);
+        this.observeSdkMessage(message, observedRunEpoch);
         for (const agentMessage of this.outputMultiplexer.convert(message)) {
-          await this.output.publish(agentMessage);
+          await this.output.publish({
+            ...agentMessage,
+            runEpoch: observedRunEpoch,
+          });
         }
         if (message.type === "result") {
-          this.inputQueue.releasePendingInform();
-          if (
-            this.currentState !== "idle" &&
-            this.currentState !== "closed" &&
-            this.currentState !== "failed"
-          ) {
-            this.transition("idle");
+          if (observedRunEpoch === this.runEpoch) {
+            this.inputQueue.releasePendingInform();
+            if (
+              this.currentState !== "idle" &&
+              this.currentState !== "closed" &&
+              this.currentState !== "failed"
+            ) {
+              this.transition("idle");
+            }
           }
+          this.recordTerminal(observedRunEpoch);
         }
       }
       this.output.close();
@@ -235,6 +426,9 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
       }
     } finally {
       this.inputQueue.close();
+      this.rejectTerminalWaiters(
+        this.terminalUnavailable(failed ? "failed" : "closed"),
+      );
       if (
         !this.closing &&
         this.currentState !== "closed" &&
@@ -265,11 +459,15 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
     }
   }
 
-  private observeSdkMessage(message: SDKMessage): void {
+  private observeSdkMessage(
+    message: SDKMessage,
+    observedRunEpoch: number,
+  ): void {
     if (message.type === "system" && message.subtype === "init") {
       this.claudeSessionId = message.session_id;
     }
     if (
+      observedRunEpoch === this.runEpoch &&
       message.type !== "result" &&
       (this.currentState === "idle" ||
         this.currentState === "evaluating" ||
@@ -277,6 +475,80 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
     ) {
       this.transition("running");
     }
+  }
+
+  private observeSupplementalInputHandoff(input: AgentSupplementalInput): void {
+    const inputRunEpoch = input.runEpoch ?? this.runEpoch;
+    if (
+      inputRunEpoch !== this.runEpoch ||
+      this.currentState === "closed" ||
+      this.currentState === "failed"
+    ) {
+      return;
+    }
+
+    this.providerOutputEpoch = inputRunEpoch;
+    if (
+      this.currentState === "starting" ||
+      this.currentState === "idle" ||
+      this.currentState === "evaluating" ||
+      this.currentState === "interrupted"
+    ) {
+      this.transition("running");
+    }
+  }
+
+  private recordTerminal(runEpoch: number): void {
+    const terminal: RuntimeTurnTerminal = {
+      runtimeSessionId: this.runtimeSessionId,
+      runEpoch,
+      terminalSequence: ++this.terminalSequence,
+      state: "idle",
+    };
+    this.terminalHistory.push(terminal);
+    if (this.terminalHistory.length > 64) this.terminalHistory.shift();
+
+    for (const waiter of [...this.terminalWaiters]) {
+      if (
+        waiter.expectedRunEpoch !== runEpoch ||
+        waiter.afterTerminalSequence >= terminal.terminalSequence
+      ) {
+        continue;
+      }
+      this.terminalWaiters.delete(waiter);
+      this.removeWaiterAbortListener(waiter);
+      waiter.resolve(structuredClone(terminal));
+    }
+  }
+
+  private rejectTerminalWaiters(error: Error): void {
+    for (const waiter of this.terminalWaiters) {
+      this.removeWaiterAbortListener(waiter);
+      waiter.reject(error);
+    }
+    this.terminalWaiters.clear();
+  }
+
+  private removeWaiterAbortListener(waiter: TerminalWaiter): void {
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+    }
+  }
+
+  private terminalWaitAborted(): ClaudeRuntimeSessionError {
+    return new ClaudeRuntimeSessionError(
+      "terminal_wait_aborted",
+      "Waiting for the Claude turn terminal boundary was aborted",
+    );
+  }
+
+  private terminalUnavailable(
+    state: "closed" | "failed",
+  ): ClaudeRuntimeSessionError {
+    return new ClaudeRuntimeSessionError(
+      "terminal_unavailable",
+      `Claude Runtime Session became ${state} before the turn terminal boundary was observed`,
+    );
   }
 
   private transition(next: RuntimeSessionState): void {
@@ -288,8 +560,12 @@ export class ClaudeRuntimeSession implements RuntimeInstructionTransportPort {
 
 export type ClaudeRuntimeSessionErrorCode =
   | "already_started"
+  | "invalid_terminal_boundary"
   | "invalid_run_epoch"
-  | "not_started";
+  | "not_started"
+  | "terminal_unavailable"
+  | "terminal_wait_aborted"
+  | "turn_not_terminal";
 
 export class ClaudeRuntimeSessionError extends Error {
   constructor(

--- a/apps/web/lib/ai/runtime-instructions/goal-command-policy.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-command-policy.ts
@@ -1,0 +1,70 @@
+import {
+  canonicalJson,
+  type GoalConstraint,
+  type GoalSource,
+  type RuntimeInstructionSource,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+export function findUnsupportedRuntimeConstraint(
+  constraints: readonly GoalConstraint[],
+): GoalConstraint | undefined {
+  return constraints.find(
+    (constraint) => constraint.enforcement === "runtime_enforced",
+  );
+}
+
+export function goalSourceMatchesCommand(
+  goalSource: GoalSource,
+  commandSource: RuntimeInstructionSource,
+): boolean {
+  if (commandSource.type === "user") return goalSource.type === "user";
+  return (
+    commandSource.type === "automation" &&
+    goalSource.type !== "user" &&
+    goalSource.id === commandSource.sourceRef
+  );
+}
+
+export function findUnauthorizedConstraintChange(
+  current: readonly GoalConstraint[],
+  next: readonly GoalConstraint[],
+  source: RuntimeInstructionSource,
+): GoalConstraint | undefined {
+  const currentById = new Map(
+    current.map((constraint) => [constraint.id, constraint]),
+  );
+  const nextById = new Map(
+    next.map((constraint) => [constraint.id, constraint]),
+  );
+  const changedIds = new Set([...currentById.keys(), ...nextById.keys()]);
+
+  for (const id of changedIds) {
+    const previous = currentById.get(id);
+    const revised = nextById.get(id);
+    if (
+      previous !== undefined &&
+      revised !== undefined &&
+      canonicalJson(previous) === canonicalJson(revised)
+    ) {
+      continue;
+    }
+    if (previous && !constraintAuthorityMatchesSource(previous, source)) {
+      return previous;
+    }
+    if (revised && !constraintAuthorityMatchesSource(revised, source)) {
+      return revised;
+    }
+  }
+  return undefined;
+}
+
+function constraintAuthorityMatchesSource(
+  constraint: GoalConstraint,
+  source: RuntimeInstructionSource,
+): boolean {
+  return (
+    constraint.authority === source.authority &&
+    (constraint.authority === "user" ||
+      constraint.sourceRef === source.sourceRef)
+  );
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
@@ -1,0 +1,773 @@
+import {
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  RuntimeInstructionSchema,
+  RuntimeInstructionSourceSchema,
+  transitionAgentGoal,
+  type AgentGoal,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalStatePort,
+  type GoalCommandIdentity,
+  type GoalLifecycleTransitionAction,
+  type RuntimeClockPort,
+  type RuntimeIdGeneratorPort,
+  type RuntimeInstructionDraft,
+  type RuntimeInstructionSource,
+  type RuntimeSessionLifecycleControlPort,
+  type RuntimeTerminalInputHold,
+  type RuntimeTurnBoundary,
+  type RuntimeTurnTerminal,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { createGoalCommandFingerprint } from "./command-fingerprint";
+import type {
+  GoalCommandResult,
+  GoalLifecycleCommandSource,
+} from "./goal-service";
+import { GoalServiceError } from "./goal-service-error";
+import type {
+  RuntimeInstructionDispatch,
+  RuntimeInstructionDispatcher,
+} from "./instruction-dispatcher";
+import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import type { RuntimeSessionRegistry } from "./runtime-session-registry";
+
+interface GoalLifecycleCommand {
+  ownerId: string;
+  runtimeSessionId: string;
+  goalId: string;
+  expectedRevision: number;
+  idempotencyKey: string;
+  source: GoalLifecycleCommandSource;
+  reason?: string;
+}
+
+export type PauseGoalCommand = GoalLifecycleCommand;
+export type ResumeGoalCommand = GoalLifecycleCommand;
+export type CancelGoalCommand = GoalLifecycleCommand;
+
+interface ParsedLifecycleCommand {
+  ownerId: string;
+  runtimeSessionId: string;
+  goalId: string;
+  expectedRevision: number;
+  idempotencyKey: string;
+  source: GoalLifecycleCommandSource;
+  reason?: string;
+  command: GoalCommandIdentity;
+}
+
+interface HeldTerminalBarrier {
+  transport: RuntimeSessionLifecycleControlPort;
+  boundary: RuntimeTurnBoundary;
+  hold: RuntimeTerminalInputHold;
+}
+
+/**
+ * Applies Goal lifecycle operations at provider turn boundaries.
+ *
+ * Pause and cancel are control-plane operations: they never enter Claude's
+ * normal input queue. Resume is a regular steer that releases retained input
+ * only after the paused turn has become terminal.
+ */
+export class GoalLifecycleService {
+  private readonly commands = new KeyedSerialExecutor();
+  private readonly terminalBarriers = new Map<string, HeldTerminalBarrier>();
+
+  constructor(
+    private readonly state: AgentGoalStatePort,
+    private readonly dispatcher: RuntimeInstructionDispatcher,
+    private readonly sessions: RuntimeSessionRegistry,
+    private readonly clock: RuntimeClockPort,
+    private readonly ids: RuntimeIdGeneratorPort,
+    private readonly terminalTimeoutMs = 30_000,
+  ) {
+    if (
+      !Number.isInteger(terminalTimeoutMs) ||
+      terminalTimeoutMs <= 0 ||
+      terminalTimeoutMs > 300_000
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "terminalTimeoutMs must be an integer between 1 and 300000",
+      );
+    }
+  }
+
+  pause(input: PauseGoalCommand): Promise<GoalCommandResult> {
+    return this.commands.run(commandScope(input), () =>
+      this.interruptingTransition("pause", input),
+    );
+  }
+
+  cancel(input: CancelGoalCommand): Promise<GoalCommandResult> {
+    return this.commands.run(commandScope(input), () =>
+      this.interruptingTransition("cancel", input),
+    );
+  }
+
+  resume(input: ResumeGoalCommand): Promise<GoalCommandResult> {
+    return this.commands.run(commandScope(input), () =>
+      this.resumeSerialized(input),
+    );
+  }
+
+  private async interruptingTransition(
+    action: GoalLifecycleTransitionAction,
+    input: GoalLifecycleCommand,
+  ): Promise<GoalCommandResult> {
+    const command = parseLifecycleCommand(action, input);
+    let stored = await this.state.findLifecycleTransitionByIdempotency({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      command: command.command,
+    });
+    const wasReplay = stored !== null;
+
+    if (!stored) {
+      const transport = await this.sessions.resolveLifecycle(
+        command.ownerId,
+        command.runtimeSessionId,
+      );
+      const expectedRunEpoch = transport
+        ? this.captureLiveBoundary(transport).runEpoch
+        : await this.state.getRuntimeSessionRunEpoch(
+            command.ownerId,
+            command.runtimeSessionId,
+          );
+      const current = await this.requireGoal(command);
+      assertLifecycleAuthority(current, command.source);
+      const now = this.clock.now();
+      const goal = transitionAgentGoal({
+        current,
+        expectedRevision: command.expectedRevision,
+        status: action === "pause" ? "paused" : "cancelled",
+        now,
+      });
+      const instruction = instructionDraft({
+        schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+        id: this.ids.generate(),
+        goalId: goal.id,
+        goalRevision: goal.revision,
+        kind: action === "pause" ? "goal.pause" : "goal.cancel",
+        deliveryMode: "interrupt_replace",
+        targetSessionId: command.runtimeSessionId,
+        payload: {
+          ...(command.reason === undefined ? {} : { reason: command.reason }),
+          expectedRunEpoch,
+        },
+        source: command.source,
+        idempotencyKey: command.idempotencyKey,
+        issuedAt: now.toISOString(),
+      });
+      if (transport) this.assertCurrentTransport(command.ownerId, transport);
+      stored = await this.state.prepareLifecycleTransition({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        action,
+        expectedRevision: command.expectedRevision,
+        expectedRunEpoch,
+        goal,
+        instruction,
+        command: command.command,
+      });
+    }
+
+    const transition = stored.transition;
+    const transport = await this.sessions.resolveLifecycle(
+      command.ownerId,
+      command.runtimeSessionId,
+    );
+    if (!transport) {
+      return lifecycleResult(
+        transition,
+        wasReplay,
+        await this.dispatchControl(transition, command.ownerId),
+      );
+    }
+
+    if (transition.phase === "finalized") {
+      if (transport.runEpoch !== transition.runEpoch) {
+        throw new GoalServiceError(
+          "invalid_command",
+          `Finalized ${transition.action} expects runEpoch ${transition.runEpoch}, live Runtime Session is ${transport.runEpoch}`,
+        );
+      }
+      const controlDispatch = await this.dispatchControl(
+        transition,
+        command.ownerId,
+      );
+      if (controlDispatch.status !== "accepted") {
+        return lifecycleResult(transition, wasReplay, controlDispatch);
+      }
+      await this.commitControlBarrier(transition, command.ownerId, transport);
+      return lifecycleResult(transition, wasReplay, controlDispatch);
+    }
+
+    if (
+      transition.phase === "boundary_observed" &&
+      transition.action !== "cancel"
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "Only Goal cancellation may enter boundary_observed",
+      );
+    }
+
+    if (transition.phase === "boundary_observed") {
+      const controlDispatch = await this.dispatchControl(
+        transition,
+        command.ownerId,
+      );
+      if (controlDispatch.status !== "accepted") {
+        return lifecycleResult(transition, wasReplay, controlDispatch);
+      }
+      this.assertCurrentTransport(command.ownerId, transport);
+      if (transport.runEpoch === transition.expectedRunEpoch) {
+        this.getOrCaptureTerminalBarrier(
+          transition,
+          command.ownerId,
+          transport,
+        );
+      }
+      this.reconcileCancelEpoch(transition, transport);
+      stored = await this.state.finalizeLifecycleTransition({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        goalId: transition.transitionedGoal.goal.id,
+        expectedRunEpoch: transition.expectedRunEpoch,
+        nextRunEpoch: transition.runEpoch,
+        command: command.command,
+      });
+      this.releaseTerminalBarrier(transition.instruction.id);
+      return lifecycleResult(stored.transition, wasReplay, controlDispatch);
+    }
+
+    if (
+      transition.phase !== "prepared" ||
+      transport.runEpoch !== transition.expectedRunEpoch
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        `${transition.phase} ${transition.action} expects runEpoch ${transition.expectedRunEpoch}, live Runtime Session is ${transport.runEpoch}`,
+      );
+    }
+    const barrier = this.getOrCaptureTerminalBarrier(
+      transition,
+      command.ownerId,
+      transport,
+    );
+    const controlDispatch = await this.dispatchControl(
+      transition,
+      command.ownerId,
+    );
+    if (controlDispatch.status !== "accepted") {
+      // The authoritative transition remains prepared. Retaining the same
+      // barrier prevents old input from leaking before an idempotent retry.
+      return lifecycleResult(transition, wasReplay, controlDispatch);
+    }
+    this.assertCurrentTransport(command.ownerId, transport);
+    const terminal =
+      barrier.boundary.state === "idle"
+        ? terminalAtBoundary(barrier.boundary)
+        : await this.waitForTerminal(
+            (signal) =>
+              transport.waitForTurnTerminal({
+                expectedRunEpoch: transition.expectedRunEpoch,
+                afterTerminalSequence: barrier.boundary.terminalSequence,
+                signal,
+              }),
+            command.runtimeSessionId,
+          );
+    this.validateTerminal(terminal, barrier.boundary);
+    this.assertCurrentTransport(command.ownerId, transport);
+    await this.commitControlBarrier(transition, command.ownerId, transport);
+
+    const nextRunEpoch =
+      transition.action === "cancel"
+        ? transition.expectedRunEpoch + 1
+        : transition.expectedRunEpoch;
+    if (transition.action === "cancel") {
+      stored = await this.state.markLifecycleTransitionBoundary({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        goalId: transition.transitionedGoal.goal.id,
+        expectedRunEpoch: transition.expectedRunEpoch,
+        nextRunEpoch,
+        command: command.command,
+      });
+      this.advanceAndValidate(stored.transition, transport);
+    }
+    stored = await this.state.finalizeLifecycleTransition({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      goalId: transition.transitionedGoal.goal.id,
+      expectedRunEpoch: transition.expectedRunEpoch,
+      nextRunEpoch,
+      command: command.command,
+    });
+    this.releaseTerminalBarrier(transition.instruction.id);
+    return lifecycleResult(stored.transition, wasReplay, controlDispatch);
+  }
+
+  private async resumeSerialized(
+    input: ResumeGoalCommand,
+  ): Promise<GoalCommandResult> {
+    const command = parseLifecycleCommand("resume", input);
+    const replay = await this.state.findCommitByIdempotency({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      command: command.command,
+    });
+    if (replay) {
+      return {
+        ...replay,
+        dispatch: await this.dispatcher.drain({
+          ownerId: command.ownerId,
+          runtimeSessionId: command.runtimeSessionId,
+          targetInstructionId: replay.instruction.id,
+        }),
+      };
+    }
+
+    const current = await this.requireGoal(command);
+    assertLifecycleAuthority(current, command.source);
+    const now = this.clock.now();
+    const goal = transitionAgentGoal({
+      current,
+      expectedRevision: command.expectedRevision,
+      status: "active",
+      now,
+    });
+    const instruction = instructionDraft({
+      schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+      id: this.ids.generate(),
+      goalId: goal.id,
+      goalRevision: goal.revision,
+      kind: "goal.resume",
+      deliveryMode: "steer",
+      targetSessionId: command.runtimeSessionId,
+      payload: command.reason === undefined ? {} : { reason: command.reason },
+      source: command.source,
+      idempotencyKey: command.idempotencyKey,
+      issuedAt: now.toISOString(),
+    });
+    const commit = await this.state.commitTransition({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      expectedRevision: command.expectedRevision,
+      goal,
+      instruction,
+      command: command.command,
+    });
+    return {
+      ...commit,
+      dispatch: await this.dispatcher.drain({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        targetInstructionId: commit.instruction.id,
+      }),
+    };
+  }
+
+  private async requireGoal(
+    command: ParsedLifecycleCommand,
+  ): Promise<AgentGoal> {
+    const persisted = await this.state.getGoal(command.ownerId, command.goalId);
+    if (!persisted) {
+      throw new GoalServiceError(
+        "goal_not_found",
+        `Goal ${command.goalId} does not exist for this owner`,
+      );
+    }
+    if (persisted.runtimeSessionId !== command.runtimeSessionId) {
+      throw new GoalServiceError(
+        "goal_session_mismatch",
+        `Goal ${command.goalId} belongs to a different Runtime Session`,
+      );
+    }
+    return persisted.goal;
+  }
+
+  private captureLiveBoundary(
+    transport: RuntimeSessionLifecycleControlPort,
+  ): RuntimeTurnBoundary {
+    const boundary = transport.captureTurnBoundary();
+    this.validateBoundary(boundary, transport);
+    return boundary;
+  }
+
+  private getOrCaptureTerminalBarrier(
+    transition: AgentGoalLifecycleTransition,
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): HeldTerminalBarrier {
+    const existing = this.terminalBarriers.get(transition.instruction.id);
+    if (existing) {
+      if (existing.transport !== transport) {
+        throw new GoalServiceError(
+          "invalid_command",
+          `Runtime Session ${transition.runtimeSessionId} changed while its terminal input barrier was active`,
+        );
+      }
+      return existing;
+    }
+
+    const captured = transport.captureTurnBoundaryAndHoldPendingInput(
+      transition.expectedRunEpoch,
+    );
+    try {
+      this.validateBoundary(captured.boundary, transport);
+      this.validateHold(captured.hold, transition.expectedRunEpoch);
+    } catch (error) {
+      captured.hold.release();
+      throw error;
+    }
+    this.assertCurrentTransport(ownerId, transport);
+    const barrier = {
+      transport,
+      boundary: captured.boundary,
+      hold: captured.hold,
+    };
+    this.terminalBarriers.set(transition.instruction.id, barrier);
+    return barrier;
+  }
+
+  private validateBoundary(
+    boundary: RuntimeTurnBoundary,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): void {
+    if (
+      boundary.runtimeSessionId !== transport.runtimeSessionId ||
+      boundary.runEpoch !== transport.runEpoch ||
+      !Number.isInteger(boundary.terminalSequence) ||
+      boundary.terminalSequence < 0
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "Runtime Session returned an invalid turn boundary",
+      );
+    }
+    if (
+      boundary.state === "starting" ||
+      boundary.state === "closed" ||
+      boundary.state === "failed"
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        `Runtime Session cannot change Goal lifecycle while ${boundary.state}`,
+      );
+    }
+  }
+
+  private validateHold(
+    hold: RuntimeTerminalInputHold,
+    expectedRunEpoch: number,
+  ): void {
+    if (
+      hold.runEpoch !== expectedRunEpoch ||
+      typeof hold.release !== "function"
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "Runtime Session returned an invalid terminal input hold",
+      );
+    }
+  }
+
+  private validateTerminal(
+    terminal: RuntimeTurnTerminal,
+    boundary: RuntimeTurnBoundary,
+  ): void {
+    const validSequence =
+      boundary.state === "idle"
+        ? terminal.terminalSequence === boundary.terminalSequence
+        : terminal.terminalSequence > boundary.terminalSequence;
+    if (
+      terminal.runtimeSessionId !== boundary.runtimeSessionId ||
+      terminal.runEpoch !== boundary.runEpoch ||
+      terminal.state !== "idle" ||
+      !Number.isInteger(terminal.terminalSequence) ||
+      !validSequence
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "Runtime Session returned a terminal event outside the captured turn boundary",
+      );
+    }
+  }
+
+  private advanceAndValidate(
+    transition: AgentGoalLifecycleTransition,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): void {
+    const advanced = transport.advanceRunEpoch({
+      expectedRunEpoch: transition.expectedRunEpoch,
+      nextRunEpoch: transition.runEpoch,
+    });
+    if (
+      advanced.previousRunEpoch !== transition.expectedRunEpoch ||
+      advanced.runEpoch !== transition.runEpoch ||
+      transport.runEpoch !== transition.runEpoch ||
+      !Array.isArray(advanced.discardedInputIds)
+    ) {
+      throw new GoalServiceError(
+        "invalid_command",
+        "Runtime Session returned an invalid cancellation epoch advance",
+      );
+    }
+  }
+
+  private reconcileCancelEpoch(
+    transition: AgentGoalLifecycleTransition,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): void {
+    if (transport.runEpoch === transition.runEpoch) return;
+    if (transport.runEpoch !== transition.expectedRunEpoch) {
+      throw new GoalServiceError(
+        "invalid_command",
+        `Goal cancellation epoch ${transition.runEpoch} cannot reconcile live Runtime Session epoch ${transport.runEpoch}`,
+      );
+    }
+    this.advanceAndValidate(transition, transport);
+  }
+
+  private releaseTerminalBarrier(instructionId: string): void {
+    const barrier = this.terminalBarriers.get(instructionId);
+    if (!barrier) return;
+    this.terminalBarriers.delete(instructionId);
+    barrier.hold.release();
+  }
+
+  private assertCurrentTransport(
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): void {
+    if (this.sessions.isCurrent(ownerId, transport)) return;
+    throw new GoalServiceError(
+      "invalid_command",
+      `Runtime Session ${transport.runtimeSessionId} changed during Goal lifecycle transition`,
+    );
+  }
+
+  private async waitForTerminal(
+    wait: (signal: AbortSignal) => Promise<RuntimeTurnTerminal>,
+    runtimeSessionId: string,
+  ): Promise<RuntimeTurnTerminal> {
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        wait(controller.signal),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new GoalServiceError(
+                "invalid_command",
+                `Runtime Session ${runtimeSessionId} did not reach a terminal turn boundary within ${this.terminalTimeoutMs}ms`,
+              ),
+            );
+          }, this.terminalTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+      controller.abort();
+    }
+  }
+
+  private dispatchControl(
+    transition: AgentGoalLifecycleTransition,
+    ownerId: string,
+  ): Promise<RuntimeInstructionDispatch> {
+    return this.dispatcher.deliverControl({
+      ownerId,
+      runtimeSessionId: transition.runtimeSessionId,
+      targetInstructionId: transition.instruction.id,
+    });
+  }
+
+  private commitControlBarrier(
+    transition: AgentGoalLifecycleTransition,
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): Promise<string[]> {
+    return this.dispatcher.commitControlBarrier({
+      ownerId,
+      runtimeSessionId: transition.runtimeSessionId,
+      targetInstructionId: transition.instruction.id,
+      transport,
+      reason: `Superseded by Goal ${transition.action} ${transition.instruction.id}`,
+      predecessorPolicy:
+        transition.action === "pause"
+          ? "preserve_predecessors"
+          : "supersede_predecessors",
+    });
+  }
+}
+
+function parseLifecycleCommand(
+  action: GoalLifecycleTransitionAction | "resume",
+  input: GoalLifecycleCommand,
+): ParsedLifecycleCommand {
+  const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+  const runtimeSessionId = requiredIdentifier(
+    input.runtimeSessionId,
+    "runtimeSessionId",
+  );
+  const goalId = requiredIdentifier(input.goalId, "goalId");
+  const idempotencyKey = requiredIdentifier(
+    input.idempotencyKey,
+    "idempotencyKey",
+  );
+  const expectedRevision = positiveInteger(
+    input.expectedRevision,
+    "expectedRevision",
+  );
+  const reason = lifecycleReason(input.reason);
+  let source: RuntimeInstructionSource;
+  try {
+    source = RuntimeInstructionSourceSchema.parse(input.source);
+  } catch (cause) {
+    throw new GoalServiceError(
+      "invalid_command",
+      "Goal lifecycle command source is invalid",
+      cause,
+    );
+  }
+  if (source.type !== "user" && source.type !== "automation") {
+    throw new GoalServiceError(
+      "invalid_lifecycle_authority",
+      `${source.type} sources cannot change Goal lifecycle state`,
+    );
+  }
+  if (source.type === "automation" && source.sourceRef === undefined) {
+    throw new GoalServiceError(
+      "invalid_lifecycle_authority",
+      "Automation lifecycle commands must identify their source",
+    );
+  }
+  const typedSource = source as GoalLifecycleCommandSource;
+  return {
+    ownerId,
+    runtimeSessionId,
+    goalId,
+    expectedRevision,
+    idempotencyKey,
+    source: typedSource,
+    ...(reason === undefined ? {} : { reason }),
+    command: {
+      idempotencyKey,
+      requestFingerprint: createGoalCommandFingerprint({
+        kind: `goal.${action}`,
+        runtimeSessionId,
+        goalId,
+        expectedRevision,
+        source: typedSource,
+        ...(reason === undefined ? {} : { reason }),
+      }),
+    },
+  };
+}
+
+function assertLifecycleAuthority(
+  goal: AgentGoal,
+  source: GoalLifecycleCommandSource,
+): void {
+  if (source.type === "user") return;
+  if (goal.source.type !== "user" && goal.source.id === source.sourceRef) {
+    return;
+  }
+  throw new GoalServiceError(
+    "invalid_lifecycle_authority",
+    `Automation source ${source.sourceRef} cannot change lifecycle state for Goal ${goal.id} from source ${goal.source.id ?? goal.source.type}`,
+  );
+}
+
+function instructionDraft(
+  draft: RuntimeInstructionDraft,
+): RuntimeInstructionDraft {
+  try {
+    const parsed = RuntimeInstructionSchema.parse({ ...draft, sequence: 1 });
+    const { sequence: _sequence, ...validated } = parsed;
+    return validated as RuntimeInstructionDraft;
+  } catch (cause) {
+    throw new GoalServiceError(
+      "invalid_command",
+      "Goal lifecycle command produced an invalid Runtime Instruction",
+      cause,
+    );
+  }
+}
+
+function lifecycleResult(
+  transition: AgentGoalLifecycleTransition,
+  deduplicated: boolean,
+  dispatch: RuntimeInstructionDispatch,
+): GoalCommandResult {
+  return {
+    goal: transition.transitionedGoal,
+    instruction: transition.instruction,
+    deduplicated,
+    dispatch,
+  };
+}
+
+function terminalAtBoundary(
+  boundary: RuntimeTurnBoundary,
+): RuntimeTurnTerminal {
+  return {
+    runtimeSessionId: boundary.runtimeSessionId,
+    runEpoch: boundary.runEpoch,
+    terminalSequence: boundary.terminalSequence,
+    state: "idle",
+  };
+}
+
+function lifecycleReason(reason: unknown): string | undefined {
+  if (reason === undefined) return undefined;
+  if (typeof reason !== "string") {
+    throw new GoalServiceError(
+      "invalid_command",
+      "Lifecycle reason must be a string",
+    );
+  }
+  const normalized = reason.trim();
+  if (normalized.length === 0 || normalized.length > 4_000) {
+    throw new GoalServiceError(
+      "invalid_command",
+      "Lifecycle reason must contain 1 to 4000 characters",
+    );
+  }
+  return normalized;
+}
+
+function requiredIdentifier(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value !== value.trim()
+  ) {
+    throw new GoalServiceError(
+      "invalid_command",
+      `${field} must contain 1 to 256 characters without surrounding whitespace`,
+    );
+  }
+  return value;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new GoalServiceError(
+      "invalid_command",
+      `${field} must be a positive integer`,
+    );
+  }
+  return value as number;
+}
+
+function commandScope(
+  input: Pick<GoalLifecycleCommand, "ownerId" | "runtimeSessionId">,
+): string {
+  return JSON.stringify([input.ownerId, input.runtimeSessionId]);
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-replacement-coordinator.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-replacement-coordinator.ts
@@ -1,0 +1,890 @@
+import {
+  CreateAgentGoalInputSchema,
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  RuntimeInstructionSchema,
+  RuntimeInstructionSourceSchema,
+  createAgentGoal,
+  transitionAgentGoal,
+  type AgentGoal,
+  type AgentGoalReplacement,
+  type AgentGoalStatePort,
+  type CreateAgentGoalInput,
+  type GoalCommandIdentity,
+  type GoalReplacementCommit,
+  type GoalSource,
+  type RuntimeClockPort,
+  type RuntimeIdGeneratorPort,
+  type RuntimeInstructionDraft,
+  type RuntimeInstructionSource,
+  type RuntimeSessionLifecycleControlPort,
+  type RuntimeTerminalInputHold,
+  type RuntimeTurnBoundary,
+  type RuntimeTurnTerminal,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { createGoalCommandFingerprint } from "./command-fingerprint";
+import {
+  findUnauthorizedConstraintChange,
+  findUnsupportedRuntimeConstraint,
+  goalSourceMatchesCommand,
+} from "./goal-command-policy";
+import type {
+  RuntimeInstructionDispatch,
+  RuntimeInstructionDispatcher,
+} from "./instruction-dispatcher";
+import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import type { RuntimeSessionRegistry } from "./runtime-session-registry";
+
+export type GoalReplacementCommandSource =
+  | {
+      type: "user";
+      authority: "user";
+      sourceRef?: string;
+    }
+  | {
+      type: "automation";
+      authority: "automation";
+      sourceRef: string;
+    };
+
+export interface ReplaceGoalCommand {
+  ownerId: string;
+  runtimeSessionId: string;
+  goalId: string;
+  expectedRevision: number;
+  idempotencyKey: string;
+  source: GoalReplacementCommandSource;
+  reason: string;
+  replacement: CreateAgentGoalInput;
+}
+
+export interface GoalReplacementResult {
+  replacement: AgentGoalReplacement;
+  deduplicated: boolean;
+  controlDispatch: RuntimeInstructionDispatch;
+  activationDispatch?: RuntimeInstructionDispatch;
+  terminal?: RuntimeTurnTerminal;
+  discardedInputIds: string[];
+}
+
+interface HeldReplacementBarrier {
+  transport: RuntimeSessionLifecycleControlPort;
+  boundary: RuntimeTurnBoundary;
+  hold: RuntimeTerminalInputHold;
+}
+
+export type GoalReplacementCoordinatorErrorCode =
+  | "goal_not_found"
+  | "goal_session_mismatch"
+  | "invalid_authority"
+  | "invalid_command"
+  | "invalid_runtime_response"
+  | "invalid_runtime_state"
+  | "run_epoch_conflict"
+  | "runtime_changed"
+  | "runtime_unavailable"
+  | "terminal_timeout";
+
+export class GoalReplacementCoordinatorError extends Error {
+  constructor(
+    public readonly code: GoalReplacementCoordinatorErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "GoalReplacementCoordinatorError";
+  }
+}
+
+/**
+ * Coordinates the non-transactional provider boundary across durable state
+ * phases:
+ *
+ * prepare replacement -> interrupt -> observe terminal -> record boundary ->
+ * advance epoch -> finalize activation.
+ *
+ * The state adapter keeps a primary-slot reservation across those phases,
+ * so no competing activation can enter while provider I/O is in flight.
+ */
+export class GoalReplacementCoordinator {
+  private readonly commands = new KeyedSerialExecutor();
+  private readonly terminalBarriers = new Map<string, HeldReplacementBarrier>();
+
+  constructor(
+    private readonly state: AgentGoalStatePort,
+    private readonly dispatcher: RuntimeInstructionDispatcher,
+    private readonly sessions: RuntimeSessionRegistry,
+    private readonly clock: RuntimeClockPort,
+    private readonly ids: RuntimeIdGeneratorPort,
+    private readonly terminalTimeoutMs = 30_000,
+  ) {
+    if (
+      !Number.isInteger(terminalTimeoutMs) ||
+      terminalTimeoutMs <= 0 ||
+      terminalTimeoutMs > 300_000
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_command",
+        "terminalTimeoutMs must be an integer between 1 and 300000",
+      );
+    }
+  }
+
+  replace(input: ReplaceGoalCommand): Promise<GoalReplacementResult> {
+    return this.commands.run(commandScope(input), () =>
+      this.replaceSerialized(input),
+    );
+  }
+
+  private async replaceSerialized(
+    input: ReplaceGoalCommand,
+  ): Promise<GoalReplacementResult> {
+    const command = parseReplacementCommand(input);
+    let stored = await this.state.findReplacementByIdempotency({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      command: command.identity,
+    });
+
+    if (!stored) {
+      const transport = await this.requireLifecycleTransport(
+        command.ownerId,
+        command.runtimeSessionId,
+      );
+      const boundary = this.captureLiveBoundary(transport);
+
+      const current = await this.state.getGoal(command.ownerId, command.goalId);
+      if (!current) {
+        throw new GoalReplacementCoordinatorError(
+          "goal_not_found",
+          `Goal ${command.goalId} does not exist for this owner`,
+        );
+      }
+      if (current.runtimeSessionId !== command.runtimeSessionId) {
+        throw new GoalReplacementCoordinatorError(
+          "goal_session_mismatch",
+          `Goal ${command.goalId} belongs to a different Runtime Session`,
+        );
+      }
+      assertLifecycleAuthority(current.goal, command.source);
+
+      const now = this.clock.now();
+      const supersededGoal = transitionAgentGoal({
+        current: current.goal,
+        expectedRevision: command.expectedRevision,
+        status: "cancelled",
+        now,
+      });
+      const replacementGoal = createAgentGoal({
+        id: this.ids.generate(),
+        input: command.replacement,
+        now,
+      });
+      const controlInstruction = instructionDraft({
+        schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+        id: this.ids.generate(),
+        goalId: supersededGoal.id,
+        goalRevision: supersededGoal.revision,
+        kind: "control.interrupt",
+        deliveryMode: "interrupt_replace",
+        targetSessionId: command.runtimeSessionId,
+        payload: {
+          reason: command.reason,
+          expectedRunEpoch: boundary.runEpoch,
+          replacementGoalId: replacementGoal.id,
+        },
+        source: command.source,
+        idempotencyKey: command.idempotencyKey,
+        issuedAt: now.toISOString(),
+      });
+
+      this.assertCurrentTransport(command.ownerId, transport);
+      stored = await this.state.prepareReplacement({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        expectedRevision: command.expectedRevision,
+        expectedRunEpoch: boundary.runEpoch,
+        supersededGoal,
+        replacementGoal,
+        controlInstruction,
+        command: command.identity,
+      });
+    }
+
+    return this.continueReplacement(command, stored);
+  }
+
+  private async continueReplacement(
+    command: ParsedReplacementCommand,
+    initialCommit: GoalReplacementCommit,
+  ): Promise<GoalReplacementResult> {
+    let stored = initialCommit;
+    const wasReplay = initialCommit.deduplicated;
+    let replacement = stored.replacement;
+    if (replacement.phase === "activated") {
+      const live = await this.sessions.resolveLifecycle(
+        command.ownerId,
+        command.runtimeSessionId,
+      );
+      if (live && live.runEpoch !== replacement.runEpoch) {
+        throw new GoalReplacementCoordinatorError(
+          "run_epoch_conflict",
+          `Activated replacement is at runEpoch ${replacement.runEpoch}, live Runtime Session is ${live.runEpoch}`,
+        );
+      }
+      const controlDispatch = live
+        ? await this.dispatchOnTransport(
+            replacement.controlInstruction,
+            command.ownerId,
+            live,
+          )
+        : await this.dispatch(replacement.controlInstruction, command.ownerId);
+      const activationDispatch = live
+        ? await this.dispatchOnTransport(
+            requireActivationInstruction(replacement),
+            command.ownerId,
+            live,
+          )
+        : await this.dispatch(
+            requireActivationInstruction(replacement),
+            command.ownerId,
+          );
+      return {
+        replacement,
+        deduplicated: wasReplay,
+        controlDispatch,
+        activationDispatch,
+        discardedInputIds: [],
+      };
+    }
+
+    const transport = await this.sessions.resolveLifecycle(
+      command.ownerId,
+      command.runtimeSessionId,
+    );
+    if (!transport) {
+      return {
+        replacement,
+        deduplicated: stored.deduplicated,
+        controlDispatch: await this.dispatchControl(
+          replacement.controlInstruction,
+          command.ownerId,
+        ),
+        discardedInputIds: [],
+      };
+    }
+
+    let terminal: RuntimeTurnTerminal | undefined;
+    let discardedInputIds: string[] = [];
+    let controlDispatch: RuntimeInstructionDispatch;
+    if (replacement.phase === "prepared") {
+      if (transport.runEpoch !== replacement.expectedRunEpoch) {
+        throw new GoalReplacementCoordinatorError(
+          "run_epoch_conflict",
+          `Replacement expects runEpoch ${replacement.expectedRunEpoch}, live Runtime Session is ${transport.runEpoch}`,
+        );
+      }
+      const barrier = this.getOrCaptureTerminalBarrier(
+        replacement,
+        command.ownerId,
+        transport,
+      );
+      controlDispatch = await this.dispatchControl(
+        replacement.controlInstruction,
+        command.ownerId,
+      );
+      if (controlDispatch.status !== "accepted") {
+        return {
+          replacement,
+          deduplicated: wasReplay,
+          controlDispatch,
+          discardedInputIds,
+        };
+      }
+      this.assertCurrentTransport(command.ownerId, transport);
+      terminal =
+        barrier.boundary.state === "idle"
+          ? terminalAtBoundary(barrier.boundary)
+          : await this.waitForTerminal(
+              (signal) =>
+                transport.waitForTurnTerminal({
+                  expectedRunEpoch: replacement.expectedRunEpoch,
+                  afterTerminalSequence: barrier.boundary.terminalSequence,
+                  signal,
+                }),
+              command.runtimeSessionId,
+            );
+      this.validateTerminal(terminal, barrier.boundary);
+      this.assertCurrentTransport(command.ownerId, transport);
+      await this.commitControlBarrier(
+        replacement.controlInstruction,
+        command.ownerId,
+        transport,
+      );
+
+      stored = await this.state.markReplacementBoundary({
+        ownerId: command.ownerId,
+        runtimeSessionId: command.runtimeSessionId,
+        replacementGoalId: replacement.replacementGoal.goal.id,
+        expectedRunEpoch: replacement.expectedRunEpoch,
+        nextRunEpoch: replacement.expectedRunEpoch + 1,
+        command: command.identity,
+      });
+      replacement = stored.replacement;
+      discardedInputIds = this.advanceAndValidate(replacement, transport);
+      this.releaseTerminalBarrier(replacement.controlInstruction.id);
+    } else {
+      if (replacement.phase !== "boundary_observed") {
+        throw new GoalReplacementCoordinatorError(
+          "invalid_command",
+          `Cannot continue Goal replacement from phase ${replacement.phase}`,
+        );
+      }
+      if (transport.runEpoch === replacement.expectedRunEpoch) {
+        this.getOrCaptureTerminalBarrier(
+          replacement,
+          command.ownerId,
+          transport,
+        );
+      }
+      controlDispatch = await this.dispatchControl(
+        replacement.controlInstruction,
+        command.ownerId,
+      );
+      if (controlDispatch.status !== "accepted") {
+        return {
+          replacement,
+          deduplicated: wasReplay,
+          controlDispatch,
+          discardedInputIds,
+        };
+      }
+      await this.commitControlBarrier(
+        replacement.controlInstruction,
+        command.ownerId,
+        transport,
+      );
+      discardedInputIds = this.reconcileLiveEpoch(replacement, transport);
+      this.releaseTerminalBarrier(replacement.controlInstruction.id);
+    }
+
+    this.assertCurrentTransport(command.ownerId, transport);
+    const now = this.clock.now();
+    const activationInstruction = instructionDraft({
+      schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+      id: this.ids.generate(),
+      goalId: replacement.replacementGoal.goal.id,
+      goalRevision: replacement.replacementGoal.goal.revision,
+      kind: "goal.activate",
+      deliveryMode: "steer",
+      targetSessionId: command.runtimeSessionId,
+      payload: { goal: replacement.replacementGoal.goal },
+      source: command.source,
+      idempotencyKey: command.idempotencyKey,
+      issuedAt: now.toISOString(),
+    });
+    stored = await this.state.finalizeReplacement({
+      ownerId: command.ownerId,
+      runtimeSessionId: command.runtimeSessionId,
+      replacementGoalId: replacement.replacementGoal.goal.id,
+      activationInstruction,
+      command: command.identity,
+    });
+    replacement = stored.replacement;
+    const activationDispatch = await this.dispatchOnTransport(
+      requireActivationInstruction(replacement),
+      command.ownerId,
+      transport,
+    );
+
+    return {
+      replacement,
+      deduplicated: wasReplay,
+      controlDispatch,
+      activationDispatch,
+      ...(terminal === undefined ? {} : { terminal }),
+      discardedInputIds,
+    };
+  }
+
+  private async requireLifecycleTransport(
+    ownerId: string,
+    runtimeSessionId: string,
+  ) {
+    const transport = await this.sessions.resolveLifecycle(
+      ownerId,
+      runtimeSessionId,
+    );
+    if (!transport) {
+      throw new GoalReplacementCoordinatorError(
+        "runtime_unavailable",
+        `Runtime Session ${runtimeSessionId} must be live before preparing a Goal replacement`,
+      );
+    }
+    return transport;
+  }
+
+  private reconcileLiveEpoch(
+    replacement: AgentGoalReplacement,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): string[] {
+    if (transport.runEpoch === replacement.runEpoch) return [];
+    if (transport.runEpoch !== replacement.expectedRunEpoch) {
+      throw new GoalReplacementCoordinatorError(
+        "run_epoch_conflict",
+        `Live Runtime Session epoch ${transport.runEpoch} cannot reconcile replacement epoch ${replacement.runEpoch}`,
+      );
+    }
+    return this.advanceAndValidate(replacement, transport);
+  }
+
+  private advanceAndValidate(
+    replacement: AgentGoalReplacement,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): string[] {
+    const advanced = transport.advanceRunEpoch({
+      expectedRunEpoch: replacement.expectedRunEpoch,
+      nextRunEpoch: replacement.runEpoch,
+    });
+    if (
+      advanced.previousRunEpoch !== replacement.expectedRunEpoch ||
+      advanced.runEpoch !== replacement.runEpoch ||
+      transport.runEpoch !== replacement.runEpoch ||
+      !Array.isArray(advanced.discardedInputIds) ||
+      advanced.discardedInputIds.some(
+        (id) => typeof id !== "string" || id.length === 0,
+      )
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_runtime_response",
+        "Runtime Session returned an invalid runEpoch advance result",
+      );
+    }
+    return [...advanced.discardedInputIds];
+  }
+
+  private captureLiveBoundary(
+    transport: RuntimeSessionLifecycleControlPort,
+  ): RuntimeTurnBoundary {
+    const boundary = transport.captureTurnBoundary();
+    this.validateBoundary(boundary, transport);
+    return boundary;
+  }
+
+  private getOrCaptureTerminalBarrier(
+    replacement: AgentGoalReplacement,
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): HeldReplacementBarrier {
+    const instructionId = replacement.controlInstruction.id;
+    const existing = this.terminalBarriers.get(instructionId);
+    if (existing) {
+      if (existing.transport !== transport) {
+        throw new GoalReplacementCoordinatorError(
+          "runtime_changed",
+          `Runtime Session ${replacement.runtimeSessionId} changed while its terminal input barrier was active`,
+        );
+      }
+      return existing;
+    }
+
+    const captured = transport.captureTurnBoundaryAndHoldPendingInput(
+      replacement.expectedRunEpoch,
+    );
+    try {
+      this.validateBoundary(captured.boundary, transport);
+      this.validateHold(captured.hold, replacement.expectedRunEpoch);
+    } catch (error) {
+      captured.hold.release();
+      throw error;
+    }
+    this.assertCurrentTransport(ownerId, transport);
+    const barrier = {
+      transport,
+      boundary: captured.boundary,
+      hold: captured.hold,
+    };
+    this.terminalBarriers.set(instructionId, barrier);
+    return barrier;
+  }
+
+  private validateBoundary(
+    boundary: RuntimeTurnBoundary,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): void {
+    if (
+      boundary.runtimeSessionId !== transport.runtimeSessionId ||
+      boundary.runEpoch !== transport.runEpoch ||
+      !Number.isInteger(boundary.terminalSequence) ||
+      boundary.terminalSequence < 0
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_runtime_response",
+        "Runtime Session returned an invalid turn boundary",
+      );
+    }
+    if (
+      boundary.state === "starting" ||
+      boundary.state === "closed" ||
+      boundary.state === "failed"
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_runtime_state",
+        `Runtime Session cannot replace a Goal while ${boundary.state}`,
+      );
+    }
+  }
+
+  private validateHold(
+    hold: RuntimeTerminalInputHold,
+    expectedRunEpoch: number,
+  ): void {
+    if (
+      hold.runEpoch !== expectedRunEpoch ||
+      typeof hold.release !== "function"
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_runtime_response",
+        "Runtime Session returned an invalid terminal input hold",
+      );
+    }
+  }
+
+  private validateTerminal(
+    terminal: RuntimeTurnTerminal,
+    boundary: RuntimeTurnBoundary,
+  ): void {
+    const validSequence =
+      boundary.state === "idle"
+        ? terminal.terminalSequence === boundary.terminalSequence
+        : terminal.terminalSequence > boundary.terminalSequence;
+    if (
+      terminal.runtimeSessionId !== boundary.runtimeSessionId ||
+      terminal.runEpoch !== boundary.runEpoch ||
+      terminal.state !== "idle" ||
+      !Number.isInteger(terminal.terminalSequence) ||
+      !validSequence
+    ) {
+      throw new GoalReplacementCoordinatorError(
+        "invalid_runtime_response",
+        "Runtime Session returned a terminal event outside the captured turn boundary",
+      );
+    }
+  }
+
+  private assertCurrentTransport(
+    ownerId: string,
+    transport: NonNullable<
+      Awaited<ReturnType<RuntimeSessionRegistry["resolveLifecycle"]>>
+    >,
+  ): void {
+    if (this.sessions.isCurrent(ownerId, transport)) return;
+    throw new GoalReplacementCoordinatorError(
+      "runtime_changed",
+      `Runtime Session ${transport.runtimeSessionId} changed during Goal replacement`,
+    );
+  }
+
+  private releaseTerminalBarrier(instructionId: string): void {
+    const barrier = this.terminalBarriers.get(instructionId);
+    if (!barrier) return;
+    this.terminalBarriers.delete(instructionId);
+    barrier.hold.release();
+  }
+
+  private async waitForTerminal(
+    wait: (signal: AbortSignal) => Promise<RuntimeTurnTerminal>,
+    runtimeSessionId: string,
+  ): Promise<RuntimeTurnTerminal> {
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        wait(controller.signal),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new GoalReplacementCoordinatorError(
+                "terminal_timeout",
+                `Runtime Session ${runtimeSessionId} did not reach a terminal turn boundary within ${this.terminalTimeoutMs}ms`,
+              ),
+            );
+          }, this.terminalTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+      controller.abort();
+    }
+  }
+
+  private dispatchControl(
+    instruction: AgentGoalReplacement["controlInstruction"],
+    ownerId: string,
+  ): Promise<RuntimeInstructionDispatch> {
+    return this.dispatcher.deliverControl({
+      ownerId,
+      runtimeSessionId: instruction.targetSessionId,
+      targetInstructionId: instruction.id,
+    });
+  }
+
+  private commitControlBarrier(
+    instruction: AgentGoalReplacement["controlInstruction"],
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): Promise<string[]> {
+    return this.dispatcher.commitControlBarrier({
+      ownerId,
+      runtimeSessionId: instruction.targetSessionId,
+      targetInstructionId: instruction.id,
+      transport,
+      reason: `Superseded by Goal replacement ${instruction.id}`,
+      predecessorPolicy: "supersede_predecessors",
+    });
+  }
+
+  private dispatch(
+    instruction: AgentGoalReplacement["controlInstruction"],
+    ownerId: string,
+  ): Promise<RuntimeInstructionDispatch> {
+    return this.dispatcher.drain({
+      ownerId,
+      runtimeSessionId: instruction.targetSessionId,
+      targetInstructionId: instruction.id,
+    });
+  }
+
+  private dispatchOnTransport(
+    instruction: AgentGoalReplacement["controlInstruction"],
+    ownerId: string,
+    transport: RuntimeSessionLifecycleControlPort,
+  ): Promise<RuntimeInstructionDispatch> {
+    return this.dispatcher.drainOnTransport({
+      ownerId,
+      runtimeSessionId: instruction.targetSessionId,
+      targetInstructionId: instruction.id,
+      transport,
+    });
+  }
+}
+
+interface ParsedReplacementCommand {
+  ownerId: string;
+  runtimeSessionId: string;
+  goalId: string;
+  expectedRevision: number;
+  idempotencyKey: string;
+  source: RuntimeInstructionSource;
+  reason: string;
+  replacement: ReturnType<typeof CreateAgentGoalInputSchema.parse>;
+  identity: GoalCommandIdentity;
+}
+
+function parseReplacementCommand(
+  input: ReplaceGoalCommand,
+): ParsedReplacementCommand {
+  const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+  const runtimeSessionId = requiredIdentifier(
+    input.runtimeSessionId,
+    "runtimeSessionId",
+  );
+  const goalId = requiredIdentifier(input.goalId, "goalId");
+  const idempotencyKey = requiredIdentifier(
+    input.idempotencyKey,
+    "idempotencyKey",
+  );
+  const expectedRevision = positiveInteger(
+    input.expectedRevision,
+    "expectedRevision",
+  );
+  const reason = requiredText(input.reason, "reason", 4_000);
+
+  let source: RuntimeInstructionSource;
+  let replacement: ReturnType<typeof CreateAgentGoalInputSchema.parse>;
+  try {
+    source = RuntimeInstructionSourceSchema.parse(input.source);
+    replacement = CreateAgentGoalInputSchema.parse(input.replacement);
+  } catch (cause) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      "Goal replacement command is invalid",
+      cause,
+    );
+  }
+  if (source.type !== "user" && source.type !== "automation") {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_authority",
+      `${source.type} sources cannot replace a Goal`,
+    );
+  }
+  if (source.type === "automation" && source.sourceRef === undefined) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_authority",
+      "Automation Goal replacements must identify their source",
+    );
+  }
+  if (replacement.contextRefs.length > 0) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      "A replacement Goal cannot embed unresolved context",
+    );
+  }
+  const unsupported = findUnsupportedRuntimeConstraint(replacement.constraints);
+  if (unsupported) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      `Runtime-enforced constraint ${unsupported.id} cannot be activated before a policy enforcement adapter is configured`,
+    );
+  }
+  assertGoalSource(replacement.source, source);
+  const unauthorized = findUnauthorizedConstraintChange(
+    [],
+    replacement.constraints,
+    source,
+  );
+  if (unauthorized) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_authority",
+      `Command source ${source.type} cannot set ${unauthorized.authority} constraint ${unauthorized.id}`,
+    );
+  }
+
+  const identity = {
+    idempotencyKey,
+    requestFingerprint: createGoalCommandFingerprint({
+      kind: "goal.replace",
+      runtimeSessionId,
+      goalId,
+      expectedRevision,
+      source,
+      reason,
+      replacement,
+    }),
+  };
+  return {
+    ownerId,
+    runtimeSessionId,
+    goalId,
+    expectedRevision,
+    idempotencyKey,
+    source,
+    reason,
+    replacement,
+    identity,
+  };
+}
+
+function assertGoalSource(
+  goalSource: GoalSource,
+  source: RuntimeInstructionSource,
+): void {
+  if (goalSourceMatchesCommand(goalSource, source)) return;
+  throw new GoalReplacementCoordinatorError(
+    "invalid_authority",
+    "Replacement Goal source does not match the command authority",
+  );
+}
+
+function assertLifecycleAuthority(
+  goal: AgentGoal,
+  source: RuntimeInstructionSource,
+): void {
+  if (source.type === "user") return;
+  if (
+    source.type === "automation" &&
+    goal.source.type !== "user" &&
+    goal.source.id === source.sourceRef
+  ) {
+    return;
+  }
+  throw new GoalReplacementCoordinatorError(
+    "invalid_authority",
+    `Command source cannot replace Goal ${goal.id}`,
+  );
+}
+
+function instructionDraft(
+  draft: RuntimeInstructionDraft,
+): RuntimeInstructionDraft {
+  try {
+    const parsed = RuntimeInstructionSchema.parse({ ...draft, sequence: 1 });
+    const { sequence: _sequence, ...validated } = parsed;
+    return validated as RuntimeInstructionDraft;
+  } catch (cause) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      "Goal replacement produced an invalid Runtime Instruction",
+      cause,
+    );
+  }
+}
+
+function requireActivationInstruction(replacement: AgentGoalReplacement) {
+  if (!replacement.activationInstruction) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      "Activated Goal replacement is missing its activation instruction",
+    );
+  }
+  return replacement.activationInstruction;
+}
+
+function requiredIdentifier(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value !== value.trim()
+  ) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      `${field} must contain 1 to 256 characters without surrounding whitespace`,
+    );
+  }
+  return value;
+}
+
+function requiredText(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string") {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      `${field} must be a string`,
+    );
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > max) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      `${field} must contain 1 to ${max} characters`,
+    );
+  }
+  return normalized;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new GoalReplacementCoordinatorError(
+      "invalid_command",
+      `${field} must be a positive integer`,
+    );
+  }
+  return value as number;
+}
+
+function commandScope(
+  input: Pick<ReplaceGoalCommand, "ownerId" | "runtimeSessionId">,
+): string {
+  return JSON.stringify([input.ownerId, input.runtimeSessionId]);
+}
+
+function terminalAtBoundary(
+  boundary: RuntimeTurnBoundary,
+): RuntimeTurnTerminal {
+  return {
+    runtimeSessionId: boundary.runtimeSessionId,
+    runEpoch: boundary.runEpoch,
+    terminalSequence: boundary.terminalSequence,
+    state: "idle",
+  };
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-service-error.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-service-error.ts
@@ -1,0 +1,23 @@
+export type GoalServiceErrorCode =
+  | "context_not_found"
+  | "goal_not_active"
+  | "goal_not_found"
+  | "goal_session_mismatch"
+  | "invalid_command"
+  | "invalid_constraint_authority"
+  | "invalid_context_provenance"
+  | "invalid_goal_provenance"
+  | "invalid_lifecycle_authority"
+  | "no_change"
+  | "runtime_constraint_unsupported";
+
+export class GoalServiceError extends Error {
+  constructor(
+    public readonly code: GoalServiceErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "GoalServiceError";
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-service.ts
@@ -25,6 +25,18 @@ import {
 } from "@openloomi/ai/agent/runtime-instructions";
 
 import { createGoalCommandFingerprint } from "./command-fingerprint";
+import {
+  findUnauthorizedConstraintChange,
+  findUnsupportedRuntimeConstraint,
+  goalSourceMatchesCommand,
+} from "./goal-command-policy";
+import type {
+  CancelGoalCommand,
+  GoalLifecycleService,
+  PauseGoalCommand,
+  ResumeGoalCommand,
+} from "./goal-lifecycle-service";
+import { GoalServiceError } from "./goal-service-error";
 import type {
   RuntimeInstructionDispatch,
   RuntimeInstructionDispatcher,
@@ -52,6 +64,8 @@ export type GoalActivationCommandSource = Extract<
   TrustedGoalCommandSource,
   { type: "user" | "automation" }
 >;
+
+export type GoalLifecycleCommandSource = GoalActivationCommandSource;
 
 export type ContextGoalCommandSource =
   | TrustedGoalCommandSource
@@ -92,6 +106,12 @@ export interface RemoveGoalContextCommand extends GoalCommandBase<ContextGoalCom
   deliveryMode?: "next_boundary" | "steer";
 }
 
+export type {
+  CancelGoalCommand,
+  PauseGoalCommand,
+  ResumeGoalCommand,
+} from "./goal-lifecycle-service";
+
 export interface GoalCommandResult {
   goal: PersistedAgentGoal;
   instruction: GoalInstructionCommit["instruction"];
@@ -99,28 +119,10 @@ export interface GoalCommandResult {
   dispatch: RuntimeInstructionDispatch;
 }
 
-export type GoalServiceErrorCode =
-  | "context_not_found"
-  | "goal_not_active"
-  | "goal_not_found"
-  | "goal_session_mismatch"
-  | "invalid_command"
-  | "invalid_constraint_authority"
-  | "invalid_context_provenance"
-  | "invalid_goal_provenance"
-  | "no_change"
-  | "runtime_constraint_unsupported";
-
-export class GoalServiceError extends Error {
-  constructor(
-    public readonly code: GoalServiceErrorCode,
-    message: string,
-    public readonly cause?: unknown,
-  ) {
-    super(message);
-    this.name = "GoalServiceError";
-  }
-}
+export {
+  GoalServiceError,
+  type GoalServiceErrorCode,
+} from "./goal-service-error";
 
 /**
  * Application service for the first in-memory Goal runtime vertical slice.
@@ -137,6 +139,7 @@ export class GoalService {
     private readonly dispatcher: RuntimeInstructionDispatcher,
     private readonly clock: RuntimeClockPort,
     private readonly ids: RuntimeIdGeneratorPort,
+    private readonly lifecycle: GoalLifecycleService,
   ) {}
 
   activate(input: ActivateGoalCommand): Promise<GoalCommandResult> {
@@ -161,6 +164,18 @@ export class GoalService {
     return this.commands.run(commandScope(input), () =>
       this.removeContextCommand(input),
     );
+  }
+
+  pause(input: PauseGoalCommand): Promise<GoalCommandResult> {
+    return this.lifecycle.pause(input);
+  }
+
+  resume(input: ResumeGoalCommand): Promise<GoalCommandResult> {
+    return this.lifecycle.resume(input);
+  }
+
+  cancel(input: CancelGoalCommand): Promise<GoalCommandResult> {
+    return this.lifecycle.cancel(input);
   }
 
   private async activateCommand(
@@ -464,6 +479,16 @@ export class GoalService {
     return this.state.getActivePrimaryGoal(ownerId, runtimeSessionId);
   }
 
+  getRuntimeSessionRunEpoch(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<number> {
+    return this.state.getRuntimeSessionRunEpoch(
+      requiredIdentifier(ownerId, "ownerId"),
+      requiredIdentifier(runtimeSessionId, "runtimeSessionId"),
+    );
+  }
+
   replayPendingInstructions(
     ownerId: string,
     runtimeSessionId: string,
@@ -507,6 +532,21 @@ export class GoalService {
     runtimeSessionId: string,
     goalId: string,
   ): Promise<PersistedAgentGoal> {
+    const goal = await this.requireGoal(ownerId, runtimeSessionId, goalId);
+    if (goal.goal.status !== "active") {
+      throw new GoalServiceError(
+        "goal_not_active",
+        `Goal ${goalId} is ${goal.goal.status}, not active`,
+      );
+    }
+    return goal;
+  }
+
+  private async requireGoal(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalId: string,
+  ): Promise<PersistedAgentGoal> {
     const goal = await this.state.getGoal(ownerId, goalId);
     if (!goal) {
       throw new GoalServiceError(
@@ -518,12 +558,6 @@ export class GoalService {
       throw new GoalServiceError(
         "goal_session_mismatch",
         `Goal ${goalId} belongs to a different Runtime Session`,
-      );
-    }
-    if (goal.goal.status !== "active") {
-      throw new GoalServiceError(
-        "goal_not_active",
-        `Goal ${goalId} is ${goal.goal.status}, not active`,
       );
     }
     return goal;
@@ -659,9 +693,7 @@ function instructionDraft(
 function assertSupportedConstraints(
   constraints: AgentGoal["constraints"],
 ): void {
-  const unsupported = constraints.find(
-    (constraint) => constraint.enforcement === "runtime_enforced",
-  );
+  const unsupported = findUnsupportedRuntimeConstraint(constraints);
   if (unsupported) {
     throw new GoalServiceError(
       "runtime_constraint_unsupported",
@@ -674,16 +706,7 @@ function assertGoalSourceProvenance(
   goalSource: GoalSource,
   instructionSource: RuntimeInstructionSource,
 ): void {
-  if (instructionSource.type === "user" && goalSource.type === "user") {
-    return;
-  }
-  if (
-    instructionSource.type === "automation" &&
-    goalSource.type !== "user" &&
-    goalSource.id === instructionSource.sourceRef
-  ) {
-    return;
-  }
+  if (goalSourceMatchesCommand(goalSource, instructionSource)) return;
 
   throw new GoalServiceError(
     "invalid_goal_provenance",
@@ -717,42 +740,12 @@ function assertConstraintChanges(
   next: GoalConstraint[],
   source: RuntimeInstructionSource,
 ): void {
-  const currentById = new Map(
-    current.map((constraint) => [constraint.id, constraint]),
-  );
-  const nextById = new Map(
-    next.map((constraint) => [constraint.id, constraint]),
-  );
-  const changedIds = new Set([...currentById.keys(), ...nextById.keys()]);
-
-  for (const id of changedIds) {
-    const previous = currentById.get(id);
-    const revised = nextById.get(id);
-    if (
-      previous !== undefined &&
-      revised !== undefined &&
-      canonicalJson(previous) === canonicalJson(revised)
-    ) {
-      continue;
-    }
-    if (previous) assertConstraintAuthority(previous, source);
-    if (revised) assertConstraintAuthority(revised, source);
-  }
-}
-
-function assertConstraintAuthority(
-  constraint: GoalConstraint,
-  source: RuntimeInstructionSource,
-): void {
-  const sourceMatches =
-    constraint.authority === source.authority &&
-    (constraint.authority === "user" ||
-      constraint.sourceRef === source.sourceRef);
-  if (sourceMatches) return;
+  const unauthorized = findUnauthorizedConstraintChange(current, next, source);
+  if (!unauthorized) return;
 
   throw new GoalServiceError(
     "invalid_constraint_authority",
-    `Command source ${source.type} cannot change ${constraint.authority} constraint ${constraint.id}`,
+    `Command source ${source.type} cannot change ${unauthorized.authority} constraint ${unauthorized.id}`,
   );
 }
 

--- a/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
@@ -1,15 +1,21 @@
 import {
-  AgentGoalSchema,
-  RuntimeInstructionSchema,
-  canonicalJson,
   type AgentGoal,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalReplacement,
+  AgentGoalSchema,
   type AgentGoalStatePort,
   type GoalCommandIdentity,
   type GoalInstructionCommit,
+  type GoalLifecycleTransitionAction,
+  type GoalLifecycleTransitionCommit,
+  type GoalReplacementCommit,
   type GoalStatus,
   type PersistedAgentGoal,
   type RuntimeInstruction,
   type RuntimeInstructionDraft,
+  RuntimeInstructionSchema,
+  assertGoalStatusTransition,
+  canonicalJson,
 } from "@openloomi/ai/agent/runtime-instructions";
 
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
@@ -20,15 +26,36 @@ interface StoredGoalInstructionCommit {
   requestFingerprint: string;
 }
 
+interface StoredGoalReplacement {
+  replacement: AgentGoalReplacement;
+  idempotencyKey: string;
+  requestFingerprint: string;
+}
+
+interface StoredGoalLifecycleTransition {
+  transition: AgentGoalLifecycleTransition;
+  idempotencyKey: string;
+  requestFingerprint: string;
+}
+
 interface GoalSessionSnapshot {
   ownerId: string;
   runtimeSessionId: string;
   primaryGoalId?: string;
+  pendingLifecycleTransition?: StoredGoalLifecycleTransition;
+  pendingReplacement?: StoredGoalReplacement;
   goals: Map<string, PersistedAgentGoal>;
   instructions: RuntimeInstruction[];
   commitsByIdempotencyKey: Map<string, StoredGoalInstructionCommit>;
   commitsByInstructionId: Map<string, StoredGoalInstructionCommit>;
+  replacementsByIdempotencyKey: Map<string, StoredGoalReplacement>;
+  replacementsByGoalId: Map<string, StoredGoalReplacement>;
+  lifecycleTransitionsByIdempotencyKey: Map<
+    string,
+    StoredGoalLifecycleTransition
+  >;
   lastInstructionSequence: number;
+  runEpoch: number;
 }
 
 export type InMemoryGoalStateErrorCode =
@@ -37,6 +64,11 @@ export type InMemoryGoalStateErrorCode =
   | "goal_not_found"
   | "idempotency_conflict"
   | "invalid_commit"
+  | "lifecycle_transition_in_progress"
+  | "lifecycle_transition_not_found"
+  | "replacement_in_progress"
+  | "replacement_not_found"
+  | "run_epoch_conflict"
   | "revision_conflict";
 
 export class InMemoryGoalStateError extends Error {
@@ -61,6 +93,14 @@ export class InMemoryGoalStateError extends Error {
 export class InMemoryAgentGoalState implements AgentGoalStatePort {
   private readonly sessions = new Map<string, GoalSessionSnapshot>();
   private readonly mutations = new KeyedSerialExecutor();
+
+  async getRuntimeSessionRunEpoch(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<number> {
+    const scope = validatedScope(ownerId, runtimeSessionId);
+    return this.sessions.get(scope.key)?.runEpoch ?? 0;
+  }
 
   async getGoal(
     ownerId: string,
@@ -102,9 +142,70 @@ export class InMemoryAgentGoalState implements AgentGoalStatePort {
     const stored = this.sessions
       .get(scope.key)
       ?.commitsByIdempotencyKey.get(command.idempotencyKey);
-    if (!stored) return null;
+    if (!stored) {
+      const snapshot = this.sessions.get(scope.key);
+      if (
+        snapshot?.replacementsByIdempotencyKey.has(command.idempotencyKey) ||
+        snapshot?.lifecycleTransitionsByIdempotencyKey.has(
+          command.idempotencyKey,
+        )
+      ) {
+        throwIdempotencyNamespaceConflict(command);
+      }
+      return null;
+    }
     assertMatchingFingerprint(stored, command);
     return toCommit(stored, true);
+  }
+
+  async findReplacementByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit | null> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const stored = this.sessions
+      .get(scope.key)
+      ?.replacementsByIdempotencyKey.get(command.idempotencyKey);
+    if (!stored) {
+      const snapshot = this.sessions.get(scope.key);
+      if (
+        snapshot?.commitsByIdempotencyKey.has(command.idempotencyKey) ||
+        snapshot?.lifecycleTransitionsByIdempotencyKey.has(
+          command.idempotencyKey,
+        )
+      ) {
+        throwIdempotencyNamespaceConflict(command);
+      }
+      return null;
+    }
+    assertMatchingReplacementFingerprint(stored, command);
+    return toReplacementCommit(stored, true);
+  }
+
+  async findLifecycleTransitionByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit | null> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const snapshot = this.sessions.get(scope.key);
+    const stored = snapshot?.lifecycleTransitionsByIdempotencyKey.get(
+      command.idempotencyKey,
+    );
+    if (!stored) {
+      if (
+        snapshot?.commitsByIdempotencyKey.has(command.idempotencyKey) ||
+        snapshot?.replacementsByIdempotencyKey.has(command.idempotencyKey)
+      ) {
+        throwIdempotencyNamespaceConflict(command);
+      }
+      return null;
+    }
+    assertMatchingLifecycleFingerprint(stored, command);
+    return toLifecycleTransitionCommit(stored, true);
   }
 
   async commitActivation(input: {
@@ -124,8 +225,16 @@ export class InMemoryAgentGoalState implements AgentGoalStatePort {
         emptySnapshot(scope.ownerId, scope.runtimeSessionId);
       const duplicate = findIdempotentCommit(current, command);
       if (duplicate) return toCommit(duplicate, true);
+      assertNoReplacementIdempotencyCollision(current, command);
+      assertNoLifecycleIdempotencyCollision(current, command);
 
-      const existingGoal = findOwnerGoal(this.sessions, scope.ownerId, goal.id);
+      assertNoPendingReplacement(current);
+      assertNoPendingLifecycleTransition(current);
+      const existingGoal = findOwnerGoalOrReservation(
+        this.sessions,
+        scope.ownerId,
+        goal.id,
+      );
       if (existingGoal) {
         throw new InMemoryGoalStateError(
           "goal_conflict",
@@ -190,6 +299,12 @@ export class InMemoryAgentGoalState implements AgentGoalStatePort {
       const current = this.sessions.get(scope.key);
       const duplicate = current ? findIdempotentCommit(current, command) : null;
       if (duplicate) return toCommit(duplicate, true);
+      if (current) {
+        assertNoReplacementIdempotencyCollision(current, command);
+        assertNoLifecycleIdempotencyCollision(current, command);
+        assertNoPendingReplacement(current);
+        assertNoPendingLifecycleTransition(current);
+      }
 
       const persisted = current?.goals.get(goal.id);
       if (!current || !persisted) {
@@ -258,6 +373,597 @@ export class InMemoryAgentGoalState implements AgentGoalStatePort {
     });
   }
 
+  async commitTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const goal = parseGoal(input.goal);
+    const expectedRevision = positiveInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      const duplicate = current ? findIdempotentCommit(current, command) : null;
+      if (duplicate) return toCommit(duplicate, true);
+      if (current) {
+        assertNoReplacementIdempotencyCollision(current, command);
+        assertNoLifecycleIdempotencyCollision(current, command);
+        assertNoPendingReplacement(current);
+        assertNoPendingLifecycleTransition(current);
+      }
+
+      const persisted = current?.goals.get(goal.id);
+      if (!current || !persisted) {
+        throw new InMemoryGoalStateError(
+          "goal_not_found",
+          `Goal ${goal.id} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (current.primaryGoalId !== goal.id) {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          `Goal ${goal.id} is not the primary Goal for Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (persisted.goal.revision !== expectedRevision) {
+        throw new InMemoryGoalStateError(
+          "revision_conflict",
+          `Expected Goal revision ${expectedRevision}, received ${persisted.goal.revision}`,
+        );
+      }
+
+      const instruction = materializeInstruction(
+        input.instruction,
+        command,
+        current.lastInstructionSequence + 1,
+      );
+      assertTransitionCommit(
+        persisted.goal,
+        goal,
+        instruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+      );
+
+      const transitioned: PersistedAgentGoal = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        slot: "primary",
+        goal,
+      };
+      const stored = createStoredCommit(
+        transitioned,
+        instruction,
+        command.requestFingerprint,
+      );
+      const next = copySnapshot(current);
+      next.primaryGoalId = occupiesPrimarySlot(goal.status)
+        ? goal.id
+        : undefined;
+      next.goals.set(goal.id, clone(transitioned));
+      recordInstruction(next, command, stored);
+      this.sessions.set(scope.key, next);
+      return toCommit(stored, false);
+    });
+  }
+
+  async prepareLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    action: GoalLifecycleTransitionAction;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const action = lifecycleTransitionAction(input.action);
+    const goal = parseGoal(input.goal);
+    const expectedRevision = positiveInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "goal_not_found",
+          `Goal ${goal.id} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const duplicate = findIdempotentLifecycleTransition(current, command);
+      if (duplicate) {
+        return toLifecycleTransitionCommit(duplicate, true);
+      }
+      assertNoGoalCommandIdempotencyCollision(current, command);
+      assertNoReplacementIdempotencyCollision(current, command);
+      assertNoPendingReplacement(current);
+      assertNoPendingLifecycleTransition(current);
+
+      if (current.runEpoch !== expectedRunEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Expected Runtime Session epoch ${expectedRunEpoch}, received ${current.runEpoch}`,
+        );
+      }
+      const persisted = current.goals.get(goal.id);
+      if (!persisted) {
+        throw new InMemoryGoalStateError(
+          "goal_not_found",
+          `Goal ${goal.id} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (current.primaryGoalId !== goal.id) {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          `Goal ${goal.id} is not the primary Goal for Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (persisted.goal.revision !== expectedRevision) {
+        throw new InMemoryGoalStateError(
+          "revision_conflict",
+          `Expected Goal revision ${expectedRevision}, received ${persisted.goal.revision}`,
+        );
+      }
+
+      const instruction = materializeInstruction(
+        input.instruction,
+        command,
+        current.lastInstructionSequence + 1,
+      );
+      assertLifecycleTransitionPreparation(
+        persisted.goal,
+        goal,
+        instruction,
+        action,
+        scope.runtimeSessionId,
+        expectedRevision,
+        expectedRunEpoch,
+      );
+
+      const transitionedGoal: PersistedAgentGoal = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        slot: "primary",
+        goal,
+      };
+      const stored: StoredGoalLifecycleTransition = {
+        transition: {
+          ownerId: scope.ownerId,
+          runtimeSessionId: scope.runtimeSessionId,
+          action,
+          transitionedGoal,
+          instruction,
+          expectedRunEpoch,
+          runEpoch: expectedRunEpoch,
+          phase: "prepared",
+        },
+        idempotencyKey: command.idempotencyKey,
+        requestFingerprint: command.requestFingerprint,
+      };
+      const next = copySnapshot(current);
+      // A prepared cancel still owns the slot until the interrupted provider
+      // turn reaches its terminal boundary.
+      next.primaryGoalId = goal.id;
+      next.goals.set(goal.id, clone(transitionedGoal));
+      recordAggregateInstruction(
+        next,
+        transitionedGoal,
+        instruction,
+        command.requestFingerprint,
+      );
+      storeLifecycleTransition(next, stored);
+      next.pendingLifecycleTransition = clone(stored);
+      this.sessions.set(scope.key, next);
+      return toLifecycleTransitionCommit(stored, false);
+    });
+  }
+
+  async markLifecycleTransitionBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const goalId = requiredIdentifier(input.goalId, "goalId");
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = nonNegativeInteger(input.nextRunEpoch, "nextRunEpoch");
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "lifecycle_transition_not_found",
+          `No lifecycle transition exists for Goal ${goalId} in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const stored = requireLifecycleTransition(current, command, goalId);
+      assertLifecycleEpochRequest(stored, expectedRunEpoch, nextRunEpoch);
+      if (
+        stored.transition.phase === "boundary_observed" ||
+        stored.transition.phase === "finalized"
+      ) {
+        return toLifecycleTransitionCommit(stored, true);
+      }
+      if (
+        stored.transition.action !== "cancel" ||
+        stored.transition.phase !== "prepared"
+      ) {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          `Only a prepared Goal cancel can record a Runtime Session terminal boundary`,
+        );
+      }
+      assertPendingLifecycleTransition(current, stored);
+      if (current.runEpoch !== expectedRunEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Expected Runtime Session epoch ${expectedRunEpoch}, received ${current.runEpoch}`,
+        );
+      }
+
+      const updated = clone(stored);
+      updated.transition.phase = "boundary_observed";
+      updated.transition.runEpoch = nextRunEpoch;
+      const next = copySnapshot(current);
+      next.runEpoch = nextRunEpoch;
+      // The cancelled Goal continues to reserve the primary slot until the
+      // live runtime confirms it has advanced to the durable epoch.
+      next.primaryGoalId = goalId;
+      next.pendingLifecycleTransition = clone(updated);
+      storeLifecycleTransition(next, updated);
+      this.sessions.set(scope.key, next);
+      return toLifecycleTransitionCommit(updated, false);
+    });
+  }
+
+  async finalizeLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const goalId = requiredIdentifier(input.goalId, "goalId");
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = nonNegativeInteger(input.nextRunEpoch, "nextRunEpoch");
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "lifecycle_transition_not_found",
+          `No lifecycle transition exists for Goal ${goalId} in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const stored = requireLifecycleTransition(current, command, goalId);
+      assertLifecycleEpochRequest(stored, expectedRunEpoch, nextRunEpoch);
+      if (stored.transition.phase === "finalized") {
+        return toLifecycleTransitionCommit(stored, true);
+      }
+      assertPendingLifecycleTransition(current, stored);
+      if (
+        (stored.transition.action === "pause" &&
+          stored.transition.phase !== "prepared") ||
+        (stored.transition.action === "cancel" &&
+          stored.transition.phase !== "boundary_observed")
+      ) {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          stored.transition.action === "cancel"
+            ? "A Goal cancel must record its provider terminal boundary before finalization"
+            : "A Goal pause can only finalize directly from its prepared state",
+        );
+      }
+      const requiredCurrentEpoch =
+        stored.transition.action === "pause" ? expectedRunEpoch : nextRunEpoch;
+      if (current.runEpoch !== requiredCurrentEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Expected Runtime Session epoch ${requiredCurrentEpoch}, received ${current.runEpoch}`,
+        );
+      }
+
+      const updated = clone(stored);
+      updated.transition.phase = "finalized";
+      updated.transition.runEpoch = nextRunEpoch;
+      const next = copySnapshot(current);
+      next.runEpoch = nextRunEpoch;
+      next.primaryGoalId =
+        stored.transition.action === "pause" ? goalId : undefined;
+      next.pendingLifecycleTransition = undefined;
+      storeLifecycleTransition(next, updated);
+      this.sessions.set(scope.key, next);
+      return toLifecycleTransitionCommit(updated, false);
+    });
+  }
+
+  async prepareReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    supersededGoal: AgentGoal;
+    replacementGoal: AgentGoal;
+    controlInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const supersededGoal = parseGoal(input.supersededGoal);
+    const replacementGoal = parseGoal(input.replacementGoal);
+    const expectedRevision = positiveInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "goal_not_found",
+          `Goal ${supersededGoal.id} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const duplicate = findIdempotentReplacement(current, command);
+      if (duplicate) return toReplacementCommit(duplicate, true);
+      assertNoGoalCommandIdempotencyCollision(current, command);
+      assertNoLifecycleIdempotencyCollision(current, command);
+      assertNoPendingReplacement(current);
+      assertNoPendingLifecycleTransition(current);
+
+      if (current.runEpoch !== expectedRunEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Expected Runtime Session epoch ${expectedRunEpoch}, received ${current.runEpoch}`,
+        );
+      }
+      const persisted = current.goals.get(supersededGoal.id);
+      if (!persisted) {
+        throw new InMemoryGoalStateError(
+          "goal_not_found",
+          `Goal ${supersededGoal.id} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (current.primaryGoalId !== supersededGoal.id) {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          `Goal ${supersededGoal.id} is not the primary Goal for Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      if (persisted.goal.revision !== expectedRevision) {
+        throw new InMemoryGoalStateError(
+          "revision_conflict",
+          `Expected Goal revision ${expectedRevision}, received ${persisted.goal.revision}`,
+        );
+      }
+
+      const existingReplacement = findOwnerGoalOrReservation(
+        this.sessions,
+        scope.ownerId,
+        replacementGoal.id,
+      );
+      if (existingReplacement) {
+        throw new InMemoryGoalStateError(
+          "goal_conflict",
+          `Goal ${replacementGoal.id} already exists in Runtime Session ${existingReplacement.runtimeSessionId} for this owner`,
+        );
+      }
+      const controlInstruction = materializeInstruction(
+        input.controlInstruction,
+        command,
+        current.lastInstructionSequence + 1,
+      );
+      assertReplacementPreparation(
+        persisted.goal,
+        supersededGoal,
+        replacementGoal,
+        controlInstruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+        expectedRunEpoch,
+      );
+
+      const superseded: PersistedAgentGoal = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        slot: "primary",
+        goal: supersededGoal,
+      };
+      const replacement: PersistedAgentGoal = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        slot: "primary",
+        goal: replacementGoal,
+      };
+      const stored: StoredGoalReplacement = {
+        replacement: {
+          ownerId: scope.ownerId,
+          runtimeSessionId: scope.runtimeSessionId,
+          supersededGoal: superseded,
+          replacementGoal: replacement,
+          controlInstruction,
+          expectedRunEpoch,
+          runEpoch: expectedRunEpoch,
+          phase: "prepared",
+        },
+        idempotencyKey: command.idempotencyKey,
+        requestFingerprint: command.requestFingerprint,
+      };
+      const next = copySnapshot(current);
+      next.primaryGoalId = replacementGoal.id;
+      next.goals.set(supersededGoal.id, clone(superseded));
+      recordAggregateInstruction(
+        next,
+        superseded,
+        controlInstruction,
+        command.requestFingerprint,
+      );
+      storeReplacement(next, stored);
+      next.pendingReplacement = clone(stored);
+      this.sessions.set(scope.key, next);
+      return toReplacementCommit(stored, false);
+    });
+  }
+
+  async markReplacementBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const replacementGoalId = requiredIdentifier(
+      input.replacementGoalId,
+      "replacementGoalId",
+    );
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = nonNegativeInteger(input.nextRunEpoch, "nextRunEpoch");
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "replacement_not_found",
+          `Replacement Goal ${replacementGoalId} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const stored = requireReplacement(current, command, replacementGoalId);
+      assertReplacementEpochRequest(stored, expectedRunEpoch, nextRunEpoch);
+      if (stored.replacement.phase !== "prepared") {
+        return toReplacementCommit(stored, true);
+      }
+      assertPendingReplacement(current, stored);
+      if (current.runEpoch !== expectedRunEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Expected Runtime Session epoch ${expectedRunEpoch}, received ${current.runEpoch}`,
+        );
+      }
+
+      const updated = clone(stored);
+      updated.replacement.phase = "boundary_observed";
+      updated.replacement.runEpoch = nextRunEpoch;
+      const next = copySnapshot(current);
+      next.runEpoch = nextRunEpoch;
+      next.pendingReplacement = clone(updated);
+      storeReplacement(next, updated);
+      this.sessions.set(scope.key, next);
+      return toReplacementCommit(updated, false);
+    });
+  }
+
+  async finalizeReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    activationInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validatedScope(input.ownerId, input.runtimeSessionId);
+    const command = validateCommand(input.command);
+    const replacementGoalId = requiredIdentifier(
+      input.replacementGoalId,
+      "replacementGoalId",
+    );
+
+    return this.mutations.run(ownerScope(scope.ownerId), () => {
+      const current = this.sessions.get(scope.key);
+      if (!current) {
+        throw new InMemoryGoalStateError(
+          "replacement_not_found",
+          `Replacement Goal ${replacementGoalId} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+        );
+      }
+      const stored = requireReplacement(current, command, replacementGoalId);
+      if (stored.replacement.phase === "activated") {
+        return toReplacementCommit(stored, true);
+      }
+      if (stored.replacement.phase !== "boundary_observed") {
+        throw new InMemoryGoalStateError(
+          "invalid_commit",
+          "A replacement cannot activate before its Runtime Session boundary is observed",
+        );
+      }
+      assertPendingReplacement(current, stored);
+      if (current.runEpoch !== stored.replacement.runEpoch) {
+        throw new InMemoryGoalStateError(
+          "run_epoch_conflict",
+          `Replacement epoch ${stored.replacement.runEpoch} does not match Runtime Session epoch ${current.runEpoch}`,
+        );
+      }
+
+      const activationInstruction = materializeInstruction(
+        input.activationInstruction,
+        command,
+        current.lastInstructionSequence + 1,
+      );
+      assertReplacementActivation(
+        stored.replacement,
+        activationInstruction,
+        scope.runtimeSessionId,
+      );
+
+      const updated = clone(stored);
+      updated.replacement.phase = "activated";
+      updated.replacement.activationInstruction = activationInstruction;
+      const next = copySnapshot(current);
+      next.primaryGoalId = replacementGoalId;
+      next.goals.set(
+        replacementGoalId,
+        clone(stored.replacement.replacementGoal),
+      );
+      recordAggregateInstruction(
+        next,
+        stored.replacement.replacementGoal,
+        activationInstruction,
+        command.requestFingerprint,
+      );
+      next.pendingReplacement = undefined;
+      storeReplacement(next, updated);
+      this.sessions.set(scope.key, next);
+      return toReplacementCommit(updated, false);
+    });
+  }
+
   async listInstructions(
     ownerId: string,
     runtimeSessionId: string,
@@ -278,7 +984,11 @@ function emptySnapshot(
     instructions: [],
     commitsByIdempotencyKey: new Map(),
     commitsByInstructionId: new Map(),
+    replacementsByIdempotencyKey: new Map(),
+    replacementsByGoalId: new Map(),
+    lifecycleTransitionsByIdempotencyKey: new Map(),
     lastInstructionSequence: 0,
+    runEpoch: 0,
   };
 }
 
@@ -289,6 +999,21 @@ function copySnapshot(snapshot: GoalSessionSnapshot): GoalSessionSnapshot {
     instructions: [...snapshot.instructions],
     commitsByIdempotencyKey: new Map(snapshot.commitsByIdempotencyKey),
     commitsByInstructionId: new Map(snapshot.commitsByInstructionId),
+    replacementsByIdempotencyKey: new Map(
+      snapshot.replacementsByIdempotencyKey,
+    ),
+    replacementsByGoalId: new Map(snapshot.replacementsByGoalId),
+    lifecycleTransitionsByIdempotencyKey: new Map(
+      snapshot.lifecycleTransitionsByIdempotencyKey,
+    ),
+    pendingLifecycleTransition:
+      snapshot.pendingLifecycleTransition === undefined
+        ? undefined
+        : clone(snapshot.pendingLifecycleTransition),
+    pendingReplacement:
+      snapshot.pendingReplacement === undefined
+        ? undefined
+        : clone(snapshot.pendingReplacement),
   };
 }
 
@@ -302,6 +1027,30 @@ function findIdempotentCommit(
   return stored;
 }
 
+function findIdempotentReplacement(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+): StoredGoalReplacement | null {
+  const stored = snapshot.replacementsByIdempotencyKey.get(
+    command.idempotencyKey,
+  );
+  if (!stored) return null;
+  assertMatchingReplacementFingerprint(stored, command);
+  return stored;
+}
+
+function findIdempotentLifecycleTransition(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+): StoredGoalLifecycleTransition | null {
+  const stored = snapshot.lifecycleTransitionsByIdempotencyKey.get(
+    command.idempotencyKey,
+  );
+  if (!stored) return null;
+  assertMatchingLifecycleFingerprint(stored, command);
+  return stored;
+}
+
 function assertMatchingFingerprint(
   stored: StoredGoalInstructionCommit,
   command: GoalCommandIdentity,
@@ -312,6 +1061,68 @@ function assertMatchingFingerprint(
       `Idempotency key ${command.idempotencyKey} was already used for a different Goal command`,
     );
   }
+}
+
+function assertMatchingReplacementFingerprint(
+  stored: StoredGoalReplacement,
+  command: GoalCommandIdentity,
+): void {
+  if (stored.requestFingerprint !== command.requestFingerprint) {
+    throw new InMemoryGoalStateError(
+      "idempotency_conflict",
+      `Idempotency key ${command.idempotencyKey} was already used for a different Goal replacement`,
+    );
+  }
+}
+
+function assertMatchingLifecycleFingerprint(
+  stored: StoredGoalLifecycleTransition,
+  command: GoalCommandIdentity,
+): void {
+  if (stored.requestFingerprint !== command.requestFingerprint) {
+    throw new InMemoryGoalStateError(
+      "idempotency_conflict",
+      `Idempotency key ${command.idempotencyKey} was already used for a different Goal lifecycle transition`,
+    );
+  }
+}
+
+function assertNoReplacementIdempotencyCollision(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+): void {
+  if (snapshot.replacementsByIdempotencyKey.has(command.idempotencyKey)) {
+    throwIdempotencyNamespaceConflict(command);
+  }
+}
+
+function assertNoGoalCommandIdempotencyCollision(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+): void {
+  if (snapshot.commitsByIdempotencyKey.has(command.idempotencyKey)) {
+    throwIdempotencyNamespaceConflict(command);
+  }
+}
+
+function assertNoLifecycleIdempotencyCollision(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+): void {
+  if (
+    snapshot.lifecycleTransitionsByIdempotencyKey.has(command.idempotencyKey)
+  ) {
+    throwIdempotencyNamespaceConflict(command);
+  }
+}
+
+function throwIdempotencyNamespaceConflict(
+  command: GoalCommandIdentity,
+): never {
+  throw new InMemoryGoalStateError(
+    "idempotency_conflict",
+    `Idempotency key ${command.idempotencyKey} was already used by another Runtime Goal command`,
+  );
 }
 
 function materializeInstruction(
@@ -353,6 +1164,83 @@ function assertActivationCommit(
     throw new InMemoryGoalStateError(
       "invalid_commit",
       "Activation must atomically commit an active revision-one Goal and its matching instruction",
+    );
+  }
+}
+
+function assertReplacementPreparation(
+  previousGoal: AgentGoal,
+  supersededGoal: AgentGoal,
+  replacementGoal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+  expectedRunEpoch: number,
+): void {
+  try {
+    assertGoalStatusTransition(previousGoal.status, "cancelled");
+  } catch (cause) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `Goal replacement cannot supersede a ${previousGoal.status} Goal`,
+      cause,
+    );
+  }
+
+  const expectedSupersededGoal: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: "cancelled",
+    updatedAt: supersededGoal.updatedAt,
+  };
+  if (
+    supersededGoal.id === replacementGoal.id ||
+    supersededGoal.revision !== expectedRevision + 1 ||
+    Date.parse(supersededGoal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expectedSupersededGoal) !== canonicalJson(supersededGoal) ||
+    replacementGoal.revision !== 1 ||
+    replacementGoal.status !== "active"
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "Replacement preparation must only cancel the current Goal and reserve a distinct active revision-one Goal",
+    );
+  }
+  if (
+    instruction.kind !== "control.interrupt" ||
+    instruction.deliveryMode !== "interrupt_replace" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== supersededGoal.id ||
+    instruction.goalRevision !== supersededGoal.revision ||
+    instruction.payload.replacementGoalId !== replacementGoal.id ||
+    instruction.payload.expectedRunEpoch !== expectedRunEpoch
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "Replacement preparation requires a matching control.interrupt instruction and run epoch",
+    );
+  }
+}
+
+function assertReplacementActivation(
+  replacement: AgentGoalReplacement,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+): void {
+  assertActivationCommit(
+    replacement.replacementGoal.goal,
+    instruction,
+    runtimeSessionId,
+  );
+  if (
+    canonicalJson(instruction.source) !==
+      canonicalJson(replacement.controlInstruction.source) ||
+    Date.parse(instruction.issuedAt) <
+      Date.parse(replacement.controlInstruction.issuedAt)
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "Replacement activation must preserve command authority and monotonic instruction time",
     );
   }
 }
@@ -408,6 +1296,118 @@ function assertRevisionCommit(
         instruction.payload.contextRefId,
       );
       return;
+  }
+}
+
+function assertTransitionCommit(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+): void {
+  if (
+    previousGoal.status !== "paused" ||
+    goal.status !== "active" ||
+    goal.revision !== expectedRevision + 1 ||
+    instruction.kind !== "goal.resume" ||
+    instruction.deliveryMode !== "steer" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "An ordinary Goal transition may only resume a paused Goal with its matching steer instruction",
+    );
+  }
+
+  try {
+    assertGoalStatusTransition(previousGoal.status, goal.status);
+  } catch (cause) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `Goal lifecycle transition ${previousGoal.status} -> ${goal.status} is invalid`,
+      cause,
+    );
+  }
+
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: goal.status,
+    updatedAt: goal.updatedAt,
+  };
+  if (
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expected) !== canonicalJson(goal)
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "A Goal lifecycle commit may change only status, revision, and updatedAt",
+    );
+  }
+}
+
+function assertLifecycleTransitionPreparation(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  action: GoalLifecycleTransitionAction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+  expectedRunEpoch: number,
+): void {
+  const expectedStatus = action === "pause" ? "paused" : "cancelled";
+  const instructionExpectedRunEpoch =
+    instruction.kind === "goal.pause" || instruction.kind === "goal.cancel"
+      ? instruction.payload.expectedRunEpoch
+      : undefined;
+  const validSourceStatus =
+    action === "pause"
+      ? previousGoal.status === "active"
+      : previousGoal.status === "active" || previousGoal.status === "paused";
+  if (
+    !validSourceStatus ||
+    goal.status !== expectedStatus ||
+    goal.revision !== expectedRevision + 1 ||
+    instruction.kind !== `goal.${action}` ||
+    instruction.deliveryMode !== "interrupt_replace" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision ||
+    instructionExpectedRunEpoch !== expectedRunEpoch
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `A Goal ${action} barrier must advance the authoritative Goal exactly once with its matching interrupting steer instruction`,
+    );
+  }
+
+  try {
+    assertGoalStatusTransition(previousGoal.status, goal.status);
+  } catch (cause) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `Goal lifecycle transition ${previousGoal.status} -> ${goal.status} is invalid`,
+      cause,
+    );
+  }
+
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: expectedStatus,
+    updatedAt: goal.updatedAt,
+  };
+  if (
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expected) !== canonicalJson(goal)
+  ) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `A Goal ${action} barrier may change only status, revision, and updatedAt`,
+    );
   }
 }
 
@@ -506,6 +1506,53 @@ function recordInstruction(
   snapshot.lastInstructionSequence = stored.instruction.sequence;
 }
 
+function recordAggregateInstruction(
+  snapshot: GoalSessionSnapshot,
+  goal: PersistedAgentGoal,
+  instruction: RuntimeInstruction,
+  requestFingerprint: string,
+): void {
+  const instructionCollision = snapshot.commitsByInstructionId.get(
+    instruction.id,
+  );
+  if (instructionCollision) {
+    throw new InMemoryGoalStateError(
+      "idempotency_conflict",
+      `Instruction ID ${instruction.id} is already present in the outbox`,
+    );
+  }
+  snapshot.instructions.push(clone(instruction));
+  snapshot.commitsByInstructionId.set(
+    instruction.id,
+    clone({ goal, instruction, requestFingerprint }),
+  );
+  snapshot.lastInstructionSequence = instruction.sequence;
+}
+
+function storeReplacement(
+  snapshot: GoalSessionSnapshot,
+  stored: StoredGoalReplacement,
+): void {
+  snapshot.replacementsByIdempotencyKey.set(
+    stored.idempotencyKey,
+    clone(stored),
+  );
+  snapshot.replacementsByGoalId.set(
+    stored.replacement.replacementGoal.goal.id,
+    clone(stored),
+  );
+}
+
+function storeLifecycleTransition(
+  snapshot: GoalSessionSnapshot,
+  stored: StoredGoalLifecycleTransition,
+): void {
+  snapshot.lifecycleTransitionsByIdempotencyKey.set(
+    stored.idempotencyKey,
+    clone(stored),
+  );
+}
+
 function toCommit(
   stored: StoredGoalInstructionCommit,
   deduplicated: boolean,
@@ -513,6 +1560,26 @@ function toCommit(
   return {
     goal: clone(stored.goal),
     instruction: clone(stored.instruction),
+    deduplicated,
+  };
+}
+
+function toReplacementCommit(
+  stored: StoredGoalReplacement,
+  deduplicated: boolean,
+): GoalReplacementCommit {
+  return {
+    replacement: clone(stored.replacement),
+    deduplicated,
+  };
+}
+
+function toLifecycleTransitionCommit(
+  stored: StoredGoalLifecycleTransition,
+  deduplicated: boolean,
+): GoalLifecycleTransitionCommit {
+  return {
+    transition: clone(stored.transition),
     deduplicated,
   };
 }
@@ -541,6 +1608,175 @@ function validateCommand(command: GoalCommandIdentity): GoalCommandIdentity {
     );
   }
   return { idempotencyKey, requestFingerprint: command.requestFingerprint };
+}
+
+function requireReplacement(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+  replacementGoalId: string,
+): StoredGoalReplacement {
+  const stored = snapshot.replacementsByIdempotencyKey.get(
+    command.idempotencyKey,
+  );
+  if (!stored) {
+    if (
+      snapshot.commitsByIdempotencyKey.has(command.idempotencyKey) ||
+      snapshot.lifecycleTransitionsByIdempotencyKey.has(command.idempotencyKey)
+    ) {
+      throwIdempotencyNamespaceConflict(command);
+    }
+    throw new InMemoryGoalStateError(
+      "replacement_not_found",
+      `No Goal replacement exists for idempotency key ${command.idempotencyKey}`,
+    );
+  }
+  assertMatchingReplacementFingerprint(stored, command);
+  if (stored.replacement.replacementGoal.goal.id !== replacementGoalId) {
+    throw new InMemoryGoalStateError(
+      "replacement_not_found",
+      `Replacement Goal ${replacementGoalId} does not match the stored replacement`,
+    );
+  }
+  return stored;
+}
+
+function requireLifecycleTransition(
+  snapshot: GoalSessionSnapshot,
+  command: GoalCommandIdentity,
+  goalId: string,
+): StoredGoalLifecycleTransition {
+  const stored = snapshot.lifecycleTransitionsByIdempotencyKey.get(
+    command.idempotencyKey,
+  );
+  if (!stored) {
+    if (
+      snapshot.commitsByIdempotencyKey.has(command.idempotencyKey) ||
+      snapshot.replacementsByIdempotencyKey.has(command.idempotencyKey)
+    ) {
+      throwIdempotencyNamespaceConflict(command);
+    }
+    throw new InMemoryGoalStateError(
+      "lifecycle_transition_not_found",
+      `No Goal lifecycle transition exists for idempotency key ${command.idempotencyKey}`,
+    );
+  }
+  assertMatchingLifecycleFingerprint(stored, command);
+  if (stored.transition.transitionedGoal.goal.id !== goalId) {
+    throw new InMemoryGoalStateError(
+      "lifecycle_transition_not_found",
+      `Goal ${goalId} does not match the stored lifecycle transition`,
+    );
+  }
+  return stored;
+}
+
+function assertNoPendingReplacement(snapshot: GoalSessionSnapshot): void {
+  if (!snapshot.pendingReplacement) return;
+  throw new InMemoryGoalStateError(
+    "replacement_in_progress",
+    `Runtime Session ${snapshot.runtimeSessionId} is reserving replacement Goal ${snapshot.pendingReplacement.replacement.replacementGoal.goal.id}`,
+  );
+}
+
+function assertNoPendingLifecycleTransition(
+  snapshot: GoalSessionSnapshot,
+): void {
+  if (!snapshot.pendingLifecycleTransition) return;
+  const transition = snapshot.pendingLifecycleTransition.transition;
+  throw new InMemoryGoalStateError(
+    "lifecycle_transition_in_progress",
+    `Runtime Session ${snapshot.runtimeSessionId} is finalizing ${transition.action} for Goal ${transition.transitionedGoal.goal.id}`,
+  );
+}
+
+function assertPendingReplacement(
+  snapshot: GoalSessionSnapshot,
+  stored: StoredGoalReplacement,
+): void {
+  const pending = snapshot.pendingReplacement;
+  if (
+    !pending ||
+    pending.idempotencyKey !== stored.idempotencyKey ||
+    pending.replacement.replacementGoal.goal.id !==
+      stored.replacement.replacementGoal.goal.id
+  ) {
+    throw new InMemoryGoalStateError(
+      "replacement_not_found",
+      `Replacement Goal ${stored.replacement.replacementGoal.goal.id} is not the pending primary reservation`,
+    );
+  }
+}
+
+function assertPendingLifecycleTransition(
+  snapshot: GoalSessionSnapshot,
+  stored: StoredGoalLifecycleTransition,
+): void {
+  const pending = snapshot.pendingLifecycleTransition;
+  if (
+    !pending ||
+    pending.idempotencyKey !== stored.idempotencyKey ||
+    pending.transition.transitionedGoal.goal.id !==
+      stored.transition.transitionedGoal.goal.id
+  ) {
+    throw new InMemoryGoalStateError(
+      "lifecycle_transition_not_found",
+      `Lifecycle transition for Goal ${stored.transition.transitionedGoal.goal.id} is not the pending primary reservation`,
+    );
+  }
+}
+
+function assertReplacementEpochRequest(
+  stored: StoredGoalReplacement,
+  expectedRunEpoch: number,
+  nextRunEpoch: number,
+): void {
+  if (
+    expectedRunEpoch !== stored.replacement.expectedRunEpoch ||
+    nextRunEpoch !== expectedRunEpoch + 1
+  ) {
+    throw new InMemoryGoalStateError(
+      "run_epoch_conflict",
+      `Replacement must advance Runtime Session epoch ${stored.replacement.expectedRunEpoch} exactly once`,
+    );
+  }
+  if (
+    stored.replacement.phase !== "prepared" &&
+    stored.replacement.runEpoch !== nextRunEpoch
+  ) {
+    throw new InMemoryGoalStateError(
+      "run_epoch_conflict",
+      `Replacement already observed Runtime Session epoch ${stored.replacement.runEpoch}`,
+    );
+  }
+}
+
+function assertLifecycleEpochRequest(
+  stored: StoredGoalLifecycleTransition,
+  expectedRunEpoch: number,
+  nextRunEpoch: number,
+): void {
+  const requiredNextRunEpoch =
+    stored.transition.action === "pause"
+      ? stored.transition.expectedRunEpoch
+      : stored.transition.expectedRunEpoch + 1;
+  if (
+    expectedRunEpoch !== stored.transition.expectedRunEpoch ||
+    nextRunEpoch !== requiredNextRunEpoch
+  ) {
+    throw new InMemoryGoalStateError(
+      "run_epoch_conflict",
+      `Goal ${stored.transition.action} must finalize Runtime Session epoch ${stored.transition.expectedRunEpoch} as epoch ${requiredNextRunEpoch}`,
+    );
+  }
+  if (
+    stored.transition.phase === "finalized" &&
+    stored.transition.runEpoch !== nextRunEpoch
+  ) {
+    throw new InMemoryGoalStateError(
+      "run_epoch_conflict",
+      `Goal ${stored.transition.action} already finalized Runtime Session epoch ${stored.transition.runEpoch}`,
+    );
+  }
 }
 
 function occupiesPrimarySlot(status: GoalStatus): boolean {
@@ -591,6 +1827,28 @@ function positiveInteger(value: unknown, field: string): number {
   return value as number;
 }
 
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      `${field} must be a non-negative integer`,
+    );
+  }
+  return value as number;
+}
+
+function lifecycleTransitionAction(
+  value: unknown,
+): GoalLifecycleTransitionAction {
+  if (value !== "pause" && value !== "cancel") {
+    throw new InMemoryGoalStateError(
+      "invalid_commit",
+      "Lifecycle transition action must be pause or cancel",
+    );
+  }
+  return value;
+}
+
 function sessionScope(ownerId: string, runtimeSessionId: string): string {
   return JSON.stringify([ownerId, runtimeSessionId]);
 }
@@ -599,7 +1857,7 @@ function ownerScope(ownerId: string): string {
   return JSON.stringify([ownerId]);
 }
 
-function findOwnerGoal(
+function findOwnerGoalOrReservation(
   sessions: ReadonlyMap<string, GoalSessionSnapshot>,
   ownerId: string,
   goalId: string,
@@ -608,6 +1866,8 @@ function findOwnerGoal(
     if (snapshot.ownerId !== ownerId) continue;
     const goal = snapshot.goals.get(goalId);
     if (goal) return goal;
+    const reserved = snapshot.pendingReplacement?.replacement.replacementGoal;
+    if (reserved?.goal.id === goalId) return reserved;
   }
   return null;
 }

--- a/apps/web/lib/ai/runtime-instructions/index.ts
+++ b/apps/web/lib/ai/runtime-instructions/index.ts
@@ -1,4 +1,5 @@
 export * from "./goal-service";
+export * from "./goal-replacement-coordinator";
 export type { RuntimeInstructionDispatch } from "./instruction-dispatcher";
 export { getAgentGoalRuntime, type AgentGoalRuntime } from "./runtime";
 export type { RuntimeSessionRegistration } from "./runtime-session-registry";

--- a/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
+++ b/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
@@ -16,6 +16,21 @@ export interface RuntimeInstructionDrainInput {
   targetInstructionId: string;
 }
 
+export interface RuntimeInstructionControlInput extends RuntimeInstructionDrainInput {}
+
+export interface RuntimeInstructionTransportDrainInput extends RuntimeInstructionDrainInput {
+  transport: RuntimeInstructionTransportPort;
+}
+
+export type RuntimeInstructionControlBarrierPolicy =
+  | "preserve_predecessors"
+  | "supersede_predecessors";
+
+export interface RuntimeInstructionControlBarrierInput extends RuntimeInstructionTransportDrainInput {
+  predecessorPolicy: RuntimeInstructionControlBarrierPolicy;
+  reason: string;
+}
+
 export interface RuntimeInstructionOutboxReader {
   listInstructions(
     ownerId: string,
@@ -46,6 +61,12 @@ export type RuntimeInstructionDispatch =
       status: "unavailable";
       runtimeSessionId: string;
       instructionId: string;
+    }
+  | {
+      status: "superseded";
+      runtimeSessionId: string;
+      instructionId: string;
+      reason: string;
     }
   | RuntimeInstructionDispatchFailure
   | {
@@ -78,9 +99,17 @@ interface AcceptedInstruction {
   receipt: RuntimeDeliveryReceipt;
 }
 
+interface SupersededInstruction {
+  instructionId: string;
+  instruction: RuntimeInstruction;
+  reason: string;
+}
+
 interface TransportProgress {
   acceptedThroughSequence: number;
   acceptedBySequence: Map<number, AcceptedInstruction>;
+  supersededBySequence: Map<number, SupersededInstruction>;
+  directlyAcceptedById: Map<string, AcceptedInstruction>;
 }
 
 interface ParsedDrain {
@@ -135,6 +164,155 @@ export class RuntimeInstructionDispatcher {
     );
   }
 
+  /**
+   * Drains only while the session resolver still points at the exact transport
+   * that established the lifecycle boundary. The identity check is serialized
+   * with delivery progress so an unregister/re-register ABA cannot redirect
+   * the post-boundary drain to a different runtime instance.
+   */
+  drainOnTransport(
+    input: RuntimeInstructionTransportDrainInput,
+  ): Promise<RuntimeInstructionDispatch> {
+    const parsedInput = parseDrainIdentifiers(input);
+    assertTransportTargetsSession(
+      input.transport,
+      parsedInput.runtimeSessionId,
+    );
+    const scope = sessionScope(
+      parsedInput.ownerId,
+      parsedInput.runtimeSessionId,
+    );
+    return this.deliveries.run(scope, async () =>
+      this.drainSerialized(
+        scope,
+        await this.readCanonicalOutbox(parsedInput),
+        input.transport,
+      ),
+    );
+  }
+
+  /**
+   * Delivers an interrupting lifecycle instruction without draining stale
+   * predecessors. The instruction must still exist in the canonical outbox.
+   */
+  deliverControl(
+    input: RuntimeInstructionControlInput,
+  ): Promise<RuntimeInstructionDispatch> {
+    const parsedInput = parseDrainIdentifiers(input);
+    const scope = sessionScope(
+      parsedInput.ownerId,
+      parsedInput.runtimeSessionId,
+    );
+    return this.deliveries.run(scope, async () => {
+      const parsed = await this.readCanonicalOutbox(parsedInput);
+      assertControlInstruction(parsed.target);
+      let transport: RuntimeInstructionTransportPort | null;
+      try {
+        transport = await this.resolveTransport(parsed);
+      } catch (cause) {
+        return transportFailure(
+          parsed.runtimeSessionId,
+          parsed.target.id,
+          cause instanceof Error ? cause : new Error(String(cause)),
+        );
+      }
+      if (!transport) {
+        return {
+          status: "unavailable",
+          runtimeSessionId: parsed.runtimeSessionId,
+          instructionId: parsed.target.id,
+        };
+      }
+      const progress = this.getProgress(transport, scope, parsed.instructions);
+      const cached = progress.directlyAcceptedById.get(parsed.target.id);
+      if (cached) return accepted(cached.receipt);
+      const sequential = progress.acceptedBySequence.get(
+        parsed.target.sequence,
+      );
+      if (sequential?.instructionId === parsed.target.id) {
+        return accepted(sequential.receipt);
+      }
+
+      const result = await this.deliverOne(transport, parsed.target);
+      if (result.status === "accepted") {
+        progress.directlyAcceptedById.set(parsed.target.id, {
+          instructionId: parsed.target.id,
+          instruction: structuredClone(parsed.target),
+          receipt: structuredClone(result.receipt),
+        });
+      }
+      return result;
+    });
+  }
+
+  /**
+   * Commits an accepted control instruction as an outbox barrier after the
+   * provider reached the terminal boundary. Depending on the lifecycle
+   * operation, undelivered predecessors are either preserved for a later
+   * resume or fenced as superseded before a new run epoch can drain.
+   */
+  commitControlBarrier(
+    input: RuntimeInstructionControlBarrierInput,
+  ): Promise<string[]> {
+    const parsedInput = parseDrainIdentifiers(input);
+    const predecessorPolicy = parseControlBarrierPolicy(
+      input.predecessorPolicy,
+    );
+    const reason = requiredText(input.reason, "reason");
+    const scope = sessionScope(
+      parsedInput.ownerId,
+      parsedInput.runtimeSessionId,
+    );
+    return this.deliveries.run(scope, async () => {
+      const parsed = await this.readCanonicalOutbox(parsedInput);
+      assertControlInstruction(parsed.target);
+      const resolved = await this.resolveTransport(parsed);
+      if (resolved !== input.transport) {
+        throw new RuntimeInstructionDispatcherError(
+          "outbox_progress_conflict",
+          `Runtime Session ${parsed.runtimeSessionId} changed before its control barrier was committed`,
+        );
+      }
+      const progress = this.getProgress(
+        input.transport,
+        scope,
+        parsed.instructions,
+      );
+      const control =
+        progress.directlyAcceptedById.get(parsed.target.id) ??
+        progress.acceptedBySequence.get(parsed.target.sequence);
+      if (!control) {
+        throw new RuntimeInstructionDispatcherError(
+          "outbox_progress_conflict",
+          `Control instruction ${parsed.target.id} was not accepted by this transport`,
+        );
+      }
+
+      progress.acceptedBySequence.set(parsed.target.sequence, control);
+      if (predecessorPolicy === "preserve_predecessors") {
+        advanceSettledPrefix(progress, parsed.instructions);
+        return [];
+      }
+
+      const supersededInstructionIds: string[] = [];
+      for (const instruction of parsed.instructions) {
+        if (instruction.sequence > parsed.target.sequence) break;
+        if (instruction.sequence <= progress.acceptedThroughSequence) continue;
+
+        if (instruction.id !== parsed.target.id) {
+          progress.supersededBySequence.set(instruction.sequence, {
+            instructionId: instruction.id,
+            instruction: structuredClone(instruction),
+            reason,
+          });
+          supersededInstructionIds.push(instruction.id);
+        }
+      }
+      advanceSettledPrefix(progress, parsed.instructions);
+      return supersededInstructionIds;
+    });
+  }
+
   private async readCanonicalOutbox(input: {
     ownerId: string;
     runtimeSessionId: string;
@@ -159,13 +337,11 @@ export class RuntimeInstructionDispatcher {
   private async drainSerialized(
     scope: string,
     input: ParsedDrain,
+    expectedTransport?: RuntimeInstructionTransportPort,
   ): Promise<RuntimeInstructionDispatch> {
     let transport: RuntimeInstructionTransportPort | null;
     try {
-      transport = await this.sessions.resolve(
-        input.ownerId,
-        input.runtimeSessionId,
-      );
+      transport = await this.resolveTransport(input);
     } catch (cause) {
       return transportFailure(
         input.runtimeSessionId,
@@ -180,31 +356,13 @@ export class RuntimeInstructionDispatcher {
         instructionId: input.target.id,
       };
     }
-    if (transport.runtimeSessionId !== input.runtimeSessionId) {
-      return transportFailure(
-        input.runtimeSessionId,
-        input.target.id,
-        new Error(
-          "Runtime resolver returned a transport for a different session",
-        ),
+    if (expectedTransport && transport !== expectedTransport) {
+      throw new RuntimeInstructionDispatcherError(
+        "outbox_progress_conflict",
+        `Runtime Session ${input.runtimeSessionId} changed before its outbox was drained`,
       );
     }
-
-    let transportProgress = this.progressByTransport.get(transport);
-    if (!transportProgress) {
-      transportProgress = new Map();
-      this.progressByTransport.set(transport, transportProgress);
-    }
-    let progress = transportProgress.get(scope);
-    if (!progress) {
-      progress = {
-        acceptedThroughSequence: 0,
-        acceptedBySequence: new Map(),
-      };
-      transportProgress.set(scope, progress);
-    } else {
-      assertCompatibleProgress(progress, input.instructions);
-    }
+    const progress = this.getProgress(transport, scope, input.instructions);
 
     for (const instruction of input.instructions) {
       if (instruction.sequence <= progress.acceptedThroughSequence) continue;
@@ -212,6 +370,37 @@ export class RuntimeInstructionDispatcher {
         throw new RuntimeInstructionDispatcherError(
           "outbox_progress_conflict",
           `Cannot deliver sequence ${instruction.sequence} after accepted sequence ${progress.acceptedThroughSequence}`,
+        );
+      }
+
+      const alreadyAccepted = progress.acceptedBySequence.get(
+        instruction.sequence,
+      );
+      if (alreadyAccepted) {
+        assertSameProgressInstruction(alreadyAccepted, instruction);
+        progress.acceptedThroughSequence = instruction.sequence;
+        continue;
+      }
+      const superseded = progress.supersededBySequence.get(
+        instruction.sequence,
+      );
+      if (superseded) {
+        assertSameProgressInstruction(superseded, instruction);
+        progress.acceptedThroughSequence = instruction.sequence;
+        continue;
+      }
+
+      const uncommittedControl = progress.directlyAcceptedById.get(
+        instruction.id,
+      );
+      if (uncommittedControl) {
+        if (input.target.sequence <= progress.acceptedThroughSequence) break;
+        if (input.target.id === instruction.id) {
+          return accepted(uncommittedControl.receipt);
+        }
+        throw new RuntimeInstructionDispatcherError(
+          "outbox_progress_conflict",
+          `Control instruction ${instruction.id} reached the runtime but its terminal barrier has not been committed`,
         );
       }
 
@@ -242,13 +431,67 @@ export class RuntimeInstructionDispatcher {
     }
 
     const target = progress.acceptedBySequence.get(input.target.sequence);
-    if (!target || target.instructionId !== input.target.id) {
-      throw new RuntimeInstructionDispatcherError(
-        "outbox_progress_conflict",
-        `Target instruction ${input.target.id} was not reached by the contiguous outbox drain`,
+    if (target?.instructionId === input.target.id) {
+      return accepted(target.receipt);
+    }
+    const supersededTarget = progress.supersededBySequence.get(
+      input.target.sequence,
+    );
+    if (supersededTarget?.instructionId === input.target.id) {
+      return {
+        status: "superseded",
+        runtimeSessionId: input.runtimeSessionId,
+        instructionId: input.target.id,
+        reason: supersededTarget.reason,
+      };
+    }
+    throw new RuntimeInstructionDispatcherError(
+      "outbox_progress_conflict",
+      `Target instruction ${input.target.id} was not reached by the contiguous outbox drain`,
+    );
+  }
+
+  private async resolveTransport(
+    input: ParsedDrain,
+  ): Promise<RuntimeInstructionTransportPort | null> {
+    const transport = await this.sessions.resolve(
+      input.ownerId,
+      input.runtimeSessionId,
+    );
+    if (
+      transport !== null &&
+      transport.runtimeSessionId !== input.runtimeSessionId
+    ) {
+      throw new Error(
+        "Runtime resolver returned a transport for a different session",
       );
     }
-    return accepted(target.receipt);
+    return transport;
+  }
+
+  private getProgress(
+    transport: RuntimeInstructionTransportPort,
+    scope: string,
+    instructions: readonly RuntimeInstruction[],
+  ): TransportProgress {
+    let transportProgress = this.progressByTransport.get(transport);
+    if (!transportProgress) {
+      transportProgress = new Map();
+      this.progressByTransport.set(transport, transportProgress);
+    }
+    let progress = transportProgress.get(scope);
+    if (!progress) {
+      progress = {
+        acceptedThroughSequence: 0,
+        acceptedBySequence: new Map(),
+        supersededBySequence: new Map(),
+        directlyAcceptedById: new Map(),
+      };
+      transportProgress.set(scope, progress);
+    } else {
+      assertCompatibleProgress(progress, instructions);
+    }
+    return progress;
   }
 
   private async deliverOne(
@@ -363,11 +606,13 @@ function assertCompatibleProgress(
     sequence++
   ) {
     const acceptedInstruction = progress.acceptedBySequence.get(sequence);
+    const supersededInstruction = progress.supersededBySequence.get(sequence);
     const suppliedInstruction = instructions[sequence - 1];
+    const settledInstruction = acceptedInstruction ?? supersededInstruction;
     if (
-      !acceptedInstruction ||
-      acceptedInstruction.instructionId !== suppliedInstruction.id ||
-      canonicalJson(acceptedInstruction.instruction) !==
+      !settledInstruction ||
+      settledInstruction.instructionId !== suppliedInstruction.id ||
+      canonicalJson(settledInstruction.instruction) !==
         canonicalJson(suppliedInstruction)
     ) {
       throw new RuntimeInstructionDispatcherError(
@@ -375,6 +620,112 @@ function assertCompatibleProgress(
         `Outbox instruction at sequence ${sequence} differs from the instruction already accepted by this transport`,
       );
     }
+  }
+
+  for (const directlyAccepted of progress.directlyAcceptedById.values()) {
+    const suppliedInstruction = instructions.find(
+      ({ id }) => id === directlyAccepted.instructionId,
+    );
+    if (
+      !suppliedInstruction ||
+      canonicalJson(directlyAccepted.instruction) !==
+        canonicalJson(suppliedInstruction)
+    ) {
+      throw new RuntimeInstructionDispatcherError(
+        "outbox_progress_conflict",
+        `Directly accepted control instruction ${directlyAccepted.instructionId} differs from the authoritative outbox`,
+      );
+    }
+  }
+}
+
+function advanceSettledPrefix(
+  progress: TransportProgress,
+  instructions: readonly RuntimeInstruction[],
+): void {
+  while (progress.acceptedThroughSequence < instructions.length) {
+    const nextSequence = progress.acceptedThroughSequence + 1;
+    const suppliedInstruction = instructions[nextSequence - 1];
+    const settledInstruction =
+      progress.acceptedBySequence.get(nextSequence) ??
+      progress.supersededBySequence.get(nextSequence);
+    if (!settledInstruction) return;
+    assertSameProgressInstruction(settledInstruction, suppliedInstruction);
+    progress.acceptedThroughSequence = nextSequence;
+  }
+}
+
+function assertSameProgressInstruction(
+  settledInstruction: AcceptedInstruction | SupersededInstruction,
+  suppliedInstruction: RuntimeInstruction,
+): void {
+  if (
+    settledInstruction.instructionId !== suppliedInstruction.id ||
+    canonicalJson(settledInstruction.instruction) !==
+      canonicalJson(suppliedInstruction)
+  ) {
+    throw new RuntimeInstructionDispatcherError(
+      "outbox_progress_conflict",
+      `Outbox instruction at sequence ${suppliedInstruction.sequence} differs from the instruction already settled by this transport`,
+    );
+  }
+}
+
+function parseDrainIdentifiers(
+  input: RuntimeInstructionDrainInput,
+): RuntimeInstructionDrainInput {
+  return {
+    ownerId: requiredIdentifier(input.ownerId, "ownerId"),
+    runtimeSessionId: requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    ),
+    targetInstructionId: requiredIdentifier(
+      input.targetInstructionId,
+      "targetInstructionId",
+    ),
+  };
+}
+
+function parseControlBarrierPolicy(
+  value: unknown,
+): RuntimeInstructionControlBarrierPolicy {
+  if (value !== "preserve_predecessors" && value !== "supersede_predecessors") {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      "predecessorPolicy must be preserve_predecessors or supersede_predecessors",
+    );
+  }
+  return value;
+}
+
+function assertTransportTargetsSession(
+  transport: RuntimeInstructionTransportPort,
+  runtimeSessionId: string,
+): void {
+  if (
+    !transport ||
+    typeof transport !== "object" ||
+    transport.runtimeSessionId !== runtimeSessionId
+  ) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      "Expected transport must belong to the Runtime Session being drained",
+    );
+  }
+}
+
+function assertControlInstruction(instruction: RuntimeInstruction): void {
+  if (
+    instruction.deliveryMode !== "interrupt_replace" ||
+    (instruction.kind !== "control.interrupt" &&
+      instruction.kind !== "goal.pause" &&
+      instruction.kind !== "goal.cancel")
+  ) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      `Instruction ${instruction.id} is not an interrupting lifecycle control`,
+    );
   }
 }
 
@@ -468,6 +819,23 @@ function requiredIdentifier(value: unknown, field: string): string {
     );
   }
   return value;
+}
+
+function requiredText(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      `${field} must be a string`,
+    );
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > 4_000) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      `${field} must contain 1 to 4000 characters`,
+    );
+  }
+  return normalized;
 }
 
 function sessionScope(ownerId: string, runtimeSessionId: string): string {

--- a/apps/web/lib/ai/runtime-instructions/runtime-session-registry.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-session-registry.ts
@@ -1,5 +1,6 @@
 import type {
   RuntimeInstructionTransportPort,
+  RuntimeSessionLifecycleControlPort,
   RuntimeSessionResolverPort,
 } from "@openloomi/ai/agent/runtime-instructions";
 
@@ -17,6 +18,7 @@ export interface RuntimeSessionRegistration {
 
 export type RuntimeSessionRegistryErrorCode =
   | "invalid_registration"
+  | "lifecycle_unsupported"
   | "owner_conflict"
   | "transport_conflict";
 
@@ -106,9 +108,45 @@ export class RuntimeSessionRegistry implements RuntimeSessionResolverPort {
     return session?.ownerId === ownerId ? session.transport : null;
   }
 
+  async resolveLifecycle(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeSessionLifecycleControlPort | null> {
+    const transport = await this.resolve(ownerId, runtimeSessionId);
+    if (!transport) return null;
+    if (!isLifecycleControl(transport)) {
+      throw new RuntimeSessionRegistryError(
+        "lifecycle_unsupported",
+        `Runtime Session ${runtimeSessionId} does not support Goal replacement lifecycle control`,
+      );
+    }
+    return transport;
+  }
+
+  isCurrent(
+    ownerId: string,
+    transport: RuntimeInstructionTransportPort,
+  ): boolean {
+    const session = this.sessions.get(transport.runtimeSessionId);
+    return session?.ownerId === ownerId && session.transport === transport;
+  }
+
   get size(): number {
     return this.sessions.size;
   }
+}
+
+function isLifecycleControl(
+  transport: RuntimeInstructionTransportPort,
+): transport is RuntimeSessionLifecycleControlPort {
+  const candidate = transport as Partial<RuntimeSessionLifecycleControlPort>;
+  return (
+    typeof candidate.runEpoch === "number" &&
+    typeof candidate.captureTurnBoundary === "function" &&
+    typeof candidate.captureTurnBoundaryAndHoldPendingInput === "function" &&
+    typeof candidate.waitForTurnTerminal === "function" &&
+    typeof candidate.advanceRunEpoch === "function"
+  );
 }
 
 const MAX_RUNTIME_IDENTIFIER_CHARACTERS = 256;

--- a/apps/web/lib/ai/runtime-instructions/runtime.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime.ts
@@ -4,6 +4,8 @@ import type {
 } from "@openloomi/ai/agent/runtime-instructions";
 
 import { GoalService } from "./goal-service";
+import { GoalLifecycleService } from "./goal-lifecycle-service";
+import { GoalReplacementCoordinator } from "./goal-replacement-coordinator";
 import { InMemoryAgentGoalState } from "./in-memory-goal-state";
 import { RuntimeInstructionDispatcher } from "./instruction-dispatcher";
 import { RuntimeSessionRegistry } from "./runtime-session-registry";
@@ -13,11 +15,12 @@ export interface InMemoryAgentGoalRuntime {
   readonly sessions: RuntimeSessionRegistry;
   readonly dispatcher: RuntimeInstructionDispatcher;
   readonly goals: GoalService;
+  readonly replacements: GoalReplacementCoordinator;
 }
 
 export type AgentGoalRuntime = Pick<
   InMemoryAgentGoalRuntime,
-  "sessions" | "goals"
+  "sessions" | "goals" | "replacements"
 >;
 
 export function createInMemoryAgentGoalRuntime(
@@ -29,13 +32,32 @@ export function createInMemoryAgentGoalRuntime(
   const state = new InMemoryAgentGoalState();
   const sessions = new RuntimeSessionRegistry();
   const dispatcher = new RuntimeInstructionDispatcher(sessions, state);
+  const clock = options.clock ?? { now: () => new Date() };
+  const idGenerator = options.idGenerator ?? {
+    generate: () => crypto.randomUUID(),
+  };
+  const lifecycle = new GoalLifecycleService(
+    state,
+    dispatcher,
+    sessions,
+    clock,
+    idGenerator,
+  );
   const goals = new GoalService(
     state,
     dispatcher,
-    options.clock ?? { now: () => new Date() },
-    options.idGenerator ?? { generate: () => crypto.randomUUID() },
+    clock,
+    idGenerator,
+    lifecycle,
   );
-  return { state, sessions, dispatcher, goals };
+  const replacements = new GoalReplacementCoordinator(
+    state,
+    dispatcher,
+    sessions,
+    clock,
+    idGenerator,
+  );
+  return { state, sessions, dispatcher, goals, replacements };
 }
 
 let agentGoalRuntime: InMemoryAgentGoalRuntime | undefined;

--- a/apps/web/tests/unit/agent-supplemental-input-queue.test.ts
+++ b/apps/web/tests/unit/agent-supplemental-input-queue.test.ts
@@ -136,9 +136,12 @@ describe("AgentSupplementalInputQueue delivery", () => {
     await queue.enqueue({ ...input("old-inform"), runEpoch: 5 });
 
     expect(queue.getRunEpoch()).toBe(5);
-    expect(queue.advanceRunEpoch(6)).toMatchObject([
-      { id: "old-inform", runEpoch: 5 },
-    ]);
+    expect(
+      queue.advanceRunEpoch({
+        expectedRunEpoch: 5,
+        nextRunEpoch: 6,
+      }),
+    ).toMatchObject([{ id: "old-inform", runEpoch: 5 }]);
     expect(queue.hasPending()).toBe(false);
     await expect(
       queue.enqueue({ ...input("late-old-run"), runEpoch: 5 }),
@@ -174,6 +177,31 @@ describe("AgentSupplementalInputQueue delivery", () => {
     expect(queue.releasePendingInform()).toBe(0);
     await expect(waiting).resolves.toMatchObject({
       value: { id: "boundary-input", intent: "inform" },
+    });
+  });
+
+  it("wakes a waiting consumer when the last input hold is released", async () => {
+    const queue = new AgentSupplementalInputQueue({ runEpoch: 2 });
+    const iterator = queue[Symbol.asyncIterator]();
+    const waiting = iterator.next();
+    const firstHold = queue.holdPendingInputForRunEpoch(2);
+    const lastHold = queue.holdPendingInputForRunEpoch(2);
+
+    await queue.enqueue({
+      ...input("held-steer", "steer"),
+      runEpoch: 2,
+    });
+    firstHold.release();
+    let delivered = false;
+    void waiting.then(() => {
+      delivered = true;
+    });
+    await Promise.resolve();
+    expect(delivered).toBe(false);
+
+    lastHold.release();
+    await expect(waiting).resolves.toMatchObject({
+      value: { id: "held-steer", runEpoch: 2 },
     });
   });
 
@@ -330,6 +358,41 @@ describe("AgentSupplementalInputQueue interruption", () => {
       error: expect.objectContaining({ message: "provider interrupt failed" }),
     });
     expect(queue.size).toBe(1);
+  });
+
+  it("does not coalesce a new-epoch interrupt with an old in-flight interrupt", async () => {
+    const queue = new AgentSupplementalInputQueue({ runEpoch: 0 });
+    const oldInterrupt = deferred<void>();
+    const newInterrupt = deferred<void>();
+    const interruptHandler = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => oldInterrupt.promise)
+      .mockImplementationOnce(() => newInterrupt.promise);
+    queue.setInterruptHandler(interruptHandler);
+
+    const oldDelivery = queue.enqueue({
+      ...input("old-steer", "steer"),
+      runEpoch: 0,
+    });
+    await vi.waitFor(() => expect(interruptHandler).toHaveBeenCalledOnce());
+    queue.advanceRunEpoch({ expectedRunEpoch: 0, nextRunEpoch: 1 });
+
+    const newDelivery = queue.enqueue({
+      ...input("new-steer", "steer"),
+      runEpoch: 1,
+    });
+    await vi.waitFor(() => expect(interruptHandler).toHaveBeenCalledTimes(2));
+    newInterrupt.resolve();
+    await expect(newDelivery).resolves.toMatchObject({
+      status: "accepted",
+      interrupt: { status: "completed", coalesced: false },
+    });
+
+    oldInterrupt.resolve();
+    await expect(oldDelivery).resolves.toMatchObject({
+      status: "superseded",
+      interrupt: { status: "completed", coalesced: false },
+    });
   });
 });
 

--- a/apps/web/tests/unit/claude-runtime-session.test.ts
+++ b/apps/web/tests/unit/claude-runtime-session.test.ts
@@ -13,6 +13,8 @@ import type { AgentSupplementalInputSource } from "@openloomi/ai/agent/types";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  type ClaudeGoalRuntimeEpochMismatchError,
+  type ClaudeGoalRuntimeRecoveryRequiredError,
   ClaudeInputMultiplexer,
   ClaudeGoalRuntimeRegistrationError,
   ClaudeRuntimeSession,
@@ -242,6 +244,70 @@ describe("Claude Goal runtime registration", () => {
     expect(runtime.state).toBe("closed");
     expect(goalRuntime.sessions.size).toBe(0);
   });
+
+  it("fails closed for stale or not-yet-recoverable run epochs", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const runtime = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const goalRuntime = createInMemoryAgentGoalRuntime();
+    vi.spyOn(goalRuntime.goals, "getRuntimeSessionRunEpoch").mockResolvedValue(
+      1,
+    );
+
+    await expect(
+      startClaudeGoalRuntimeSession({
+        session: { user: { id: "authenticated-owner" } },
+        runtime,
+        start: { initialPrompt: "initial request" },
+        goalRuntime,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "ClaudeGoalRuntimeEpochMismatchError",
+        code: "run_epoch_mismatch",
+        runtimeSessionId: SESSION_ID,
+        expectedRunEpoch: 1,
+        actualRunEpoch: 0,
+      }) satisfies Partial<ClaudeGoalRuntimeEpochMismatchError>,
+    );
+    expect(sdk.queryInput).toBeUndefined();
+    expect(handle.close).not.toHaveBeenCalled();
+    expect(runtime.state).toBe("closed");
+    expect(goalRuntime.sessions.size).toBe(0);
+
+    const matchingEpochHandle = createControlledClaudeQuery();
+    const matchingEpochSdk = createFakeClaudeSdkTransport(matchingEpochHandle);
+    const matchingEpochRuntime = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 1,
+      sdkTransport: matchingEpochSdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    await expect(
+      startClaudeGoalRuntimeSession({
+        session: { user: { id: "authenticated-owner" } },
+        runtime: matchingEpochRuntime,
+        start: { initialPrompt: "initial request" },
+        goalRuntime,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "ClaudeGoalRuntimeRecoveryRequiredError",
+        code: "run_epoch_recovery_required",
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 1,
+      }) satisfies Partial<ClaudeGoalRuntimeRecoveryRequiredError>,
+    );
+    expect(matchingEpochSdk.queryInput).toBeUndefined();
+    expect(matchingEpochRuntime.state).toBe("closed");
+  });
 });
 
 describe("ClaudeRuntimeSession", () => {
@@ -319,7 +385,20 @@ describe("ClaudeRuntimeSession", () => {
 
     await session.interrupt("manual replacement");
     expect(handle.interrupt).toHaveBeenCalledTimes(2);
-    session.advanceRunEpoch(3);
+    const boundary = session.captureTurnBoundary();
+    const terminal = session.waitForTurnTerminal({
+      expectedRunEpoch: 2,
+      afterTerminalSequence: boundary.terminalSequence,
+    });
+    handle.push(resultMessage());
+    await expect(terminal).resolves.toMatchObject({
+      runEpoch: 2,
+      state: "idle",
+    });
+    session.advanceRunEpoch({
+      expectedRunEpoch: 2,
+      nextRunEpoch: 3,
+    });
     expect(session.runEpoch).toBe(3);
     await session.close();
   });
@@ -339,12 +418,186 @@ describe("ClaudeRuntimeSession", () => {
     await expect(
       session.interrupt({ reason: "stale", expectedRunEpoch: 3 }),
     ).rejects.toMatchObject({ code: "invalid_run_epoch" });
-    expect(() => session.advanceRunEpoch(4)).toThrowError(
-      expect.objectContaining({ code: "invalid_run_epoch" }),
-    );
+    const terminal = session.waitForTurnTerminal({
+      expectedRunEpoch: 4,
+      afterTerminalSequence: 0,
+    });
+    handle.push(resultMessage());
+    await terminal;
+    expect(() =>
+      session.advanceRunEpoch({
+        expectedRunEpoch: 4,
+        nextRunEpoch: 4,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "invalid_run_epoch" }));
     expect(() => session.start({ initialPrompt: "again" })).toThrowError(
       expect.objectContaining({ code: "already_started" }),
     );
+    await session.close();
+  });
+
+  it("remembers terminal boundaries that arrive before a waiter is attached", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+    const boundary = session.captureTurnBoundary();
+
+    handle.push(resultMessage());
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: "result", runEpoch: 0 },
+    });
+
+    await expect(
+      session.waitForTurnTerminal({
+        expectedRunEpoch: 0,
+        afterTerminalSequence: boundary.terminalSequence,
+      }),
+    ).resolves.toMatchObject({
+      runEpoch: 0,
+      terminalSequence: 1,
+      state: "idle",
+    });
+    await session.close();
+  });
+
+  it("removes an aborted terminal waiter without consuming a later boundary", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+    const controller = new AbortController();
+    const waiting = session.waitForTurnTerminal({
+      expectedRunEpoch: 0,
+      afterTerminalSequence: 0,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await expect(waiting).rejects.toMatchObject({
+      code: "terminal_wait_aborted",
+    });
+
+    handle.push(resultMessage());
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: "result", runEpoch: 0 },
+    });
+    await expect(
+      session.waitForTurnTerminal({
+        expectedRunEpoch: 0,
+        afterTerminalSequence: 0,
+      }),
+    ).resolves.toMatchObject({
+      runEpoch: 0,
+      terminalSequence: 1,
+    });
+    await session.close();
+  });
+
+  it("atomically holds terminal input and marks the next SDK handoff as running", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+    const prompt = sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>;
+    const input = prompt[Symbol.asyncIterator]();
+    await input.next();
+
+    await session.deliver(
+      runtimeInstruction({
+        deliveryMode: "next_boundary",
+        idempotencyKey: "held-terminal-context",
+      }),
+    );
+    const captured = session.captureTurnBoundaryAndHoldPendingInput(0);
+    const waitingInput = input.next();
+    let handedOff = false;
+    void waitingInput.then(() => {
+      handedOff = true;
+    });
+
+    const terminal = session.waitForTurnTerminal({
+      expectedRunEpoch: captured.boundary.runEpoch,
+      afterTerminalSequence: captured.boundary.terminalSequence,
+    });
+    handle.push(resultMessage());
+    await output.next();
+    await terminal;
+    expect(session.state).toBe("idle");
+    expect(handedOff).toBe(false);
+
+    captured.hold.release({ releasePendingIfIdle: true });
+    await expect(waitingInput).resolves.toMatchObject({
+      value: {
+        priority: "next",
+        message: { content: expect.stringContaining("context.remove") },
+      },
+    });
+    expect(session.state).toBe("running");
+    await session.close();
+  });
+
+  it("does not release new-epoch informs for a delayed old result", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+    const terminal = session.waitForTurnTerminal({
+      expectedRunEpoch: 0,
+      afterTerminalSequence: 0,
+    });
+    handle.push(resultMessage());
+    await output.next();
+    await terminal;
+    session.advanceRunEpoch({
+      expectedRunEpoch: 0,
+      nextRunEpoch: 1,
+    });
+
+    await session.deliver(
+      runtimeInstruction({
+        id: "88888888-8888-4888-8888-888888888888",
+        sequence: 2,
+        deliveryMode: "next_boundary",
+        idempotencyKey: "new-epoch-inform",
+      }),
+    );
+    expect(session.liveInputSource.hasPending?.()).toBe(true);
+
+    handle.push(resultMessage());
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: "result", runEpoch: 0 },
+    });
+    expect(session.liveInputSource.hasPending?.()).toBe(true);
+    expect(session.state).toBe("idle");
     await session.close();
   });
 });

--- a/apps/web/tests/unit/runtime-instruction-protocol.test.ts
+++ b/apps/web/tests/unit/runtime-instruction-protocol.test.ts
@@ -339,13 +339,53 @@ describe("Runtime Instruction protocol", () => {
       kind: "control.interrupt" as const,
       deliveryMode: "steer" as const,
       targetSessionId: SESSION_ID,
-      payload: { reason: "Replace the active Goal" },
+      payload: {
+        reason: "Replace the active Goal",
+        expectedRunEpoch: 0,
+      },
       source: { type: "user" as const, authority: "user" as const },
       idempotencyKey: "interrupt-goal-1",
       issuedAt: NOW.toISOString(),
     };
 
     expect(RuntimeInstructionSchema.safeParse(interrupt).success).toBe(false);
+  });
+
+  it("binds replacement interrupts to an old Goal and run epoch", () => {
+    const replacementGoalId = "99999999-9999-4999-8999-999999999999";
+    const interrupt = {
+      schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+      id: INSTRUCTION_ID,
+      sequence: 2,
+      goalId: GOAL_ID,
+      goalRevision: 2,
+      kind: "control.interrupt" as const,
+      deliveryMode: "interrupt_replace" as const,
+      targetSessionId: SESSION_ID,
+      payload: {
+        reason: "Replace the active Goal",
+        expectedRunEpoch: 4,
+        replacementGoalId,
+      },
+      source: { type: "user" as const, authority: "user" as const },
+      idempotencyKey: "interrupt-goal-1",
+      issuedAt: NOW.toISOString(),
+    };
+
+    expect(RuntimeInstructionSchema.safeParse(interrupt).success).toBe(true);
+    expect(
+      RuntimeInstructionSchema.safeParse({
+        ...interrupt,
+        goalId: undefined,
+        goalRevision: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      RuntimeInstructionSchema.safeParse({
+        ...interrupt,
+        payload: { ...interrupt.payload, replacementGoalId: GOAL_ID },
+      }).success,
+    ).toBe(false);
   });
 
   it("keeps evaluation results internally consistent", () => {

--- a/apps/web/tests/unit/runtime-instruction-transport.test.ts
+++ b/apps/web/tests/unit/runtime-instruction-transport.test.ts
@@ -63,7 +63,7 @@ describe("SupplementalInputRuntimeInstructionTransport", () => {
     expect(pending?.content).toContain('delivery_mode="next_boundary"');
   });
 
-  it("maps steer and interrupt-replace delivery to immediate input", async () => {
+  it("maps steer to immediate input and executes control interrupts directly", async () => {
     const queue = new AgentSupplementalInputQueue({ runEpoch: 4 });
     const interrupt = vi.fn(async () => {});
     queue.setInterruptHandler(interrupt);
@@ -85,15 +85,41 @@ describe("SupplementalInputRuntimeInstructionTransport", () => {
       sequence: 2,
       kind: "control.interrupt",
       deliveryMode: "interrupt_replace",
-      payload: { reason: "replace the active goal" },
+      payload: {
+        reason: "replace the active goal",
+        expectedRunEpoch: 4,
+      },
       idempotencyKey: "interrupt-2",
     });
-    const replacementInput = iterator.next();
     await expect(runtimeTransport.deliver(replacement)).resolves.toMatchObject({
       state: "queued",
     });
-    await expect(replacementInput).resolves.toMatchObject({
-      value: { id: replacement.id, intent: "steer" },
+    expect(interrupt).toHaveBeenCalledTimes(2);
+    expect(queue.hasPending()).toBe(false);
+
+    await expect(runtimeTransport.deliver(replacement)).resolves.toMatchObject({
+      state: "queued",
+      reason: expect.stringContaining("already accepted"),
+    });
+    expect(interrupt).toHaveBeenCalledTimes(2);
+
+    if (replacement.kind !== "control.interrupt") {
+      throw new Error("Expected a control interrupt fixture");
+    }
+    await expect(
+      runtimeTransport.deliver(
+        {
+          ...replacement,
+          id: "77777777-7777-4777-8777-777777777777",
+          sequence: 3,
+          payload: { ...replacement.payload, expectedRunEpoch: 3 },
+          idempotencyKey: "interrupt-stale",
+        },
+        { interruptControl: false },
+      ),
+    ).resolves.toMatchObject({
+      state: "rejected",
+      reason: expect.stringContaining("active epoch is 4"),
     });
     expect(interrupt).toHaveBeenCalledTimes(2);
     queue.close();

--- a/apps/web/tests/unit/runtime-instructions/goal-lifecycle-claude-vertical-slice.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-lifecycle-claude-vertical-slice.test.ts
@@ -1,0 +1,304 @@
+import type {
+  HookCallback,
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { CreateAgentGoalInput } from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ClaudeRuntimeSession,
+  createClaudeSupplementalInputHooks,
+  startClaudeGoalRuntimeSession,
+} from "@/lib/ai/extensions/agent/claude/runtime";
+import { createInMemoryAgentGoalRuntime } from "@/lib/ai/runtime-instructions/runtime";
+import {
+  createControlledClaudeQuery,
+  createFakeClaudeSdkTransport,
+} from "../../helpers/claude-runtime";
+import {
+  DeterministicRuntimeIds,
+  FixedRuntimeClock,
+} from "../../helpers/goal-runtime";
+
+const OWNER_ID = "owner-lifecycle-vertical";
+const SESSION_ID = "claude-lifecycle-session_V1StGXR8";
+const NOW = new Date("2026-07-29T09:00:00.000Z");
+
+function goalInput(objective: string): CreateAgentGoalInput {
+  return {
+    objective,
+    successCriteria: [
+      {
+        id: "lifecycle-observed",
+        description: "The lifecycle transition is applied at a turn boundary",
+        verification: { type: "model_evidence" },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 80,
+    maxTurns: 5,
+    completionPolicy: "model_evaluator",
+    source: { type: "user" },
+  };
+}
+
+function resultMessage(): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 10,
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 4, output_tokens: 2 },
+  } as SDKMessage;
+}
+
+async function createHarness(idPrefix: string) {
+  const handle = createControlledClaudeQuery();
+  const sdk = createFakeClaudeSdkTransport(handle);
+  const claude = new ClaudeRuntimeSession({
+    runtimeSessionId: SESSION_ID,
+    runEpoch: 0,
+    sdkTransport: sdk.transport,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    createMessageId: () => `${idPrefix}-agent-message`,
+  });
+  const runtime = createInMemoryAgentGoalRuntime({
+    clock: new FixedRuntimeClock(NOW),
+    idGenerator: new DeterministicRuntimeIds(idPrefix),
+  });
+  const registration = await startClaudeGoalRuntimeSession({
+    session: { user: { id: OWNER_ID } },
+    runtime: claude,
+    start: { initialPrompt: "Start the lifecycle test Goal" },
+    goalRuntime: runtime,
+  });
+  const sdkInput = (sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>)[
+    Symbol.asyncIterator
+  ]();
+  await sdkInput.next();
+
+  return { claude, handle, registration, runtime, sdkInput };
+}
+
+async function addPendingContext(
+  harness: Awaited<ReturnType<typeof createHarness>>,
+  goalId: string,
+  expectedRevision: number,
+  idempotencyKey: string,
+) {
+  return harness.runtime.goals.upsertContext({
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    goalId,
+    expectedRevision,
+    idempotencyKey,
+    source: {
+      type: "connector",
+      authority: "untrusted_data",
+      sourceRef: "jira:JIRA-176",
+    },
+    contextRef: {
+      id: `${idempotencyKey}-context`,
+      kind: "connector_record",
+      refId: "JIRA-176",
+      origin: "connector",
+      sourceRef: "jira:JIRA-176",
+      summary: "Pending context fenced by the lifecycle transition",
+    },
+  });
+}
+
+describe("Claude Goal lifecycle vertical slice", () => {
+  it("pauses at a terminal boundary and retains pending context until resume", async () => {
+    const harness = await createHarness("30000000");
+    const activated = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "pause-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Pause and resume the same Goal"),
+    });
+    await harness.sdkInput.next();
+    const context = await addPendingContext(
+      harness,
+      activated.goal.goal.id,
+      1,
+      "pause-context",
+    );
+    const waitingSdkInput = harness.sdkInput.next();
+
+    const pausing = harness.runtime.goals.pause({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 2,
+      idempotencyKey: "pause-command",
+      source: { type: "user", authority: "user" },
+      reason: "Pause until the user resumes",
+    });
+    await vi.waitFor(() => {
+      expect(harness.handle.interrupt).toHaveBeenCalledTimes(2);
+    });
+
+    const hooks = createClaudeSupplementalInputHooks({
+      supplementalInput: harness.claude.liveInputSource,
+      sessionId: SESSION_ID,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const postToolBatch = hooks?.PostToolBatch?.[0]?.hooks[0] as HookCallback;
+    await expect(
+      postToolBatch({} as never, undefined, {
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({});
+
+    let sdkInputSettled = false;
+    void waitingSdkInput.then(() => {
+      sdkInputSettled = true;
+    });
+    harness.handle.push(resultMessage());
+    const paused = await pausing;
+    await Promise.resolve();
+
+    expect(paused).toMatchObject({
+      goal: { goal: { status: "paused", revision: 3 } },
+      instruction: {
+        kind: "goal.pause",
+        payload: { expectedRunEpoch: 0 },
+      },
+      dispatch: { status: "accepted" },
+    });
+    expect(harness.claude.runEpoch).toBe(0);
+    expect(harness.claude.state).toBe("idle");
+    expect(sdkInputSettled).toBe(false);
+    expect(harness.claude.liveInputSource.hasPending?.()).toBe(true);
+
+    const resumed = await harness.runtime.goals.resume({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 3,
+      idempotencyKey: "resume-command",
+      source: { type: "user", authority: "user" },
+      reason: "Continue the paused Goal",
+    });
+    await expect(waitingSdkInput).resolves.toMatchObject({
+      value: {
+        message: {
+          content: expect.stringContaining(
+            `context_id="${context.goal.goal.contextRefs[0]?.id}"`,
+          ),
+        },
+      },
+    });
+    await expect(harness.sdkInput.next()).resolves.toMatchObject({
+      value: {
+        message: { content: expect.stringContaining('kind="goal.resume"') },
+      },
+    });
+    expect(resumed).toMatchObject({
+      goal: { goal: { status: "active", revision: 4 } },
+      instruction: { kind: "goal.resume" },
+      dispatch: { status: "accepted" },
+    });
+    expect(harness.handle.interrupt).toHaveBeenCalledTimes(2);
+
+    harness.registration?.release();
+    await harness.claude.close();
+  });
+
+  it("cancels only after terminal, advances the epoch, and discards old input", async () => {
+    const harness = await createHarness("40000000");
+    const activated = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "cancel-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Cancel this Goal at a safe boundary"),
+    });
+    await harness.sdkInput.next();
+    const context = await addPendingContext(
+      harness,
+      activated.goal.goal.id,
+      1,
+      "cancel-context",
+    );
+    const waitingSdkInput = harness.sdkInput.next();
+
+    const cancelling = harness.runtime.goals.cancel({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 2,
+      idempotencyKey: "cancel-command",
+      source: { type: "user", authority: "user" },
+      reason: "Cancel before activating another Goal",
+    });
+    await vi.waitFor(() => {
+      expect(harness.handle.interrupt).toHaveBeenCalledTimes(2);
+    });
+
+    await expect(
+      harness.runtime.goals.activate({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        idempotencyKey: "activate-too-early",
+        source: { type: "user", authority: "user" },
+        goal: goalInput("Must not activate before cancellation is terminal"),
+      }),
+    ).rejects.toMatchObject({ code: "lifecycle_transition_in_progress" });
+    expect(harness.claude.runEpoch).toBe(0);
+
+    harness.handle.push(resultMessage());
+    const cancelled = await cancelling;
+    expect(cancelled).toMatchObject({
+      goal: { goal: { status: "cancelled", revision: 3 } },
+      instruction: {
+        kind: "goal.cancel",
+        payload: { expectedRunEpoch: 0 },
+      },
+      dispatch: { status: "accepted" },
+    });
+    expect(harness.claude.runEpoch).toBe(1);
+    expect(harness.claude.liveInputSource.hasPending?.()).toBe(false);
+
+    const next = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "activate-after-cancel",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Run only after cancellation crossed the boundary"),
+    });
+    await expect(waitingSdkInput).resolves.toMatchObject({
+      value: {
+        message: {
+          content: expect.stringContaining(
+            "Run only after cancellation crossed the boundary",
+          ),
+        },
+      },
+    });
+    expect(next).toMatchObject({
+      goal: { goal: { status: "active", revision: 1 } },
+      instruction: { kind: "goal.activate", sequence: 4 },
+      dispatch: { status: "accepted" },
+    });
+    expect(
+      (await harness.runtime.state.listInstructions(OWNER_ID, SESSION_ID)).map(
+        ({ kind }) => kind,
+      ),
+    ).toEqual([
+      "goal.activate",
+      "context.upsert",
+      "goal.cancel",
+      "goal.activate",
+    ]);
+    expect(context.instruction.id).not.toBe(next.instruction.id);
+
+    harness.registration?.release();
+    await harness.claude.close();
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
@@ -1,0 +1,202 @@
+import {
+  type AgentGoal,
+  type GoalCommandIdentity,
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  type RuntimeInstructionDraft,
+  createAgentGoal,
+  transitionAgentGoal,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it } from "vitest";
+
+import {
+  InMemoryAgentGoalState,
+  type InMemoryGoalStateError,
+} from "@/lib/ai/runtime-instructions/in-memory-goal-state";
+
+const OWNER_ID = "lifecycle-state-owner";
+const SESSION_ID = "lifecycle-state-session";
+const STARTED_AT = new Date("2026-07-29T08:00:00.000Z");
+const TRANSITIONED_AT = new Date("2026-07-29T08:01:00.000Z");
+
+function uuid(value: number): string {
+  return `50000000-0000-4000-8000-${String(value).padStart(12, "0")}`;
+}
+
+function command(
+  idempotencyKey: string,
+  fingerprintCharacter: string,
+): GoalCommandIdentity {
+  return {
+    idempotencyKey,
+    requestFingerprint: fingerprintCharacter.repeat(64),
+  };
+}
+
+function newGoal(id: string, objective: string, now: Date): AgentGoal {
+  return createAgentGoal({
+    id,
+    now,
+    input: {
+      objective,
+      successCriteria: [
+        {
+          id: "lifecycle-complete",
+          description: "The lifecycle transition completes",
+          verification: { type: "manual" },
+          required: true,
+        },
+      ],
+      constraints: [],
+      contextRefs: [],
+      priority: 80,
+      maxTurns: 8,
+      completionPolicy: "manual",
+      source: { type: "user" },
+    },
+  });
+}
+
+function activationDraft(
+  goal: AgentGoal,
+  id: string,
+  idempotencyKey: string,
+): RuntimeInstructionDraft {
+  return {
+    schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+    id,
+    goalId: goal.id,
+    goalRevision: goal.revision,
+    kind: "goal.activate",
+    deliveryMode: "steer",
+    targetSessionId: SESSION_ID,
+    payload: { goal },
+    source: { type: "user", authority: "user" },
+    idempotencyKey,
+    issuedAt: goal.updatedAt,
+  };
+}
+
+async function activeState() {
+  const state = new InMemoryAgentGoalState();
+  const goal = newGoal(uuid(1), "Original Goal", STARTED_AT);
+  await state.commitActivation({
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    goal,
+    instruction: activationDraft(goal, uuid(2), "initial-activation"),
+    command: command("initial-activation", "a"),
+  });
+  return { state, goal };
+}
+
+function cancelInput(goal: AgentGoal) {
+  const cancelledGoal = transitionAgentGoal({
+    current: goal,
+    expectedRevision: goal.revision,
+    status: "cancelled",
+    now: TRANSITIONED_AT,
+  });
+  const idempotencyKey = "cancel-primary";
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    action: "cancel" as const,
+    expectedRevision: goal.revision,
+    expectedRunEpoch: 0,
+    goal: cancelledGoal,
+    instruction: {
+      schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+      id: uuid(3),
+      goalId: goal.id,
+      goalRevision: cancelledGoal.revision,
+      kind: "goal.cancel",
+      deliveryMode: "interrupt_replace",
+      targetSessionId: SESSION_ID,
+      payload: {
+        reason: "Cancel at the provider turn boundary",
+        expectedRunEpoch: 0,
+      },
+      source: { type: "user", authority: "user" },
+      idempotencyKey,
+      issuedAt: cancelledGoal.updatedAt,
+    } satisfies RuntimeInstructionDraft,
+    command: command(idempotencyKey, "b"),
+  };
+}
+
+describe("InMemoryAgentGoalState lifecycle transition barriers", () => {
+  it("advances cancel through a durable boundary before releasing its slot", async () => {
+    const { state, goal } = await activeState();
+    const input = cancelInput(goal);
+    const prepared = await state.prepareLifecycleTransition(input);
+
+    expect(prepared.transition).toMatchObject({
+      phase: "prepared",
+      expectedRunEpoch: 0,
+      runEpoch: 0,
+      transitionedGoal: { goal: { status: "cancelled", revision: 2 } },
+    });
+    await expect(
+      state.finalizeLifecycleTransition({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: goal.id,
+        expectedRunEpoch: 0,
+        nextRunEpoch: 1,
+        command: input.command,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_commit",
+    } satisfies Partial<InMemoryGoalStateError>);
+
+    const boundary = await state.markLifecycleTransitionBoundary({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: goal.id,
+      expectedRunEpoch: 0,
+      nextRunEpoch: 1,
+      command: input.command,
+    });
+    expect(boundary.transition).toMatchObject({
+      phase: "boundary_observed",
+      runEpoch: 1,
+    });
+    await expect(
+      state.getRuntimeSessionRunEpoch(OWNER_ID, SESSION_ID),
+    ).resolves.toBe(1);
+
+    const nextGoal = newGoal(uuid(4), "Next Goal", TRANSITIONED_AT);
+    await expect(
+      state.commitActivation({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goal: nextGoal,
+        instruction: activationDraft(nextGoal, uuid(5), "activate-next"),
+        command: command("activate-next", "c"),
+      }),
+    ).rejects.toMatchObject({
+      code: "lifecycle_transition_in_progress",
+    } satisfies Partial<InMemoryGoalStateError>);
+
+    const finalized = await state.finalizeLifecycleTransition({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: goal.id,
+      expectedRunEpoch: 0,
+      nextRunEpoch: 1,
+      command: input.command,
+    });
+    expect(finalized.transition.phase).toBe("finalized");
+    await expect(
+      state.commitActivation({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goal: nextGoal,
+        instruction: activationDraft(nextGoal, uuid(5), "activate-next"),
+        command: command("activate-next", "c"),
+      }),
+    ).resolves.toMatchObject({
+      goal: { goal: { id: nextGoal.id, status: "active" } },
+    });
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/goal-replacement-coordinator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-replacement-coordinator.test.ts
@@ -1,0 +1,563 @@
+import type {
+  CreateAgentGoalInput,
+  RuntimeDeliveryReceipt,
+  RuntimeInstruction,
+  RuntimeRunEpochAdvanceResult,
+  RuntimeSessionLifecycleControlPort,
+  RuntimeSessionState,
+  RuntimeTurnBoundary,
+  RuntimeTurnTerminal,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it } from "vitest";
+
+import type { ReplaceGoalCommand } from "@/lib/ai/runtime-instructions/goal-replacement-coordinator";
+import { createInMemoryAgentGoalRuntime } from "@/lib/ai/runtime-instructions/runtime";
+import {
+  DeterministicRuntimeIds,
+  FixedRuntimeClock,
+} from "../../helpers/goal-runtime";
+
+const OWNER_ID = "replacement-coordinator-owner";
+const SESSION_ID = "replacement-coordinator-session";
+const NOW = new Date("2026-07-29T10:00:00.000Z");
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+interface TerminalWaiter {
+  expectedRunEpoch: number;
+  afterTerminalSequence: number;
+  deferred: Deferred<RuntimeTurnTerminal>;
+}
+
+type ControlOutcome = "queued" | "rejected";
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+class ControlledLifecycleTransport implements RuntimeSessionLifecycleControlPort {
+  readonly delivered: RuntimeInstruction[] = [];
+  readonly waitRequests: Array<{
+    expectedRunEpoch: number;
+    afterTerminalSequence: number;
+  }> = [];
+  readonly epochAdvances: Array<{
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+  }> = [];
+  readonly terminalWaitStarted = deferred<void>();
+
+  runEpoch = 0;
+  state: RuntimeSessionState = "running";
+  controlAttempts = 0;
+  providerInterrupts = 0;
+  directInterrupts = 0;
+
+  private terminalSequence = 0;
+  private readonly terminalHistory: RuntimeTurnTerminal[] = [];
+  private readonly terminalWaiters = new Set<TerminalWaiter>();
+  private readonly pendingInputs: Array<{ id: string; runEpoch: number }> = [];
+  private readonly controlOutcomes: ControlOutcome[] = [];
+
+  constructor(readonly runtimeSessionId: string) {}
+
+  enqueuePending(id: string, runEpoch = this.runEpoch): void {
+    this.pendingInputs.push({ id, runEpoch });
+  }
+
+  pendingIds(): string[] {
+    return this.pendingInputs.map(({ id }) => id);
+  }
+
+  rejectNextControl(): void {
+    this.controlOutcomes.push("rejected");
+  }
+
+  async deliver(
+    instruction: RuntimeInstruction,
+  ): Promise<RuntimeDeliveryReceipt> {
+    this.delivered.push(structuredClone(instruction));
+    if (instruction.kind === "control.interrupt") {
+      this.controlAttempts++;
+      const outcome = this.controlOutcomes.shift() ?? "queued";
+      if (outcome === "rejected") {
+        return receipt(instruction, "rejected", "provider rejected interrupt");
+      }
+      this.providerInterrupts++;
+    }
+    return receipt(instruction, "queued");
+  }
+
+  async interrupt(): Promise<void> {
+    this.directInterrupts++;
+  }
+
+  captureTurnBoundary(): RuntimeTurnBoundary {
+    const boundary = {
+      runtimeSessionId: this.runtimeSessionId,
+      runEpoch: this.runEpoch,
+      terminalSequence: this.terminalSequence,
+      state: this.state,
+    } satisfies RuntimeTurnBoundary;
+    return boundary;
+  }
+
+  captureTurnBoundaryAndHoldPendingInput(expectedRunEpoch: number) {
+    if (expectedRunEpoch !== this.runEpoch) {
+      throw new Error(`Cannot hold stale runEpoch ${expectedRunEpoch}`);
+    }
+    const hold = {
+      runEpoch: expectedRunEpoch,
+      release() {},
+    };
+    const boundary = this.captureTurnBoundary();
+    return { boundary, hold };
+  }
+
+  waitForTurnTerminal(input: {
+    expectedRunEpoch: number;
+    afterTerminalSequence: number;
+  }): Promise<RuntimeTurnTerminal> {
+    this.waitRequests.push({ ...input });
+    this.terminalWaitStarted.resolve();
+    const observed = this.terminalHistory.find(
+      (terminal) =>
+        terminal.runEpoch === input.expectedRunEpoch &&
+        terminal.terminalSequence > input.afterTerminalSequence,
+    );
+    if (observed) return Promise.resolve(structuredClone(observed));
+
+    const waiter: TerminalWaiter = {
+      ...input,
+      deferred: deferred<RuntimeTurnTerminal>(),
+    };
+    this.terminalWaiters.add(waiter);
+    return waiter.deferred.promise;
+  }
+
+  advanceRunEpoch(input: {
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+  }): RuntimeRunEpochAdvanceResult {
+    if (
+      input.expectedRunEpoch !== this.runEpoch ||
+      input.nextRunEpoch !== this.runEpoch + 1
+    ) {
+      throw new Error(
+        `Invalid epoch advance ${input.expectedRunEpoch} -> ${input.nextRunEpoch}`,
+      );
+    }
+    this.epochAdvances.push({ ...input });
+    const discardedInputIds = this.pendingInputs
+      .filter(({ runEpoch }) => runEpoch === input.expectedRunEpoch)
+      .map(({ id }) => id);
+    for (let index = this.pendingInputs.length - 1; index >= 0; index--) {
+      if (this.pendingInputs[index]?.runEpoch === input.expectedRunEpoch) {
+        this.pendingInputs.splice(index, 1);
+      }
+    }
+    const previousRunEpoch = this.runEpoch;
+    this.runEpoch = input.nextRunEpoch;
+    this.state = "idle";
+    return {
+      previousRunEpoch,
+      runEpoch: this.runEpoch,
+      discardedInputIds,
+    };
+  }
+
+  emitTerminal(runEpoch = this.runEpoch): RuntimeTurnTerminal {
+    this.state = "idle";
+    const terminal = {
+      runtimeSessionId: this.runtimeSessionId,
+      runEpoch,
+      terminalSequence: ++this.terminalSequence,
+      state: "idle",
+    } satisfies RuntimeTurnTerminal;
+    this.terminalHistory.push(terminal);
+    for (const waiter of [...this.terminalWaiters]) {
+      if (
+        waiter.expectedRunEpoch === terminal.runEpoch &&
+        waiter.afterTerminalSequence < terminal.terminalSequence
+      ) {
+        this.terminalWaiters.delete(waiter);
+        waiter.deferred.resolve(structuredClone(terminal));
+      }
+    }
+    return terminal;
+  }
+
+  failTerminal(error: unknown): void {
+    for (const waiter of this.terminalWaiters) {
+      waiter.deferred.reject(error);
+    }
+    this.terminalWaiters.clear();
+  }
+}
+
+function receipt(
+  instruction: RuntimeInstruction,
+  state: "queued" | "rejected",
+  reason?: string,
+): RuntimeDeliveryReceipt {
+  return {
+    instructionId: instruction.id,
+    runtimeSessionId: instruction.targetSessionId,
+    state,
+    recordedAt: NOW.toISOString(),
+    ...(reason === undefined ? {} : { reason }),
+  };
+}
+
+function goalInput(
+  objective: string,
+  overrides: Partial<CreateAgentGoalInput> = {},
+): CreateAgentGoalInput {
+  return {
+    objective,
+    successCriteria: [
+      {
+        id: "replacement-finished",
+        description: "The replacement Goal is activated safely",
+        verification: { type: "manual" },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 80,
+    maxTurns: 8,
+    completionPolicy: "manual",
+    source: { type: "user" },
+    ...overrides,
+  };
+}
+
+function createHarness() {
+  const runtime = createInMemoryAgentGoalRuntime({
+    clock: new FixedRuntimeClock(NOW),
+    idGenerator: new DeterministicRuntimeIds("40000000"),
+  });
+  const transport = new ControlledLifecycleTransport(SESSION_ID);
+  let registration = runtime.sessions.register({
+    ownerId: OWNER_ID,
+    transport,
+  });
+
+  return {
+    runtime,
+    transport,
+    release() {
+      registration.release();
+    },
+    register(candidate = transport) {
+      registration = runtime.sessions.register({
+        ownerId: OWNER_ID,
+        transport: candidate,
+      });
+      return registration;
+    },
+  };
+}
+
+async function activateOriginal(
+  harness: ReturnType<typeof createHarness>,
+  idempotencyKey = "activate-original",
+) {
+  return harness.runtime.goals.activate({
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    idempotencyKey,
+    source: userSource(),
+    goal: goalInput("Complete the original Goal"),
+  });
+}
+
+function replacementCommand(
+  goalId: string,
+  overrides: Partial<ReplaceGoalCommand> = {},
+): ReplaceGoalCommand {
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    goalId,
+    expectedRevision: 1,
+    idempotencyKey: "replace-original",
+    source: userSource(),
+    reason: "A higher-priority Goal supersedes the current work",
+    replacement: goalInput("Complete the replacement Goal"),
+    ...overrides,
+  };
+}
+
+function userSource() {
+  return { type: "user", authority: "user" } as const;
+}
+
+async function expectNotSettled(promise: Promise<unknown>): Promise<void> {
+  let settled = false;
+  void promise.finally(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(settled).toBe(false);
+}
+
+describe("GoalReplacementCoordinator", () => {
+  it("waits for the captured terminal boundary before advancing the epoch and activating the reserved Goal", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+    const command = replacementCommand(activated.goal.goal.id);
+    harness.transport.enqueuePending("old-context-inform");
+
+    const replacing = harness.runtime.replacements.replace(command);
+    await harness.transport.terminalWaitStarted.promise;
+
+    await expectNotSettled(replacing);
+    expect(harness.transport.runEpoch).toBe(0);
+    expect(harness.transport.epochAdvances).toEqual([]);
+    expect(harness.transport.pendingIds()).toEqual(["old-context-inform"]);
+    const beforeTerminal = await harness.runtime.state.listInstructions(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(beforeTerminal.map(({ kind }) => kind)).toEqual([
+      "goal.activate",
+      "control.interrupt",
+    ]);
+    const control = beforeTerminal[1];
+    expect(control).toMatchObject({
+      sequence: 2,
+      goalId: activated.goal.goal.id,
+      goalRevision: 2,
+      kind: "control.interrupt",
+      payload: {
+        expectedRunEpoch: 0,
+        replacementGoalId: expect.any(String),
+      },
+    });
+    if (control?.kind !== "control.interrupt") {
+      throw new Error("Expected a replacement control instruction");
+    }
+    await expect(
+      harness.runtime.state.getGoal(
+        OWNER_ID,
+        control.payload.replacementGoalId as string,
+      ),
+    ).resolves.toBeNull();
+
+    const terminal = harness.transport.emitTerminal(0);
+    const result = await replacing;
+
+    expect(result).toMatchObject({
+      replacement: {
+        phase: "activated",
+        expectedRunEpoch: 0,
+        runEpoch: 1,
+      },
+      terminal,
+      discardedInputIds: ["old-context-inform"],
+      controlDispatch: { status: "accepted" },
+      activationDispatch: { status: "accepted" },
+    });
+    expect(harness.transport.runEpoch).toBe(1);
+    expect(harness.transport.epochAdvances).toEqual([
+      { expectedRunEpoch: 0, nextRunEpoch: 1 },
+    ]);
+    expect(harness.transport.pendingIds()).toEqual([]);
+    expect(harness.transport.providerInterrupts).toBe(1);
+    expect(harness.transport.directInterrupts).toBe(0);
+
+    const outbox = await harness.runtime.state.listInstructions(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(outbox.map(({ sequence, kind }) => ({ sequence, kind }))).toEqual([
+      { sequence: 1, kind: "goal.activate" },
+      { sequence: 2, kind: "control.interrupt" },
+      { sequence: 3, kind: "goal.activate" },
+    ]);
+    expect(outbox[2]).toMatchObject({
+      goalId: control.payload.replacementGoalId,
+      goalRevision: 1,
+    });
+    await expect(
+      harness.runtime.goals.getActivePrimaryGoal(OWNER_ID, SESSION_ID),
+    ).resolves.toEqual(result.replacement.replacementGoal);
+  });
+
+  it("keeps a rejected interrupt prepared and resumes the same replacement on an idempotent retry", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+    const command = replacementCommand(activated.goal.goal.id);
+    harness.transport.rejectNextControl();
+
+    const rejected = await harness.runtime.replacements.replace(command);
+
+    expect(rejected).toMatchObject({
+      replacement: { phase: "prepared" },
+      deduplicated: false,
+      controlDispatch: {
+        status: "rejected",
+        receipt: { reason: "provider rejected interrupt" },
+      },
+    });
+    expect(rejected.activationDispatch).toBeUndefined();
+    expect(harness.transport.runEpoch).toBe(0);
+    expect(harness.transport.epochAdvances).toEqual([]);
+    await expect(
+      harness.runtime.state.getGoal(
+        OWNER_ID,
+        rejected.replacement.replacementGoal.goal.id,
+      ),
+    ).resolves.toBeNull();
+
+    const retrying = harness.runtime.replacements.replace(command);
+    await harness.transport.terminalWaitStarted.promise;
+    harness.transport.emitTerminal(0);
+    const retried = await retrying;
+
+    expect(retried.replacement.phase).toBe("activated");
+    expect(retried.deduplicated).toBe(true);
+    expect(retried.replacement.replacementGoal.goal.id).toBe(
+      rejected.replacement.replacementGoal.goal.id,
+    );
+    expect(retried.replacement.controlInstruction.id).toBe(
+      rejected.replacement.controlInstruction.id,
+    );
+    expect(harness.transport.controlAttempts).toBe(2);
+    expect(harness.transport.providerInterrupts).toBe(1);
+  });
+
+  it("rejects replacement constraints that exceed the command authority", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+
+    await expect(
+      harness.runtime.replacements.replace(
+        replacementCommand(activated.goal.goal.id, {
+          replacement: goalInput("Unauthorized policy replacement", {
+            constraints: [
+              {
+                id: "organization-only",
+                description: "Pretend to be an organization policy",
+                enforcement: "model_guidance",
+                authority: "organization_policy",
+                sourceRef: "policy:privacy",
+              },
+            ],
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "invalid_authority" });
+    await expect(
+      harness.runtime.state.listInstructions(OWNER_ID, SESSION_ID),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("returns stable IDs for an activated-command retry without interrupting or advancing the runtime again", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+    const command = replacementCommand(activated.goal.goal.id);
+    const replacing = harness.runtime.replacements.replace(command);
+    await harness.transport.terminalWaitStarted.promise;
+    harness.transport.emitTerminal(0);
+    const first = await replacing;
+    const deliveredBeforeRetry = structuredClone(harness.transport.delivered);
+
+    const retry = await harness.runtime.replacements.replace(command);
+
+    expect(retry.deduplicated).toBe(true);
+    expect(retry.replacement).toEqual(first.replacement);
+    expect(retry.replacement.controlInstruction.id).toBe(
+      first.replacement.controlInstruction.id,
+    );
+    expect(retry.replacement.activationInstruction?.id).toBe(
+      first.replacement.activationInstruction?.id,
+    );
+    expect(harness.transport.delivered).toEqual(deliveredBeforeRetry);
+    expect(harness.transport.providerInterrupts).toBe(1);
+    expect(harness.transport.epochAdvances).toHaveLength(1);
+  });
+
+  it("fails closed when the registered transport changes while waiting for the old terminal", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+    const replacing = harness.runtime.replacements.replace(
+      replacementCommand(activated.goal.goal.id),
+    );
+    await harness.transport.terminalWaitStarted.promise;
+
+    harness.release();
+    const replacementTransport = new ControlledLifecycleTransport(SESSION_ID);
+    harness.register(replacementTransport);
+    harness.transport.emitTerminal(0);
+
+    await expect(replacing).rejects.toMatchObject({ code: "runtime_changed" });
+    expect(harness.transport.runEpoch).toBe(0);
+    expect(replacementTransport.runEpoch).toBe(0);
+    expect(replacementTransport.delivered).toEqual([]);
+    const outbox = await harness.runtime.state.listInstructions(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(outbox.map(({ kind }) => kind)).toEqual([
+      "goal.activate",
+      "control.interrupt",
+    ]);
+    const control = outbox[1];
+    if (control?.kind !== "control.interrupt") {
+      throw new Error("Expected a replacement control instruction");
+    }
+    await expect(
+      harness.runtime.state.getGoal(
+        OWNER_ID,
+        control.payload.replacementGoalId as string,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("fails closed when terminal observation fails", async () => {
+    const harness = createHarness();
+    const activated = await activateOriginal(harness);
+    const replacing = harness.runtime.replacements.replace(
+      replacementCommand(activated.goal.goal.id),
+    );
+    await harness.transport.terminalWaitStarted.promise;
+
+    harness.transport.failTerminal(new Error("terminal stream closed"));
+
+    await expect(replacing).rejects.toThrow("terminal stream closed");
+    expect(harness.transport.runEpoch).toBe(0);
+    expect(harness.transport.epochAdvances).toEqual([]);
+    const outbox = await harness.runtime.state.listInstructions(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(outbox.map(({ kind }) => kind)).toEqual([
+      "goal.activate",
+      "control.interrupt",
+    ]);
+    const control = outbox[1];
+    if (control?.kind !== "control.interrupt") {
+      throw new Error("Expected a replacement control instruction");
+    }
+    await expect(
+      harness.runtime.state.getGoal(
+        OWNER_ID,
+        control.payload.replacementGoalId as string,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/goal-runtime-vertical-slice.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-runtime-vertical-slice.test.ts
@@ -1,5 +1,6 @@
 import type {
   HookCallback,
+  SDKMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { CreateAgentGoalInput } from "@openloomi/ai/agent/runtime-instructions";
@@ -42,6 +43,16 @@ function goalInput(): CreateAgentGoalInput {
     completionPolicy: "model_evaluator",
     source: { type: "user" },
   };
+}
+
+function resultMessage(): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 10,
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 4, output_tokens: 2 },
+  } as SDKMessage;
 }
 
 describe("Claude Goal runtime vertical slice", () => {
@@ -179,6 +190,153 @@ describe("Claude Goal runtime vertical slice", () => {
       { sequence: 3, kind: "context.upsert" },
     ]);
     expect(handle.interrupt).toHaveBeenCalledTimes(2);
+
+    registration?.release();
+    await claude.close();
+  });
+
+  it("replaces a live Claude Goal only after the old turn terminates and fences pending old-epoch input", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const claude = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "replacement-agent-message-id",
+    });
+    const runtime = createInMemoryAgentGoalRuntime({
+      clock: new FixedRuntimeClock(NOW),
+      idGenerator: new DeterministicRuntimeIds("20000000"),
+    });
+    const registration = await startClaudeGoalRuntimeSession({
+      session: { user: { id: OWNER_ID } },
+      runtime: claude,
+      start: { initialPrompt: "Start the original Goal" },
+      goalRuntime: runtime,
+    });
+    const sdkInput = (sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>)[
+      Symbol.asyncIterator
+    ]();
+    await sdkInput.next();
+
+    const activated = await runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "replacement-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput(),
+    });
+    await expect(sdkInput.next()).resolves.toMatchObject({
+      value: {
+        priority: "now",
+        message: { content: expect.stringContaining('kind="goal.activate"') },
+      },
+    });
+
+    const context = await runtime.goals.upsertContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 1,
+      idempotencyKey: "replacement-old-context",
+      source: {
+        type: "connector",
+        authority: "untrusted_data",
+        sourceRef: "jira:JIRA-176",
+      },
+      contextRef: {
+        id: "jira-replacement-context",
+        kind: "connector_record",
+        refId: "JIRA-176",
+        origin: "connector",
+        sourceRef: "jira:JIRA-176",
+        summary: "Context that must not cross the replacement boundary",
+      },
+    });
+    expect(claude.liveInputSource.hasPending?.()).toBe(true);
+    const nextRuntimeInput = sdkInput.next();
+
+    const replacing = runtime.replacements.replace({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 2,
+      idempotencyKey: "replacement-command",
+      source: { type: "user", authority: "user" },
+      reason: "Switch to the new primary Goal",
+      replacement: {
+        ...goalInput(),
+        objective: "Execute only the replacement Goal",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(handle.interrupt).toHaveBeenCalledTimes(2);
+    });
+    const hooks = createClaudeSupplementalInputHooks({
+      supplementalInput: claude.liveInputSource,
+      sessionId: SESSION_ID,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const postToolBatch = hooks?.PostToolBatch?.[0]?.hooks[0] as HookCallback;
+    await expect(
+      postToolBatch({} as never, undefined, {
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({});
+
+    await expect(
+      runtime.goals.getActivePrimaryGoal(OWNER_ID, SESSION_ID),
+    ).resolves.toBeNull();
+    await expect(
+      runtime.state.listInstructions(OWNER_ID, SESSION_ID),
+    ).resolves.toMatchObject([
+      { sequence: 1, kind: "goal.activate" },
+      { sequence: 2, kind: "context.upsert" },
+      { sequence: 3, kind: "control.interrupt" },
+    ]);
+
+    handle.push(resultMessage());
+    const replaced = await replacing;
+
+    expect(replaced).toMatchObject({
+      replacement: {
+        phase: "activated",
+        expectedRunEpoch: 0,
+        runEpoch: 1,
+      },
+      discardedInputIds: [context.instruction.id],
+      controlDispatch: { status: "accepted" },
+      activationDispatch: { status: "accepted" },
+    });
+    expect(claude.runEpoch).toBe(1);
+    // The replacement activation has already been handed to the pending SDK
+    // iterator below, so it is no longer resident in the queue.
+    expect(claude.liveInputSource.hasPending?.()).toBe(false);
+    expect(handle.interrupt).toHaveBeenCalledTimes(2);
+    await expect(nextRuntimeInput).resolves.toMatchObject({
+      value: {
+        priority: "now",
+        message: {
+          content: expect.stringContaining("Execute only the replacement Goal"),
+        },
+      },
+    });
+    expect(claude.liveInputSource.hasPending?.()).toBe(false);
+    await expect(
+      runtime.goals.getGoal(OWNER_ID, activated.goal.goal.id),
+    ).resolves.toMatchObject({ goal: { status: "cancelled", revision: 3 } });
+    await expect(
+      runtime.goals.getActivePrimaryGoal(OWNER_ID, SESSION_ID),
+    ).resolves.toEqual(replaced.replacement.replacementGoal);
+    await expect(
+      runtime.state.listInstructions(OWNER_ID, SESSION_ID),
+    ).resolves.toMatchObject([
+      { sequence: 1, kind: "goal.activate" },
+      { sequence: 2, kind: "context.upsert" },
+      { sequence: 3, kind: "control.interrupt" },
+      { sequence: 4, kind: "goal.activate" },
+    ]);
 
     registration?.release();
     await claude.close();

--- a/apps/web/tests/unit/runtime-instructions/instruction-dispatcher.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/instruction-dispatcher.test.ts
@@ -17,7 +17,9 @@ const INSTRUCTION_IDS = [
   "20000000-0000-4000-8000-000000000001",
   "20000000-0000-4000-8000-000000000002",
   "20000000-0000-4000-8000-000000000003",
+  "20000000-0000-4000-8000-000000000004",
 ] as const;
+const GOAL_ID = "30000000-0000-4000-8000-000000000001";
 
 type DeliveryBehavior = (
   instruction: RuntimeInstruction,
@@ -52,6 +54,30 @@ function instruction(sequence: number): RuntimeInstruction {
     payload: { contextRefId: `context-${sequence}` },
     source: { type: "user", authority: "user" },
     idempotencyKey: `dispatcher-instruction-${sequence}`,
+    issuedAt: NOW,
+  });
+}
+
+function lifecycleInstruction(
+  sequence: number,
+  kind: "goal.pause" | "goal.cancel" | "goal.resume",
+): RuntimeInstruction {
+  return RuntimeInstructionSchema.parse({
+    schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+    id: INSTRUCTION_IDS[sequence - 1],
+    sequence,
+    kind,
+    goalId: GOAL_ID,
+    goalRevision: sequence,
+    deliveryMode:
+      kind === "goal.resume" ? "steer" : ("interrupt_replace" as const),
+    targetSessionId: SESSION_ID,
+    payload:
+      kind === "goal.resume"
+        ? {}
+        : { expectedRunEpoch: 0, reason: `${kind} test` },
+    source: { type: "user", authority: "user" },
+    idempotencyKey: `dispatcher-${kind}-${sequence}`,
     issuedAt: NOW,
   });
 }
@@ -291,6 +317,147 @@ describe("RuntimeInstructionDispatcher ordered outbox drain", () => {
       code: "outbox_read_failed",
       cause: expect.objectContaining({ message: "state unavailable" }),
     });
+  });
+});
+
+describe("RuntimeInstructionDispatcher control barriers", () => {
+  it("preserves pause predecessors and later drains them without redelivering the pause", async () => {
+    const instructions = [
+      instruction(1),
+      lifecycleInstruction(2, "goal.pause"),
+    ];
+    const transport = new ScriptedTransport(SESSION_ID);
+    const dispatcher = registeredDispatcher(transport, instructions);
+
+    await dispatcher.deliverControl({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      targetInstructionId: instructions[1].id,
+    });
+    await expect(
+      dispatcher.commitControlBarrier({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[1].id,
+        transport,
+        predecessorPolicy: "preserve_predecessors",
+        reason: "Pause retains pending work",
+      }),
+    ).resolves.toEqual([]);
+
+    instructions.push(lifecycleInstruction(3, "goal.resume"));
+    await expect(
+      dispatcher.drainOnTransport({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[2].id,
+        transport,
+      }),
+    ).resolves.toMatchObject({
+      status: "accepted",
+      instructionId: instructions[2].id,
+    });
+    expect(transport.delivered.map(({ id }) => id)).toEqual([
+      instructions[1].id,
+      instructions[0].id,
+      instructions[2].id,
+    ]);
+  });
+
+  it("supersedes cancel predecessors while allowing later instructions to drain", async () => {
+    const instructions = [
+      instruction(1),
+      lifecycleInstruction(2, "goal.cancel"),
+    ];
+    const transport = new ScriptedTransport(SESSION_ID);
+    const dispatcher = registeredDispatcher(transport, instructions);
+
+    await dispatcher.deliverControl({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      targetInstructionId: instructions[1].id,
+    });
+    await expect(
+      dispatcher.commitControlBarrier({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[1].id,
+        transport,
+        predecessorPolicy: "supersede_predecessors",
+        reason: "Cancel fences pending work",
+      }),
+    ).resolves.toEqual([instructions[0].id]);
+
+    instructions.push(instruction(3));
+    await expect(
+      dispatcher.drainOnTransport({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[2].id,
+        transport,
+      }),
+    ).resolves.toMatchObject({
+      status: "accepted",
+      instructionId: instructions[2].id,
+    });
+    await expect(
+      dispatcher.drain({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[0].id,
+      }),
+    ).resolves.toMatchObject({
+      status: "superseded",
+      instructionId: instructions[0].id,
+    });
+    expect(transport.delivered.map(({ id }) => id)).toEqual([
+      instructions[1].id,
+      instructions[2].id,
+    ]);
+  });
+
+  it("fails a serialized drain when the registered transport changes during its outbox read", async () => {
+    const instructions = outbox(1);
+    const sessions = new RuntimeSessionRegistry();
+    const first = new ScriptedTransport(SESSION_ID);
+    const firstRegistration = sessions.register({
+      ownerId: OWNER_ID,
+      transport: first,
+    });
+    let continueRead!: () => void;
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const readCanContinue = new Promise<void>((resolve) => {
+      continueRead = resolve;
+    });
+    const dispatcher = new RuntimeInstructionDispatcher(sessions, {
+      async listInstructions() {
+        markReadStarted();
+        await readCanContinue;
+        return structuredClone(instructions);
+      },
+    });
+
+    const drain = dispatcher.drainOnTransport({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      targetInstructionId: instructions[0].id,
+      transport: first,
+    });
+    await readStarted;
+    firstRegistration.release();
+    const replacement = new ScriptedTransport(SESSION_ID);
+    sessions.register({ ownerId: OWNER_ID, transport: replacement });
+    continueRead();
+
+    await expect(drain).rejects.toMatchObject({
+      code: "outbox_progress_conflict",
+      message: expect.stringContaining("changed before its outbox was drained"),
+    });
+    expect(first.delivered).toEqual([]);
+    expect(replacement.delivered).toEqual([]);
   });
 });
 

--- a/packages/ai/src/agent/runtime-instructions/constants.ts
+++ b/packages/ai/src/agent/runtime-instructions/constants.ts
@@ -1,4 +1,4 @@
-export const RUNTIME_INSTRUCTION_SCHEMA_VERSION = "1" as const;
+export const RUNTIME_INSTRUCTION_SCHEMA_VERSION = "2" as const;
 
 export const DEFAULT_GOAL_MAX_TURNS = 12;
 

--- a/packages/ai/src/agent/runtime-instructions/formatter.ts
+++ b/packages/ai/src/agent/runtime-instructions/formatter.ts
@@ -86,6 +86,7 @@ function formatInstructionBody(instruction: RuntimeInstruction): string {
       return [
         "Action: Interrupt the current turn. Do not begin a replacement Goal until OpenLoomi sends its activation instruction.",
         `Reason: ${escapeText(instruction.payload.reason)}`,
+        `Expected run epoch: ${instruction.payload.expectedRunEpoch}`,
         instruction.payload.replacementGoalId
           ? `Replacement Goal: ${escapeText(instruction.payload.replacementGoalId)}`
           : undefined,

--- a/packages/ai/src/agent/runtime-instructions/ports.ts
+++ b/packages/ai/src/agent/runtime-instructions/ports.ts
@@ -1,14 +1,31 @@
 import type {
   AgentGoal,
+  AgentGoalLifecycleTransition,
+  AgentGoalReplacement,
+  GoalLifecycleTransitionAction,
   PersistedAgentGoal,
   RuntimeDeliveryReceipt,
   RuntimeInstruction,
   RuntimeInstructionDraft,
+  RuntimeRunEpochAdvanceResult,
+  RuntimeTurnBoundary,
+  RuntimeTurnBoundaryInputHold,
+  RuntimeTurnTerminal,
 } from "./types";
 
 export interface GoalInstructionCommit {
   goal: PersistedAgentGoal;
   instruction: RuntimeInstruction;
+  deduplicated: boolean;
+}
+
+export interface GoalReplacementCommit {
+  replacement: AgentGoalReplacement;
+  deduplicated: boolean;
+}
+
+export interface GoalLifecycleTransitionCommit {
+  transition: AgentGoalLifecycleTransition;
   deduplicated: boolean;
 }
 
@@ -25,6 +42,11 @@ export interface GoalCommandIdentity {
  * lookup and mutation to ownerId.
  */
 export interface AgentGoalStatePort {
+  getRuntimeSessionRunEpoch(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<number>;
+
   getGoal(ownerId: string, goalId: string): Promise<PersistedAgentGoal | null>;
 
   getActivePrimaryGoal(
@@ -43,6 +65,18 @@ export interface AgentGoalStatePort {
     command: GoalCommandIdentity;
   }): Promise<GoalInstructionCommit | null>;
 
+  findReplacementByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit | null>;
+
+  findLifecycleTransitionByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit | null>;
+
   commitActivation(input: {
     ownerId: string;
     runtimeSessionId: string;
@@ -59,6 +93,72 @@ export interface AgentGoalStatePort {
     instruction: RuntimeInstructionDraft;
     command: GoalCommandIdentity;
   }): Promise<GoalInstructionCommit>;
+
+  commitTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit>;
+
+  prepareLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    action: GoalLifecycleTransitionAction;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit>;
+
+  markLifecycleTransitionBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit>;
+
+  finalizeLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit>;
+
+  prepareReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    supersededGoal: AgentGoal;
+    replacementGoal: AgentGoal;
+    controlInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit>;
+
+  markReplacementBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit>;
+
+  finalizeReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    activationInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit>;
 }
 
 /** Provider execution boundary. PR 3 supplies the Claude implementation. */
@@ -68,6 +168,36 @@ export interface RuntimeInstructionTransportPort {
   deliver(instruction: RuntimeInstruction): Promise<RuntimeDeliveryReceipt>;
 
   interrupt(input: { reason: string; expectedRunEpoch: number }): Promise<void>;
+}
+
+/**
+ * Optional control plane implemented by long-lived runtimes that can safely
+ * replace one Goal run with another inside the same provider session.
+ */
+export interface RuntimeSessionLifecycleControlPort extends RuntimeInstructionTransportPort {
+  readonly runEpoch: number;
+
+  captureTurnBoundary(): RuntimeTurnBoundary;
+
+  /**
+   * Acquires the input fence and captures the provider boundary in one
+   * synchronous runtime operation, so an SDK handoff cannot occur between
+   * those two observations.
+   */
+  captureTurnBoundaryAndHoldPendingInput(
+    expectedRunEpoch: number,
+  ): RuntimeTurnBoundaryInputHold;
+
+  waitForTurnTerminal(input: {
+    expectedRunEpoch: number;
+    afterTerminalSequence: number;
+    signal?: AbortSignal;
+  }): Promise<RuntimeTurnTerminal>;
+
+  advanceRunEpoch(input: {
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+  }): RuntimeRunEpochAdvanceResult;
 }
 
 export interface RuntimeSessionResolverPort {

--- a/packages/ai/src/agent/runtime-instructions/schema.ts
+++ b/packages/ai/src/agent/runtime-instructions/schema.ts
@@ -441,6 +441,13 @@ const optionalReasonSchema = z
   .object({ reason: z.string().trim().min(1).max(4_000).optional() })
   .strict();
 
+const interruptingLifecyclePayloadSchema = z
+  .object({
+    reason: z.string().trim().min(1).max(4_000).optional(),
+    expectedRunEpoch: z.int().nonnegative(),
+  })
+  .strict();
+
 const goalInstructionEnvelopeSchema = instructionEnvelopeSchema.extend({
   goalId: z.uuid(),
   goalRevision: z.int().positive(),
@@ -482,7 +489,7 @@ export const RuntimeInstructionSchema = z
     }),
     goalInstructionEnvelopeSchema.extend({
       kind: z.literal("goal.pause"),
-      payload: optionalReasonSchema,
+      payload: interruptingLifecyclePayloadSchema,
     }),
     goalInstructionEnvelopeSchema.extend({
       kind: z.literal("goal.resume"),
@@ -490,7 +497,7 @@ export const RuntimeInstructionSchema = z
     }),
     goalInstructionEnvelopeSchema.extend({
       kind: z.literal("goal.cancel"),
-      payload: optionalReasonSchema,
+      payload: interruptingLifecyclePayloadSchema,
     }),
     goalInstructionEnvelopeSchema.extend({
       kind: z.literal("goal.continue"),
@@ -533,6 +540,7 @@ export const RuntimeInstructionSchema = z
       payload: z
         .object({
           reason: z.string().trim().min(1).max(4_000),
+          expectedRunEpoch: z.int().nonnegative(),
           replacementGoalId: z.uuid().optional(),
         })
         .strict(),
@@ -588,6 +596,40 @@ export const RuntimeInstructionSchema = z
         path: ["deliveryMode"],
         message: "control.interrupt requires interrupt_replace delivery",
       });
+    }
+    if (
+      (instruction.kind === "goal.pause" ||
+        instruction.kind === "goal.cancel") &&
+      instruction.deliveryMode !== "interrupt_replace"
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["deliveryMode"],
+        message: `${instruction.kind} requires interrupt_replace delivery`,
+      });
+    }
+    if (
+      instruction.kind === "control.interrupt" &&
+      instruction.payload.replacementGoalId !== undefined
+    ) {
+      if (
+        instruction.goalId === undefined ||
+        instruction.goalRevision === undefined
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["goalId"],
+          message:
+            "A replacement interrupt must identify the superseded Goal and revision",
+        });
+      }
+      if (instruction.payload.replacementGoalId === instruction.goalId) {
+        context.addIssue({
+          code: "custom",
+          path: ["payload", "replacementGoalId"],
+          message: "A replacement Goal must differ from the superseded Goal",
+        });
+      }
     }
     if (
       (instruction.kind === "goal.activate" ||

--- a/packages/ai/src/agent/runtime-instructions/types.ts
+++ b/packages/ai/src/agent/runtime-instructions/types.ts
@@ -83,6 +83,55 @@ export interface PersistedAgentGoal {
   goal: AgentGoal;
 }
 
+export type GoalLifecycleTransitionAction = "pause" | "cancel";
+export type GoalLifecycleTransitionPhase =
+  | "prepared"
+  | "boundary_observed"
+  | "finalized";
+
+/**
+ * Durable shape of a terminal-boundary lifecycle transition.
+ *
+ * The semantic pause/cancel instruction and authoritative Goal transition are
+ * committed together during `prepared`. The primary slot remains reserved
+ * until the provider turn reaches its terminal boundary. Cancel records that
+ * durable boundary before the runtime epoch is reconciled and the slot is
+ * released.
+ */
+export interface AgentGoalLifecycleTransition {
+  ownerId: string;
+  runtimeSessionId: string;
+  action: GoalLifecycleTransitionAction;
+  transitionedGoal: PersistedAgentGoal;
+  instruction: RuntimeInstruction;
+  expectedRunEpoch: number;
+  runEpoch: number;
+  phase: GoalLifecycleTransitionPhase;
+}
+
+export type GoalReplacementPhase =
+  | "prepared"
+  | "boundary_observed"
+  | "activated";
+
+/**
+ * Durable shape of a two-phase primary Goal replacement.
+ *
+ * `replacementGoal` is reserved but must not be returned by normal Goal reads
+ * until the replacement reaches `activated`.
+ */
+export interface AgentGoalReplacement {
+  ownerId: string;
+  runtimeSessionId: string;
+  supersededGoal: PersistedAgentGoal;
+  replacementGoal: PersistedAgentGoal;
+  controlInstruction: RuntimeInstruction;
+  activationInstruction?: RuntimeInstruction;
+  expectedRunEpoch: number;
+  runEpoch: number;
+  phase: GoalReplacementPhase;
+}
+
 export interface AgentGoalRun {
   id: string;
   ownerId: string;
@@ -125,4 +174,34 @@ export interface RuntimeDeliveryReceipt {
   providerEventId?: string;
   recordedAt: string;
   reason?: string;
+}
+
+export interface RuntimeTurnBoundary {
+  runtimeSessionId: string;
+  runEpoch: number;
+  terminalSequence: number;
+  state: RuntimeSessionState;
+}
+
+export interface RuntimeTurnTerminal {
+  runtimeSessionId: string;
+  runEpoch: number;
+  terminalSequence: number;
+  state: "idle";
+}
+
+export interface RuntimeRunEpochAdvanceResult {
+  previousRunEpoch: number;
+  runEpoch: number;
+  discardedInputIds: string[];
+}
+
+export interface RuntimeTerminalInputHold {
+  readonly runEpoch: number;
+  release(options?: { releasePendingIfIdle?: boolean }): void;
+}
+
+export interface RuntimeTurnBoundaryInputHold {
+  boundary: RuntimeTurnBoundary;
+  hold: RuntimeTerminalInputHold;
 }

--- a/packages/ai/src/agent/supplemental-input/queue.ts
+++ b/packages/ai/src/agent/supplemental-input/queue.ts
@@ -54,10 +54,30 @@ export type AgentSupplementalInputEnqueueResult =
       interrupt: AgentSupplementalInputInterruptResult;
     }
   | {
+      status: "superseded";
+      input: NormalizedAgentSupplementalInput;
+      interrupt: AgentSupplementalInputInterruptResult;
+    }
+  | {
       status: "duplicate";
       id: string;
       interrupt: { status: "not_requested" };
     };
+
+export interface AgentRunEpochAdvance {
+  expectedRunEpoch: number;
+  nextRunEpoch: number;
+}
+
+export interface AgentSupplementalInputEnqueueOptions {
+  /** A provider that is already idle can consume a steer without interruption. */
+  requestInterrupt?: boolean;
+}
+
+export interface AgentSupplementalInputHold {
+  readonly runEpoch: number;
+  release(): void;
+}
 
 export type NormalizedAgentSupplementalInput = Readonly<
   AgentSupplementalInput & {
@@ -76,6 +96,11 @@ type IteratorWaiter = (result: IteratorResult<AgentSupplementalInput>) => void;
 type InterruptOutcome =
   | { status: "completed" }
   | { status: "failed"; error: Error };
+
+interface InFlightInterrupt {
+  runEpoch: number;
+  operation: Promise<InterruptOutcome>;
+}
 
 const isoDateTimeSchema = z.iso.datetime({ offset: true });
 
@@ -102,12 +127,16 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
   private readonly pending: PendingInput[] = [];
   private readonly waiters: IteratorWaiter[] = [];
   private readonly acceptedIds = new Set<string>();
+  private readonly pendingInputHolds = new Map<number, Set<symbol>>();
 
   private state: "open" | "closed" | "aborted" = "open";
   private activeRunEpoch: number;
   private iteratorCreated = false;
   private interruptHandler: (() => Promise<void> | void) | null = null;
-  private interruptInFlight: Promise<InterruptOutcome> | null = null;
+  private handoffHandler:
+    | ((input: NormalizedAgentSupplementalInput) => void)
+    | null = null;
+  private interruptInFlight: InFlightInterrupt | null = null;
 
   constructor(options: AgentSupplementalInputQueueOptions = {}) {
     this.maxPendingInputs = validatePositiveIntegerOption(
@@ -129,6 +158,7 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
 
   async enqueue(
     candidate: AgentSupplementalInput,
+    options: AgentSupplementalInputEnqueueOptions = {},
   ): Promise<AgentSupplementalInputEnqueueResult> {
     if (this.state !== "open") {
       throw queueError("closed", "Supplemental input queue is closed");
@@ -175,10 +205,13 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     this.drainReleasableInputs();
 
     const interrupt =
-      input.intent === "steer"
+      input.intent === "steer" && options.requestInterrupt !== false
         ? await this.interrupt()
         : { status: "not_requested" as const };
 
+    if (input.runEpoch !== this.activeRunEpoch) {
+      return { status: "superseded", input, interrupt };
+    }
     return { status: "accepted", input, interrupt };
   }
 
@@ -198,11 +231,31 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     this.interruptHandler = handler;
   }
 
+  setHandoffHandler(
+    handler: ((input: NormalizedAgentSupplementalInput) => void) | null,
+  ): void {
+    if (handler !== null && typeof handler !== "function") {
+      throw queueError(
+        "invalid_input",
+        "Supplemental input handoff handler must be a function or null",
+      );
+    }
+    if (this.state !== "open" && handler !== null) {
+      throw queueError(
+        "closed",
+        "Cannot attach a handoff handler to a closed supplemental input queue",
+      );
+    }
+    this.handoffHandler = handler;
+  }
+
   hasPending(): boolean {
     return this.pending.length > 0;
   }
 
   takePendingInform(): AgentSupplementalInput[] {
+    if (this.isPendingInputHeld(this.activeRunEpoch)) return [];
+
     const informs: NormalizedAgentSupplementalInput[] = [];
     while (this.pending[0]?.input.intent === "inform") {
       const entry = this.pending.shift();
@@ -214,6 +267,8 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
   }
 
   releasePendingInform(): number {
+    if (this.isPendingInputHeld(this.activeRunEpoch)) return 0;
+
     let released = 0;
     for (const entry of this.pending) {
       if (entry.input.intent === "inform" && !entry.releasable) {
@@ -230,20 +285,70 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
   }
 
   /**
-   * Moves the queue to a newer run and removes inputs that can no longer be
-   * applied. Inputs already yielded remain fenced by downstream event state.
+   * Prevents both SDK iteration and hook-based reads from releasing buffered
+   * inform inputs while a turn-ending lifecycle transition is in flight.
    */
-  advanceRunEpoch(nextRunEpoch: number): AgentSupplementalInput[] {
-    const normalizedEpoch = validateRunEpoch(nextRunEpoch);
-    if (normalizedEpoch <= this.activeRunEpoch) {
+  holdPendingInputForRunEpoch(
+    expectedRunEpoch: number,
+  ): AgentSupplementalInputHold {
+    const runEpoch = validateRunEpoch(expectedRunEpoch);
+    if (this.state !== "open") {
+      throw queueError(
+        "closed",
+        "Cannot hold pending input on a closed supplemental input queue",
+      );
+    }
+    if (runEpoch !== this.activeRunEpoch) {
       throw queueError(
         "epoch_mismatch",
-        `nextRunEpoch must be greater than active runEpoch ${this.activeRunEpoch}`,
+        `Expected active runEpoch ${runEpoch}, received ${this.activeRunEpoch}`,
       );
     }
 
-    this.activeRunEpoch = normalizedEpoch;
+    const token = Symbol(`runEpoch:${runEpoch}`);
+    const holds = this.pendingInputHolds.get(runEpoch) ?? new Set<symbol>();
+    holds.add(token);
+    this.pendingInputHolds.set(runEpoch, holds);
+
+    let released = false;
+    return {
+      runEpoch,
+      release: () => {
+        if (released) return;
+        released = true;
+        const activeHolds = this.pendingInputHolds.get(runEpoch);
+        if (activeHolds === undefined || !activeHolds.delete(token)) return;
+        if (activeHolds.size > 0) return;
+
+        this.pendingInputHolds.delete(runEpoch);
+        this.drainReleasableInputs();
+      },
+    };
+  }
+
+  /**
+   * Moves the queue to a newer run and removes inputs that can no longer be
+   * applied. Inputs already yielded remain fenced by downstream event state.
+   */
+  advanceRunEpoch(input: AgentRunEpochAdvance): AgentSupplementalInput[] {
+    const expectedRunEpoch = validateRunEpoch(input.expectedRunEpoch);
+    const nextRunEpoch = validateRunEpoch(input.nextRunEpoch);
+    if (expectedRunEpoch !== this.activeRunEpoch) {
+      throw queueError(
+        "epoch_mismatch",
+        `Expected active runEpoch ${expectedRunEpoch}, received ${this.activeRunEpoch}`,
+      );
+    }
+    if (nextRunEpoch !== expectedRunEpoch + 1) {
+      throw queueError(
+        "epoch_mismatch",
+        `nextRunEpoch must advance exactly once from ${expectedRunEpoch}`,
+      );
+    }
+
+    this.activeRunEpoch = nextRunEpoch;
     const discarded = this.pending.splice(0).map((entry) => entry.input);
+    this.pendingInputHolds.delete(expectedRunEpoch);
     this.drainReleasableInputs();
     return discarded;
   }
@@ -255,11 +360,15 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     }
 
     const activeInterrupt = this.interruptInFlight;
-    if (activeInterrupt !== null) {
-      return withCoalescedFlag(await activeInterrupt, true);
+    if (
+      activeInterrupt !== null &&
+      activeInterrupt.runEpoch === this.activeRunEpoch
+    ) {
+      return withCoalescedFlag(await activeInterrupt.operation, true);
     }
 
     const handler = this.interruptHandler;
+    const runEpoch = this.activeRunEpoch;
     const operation: Promise<InterruptOutcome> = Promise.resolve()
       .then(() => handler())
       .then((): InterruptOutcome => ({ status: "completed" }))
@@ -269,12 +378,13 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
           error: normalizeError(error),
         }),
       );
-    this.interruptInFlight = operation;
+    const inFlight = { runEpoch, operation };
+    this.interruptInFlight = inFlight;
 
     try {
       return withCoalescedFlag(await operation, false);
     } finally {
-      if (this.interruptInFlight === operation) {
+      if (this.interruptInFlight === inFlight) {
         this.interruptInFlight = null;
       }
     }
@@ -285,7 +395,9 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     if (this.state !== "open") return;
     this.state = "closed";
     this.interruptHandler = null;
+    this.handoffHandler = null;
     this.acceptedIds.clear();
+    this.pendingInputHolds.clear();
     for (const entry of this.pending) {
       entry.releasable = true;
     }
@@ -297,7 +409,9 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     const discarded = this.pending.splice(0).map((entry) => entry.input);
     this.state = "aborted";
     this.interruptHandler = null;
+    this.handoffHandler = null;
     this.acceptedIds.clear();
+    this.pendingInputHolds.clear();
     this.resolveAllWaitersDone();
     return discarded;
   }
@@ -327,7 +441,8 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
 
   private next(): Promise<IteratorResult<AgentSupplementalInput>> {
     const entry = this.pending[0];
-    if (entry?.releasable) {
+    if (entry?.releasable && !this.isPendingInputHeld(entry.input.runEpoch)) {
+      this.handoffHandler?.(entry.input);
       this.pending.shift();
       return Promise.resolve({ value: entry.input, done: false });
     }
@@ -347,10 +462,17 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
   }
 
   private drainReleasableInputs(): void {
-    while (this.waiters.length > 0 && this.pending[0]?.releasable) {
-      const waiter = this.waiters.shift();
-      const entry = this.pending.shift();
+    while (
+      this.waiters.length > 0 &&
+      this.pending[0]?.releasable &&
+      !this.isPendingInputHeld(this.pending[0].input.runEpoch)
+    ) {
+      const waiter = this.waiters[0];
+      const entry = this.pending[0];
       if (waiter === undefined || entry === undefined) break;
+      this.handoffHandler?.(entry.input);
+      this.waiters.shift();
+      this.pending.shift();
       waiter({ value: entry.input, done: false });
     }
     this.finishWaitingConsumersIfDrained();
@@ -366,6 +488,10 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
     for (const waiter of this.waiters.splice(0)) {
       waiter(doneResult());
     }
+  }
+
+  private isPendingInputHeld(runEpoch: number): boolean {
+    return (this.pendingInputHolds.get(runEpoch)?.size ?? 0) > 0;
   }
 }
 

--- a/packages/ai/src/agent/supplemental-input/runtime-transport.ts
+++ b/packages/ai/src/agent/supplemental-input/runtime-transport.ts
@@ -42,6 +42,7 @@ export class SupplementalInputRuntimeInstructionTransport implements RuntimeInst
   private readonly queue: AgentSupplementalInputQueue;
   private readonly now: () => Date;
   private readonly acceptedInstructionIdentities = new Map<string, string>();
+  private readonly instructionRunEpochs = new Map<string, number>();
 
   constructor(input: {
     runtimeSessionId: string;
@@ -68,6 +69,10 @@ export class SupplementalInputRuntimeInstructionTransport implements RuntimeInst
 
   async deliver(
     candidate: RuntimeInstruction,
+    options: {
+      interruptControl?: boolean;
+      interruptSteer?: boolean;
+    } = {},
   ): Promise<RuntimeDeliveryReceipt> {
     const parsed = RuntimeInstructionSchema.safeParse(candidate);
     if (!parsed.success) {
@@ -101,20 +106,68 @@ export class SupplementalInputRuntimeInstructionTransport implements RuntimeInst
         "Instruction ID was already accepted for a different Goal revision",
       );
     }
+    if (acceptedIdentity === identity && isInterruptControl(instruction)) {
+      return this.queued(
+        instruction.id,
+        "Interrupting lifecycle instruction was already accepted",
+      );
+    }
+
+    const activeRunEpoch = this.queue.getRunEpoch();
+    const attemptedRunEpoch = this.instructionRunEpochs.get(instruction.id);
+    if (
+      attemptedRunEpoch !== undefined &&
+      attemptedRunEpoch !== activeRunEpoch
+    ) {
+      return this.rejected(
+        instruction.id,
+        `Instruction is fenced to runEpoch ${attemptedRunEpoch}, not active runEpoch ${activeRunEpoch}`,
+      );
+    }
+    this.instructionRunEpochs.set(instruction.id, activeRunEpoch);
 
     try {
-      const result = await this.queue.enqueue({
-        id: instruction.id,
-        content: formatRuntimeInstruction(instruction),
-        createdAt: instruction.issuedAt,
-        runEpoch: this.queue.getRunEpoch(),
-        intent:
-          instruction.deliveryMode === "next_boundary" ? "inform" : "steer",
-      });
+      if (isInterruptControl(instruction)) {
+        const expectedRunEpoch = instruction.payload.expectedRunEpoch;
+        if (expectedRunEpoch !== activeRunEpoch) {
+          return this.rejected(
+            instruction.id,
+            `Expected run epoch ${expectedRunEpoch}, active epoch is ${activeRunEpoch}`,
+          );
+        }
+        if (options.interruptControl !== false) {
+          await this.interrupt({
+            reason:
+              instruction.payload.reason ??
+              `Apply ${instruction.kind} lifecycle transition`,
+            expectedRunEpoch,
+          });
+        }
+        this.acceptedInstructionIdentities.set(instruction.id, identity);
+        return this.queued(instruction.id);
+      }
+
+      const result = await this.queue.enqueue(
+        {
+          id: instruction.id,
+          content: formatRuntimeInstruction(instruction),
+          createdAt: instruction.issuedAt,
+          runEpoch: this.queue.getRunEpoch(),
+          intent:
+            instruction.deliveryMode === "next_boundary" ? "inform" : "steer",
+        },
+        { requestInterrupt: options.interruptSteer },
+      );
 
       if (result.status === "duplicate") {
         this.acceptedInstructionIdentities.set(instruction.id, identity);
         return this.queued(instruction.id, "Instruction was already queued");
+      }
+      if (result.status === "superseded") {
+        return this.rejected(
+          instruction.id,
+          `Instruction was superseded while runEpoch advanced from ${result.input.runEpoch}`,
+        );
       }
       this.acceptedInstructionIdentities.set(instruction.id, identity);
       if (result.interrupt.status === "unavailable") {
@@ -154,6 +207,12 @@ export class SupplementalInputRuntimeInstructionTransport implements RuntimeInst
     }
 
     const result = await this.queue.interrupt();
+    if (this.queue.getRunEpoch() !== input.expectedRunEpoch) {
+      throw new SupplementalInputRuntimeTransportError(
+        "invalid_run_epoch",
+        `Run epoch advanced while interrupt ${input.expectedRunEpoch} was in flight`,
+      );
+    }
     if (result.status === "completed") return;
     if (result.status === "failed") {
       throw new SupplementalInputRuntimeTransportError(
@@ -168,15 +227,25 @@ export class SupplementalInputRuntimeInstructionTransport implements RuntimeInst
     );
   }
 
-  advanceRunEpoch(nextRunEpoch: number): AgentSupplementalInput[] {
-    const activeRunEpoch = this.queue.getRunEpoch();
-    if (!Number.isInteger(nextRunEpoch) || nextRunEpoch <= activeRunEpoch) {
-      throw new SupplementalInputRuntimeTransportError(
-        "invalid_run_epoch",
-        `nextRunEpoch must be greater than active run epoch ${activeRunEpoch}`,
-      );
+  advanceRunEpoch(input: {
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+  }): AgentSupplementalInput[] {
+    try {
+      return this.queue.advanceRunEpoch(input);
+    } catch (error) {
+      if (
+        error instanceof AgentSupplementalInputQueueError &&
+        error.code === "epoch_mismatch"
+      ) {
+        throw new SupplementalInputRuntimeTransportError(
+          "invalid_run_epoch",
+          error.message,
+          error,
+        );
+      }
+      throw error;
     }
-    return this.queue.advanceRunEpoch(nextRunEpoch);
   }
 
   private queued(
@@ -224,4 +293,17 @@ function instructionRevisionIdentity(instruction: RuntimeInstruction): string {
     instruction.goalId ?? "no-goal",
     instruction.goalRevision?.toString() ?? "no-revision",
   ].join(":");
+}
+
+function isInterruptControl(
+  instruction: RuntimeInstruction,
+): instruction is Extract<
+  RuntimeInstruction,
+  { kind: "control.interrupt" | "goal.pause" | "goal.cancel" }
+> {
+  return (
+    instruction.kind === "control.interrupt" ||
+    instruction.kind === "goal.pause" ||
+    instruction.kind === "goal.cancel"
+  );
 }

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -81,6 +81,8 @@ export interface AgentMessage {
   /** Unique identifier for deduplication */
   messageId?: string;
   sessionId?: string;
+  /** Goal run fence captured when the provider event was observed. */
+  runEpoch?: number;
   content?: string;
   name?: string;
   id?: string;


### PR DESCRIPTION
## Summary

Add lifecycle and replacement semantics to the Claude Goal Runtime.

Related to #176.

## What Changed

- Add Goal pause, resume, and cancel operations.
- Add active Goal replacement with terminal-boundary coordination.
- Keep lifecycle control instructions outside the normal Claude input queue.
- Wait for the previous Claude turn to terminate before advancing the runtime epoch.
- Fence stale inputs and delayed provider events with `runEpoch`.
- Preserve pending predecessor instructions during pause and resume.
- Supersede obsolete predecessor instructions during cancellation and replacement.
- Add idempotent retry handling for lifecycle and replacement commands.
- Fail closed when the active runtime transport changes during a transition.
- Prevent unrecoverable non-zero epochs from starting on a fresh Claude runtime.
- Add focused coverage for lifecycle state barriers, Claude SDK input handling, replacement races, and stale-event rejection.

## Validation

- `pnpm lint`
- `pnpm tsc`
- Prettier check for all changed files
- 11 related test files passed
- 99 related tests passed