### PR TITLE
feat(skills): add OpenLoomi skill-only distribution entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ OpenLoomi ships official marketplace plugins that turn your existing agent into 
 
 The slim public marketplace lives at [`melandlabs/plugins`](https://github.com/melandlabs/plugins) so adding it only fetches the plugin payloads. See the plugin docs for full reference: [`plugins/claude`](https://openloomi.ai/docs/plugins/claude) · [`plugins/codex`](https://openloomi.ai/docs/plugins/codex).
 
-**Use in skill-only agent runtimes** (for WorkBuddy and other agents that
-support Skills but do not support OpenLoomi plugins):
+**Use in skill-only agent runtimes**:
 
 Install the OpenLoomi skill set directly from this repository:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ OpenLoomi ships official marketplace plugins that turn your existing agent into 
 
 The slim public marketplace lives at [`melandlabs/plugins`](https://github.com/melandlabs/plugins) so adding it only fetches the plugin payloads. See the plugin docs for full reference: [`plugins/claude`](https://openloomi.ai/docs/plugins/claude) · [`plugins/codex`](https://openloomi.ai/docs/plugins/codex).
 
+**Use in skill-only agent runtimes** (for WorkBuddy and other agents that
+support Skills but do not support OpenLoomi plugins):
+
+Install the OpenLoomi skill set directly from this repository:
+
+```bash
+npx skills add https://github.com/melandlabs/openloomi/tree/main/skills \
+  --skill openloomi openloomi-setup openloomi-memory openloomi-connectors openloomi-loop openloomi-api openloomi-feature-guide composio \
+  -y
+```
+
+Start with the `openloomi` or `openloomi-setup` skill. The first setup pass
+checks whether OpenLoomi Desktop is installed, whether the local API is
+reachable, and whether a local session token is available. If OpenLoomi
+Desktop is missing, the skill points the user to the official Getting Started
+guide and release downloads before continuing.
+
 **Develop locally** (for developers):
 
 ```bash

--- a/skills/openloomi-api/SKILL.md
+++ b/skills/openloomi-api/SKILL.md
@@ -3,7 +3,7 @@ name: openloomi-api
 description: "openloomi HTTP API reference (local-first, served from the OpenLoomi Desktop app at http://localhost:3414). Use when working with openloomi backend routes — auth, AI, files, integrations, RAG, memory, Loop, pet, workspace, platform callbacks. Triggers: API endpoints, backend routes, /api/*, local API, port 3414, integrations REST, OAuth start, RAG search, loop state, memory search, pet state, audit logs"
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+> **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).
 
 # OpenLoomi API Documentation
 

--- a/skills/openloomi-connectors/SKILL.md
+++ b/skills/openloomi-connectors/SKILL.md
@@ -6,7 +6,7 @@ metadata:
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+> **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).
 
 # OpenLoomi Connectors Skill
 

--- a/skills/openloomi-feature-guide/SKILL.md
+++ b/skills/openloomi-feature-guide/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   version: 0.8.8
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+> **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).
 
 # OpenLoomi Product Features
 

--- a/skills/openloomi-loop/SKILL.md
+++ b/skills/openloomi-loop/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   version: 0.8.8
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+> **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).
 
 # OpenLoomi Loop — The Proactive Execution Brain
 

--- a/skills/openloomi-memory/SKILL.md
+++ b/skills/openloomi-memory/SKILL.md
@@ -6,7 +6,7 @@ metadata:
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-memory.cjs *)
 ---
 
-> **Note:** If you haven't downloaded or installed openloomi yet, please refer to [Getting Started](https://openloomi.ai/docs/getting-started) for installation instructions.
+> **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).
 
 # OpenLoomi Memory Skill
 

--- a/skills/openloomi-setup/SKILL.md
+++ b/skills/openloomi-setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: openloomi-setup
 description: "OpenLoomi first-use setup and readiness guidance for skill-only agent runtimes. Use when OpenLoomi is not yet installed, the local API is not reachable, the session/token is missing, or the user needs a manual install and launch walkthrough before using OpenLoomi skills."
+allowed-tools: "Bash(node $SKILL_DIR/scripts/openloomi-setup.cjs *)"
 ---
 
 # OpenLoomi Setup
@@ -49,4 +50,3 @@ If the desktop app is missing, direct the user to:
 
 - `https://openloomi.ai/docs/getting-started`
 - `https://github.com/melandlabs/openloomi/releases`
-

--- a/skills/openloomi-setup/SKILL.md
+++ b/skills/openloomi-setup/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: openloomi-setup
+description: "OpenLoomi first-use setup and readiness guidance for skill-only agent runtimes. Use when OpenLoomi is not yet installed, the local API is not reachable, the session/token is missing, or the user needs a manual install and launch walkthrough before using OpenLoomi skills."
+---
+
+# OpenLoomi Setup
+
+Use this skill first when OpenLoomi readiness is unknown.
+
+Keep it lightweight and manual-first:
+
+- If OpenLoomi Desktop is not installed, point the user to the official
+  Getting Started docs.
+- If the desktop app is installed but not running, tell the user to open it.
+- If the local API is not reachable, ask the user to retry after launch.
+- If the token/session is missing, ask the user to complete sign-in or guest
+  session setup inside OpenLoomi.
+
+## Check Readiness
+
+Run the bundled status script when you need a quick local check:
+
+```bash
+node "$SKILL_DIR/scripts/openloomi-setup.cjs" status
+```
+
+The script reports:
+
+- whether OpenLoomi Desktop looks installed
+- whether the local API responds on `3414` or `3515`
+- whether `~/.openloomi/token` exists
+- what the next manual step should be
+
+## Output Contract
+
+Treat `ready: true` as the handoff point to the other OpenLoomi skills:
+
+- `openloomi-memory`
+- `openloomi-connectors`
+- `openloomi-loop`
+- `openloomi-api`
+
+If `ready` is false, surface the returned `nextAction` and the official
+Getting Started link instead of guessing.
+
+## Official Install Path
+
+If the desktop app is missing, direct the user to:
+
+- `https://openloomi.ai/docs/getting-started`
+- `https://github.com/melandlabs/openloomi/releases`
+

--- a/skills/openloomi-setup/scripts/openloomi-setup.cjs
+++ b/skills/openloomi-setup/scripts/openloomi-setup.cjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+const PORTS = [3414, 3515];
+const TOKEN_PATH = path.join(os.homedir(), '.openloomi', 'token');
+const OFFICIAL_SETUP_URL = 'https://openloomi.ai/docs/getting-started';
+const OFFICIAL_RELEASES_URL = 'https://github.com/melandlabs/openloomi/releases';
+const REQUEST_TIMEOUT_MS = 1500;
+
+function fileExists(targetPath) {
+  try {
+    return fs.existsSync(targetPath);
+  } catch {
+    return false;
+  }
+}
+
+function firstExisting(paths) {
+  return paths.find((candidate) => candidate && fileExists(candidate)) || null;
+}
+
+function gatherInstallCandidates() {
+  const candidates = new Set();
+  const home = os.homedir();
+  const add = (...items) => {
+    for (const item of items.flat()) {
+      if (item) candidates.add(path.normalize(item));
+    }
+  };
+
+  add(process.env.OPENLOOMI_APP, process.env.OPENLOOMI_BIN);
+
+  if (process.env.OPENLOOMI_INSTALL_DIR) {
+    const installDir = path.normalize(process.env.OPENLOOMI_INSTALL_DIR);
+    add(
+      installDir,
+      path.join(installDir, 'OpenLoomi.app'),
+      path.join(installDir, 'openloomi.exe'),
+      path.join(installDir, 'openloomi'),
+      path.join(installDir, 'Contents', 'MacOS', 'OpenLoomi'),
+    );
+  }
+
+  if (process.platform === 'darwin') {
+    add(
+      '/Applications/OpenLoomi.app',
+      path.join(home, 'Applications', 'OpenLoomi.app'),
+      path.join(home, 'Applications', 'OpenLoomi.app', 'Contents', 'MacOS', 'OpenLoomi'),
+    );
+  } else if (process.platform === 'win32') {
+    add(
+      path.join(process.env.ProgramFiles || 'C:\\Program Files', 'OpenLoomi', 'OpenLoomi.exe'),
+      path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'OpenLoomi', 'OpenLoomi.exe'),
+      path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'Programs', 'OpenLoomi', 'OpenLoomi.exe'),
+      path.join(home, 'AppData', 'Local', 'OpenLoomi', 'OpenLoomi.exe'),
+    );
+  } else {
+    add(
+      '/opt/OpenLoomi/openloomi',
+      '/usr/bin/openloomi',
+      '/usr/local/bin/openloomi',
+      path.join(home, '.local', 'bin', 'openloomi'),
+      path.join(home, '.local', 'share', 'OpenLoomi', 'openloomi'),
+    );
+  }
+
+  return [...candidates];
+}
+
+function detectInstalled() {
+  const candidates = gatherInstallCandidates();
+  const installedPath = firstExisting(candidates);
+  return {
+    installed: Boolean(installedPath),
+    installedPath,
+    candidates,
+  };
+}
+
+function readToken() {
+  const envToken = (process.env.OPENLOOMI_AUTH_TOKEN || '').trim();
+  if (envToken) {
+    return { tokenPresent: true, tokenSource: 'env', tokenPath: null };
+  }
+
+  try {
+    if (!fs.existsSync(TOKEN_PATH)) {
+      return { tokenPresent: false, tokenSource: null, tokenPath: TOKEN_PATH };
+    }
+    const encoded = fs.readFileSync(TOKEN_PATH, 'utf8').trim();
+    if (!encoded) {
+      return { tokenPresent: false, tokenSource: 'file-empty', tokenPath: TOKEN_PATH };
+    }
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8').trim();
+    return {
+      tokenPresent: Boolean(decoded),
+      tokenSource: decoded ? 'file' : 'file-invalid',
+      tokenPath: TOKEN_PATH,
+    };
+  } catch {
+    return { tokenPresent: false, tokenSource: 'file-error', tokenPath: TOKEN_PATH };
+  }
+}
+
+function probeOnce(baseUrl, endpoint) {
+  return new Promise((resolve) => {
+    const url = new URL(endpoint, baseUrl);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: 'GET',
+        timeout: REQUEST_TIMEOUT_MS,
+        headers: { 'Accept': 'application/json, text/plain, */*' },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => {
+          resolve({
+            baseUrl,
+            endpoint,
+            reachable: true,
+            status: res.statusCode,
+            note: res.statusCode >= 200 && res.statusCode < 500 ? 'http-response' : 'unexpected-status',
+          });
+        });
+      },
+    );
+
+    req.on('timeout', () => {
+      req.destroy(new Error('timeout'));
+    });
+    req.on('error', (error) => {
+      resolve({
+        baseUrl,
+        endpoint,
+        reachable: false,
+        status: null,
+        note: error.code || error.message || 'network-error',
+      });
+    });
+    req.end();
+  });
+}
+
+async function probeApi() {
+  const bases = [];
+  if (process.env.OPENLOOMI_API_URL) bases.push(process.env.OPENLOOMI_API_URL);
+  bases.push(...PORTS.map((port) => `http://127.0.0.1:${port}`));
+
+  const attempts = [];
+  for (const baseUrl of bases) {
+    for (const endpoint of ['/api/native/providers', '/api/remote-auth/user', '/']) {
+      // Stop at the first reachable response for a given base.
+      // Keep the individual attempts for debugging and UX hints.
+      // eslint-disable-next-line no-await-in-loop
+      const attempt = await probeOnce(baseUrl, endpoint);
+      attempts.push(attempt);
+      if (attempt.reachable) {
+        return {
+          apiReachable: true,
+          apiBaseUrl: baseUrl,
+          apiProbe: attempts,
+        };
+      }
+    }
+  }
+
+  return {
+    apiReachable: false,
+    apiBaseUrl: null,
+    apiProbe: attempts,
+  };
+}
+
+function deriveNextAction({ installed, apiReachable, tokenPresent }) {
+  if (apiReachable && tokenPresent) return null;
+  if (!apiReachable && !installed) return 'install_openloomi';
+  if (!apiReachable) return 'open_openloomi';
+  if (!tokenPresent) return 'finish_session';
+  return null;
+}
+
+function buildHints(state) {
+  const hints = [];
+  if (state.ready) {
+    hints.push('OpenLoomi is ready. Continue with memory, connectors, Loop, or API skills.');
+    return hints;
+  }
+
+  if (!state.installed) {
+    hints.push(`Install OpenLoomi from ${OFFICIAL_SETUP_URL}`);
+    hints.push(`Official releases: ${OFFICIAL_RELEASES_URL}`);
+    return hints;
+  }
+
+  if (!state.apiReachable) {
+    hints.push('Open OpenLoomi Desktop and wait for the local API to start.');
+    hints.push('If the app is already open, retry after a short pause.');
+  }
+
+  if (!state.tokenPresent) {
+    hints.push('Complete sign-in or guest session setup inside OpenLoomi Desktop.');
+  }
+
+  return hints;
+}
+
+async function status() {
+  const installed = detectInstalled();
+  const token = readToken();
+  const api = await probeApi();
+
+  const ready = api.apiReachable && token.tokenPresent;
+  const nextAction = deriveNextAction({
+    installed: installed.installed,
+    apiReachable: api.apiReachable,
+    tokenPresent: token.tokenPresent,
+  });
+
+  const result = {
+    ready,
+    installed: installed.installed,
+    installedPath: installed.installedPath,
+    tokenPresent: token.tokenPresent,
+    tokenSource: token.tokenSource,
+    tokenPath: token.tokenPath,
+    apiReachable: api.apiReachable,
+    apiBaseUrl: api.apiBaseUrl,
+    apiProbe: api.apiProbe,
+    nextAction,
+    officialSetupUrl: OFFICIAL_SETUP_URL,
+    officialReleasesUrl: OFFICIAL_RELEASES_URL,
+  };
+
+  result.hints = buildHints(result);
+  return result;
+}
+
+async function main() {
+  const [command = 'status'] = process.argv.slice(2);
+
+  if (command === '-h' || command === '--help' || command === 'help') {
+    process.stdout.write([
+      'Usage: openloomi-setup <status>',
+      '',
+      'Commands:',
+      '  status   Print OpenLoomi readiness as JSON',
+    ].join('\n'));
+    return;
+  }
+
+  if (command !== 'status' && command !== 'setup-status' && command !== 'check') {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  const result = await status();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message || String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/skills/openloomi/SKILL.md
+++ b/skills/openloomi/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: openloomi
+description: "OpenLoomi entrypoint for skill-only agent runtimes without a plugin mechanism. Use when the user mentions OpenLoomi or Loomi, wants first-use setup guidance, wants to use local OpenLoomi memory, connectors, Loop, knowledge base, RAG search, or asks how to install OpenLoomi skills in runtimes such as WorkBuddy or other skill-capable agents."
+---
+
+# OpenLoomi Skills Entrypoint
+
+Use this skill as the front door for OpenLoomi in agents that can load
+skills but do not support OpenLoomi plugins.
+
+OpenLoomi remains the runtime owner. The desktop app owns memory storage,
+connector credentials, Loop execution, model/provider settings, local API
+routes, and secret handling. Skills only explain how to route work into that
+local runtime.
+
+## First Step
+
+When readiness is unknown, start with `openloomi-setup`. It guides the user
+through installing or opening OpenLoomi Desktop, confirming the local API, and
+finishing the session/token setup. Do not ask the user to paste API keys,
+OAuth tokens, connector secrets, or OpenLoomi auth tokens into chat.
+
+## Route Requests
+
+Use the narrow OpenLoomi skill that matches the task:
+
+| User intent | Use |
+| --- | --- |
+| First-use setup, install guidance, readiness checks | `openloomi-setup` |
+| Search memory, knowledge base, documents, insights | `openloomi-memory` |
+| Connect platforms, list accounts, check connector status, send replies | `openloomi-connectors` |
+| Use third-party OAuth apps such as Slack, Gmail, GitHub, Notion, Linear, or Jira | `composio`, paired with `openloomi-connectors` |
+| Inspect Loop state, run a tick, manage decisions, preferences, channels, or rules | `openloomi-loop` |
+| Answer backend route, local API, auth, RAG, integrations, or workspace questions | `openloomi-api` |
+| Explain OpenLoomi concepts, product capabilities, or user workflows | `openloomi-feature-guide` |
+
+## Boundaries
+
+- Do not depend on Codex or Claude plugin files.
+- Do not call plugin bridge scripts such as `loomi-bridge.mjs`.
+- Do not duplicate OpenLoomi business logic inside the agent.
+- Do not invent connector behavior. Use the connector and Composio skills for
+  platform-specific flows.
+- If OpenLoomi Desktop is missing or the local API is unavailable, use
+  `openloomi-setup` to provide official installation and recovery guidance.
+

--- a/skills/openloomi/SKILL.md
+++ b/skills/openloomi/SKILL.md
@@ -34,6 +34,25 @@ Use the narrow OpenLoomi skill that matches the task:
 | Answer backend route, local API, auth, RAG, integrations, or workspace questions | `openloomi-api` |
 | Explain OpenLoomi concepts, product capabilities, or user workflows | `openloomi-feature-guide` |
 
+## Common Flows
+
+Use these examples to route common requests without reimplementing OpenLoomi
+logic in the agent:
+
+- Search memory: start with `openloomi-setup` if readiness is unknown, then
+  use `openloomi-memory` to search memory, knowledge base documents, or
+  insights.
+- Post to Slack: start with `openloomi-setup`, use `openloomi-connectors` to
+  check connector/account readiness, then use `composio` for the
+  OAuth-backed Slack action when the user asks to send or post.
+- Draft an email: start with `openloomi-setup`, use `openloomi-memory` for
+  relevant context, then use `composio` or connector guidance for the mail
+  surface the user has authorized.
+- Summarize a Notion page: start with `openloomi-setup`, use `composio` for
+  the authorized Notion access path, then hand useful context to
+  `openloomi-memory` or `openloomi-api` when the user wants it saved,
+  searched, or grounded in the local knowledge base.
+
 ## Boundaries
 
 - Do not depend on Codex or Claude plugin files.
@@ -43,4 +62,3 @@ Use the narrow OpenLoomi skill that matches the task:
   platform-specific flows.
 - If OpenLoomi Desktop is missing or the local API is unavailable, use
   `openloomi-setup` to provide official installation and recovery guidance.
-


### PR DESCRIPTION
**Summary**

This PR implements the Skill-only distribution path for issue #321, targeting agent runtimes such as WorkBuddy that support Skills but do not support OpenLoomi plugins.

The design reuses the existing `skills/openloomi-*` capabilities. It adds a lightweight entrypoint skill and a manual-first setup/readiness skill so users can install the OpenLoomi skill set with `npx skills add`, import it into a skill-capable runtime, and route requests into the local OpenLoomi Desktop runtime.

**Changes**

- Added `skills/openloomi` as the Skill-only entrypoint and routing guide.
- Added `skills/openloomi-setup` for first-use setup and readiness checks.
- Added `skills/openloomi-setup/scripts/openloomi-setup.cjs`, a self-contained Node readiness script.
- Added lightweight readiness notes to existing OpenLoomi skills:
  - `openloomi-memory`
  - `openloomi-connectors`
  - `openloomi-loop`
  - `openloomi-api`
  - `openloomi-feature-guide`
- Documented the Skill-only install path in `README.md`.

**User Flow**

After this PR is merged, users can pull the OpenLoomi skill set directly from the official repository:

```powershell
npx skills add https://github.com/melandlabs/openloomi/tree/main/skills `
  --skill openloomi openloomi-setup openloomi-memory openloomi-connectors openloomi-loop openloomi-api openloomi-feature-guide composio `
  -y
```

The Skills CLI installs the selected OpenLoomi skills into the default `.agents/skills` location for the current environment, typically `C:\Users\<user>\.agents\skills` on Windows for user-level installs. Users can then import that generated skill folder, or a zip of those folders, into WorkBuddy.

On first use, users start with `openloomi` or `openloomi-setup`. The setup skill checks whether OpenLoomi Desktop is installed, whether the local API is reachable, and whether a local session token exists. If Desktop is missing, it points the user to the official install path. Once ready, requests route to the existing focused skills for memory, connectors, Loop, API, and feature guidance.

**Testing**

- Imported the generated universal skill bundle into WorkBuddy.
- Verified the setup readiness flow against local OpenLoomi Desktop.
- Smoke-tested core skill-side flows in WorkBuddy, including memory search, connector listing/status, and Loop state / pending decision guidance.