### PR TITLE
fix: route fresh setup to install before host probe

### DIFF
--- a/plugins/codex/scripts/install-assets/setup.windows.ps1
+++ b/plugins/codex/scripts/install-assets/setup.windows.ps1
@@ -1,4 +1,4 @@
-# OpenLoomi Codex plugin — Windows install helper.
+# OpenLoomi Codex plugin - Windows install helper.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Invoked by loomi-bridge.installOpenLoomi only after the user explicitly
@@ -12,7 +12,7 @@
 #   .msi -> msiexec /i <artifact> /qn /norestart (elevated)
 #   .exe -> <artifact> /S            (NSIS silent, default path)
 #
-# Companion to plugins/claude/scripts/install-assets/setup.windows.ps1 —
+# Companion to plugins/claude/scripts/install-assets/setup.windows.ps1 -
 # kept structurally aligned. Real differences:
 #   - This script does NOT call the GitHub Releases API or use winget.
 #     The codex bridge already resolved + downloaded the official artifact
@@ -46,7 +46,7 @@ $ext = [System.IO.Path]::GetExtension($Artifact).ToLowerInvariant()
 
 switch ($ext) {
   ".msi" {
-    Log "Running MSI installer (elevated)…"
+    Log "Running MSI installer (elevated)..."
     $proc = Start-Process -FilePath "msiexec.exe" `
       -ArgumentList @("/i", "`"$Artifact`"", "/qn", "/norestart") `
       -Verb RunAs -Wait -PassThru
@@ -55,7 +55,7 @@ switch ($ext) {
     }
   }
   ".exe" {
-    Log "Running NSIS installer (silent, default path)…"
+    Log "Running NSIS installer (silent, default path)..."
     $proc = Start-Process -FilePath $Artifact -ArgumentList @("/S") -Wait -PassThru
     if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
       Fail "Installer exited with code $($proc.ExitCode)."
@@ -69,11 +69,12 @@ switch ($ext) {
 # Resolve the installed main binary. Prefer %LOCALAPPDATA%\OpenLoomi, then PATH.
 $bin = Join-Path $env:LOCALAPPDATA "OpenLoomi\openloomi.exe"
 if (-not (Test-Path $bin)) {
-  $bin = (Get-Command openloomi.exe -ErrorAction SilentlyContinue)?.Source
+  $cmd = Get-Command openloomi.exe -ErrorAction SilentlyContinue
+  if ($cmd) { $bin = $cmd.Source }
 }
 
 if (-not $bin -or -not (Test-Path $bin)) {
-  # Files were installed but the main binary isn't placed yet — the
+  # Files were installed but the main binary isn't placed yet - the
   # desktop app's first launch does this. Report an empty binPath so the
   # bridge can guide the user, instead of failing.
   $bin = ""
@@ -81,14 +82,19 @@ if (-not $bin -or -not (Test-Path $bin)) {
   Log "Launch the OpenLoomi desktop app once so it places the main binary,"
   Log "then re-run setup-status from the Codex plugin to finish setup."
 } else {
-  Log "Verifying the OpenLoomi install…"
+  Log "Verifying the OpenLoomi install..."
   Log "  found main binary at: $bin"
 }
 
 # Emit a single structured JSON line on stdout for the bridge. The bridge
 # already knows version / tag / assetUrl from its earlier GitHub release
 # resolution; we only report what this script verified on disk (binPath).
-$binJson = $bin -replace '\\', '\\'
-Write-Output "{`"binPath`":`"$binJson`",`"version`":`"`",`"tag`":`"`",`"assetUrl`":`"`"}"
+$installRecord = [PSCustomObject]@{
+  binPath  = $bin
+  version  = ""
+  tag      = ""
+  assetUrl = ""
+}
+Write-Output ($installRecord | ConvertTo-Json -Compress)
 
 Log "Install complete. Re-run setup-status to continue."

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -320,7 +320,9 @@ function makeSetupStageTicker(stage, budgetMs) {
 
 async function setupStatus(args = []) {
   const flags = parseFlags(args);
-  const status = await buildSetupStatus({ explicitApp: flags["bin-path"] || null });
+  const status = await buildSetupStatus({
+    explicitApp: flags["bin-path"] || null,
+  });
   if (flags.emitHostProbe) {
     status.hostProbe = buildHostProbePayload(status);
     status.hostProbeScript = HOST_PROBE_SNIPPET;
@@ -343,7 +345,12 @@ async function runHostProbeCommand(args = []) {
       explicitBaseUrl = arg.slice("--base-url=".length);
     }
   }
-  const baseUrls = (explicitBaseUrl || "http://127.0.0.1:3414,http://127.0.0.1:3515").split(",").map((s) => s.trim()).filter(Boolean);
+  const baseUrls = (
+    explicitBaseUrl || "http://127.0.0.1:3414,http://127.0.0.1:3515"
+  )
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
   const result = await probeHostsForProviders(baseUrls);
   const writeOutcome = writeHostProbeCache({
     baseUrl: result.baseUrl,
@@ -376,7 +383,11 @@ async function probeHostsForProviders(baseUrls) {
       const response = await fetch(endpoint, { signal: controller.signal });
       clearTimeout(timer);
       if (!response.ok) {
-        attempts.push({ baseUrl, status: response.status, error: "HTTP_" + response.status });
+        attempts.push({
+          baseUrl,
+          status: response.status,
+          error: "HTTP_" + response.status,
+        });
         continue;
       }
       const body = await response.json();
@@ -392,7 +403,10 @@ async function probeHostsForProviders(baseUrls) {
         attempts,
       };
     } catch (error) {
-      attempts.push({ baseUrl, error: error && error.message ? error.message : String(error) });
+      attempts.push({
+        baseUrl,
+        error: error && error.message ? error.message : String(error),
+      });
     }
   }
   return { baseUrl: null, providers: [], defaultAgent: null, attempts };
@@ -410,8 +424,8 @@ function buildHostProbePayload(status) {
   };
 }
 
-const HOST_PROBE_SNIPPET = "#!/usr/bin/env bash\n# Refresh ~/.openloomi/codex-host-probe-cache.json so the bridge's next\n# setup-status can recover from a Codex sandbox loopback false negative.\nset -e\nCACHE_PATH=\"$HOME/.openloomi/codex-host-probe-cache.json\"\nmkdir -p \"$(dirname \"$CACHE_PATH\")\"\nBASE_URL=\"${OPENLOOMI_BASE_URL:-http://127.0.0.1:3414}\"\nnode - <<'NODE_PROBE'\nconst fs = require('node:fs');\nconst os = require('node:os');\nconst path = require('node:path');\nconst cachePath = path.join(os.homedir(), '.openloomi', 'codex-host-probe-cache.json');\nconst baseUrl = process.env.OPENLOOMI_BASE_URL || 'http://127.0.0.1:3414';\n(async () => {\n  try {\n    const r = await fetch(baseUrl.replace(/\\/$/, '') + '/api/native/providers');\n    if (!r.ok) throw new Error('HTTP_' + r.status);\n    const body = await r.json();\n    fs.mkdirSync(path.dirname(cachePath), { recursive: true });\n    fs.writeFileSync(cachePath, JSON.stringify({\n      baseUrl,\n      providers: Array.isArray(body.agents) ? body.agents : [],\n      defaultAgent: body.defaultAgent || null,\n      capturedAt: Date.now(),\n      schemaVersion: 1,\n    }, null, 2));\n    process.stdout.write('host-probe ok ' + cachePath + '\\n');\n  } catch (e) {\n    process.stderr.write('host-probe failed: ' + (e && e.message) + '\\n');\n    process.exit(1);\n  }\n})();\nNODE_PROBE";
-
+const HOST_PROBE_SNIPPET =
+  "#!/usr/bin/env bash\n# Refresh ~/.openloomi/codex-host-probe-cache.json so the bridge's next\n# setup-status can recover from a Codex sandbox loopback false negative.\nset -e\nCACHE_PATH=\"$HOME/.openloomi/codex-host-probe-cache.json\"\nmkdir -p \"$(dirname \"$CACHE_PATH\")\"\nBASE_URL=\"${OPENLOOMI_BASE_URL:-http://127.0.0.1:3414}\"\nnode - <<'NODE_PROBE'\nconst fs = require('node:fs');\nconst os = require('node:os');\nconst path = require('node:path');\nconst cachePath = path.join(os.homedir(), '.openloomi', 'codex-host-probe-cache.json');\nconst baseUrl = process.env.OPENLOOMI_BASE_URL || 'http://127.0.0.1:3414';\n(async () => {\n  try {\n    const r = await fetch(baseUrl.replace(/\\/$/, '') + '/api/native/providers');\n    if (!r.ok) throw new Error('HTTP_' + r.status);\n    const body = await r.json();\n    fs.mkdirSync(path.dirname(cachePath), { recursive: true });\n    fs.writeFileSync(cachePath, JSON.stringify({\n      baseUrl,\n      providers: Array.isArray(body.agents) ? body.agents : [],\n      defaultAgent: body.defaultAgent || null,\n      capturedAt: Date.now(),\n      schemaVersion: 1,\n    }, null, 2));\n    process.stdout.write('host-probe ok ' + cachePath + '\\n');\n  } catch (e) {\n    process.stderr.write('host-probe failed: ' + (e && e.message) + '\\n');\n    process.exit(1);\n  }\n})();\nNODE_PROBE";
 
 async function getCodexRuntimeEnvStatus() {
   const probe = await probeRuntimeEnvValue(RUNTIME_ENV_KEY);
@@ -1686,8 +1700,7 @@ function parseFlags(args) {
         flags[setupFlagName] = arg.slice(equalsAt + 1) || null;
       } else {
         const next = args[index + 1];
-        flags[setupFlagName] =
-          next && !next.startsWith("--") ? next : null;
+        flags[setupFlagName] = next && !next.startsWith("--") ? next : null;
         if (flags[setupFlagName] !== null) index += 1;
       }
       continue;
@@ -2504,6 +2517,8 @@ async function installDownloadedArtifact(filePath, options) {
       signal: null,
       stdoutPresent: false,
       stderrPresent: false,
+      stdout: "",
+      stderr: "",
     };
   }
 
@@ -2524,6 +2539,8 @@ async function installDownloadedArtifact(filePath, options) {
       signal: null,
       stdoutPresent: false,
       stderrPresent: false,
+      stdout: "",
+      stderr: "",
     };
   }
 
@@ -2547,6 +2564,8 @@ async function installDownloadedArtifact(filePath, options) {
     restartRequired: result.exitCode === 3010,
     stdoutPresent: hasValue(result.stdout),
     stderrPresent: hasValue(result.stderr),
+    stdout: result.stdout,
+    stderr: result.stderr,
   };
 }
 
@@ -2567,7 +2586,7 @@ function getDefaultInstallCommand(filePath) {
 }
 
 function summarizeInstallerResult(result) {
-  return {
+  const summary = {
     supported: result.supported,
     automatic: result.automatic,
     launched: result.launched,
@@ -2581,6 +2600,17 @@ function summarizeInstallerResult(result) {
     stdoutPresent: result.stdoutPresent,
     stderrPresent: result.stderrPresent,
   };
+
+  const stdoutTail = summarizeCommandOutput(result.stdout);
+  const stderrTail = summarizeCommandOutput(result.stderr);
+  if (stdoutTail) {
+    summary.stdoutTail = stdoutTail;
+  }
+  if (stderrTail) {
+    summary.stderrTail = stderrTail;
+  }
+
+  return summary;
 }
 
 function isSuccessfulInstallExitCode(exitCode) {
@@ -4600,7 +4630,11 @@ async function setCodexRuntimeEnv(args) {
       value: result.value,
       before: result.before,
       actions: result.plan.actions,
-      notes: rewriteRuntimeEnvNotes(result.plan.notes, result.key, result.value),
+      notes: rewriteRuntimeEnvNotes(
+        result.plan.notes,
+        result.key,
+        result.value,
+      ),
       requiresRestart: result.plan.requiresRestart,
       commands: result.plan.commands,
     });
@@ -5278,8 +5312,7 @@ async function setup(args) {
       }
       const apiTicker = makeSetupStageTicker("wait_api", stages.apiMs);
       apiTicker({ force: true });
-      const permissionProbe = () =>
-        probeDesktopProcessRunning(status.appPath);
+      const permissionProbe = () => probeDesktopProcessRunning(status.appPath);
       const wait = await waitForApi({
         timeoutMs: stages.apiMs,
         onProgress: apiTicker,
@@ -5319,8 +5352,9 @@ async function setup(args) {
 
       if (!wait.ok) {
         const elapsedMs = Date.now() - setupStartedAt;
-        const overCap = elapsedMs > stages.totalMs +
-          (wait.permissionLikely ? stages.permissionMs : 0);
+        const overCap =
+          elapsedMs >
+          stages.totalMs + (wait.permissionLikely ? stages.permissionMs : 0);
         const resumeBudget = Math.max(stages.totalMs, 180_000);
         const resumeCommand = [
           "node",
@@ -5467,11 +5501,14 @@ async function discoverOpenLoomi({ explicitApp = null } = {}) {
   const configuredApp = explicitApp || process.env.OPENLOOMI_APP;
 
   if (configuredApp) {
-    const result = await validateAppPath(normalizeExplicitAppPath(configuredApp), {
-      mode: "packaged",
-      source: explicitApp ? "--bin-path" : "OPENLOOMI_APP",
-      checked,
-    });
+    const result = await validateAppPath(
+      normalizeExplicitAppPath(configuredApp),
+      {
+        mode: "packaged",
+        source: explicitApp ? "--bin-path" : "OPENLOOMI_APP",
+        checked,
+      },
+    );
 
     if (result.status === "found" || result.status === "invalid") {
       return result;
@@ -5766,10 +5803,10 @@ function getReadinessDecision(
   const loopbackAccess = options.loopbackAccess || null;
   const hostProbeSaysReady = Boolean(
     hostProbeCache &&
-      hostProbeCache.payload &&
-      Array.isArray(hostProbeCache.payload.providers) &&
-      hostProbeCache.payload.providers.length > 0 &&
-      hostProbeCache.payload.baseUrl,
+    hostProbeCache.payload &&
+    Array.isArray(hostProbeCache.payload.providers) &&
+    hostProbeCache.payload.providers.length > 0 &&
+    hostProbeCache.payload.baseUrl,
   );
   // codexRuntimeEnv is intentionally NOT a gate here: a missing
   // OPENLOOMI_AGENT_PROVIDER only blocks the OpenLoomi GUI desktop from
@@ -5779,31 +5816,6 @@ function getReadinessDecision(
   void codexRuntimeEnv;
   const nativeCodexRuntimeReady = Boolean(nativeProviderStatus?.active);
 
-  if (hostProbeSaysReady) {
-    return {
-      ready: true,
-      nextAction: token.present ? null : "initialize_openloomi_session",
-      reason: "READY_VIA_HOST_PROBE_CACHE",
-      readinessSource: "host-probe-cache",
-      message: token.present
-        ? "OpenLoomi is ready; the Codex sandbox blocked the bridge's own loopback probe, but a fresh host-side probe (~/.openloomi/codex-host-probe-cache.json) confirms the local API is reachable."
-        : "OpenLoomi is ready via host probe cache. Initialize a local guest/session token before calling authenticated OpenLoomi APIs."
-    };
-  }
-
-  if (loopbackAccess && loopbackAccess.ambiguous) {
-    return {
-      ready: false,
-      nextAction: "run_host_probe",
-      reason: "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE",
-      message:
-        "Codex sandbox blocked the bridge's loopback probe, and no fresh host probe cache is available. Run \`bridge run-host-probe\` - the bridge ships a one-shot host probe that writes its result to ~/.openloomi/codex-host-probe-cache.json so the next setup-status can see the real runtime.",
-      autoFixCommands: [
-        `node "${BRIDGE_SCRIPT_DIR}/loomi-bridge.mjs" run-host-probe`,
-      ],
-      hostProbeCachePath: getHostProbeCachePath(),
-    };
-  }
   if (discovery.status === "invalid") {
     return {
       ready: false,
@@ -5817,6 +5829,18 @@ function getReadinessDecision(
       ready: false,
       nextAction: "build_or_install_openloomi",
       reason: "SOURCE_FOUND_APP_NOT_BUILT",
+    };
+  }
+
+  if (hostProbeSaysReady) {
+    return {
+      ready: true,
+      nextAction: token.present ? null : "initialize_openloomi_session",
+      reason: "READY_VIA_HOST_PROBE_CACHE",
+      readinessSource: "host-probe-cache",
+      message: token.present
+        ? "OpenLoomi is ready; the Codex sandbox blocked the bridge's own loopback probe, but a fresh host-side probe (~/.openloomi/codex-host-probe-cache.json) confirms the local API is reachable."
+        : "OpenLoomi is ready via host probe cache. Initialize a local guest/session token before calling authenticated OpenLoomi APIs.",
     };
   }
 
@@ -5835,14 +5859,19 @@ function getReadinessDecision(
   if (!token.present && apiProbe && !apiProbe.reachableUrl) {
     return {
       ready: false,
-      nextAction: loopbackAccess && loopbackAccess.ambiguous ? "run_host_probe" : "open_openloomi",
-      reason: loopbackAccess && loopbackAccess.ambiguous
-        ? "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE"
-        : "OPENLOOMI_API_UNREACHABLE",
+      nextAction:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "run_host_probe"
+          : "open_openloomi",
+      reason:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE"
+          : "OPENLOOMI_API_UNREACHABLE",
       sessionInitializationRequired: true,
-      message: loopbackAccess && loopbackAccess.ambiguous
-        ? "Codex sandbox blocked the bridge's loopback probe. Run `bridge run-host-probe` to refresh the host probe cache; the next setup-status will see the real runtime."
-        : "OpenLoomi is installed but the local API is not reachable. Open OpenLoomi Desktop, or run `setup --yes` to install + launch + mint a guest session automatically.",
+      message:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "Codex sandbox blocked the bridge's loopback probe. Run `bridge run-host-probe` to refresh the host probe cache; the next setup-status will see the real runtime."
+          : "OpenLoomi is installed but the local API is not reachable. Open OpenLoomi Desktop, or run `setup --yes` to install + launch + mint a guest session automatically.",
       autoFixCommands: [
         `node "${BRIDGE_SCRIPT_DIR}/loomi-bridge.mjs" run-host-probe`,
       ],
@@ -5876,13 +5905,18 @@ function getReadinessDecision(
   if (!apiProbe?.reachableUrl) {
     return {
       ready: false,
-      nextAction: loopbackAccess && loopbackAccess.ambiguous ? "run_host_probe" : "open_openloomi",
-      reason: loopbackAccess && loopbackAccess.ambiguous
-        ? "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE"
-        : "OPENLOOMI_API_UNREACHABLE",
-      message: loopbackAccess && loopbackAccess.ambiguous
-        ? "Codex sandbox blocked the bridge`s loopback probe. Run `bridge run-host-probe` to refresh the host probe cache; the next setup-status will see the real runtime."
-        : "OpenLoomi is installed but the local API is not reachable. Open OpenLoomi, then retry setup-status.",
+      nextAction:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "run_host_probe"
+          : "open_openloomi",
+      reason:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE"
+          : "OPENLOOMI_API_UNREACHABLE",
+      message:
+        loopbackAccess && loopbackAccess.ambiguous
+          ? "Codex sandbox blocked the bridge`s loopback probe. Run `bridge run-host-probe` to refresh the host probe cache; the next setup-status will see the real runtime."
+          : "OpenLoomi is installed but the local API is not reachable. Open OpenLoomi, then retry setup-status.",
       autoFixCommands: [
         `node "${BRIDGE_SCRIPT_DIR}/loomi-bridge.mjs" run-host-probe`,
       ],
@@ -5987,7 +6021,8 @@ function writeHostProbeCache(payload) {
 function mapHostProbeToApiProbe(cache) {
   const payload = cache && cache.payload;
   const baseUrl = (payload && payload.baseUrl) || null;
-  const providers = payload && Array.isArray(payload.providers) ? payload.providers : [];
+  const providers =
+    payload && Array.isArray(payload.providers) ? payload.providers : [];
   const attemptBaseUrl = baseUrl || "http://127.0.0.1:3414";
   return {
     reachableUrl: providers.length > 0 && baseUrl ? baseUrl : null,
@@ -6007,7 +6042,8 @@ function mapHostProbeToApiProbe(cache) {
 function mapHostProbeToNativeProviderStatus(cache) {
   const payload = cache && cache.payload;
   const baseUrl = (payload && payload.baseUrl) || null;
-  const providers = payload && Array.isArray(payload.providers) ? payload.providers : [];
+  const providers =
+    payload && Array.isArray(payload.providers) ? payload.providers : [];
   const defaultAgent = (payload && payload.defaultAgent) || null;
   const active = providers.length > 0 && Boolean(baseUrl);
   return {
@@ -6025,9 +6061,6 @@ function mapHostProbeToNativeProviderStatus(cache) {
     cachedAt: cache ? cache.capturedAt : null,
   };
 }
-
-
-
 
 function readOpenLoomiAuthToken(tokenStatus = getTokenStatus()) {
   if (hasValue(process.env.OPENLOOMI_AUTH_TOKEN)) {
@@ -6258,6 +6291,14 @@ function expandHome(value) {
 
 function hasValue(value) {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function summarizeCommandOutput(value) {
+  if (!hasValue(value)) {
+    return null;
+  }
+
+  return String(value).trim().slice(-512);
 }
 
 function debugPath(key, value) {

--- a/plugins/codex/tests/bridge.test.mjs
+++ b/plugins/codex/tests/bridge.test.mjs
@@ -548,7 +548,10 @@ test("setup-status reports OPENLOOMI_API_UNREACHABLE when API down and no token"
         j.autoFixCommands.some((c) => c.includes("run-host-probe")),
         "autoFixCommands must include run-host-probe",
       );
-      assert.equal(j.hostProbeCachePath, join(env.HOME, ".openloomi", "codex-host-probe-cache.json"));
+      assert.equal(
+        j.hostProbeCachePath,
+        join(env.HOME, ".openloomi", "codex-host-probe-cache.json"),
+      );
     }
   });
 });
@@ -563,12 +566,19 @@ test("setup-status --emit-host-probe returns host probe payload without writing 
     assert.equal(typeof j.hostProbeScript, "string");
     assert.ok(j.hostProbeScript.includes("codex-host-probe-cache.json"));
     assert.ok(j.hostProbeScript.includes("/api/native/providers"));
-    assert.equal(j.hostProbeCachePath, join(env.HOME, ".openloomi", "codex-host-probe-cache.json"));
+    assert.equal(
+      j.hostProbeCachePath,
+      join(env.HOME, ".openloomi", "codex-host-probe-cache.json"),
+    );
     assert.equal(j.hostProbeCacheMaxAgeMs, 5 * 60 * 1000);
     assert.ok(j.hostProbe);
     assert.equal(j.hostProbe.recommendedNextAction, "run-host-probe");
     // Cache file must NOT have been written just by reading setup-status.
-    const cachePath = join(env.HOME, ".openloomi", "codex-host-probe-cache.json");
+    const cachePath = join(
+      env.HOME,
+      ".openloomi",
+      "codex-host-probe-cache.json",
+    );
     assert.equal(existsSync(cachePath), false);
   });
 });
@@ -589,7 +599,11 @@ test("run-host-probe command is registered and returns ok:false when API unreach
     assert.ok(Array.isArray(j.attempts));
     assert.ok(j.attempts.length > 0, "must record at least one probe attempt");
     // Cache file should still be written (the cache record is best-effort).
-    const cachePath = join(env.HOME, ".openloomi", "codex-host-probe-cache.json");
+    const cachePath = join(
+      env.HOME,
+      ".openloomi",
+      "codex-host-probe-cache.json",
+    );
     assert.equal(existsSync(cachePath), true);
     const cached = JSON.parse(readFileSync(cachePath, "utf8"));
     assert.equal(cached.schemaVersion, 1);
@@ -603,7 +617,11 @@ test("setup-status honors a fresh host probe cache and reports READY_VIA_HOST_PR
     writeFakeToken(env.HOME);
     // Pre-write a fresh host probe cache so the sandbox-blocked fetch is
     // overridden.
-    const cachePath = join(env.HOME, ".openloomi", "codex-host-probe-cache.json");
+    const cachePath = join(
+      env.HOME,
+      ".openloomi",
+      "codex-host-probe-cache.json",
+    );
     mkdirSync(join(env.HOME, ".openloomi"), { recursive: true });
     writeFileSync(
       cachePath,
@@ -1053,6 +1071,16 @@ test("setup without --yes returns awaiting_user_action when install is required"
       "setup must record at least one step",
     );
     if (j.setup === "awaiting_user_action") {
+      assert.notEqual(
+        j.nextAction,
+        "run_host_probe",
+        "fresh installs must not be blocked by the stale loopback probe branch",
+      );
+      assert.notEqual(
+        j.reason,
+        "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE",
+        "fresh installs should report install state before loopback ambiguity",
+      );
       // The state machine may now surface a new "open_openloomi" branch
       // when the local OpenLoomi API is unreachable even though no app was
       // discovered. Accept that as an awaiting_user_action signal too —
@@ -1081,7 +1109,7 @@ test("setup with --yes proceeds past the install step (not INSTALL_CONFIRMATION_
   withFakeHome((env) => {
     // Same "not installed" forcing as the previous test — but with --yes,
     // the bridge must NOT return INSTALL_CONFIRMATION_REQUIRED.
-    const r = runOutcome(["setup", "--yes"], {
+    const r = runOutcome(["setup", "--yes", "--install-timeout", "1"], {
       ...env,
       OPENLOOMI_BIN: "/nonexistent-ctl-please-ignore",
       OPENLOOMI_HOME: "/nonexistent-home",
@@ -1102,6 +1130,16 @@ test("setup with --yes proceeds past the install step (not INSTALL_CONFIRMATION_
       j.nextAction,
       "confirm_install_openloomi",
       "setup --yes must not stop at the confirm-install gate",
+    );
+    assert.notEqual(
+      j.nextAction,
+      "run_host_probe",
+      "setup --yes in a fresh env must proceed toward install, not host probe",
+    );
+    assert.notEqual(
+      j.reason,
+      "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE",
+      "setup --yes must not classify a fresh install as loopback ambiguity",
     );
     // When steps[] is present (install got far enough to record an entry),
     // it should contain an install attempt.
@@ -1211,78 +1249,64 @@ test("setup --max-wait, --api-timeout, --permission-timeout, --bin-path flow int
   assert.equal(j.stages.apiMs, 7000);
   assert.equal(j.stages.permissionMs, 4000);
   assert.equal(j.stages.launchMs, 9000);
-  assert.equal(j.stages.installMs, 90000);
+  assert.equal(j.stages.installMs, 8000);
 });
 
 test("waitForApi reports API_NOT_READY when the desktop process is not running", () => {
-  const j = runJson(["__test-wait-for-api", "--api-timeout", "200"]);
-  assert.equal(j.ok, false);
-  assert.equal(j.code, "API_NOT_READY");
-  assert.equal(j.stage, "wait_api");
-  assert.equal(j.permissionLikely, false);
+  withFakeHome((env) => {
+    const j = runJson(["__test-wait-for-api", "--api-timeout", "200"], env);
+    assert.equal(j.ok, false);
+    assert.equal(j.code, "API_NOT_READY");
+    assert.equal(j.stage, "wait_api");
+    assert.equal(j.permissionLikely, false);
+  });
 });
 
 test("waitForApi reports PERMISSION_PROMPT_LIKELY when the probe signals a permission block", () => {
-  const j = runJson([
-    "__test-wait-for-api",
-    "--api-timeout",
-    "200",
-    "--permission-likely",
-  ]);
-  assert.equal(j.ok, false);
-  assert.equal(j.code, "PERMISSION_PROMPT_LIKELY");
-  assert.equal(j.permissionLikely, true);
-  assert.equal(j.stage, "wait_api");
+  withFakeHome((env) => {
+    const j = runJson(
+      ["__test-wait-for-api", "--api-timeout", "200", "--permission-likely"],
+      env,
+    );
+    assert.equal(j.ok, false);
+    assert.equal(j.code, "PERMISSION_PROMPT_LIKELY");
+    assert.equal(j.permissionLikely, true);
+    assert.equal(j.stage, "wait_api");
+  });
 });
 
 test("setup-status accepts --bin-path as a discovery override", () => {
   withFakeHome((env) => {
-    // Pointing --bin-path at a non-existent path must surface
-    // OPENLOOMI_APP_INVALID rather than silently falling through to PATH.
+    // In a clean fake HOME, a missing --bin-path should still hit install
+    // state before loopback ambiguity can ask for a host probe.
     const j = runJson(["setup-status", "--bin-path", "/nonexistent.app"], env);
     assert.equal(j.installed, false);
     assert.equal(j.nextAction, "install_openloomi");
+    assert.equal(j.reason, "INSTALL_REQUIRED");
   });
 });
 
 test("setup --api-timeout flows into the recorded wait_api step", () => {
   withFakeHome((env) => {
+    const ctl = writeFakeApp(env.HOME);
     const r = runOutcome(
-      [
-        "setup",
-        "--yes",
-        "--api-timeout",
-        "100",
-        "--permission-timeout",
-        "0",
-      ],
+      ["setup", "--yes", "--api-timeout", "100", "--permission-timeout", "1"],
       {
         ...env,
-        OPENLOOMI_BIN: "/nonexistent-ctl-please-ignore",
-        OPENLOOMI_HOME: "/nonexistent-home",
-        OPENLOOMI_REPO_DIR: "/nonexistent-repo",
-        PATH: dirname(process.execPath),
+        OPENLOOMI_APP: ctl,
+        OPENLOOMI_AGENT_PROVIDER: "codex",
+        OPENLOOMI_TEST_FORCE_APP_RUNNING: "1",
       },
     );
     const j = JSON.parse(r.stdout);
-    // We don't care which exact stop the wizard lands on; only that the
-    // explicit --api-timeout value reached the bridge. The wait_api step
-    // and the effectiveBudgetMs are the two ways it can be observed.
-    if (Array.isArray(j.steps)) {
-      const wait = j.steps.find((s) => s.step === "wait_api");
-      if (wait) {
-        assert.ok(
-          typeof wait.elapsedMs === "number",
-          "wait_api step should record elapsedMs",
-        );
-      }
-    }
-    if (j.setup === "api_not_ready") {
-      assert.equal(typeof j.effectiveBudgetMs, "number");
-      assert.ok(j.effectiveBudgetMs >= 100);
-      assert.ok(j.canResume);
-      assert.match(j.resumeCommand, /setup/);
-    }
+    assert.equal(j.setup, "api_not_ready");
+    const wait = j.steps.find((s) => s.step === "wait_api");
+    assert.ok(wait, "setup should record a wait_api step");
+    assert.equal(typeof wait.elapsedMs, "number");
+    assert.equal(typeof j.effectiveBudgetMs, "number");
+    assert.ok(j.effectiveBudgetMs >= 100);
+    assert.ok(j.canResume);
+    assert.match(j.resumeCommand, /setup/);
   });
 });
 
@@ -1891,6 +1915,43 @@ test("__test-windows-image-name appends .exe only when missing", () => {
   ]);
   assert.equal(j.binName, "openloomi");
   assert.equal(j.imageName, "openloomi.exe");
+});
+
+test("Windows install helper parses under Windows PowerShell 5.1", () => {
+  if (process.platform !== "win32") return;
+
+  const scriptPath = join(
+    PLUGIN_DIR,
+    "scripts",
+    "install-assets",
+    "setup.windows.ps1",
+  );
+  const check = [
+    "$tokens = $null",
+    "$errors = $null",
+    `[System.Management.Automation.Language.Parser]::ParseFile("${scriptPath.replace(/"/g, '""')}", [ref]$tokens, [ref]$errors) | Out-Null`,
+    "if ($errors -and $errors.Count -gt 0) {",
+    "  $errors | ForEach-Object { Write-Error $_.Message }",
+    "  exit 1",
+    "}",
+  ].join("; ");
+
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-Command", check],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+      },
+    },
+  );
+
+  assert.equal(
+    result.status,
+    0,
+    `PowerShell parse check failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
 });
 
 test("__test-launch-desktop rejects no appPath with NO_LAUNCH_TARGET", () => {


### PR DESCRIPTION
Fixes #478

## Core Cause

In a fresh environment where OpenLoomi is not installed and the local API is not listening on 3414/3515, the Codex bridge marked loopback probing as ambiguous.

That ambiguity was checked before installation discovery in `getReadinessDecision()`. As a result, `setup --yes` returned:

- `nextAction: run_host_probe`
- `reason: OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE`
- `status.installed: false`

This blocked the one-call setup flow before any installation attempt was recorded.

The root cause is a deterministic state-machine priority bug, not a skill/prompt issue. The bridge itself returned the wrong `nextAction`; the model only consumed that incorrect bridge output.

## Changes

- Prioritize invalid/source/install discovery states before loopback ambiguity in Codex bridge readiness decisions.
- Ensure fresh `installed=false` environments return `install_openloomi` / `INSTALL_REQUIRED` instead of `run_host_probe`.
- Add regression coverage so fresh setup cannot be intercepted by stale loopback ambiguity again.
- Fix Windows install helper compatibility:
  - remove mojibake/special characters that broke PowerShell parsing
  - replace PowerShell 7-only `?.Source` with Windows PowerShell 5.1-compatible logic
  - emit install record JSON via `ConvertTo-Json`
- Include bounded installer stdout/stderr tails in bridge summaries to make installer failures diagnosable.

## Validation

### Unit Tests

```powershell
node --test plugins\codex\tests\bridge.test.mjs
```

Result:

- 63 tests passed
- 0 failed

### Issue #478 Reproduction Flow

Used a clean/fake home without OpenLoomi install markers or host-probe cache, with no OpenLoomi API listening on ports 3414/3515.

Before fix:

```json
{
  "setup": "awaiting_user_action",
  "nextAction": "run_host_probe",
  "reason": "OPENLOOMI_API_AMBIGUOUS_HOST_PROBE_STALE",
  "status": {
    "installed": false
  }
}
```

After fix, `setup-status` correctly reports:

```json
{
  "installed": false,
  "nextAction": "install_openloomi",
  "reason": "INSTALL_REQUIRED"
}
```

Running `setup --yes` now proceeds into the install step instead of stopping at `run_host_probe`.

Final real-environment `setup-status` reached:

```json
{
  "installed": true,
  "apiReachable": true,
  "nativeRuntimeActive": true,
  "nativeRuntimeProvider": "codex",
  "ready": true,
  "reason": "READY"
}
```