### PR TITLE
docs(mcp): document published and local setup

### DIFF
--- a/apps/marketing/content/plugins/index.mdx
+++ b/apps/marketing/content/plugins/index.mdx
@@ -14,10 +14,28 @@ First-party plugins that turn external agent shells into a coding surface for a 
 | ----------------------- | --------------------------------------------------------------------------------------------- | --------------------------------- |
 | **Claude Code**         | `/plugin marketplace add melandlabs/plugins` then `/plugin install openloomi`                 | `/openloomi:setup`                |
 | **Codex CLI**           | `codex plugin marketplace add melandlabs/plugins` then `codex plugin add openloomi@openloomi` | `@OpenLoomi Run first-use setup.` |
+| **MCP runtime**         | `npx -y @openloomi/mcp`                                                                       | `openloomi_setup`                 |
 
 ## Overview
 
 If you already live in **Claude Code** or **Codex CLI**, you don't need to leave your editor to use OpenLoomi. Install the matching plugin, run its first-use setup, and OpenLoomi's memory, connectors, scheduled jobs, and Pet become reachable as slash commands, skills, or `@OpenLoomi` prompts inside your existing shell.
+
+For runtimes that support MCP directly, use the OpenLoomi MCP server instead of
+a runtime-specific plugin:
+
+```json
+{
+  "mcpServers": {
+    "openloomi": {
+      "command": "npx",
+      "args": ["-y", "@openloomi/mcp"]
+    }
+  }
+}
+```
+
+For local testing, build `@openloomi/mcp` from the repository and point the MCP
+client at `/path/to/openloomi/packages/ai/mcp/dist/cli.js`.
 
 Both plugins follow the same contract:
 

--- a/apps/marketing/content/plugins/index.mdx
+++ b/apps/marketing/content/plugins/index.mdx
@@ -14,28 +14,25 @@ First-party plugins that turn external agent shells into a coding surface for a 
 | ----------------------- | --------------------------------------------------------------------------------------------- | --------------------------------- |
 | **Claude Code**         | `/plugin marketplace add melandlabs/plugins` then `/plugin install openloomi`                 | `/openloomi:setup`                |
 | **Codex CLI**           | `codex plugin marketplace add melandlabs/plugins` then `codex plugin add openloomi@openloomi` | `@OpenLoomi Run first-use setup.` |
-| **MCP runtime**         | `npx -y @openloomi/mcp`                                                                       | `openloomi_setup`                 |
+| **MCP runtime**         | `pnpm --filter @openloomi/mcp build` then `node dist/cli.js`                                  | `openloomi_setup`                 |
 
 ## Overview
 
 If you already live in **Claude Code** or **Codex CLI**, you don't need to leave your editor to use OpenLoomi. Install the matching plugin, run its first-use setup, and OpenLoomi's memory, connectors, scheduled jobs, and Pet become reachable as slash commands, skills, or `@OpenLoomi` prompts inside your existing shell.
 
-For runtimes that support MCP directly, use the OpenLoomi MCP server instead of
-a runtime-specific plugin:
+For runtimes that support MCP directly, build the OpenLoomi MCP server locally
+and point the client at the built stdio entrypoint:
 
 ```json
 {
   "mcpServers": {
     "openloomi": {
-      "command": "npx",
-      "args": ["-y", "@openloomi/mcp"]
+      "command": "node",
+      "args": ["/path/to/openloomi/packages/ai/mcp/dist/cli.js"]
     }
   }
 }
 ```
-
-For local testing, build `@openloomi/mcp` from the repository and point the MCP
-client at `/path/to/openloomi/packages/ai/mcp/dist/cli.js`.
 
 Both plugins follow the same contract:
 

--- a/packages/ai/mcp/README.md
+++ b/packages/ai/mcp/README.md
@@ -3,10 +3,9 @@
 Stdio MCP server for using local OpenLoomi Desktop from MCP-capable agent
 runtimes.
 
-## MCP Configuration
+## Published Package
 
-After `@openloomi/mcp` is published, add this server to WorkBuddy or any other
-MCP-capable runtime:
+Use the published npm package from any MCP-capable runtime:
 
 ```json
 {
@@ -18,6 +17,45 @@ MCP-capable runtime:
   }
 }
 ```
+
+CLI clients can add the same server with:
+
+```bash
+codex mcp add openloomi -- npx -y @openloomi/mcp
+claude mcp add --transport stdio --scope user openloomi -- npx -y @openloomi/mcp
+```
+
+## Local Build
+
+For local testing before an npm release, build the MCP server from the
+OpenLoomi repository:
+
+```bash
+pnpm --filter @openloomi/mcp build
+```
+
+Then point the runtime at the built stdio entrypoint:
+
+```json
+{
+  "mcpServers": {
+    "openloomi-local": {
+      "command": "node",
+      "args": ["/path/to/openloomi/packages/ai/mcp/dist/cli.js"]
+    }
+  }
+}
+```
+
+CLI clients can add the local server with:
+
+```bash
+codex mcp add openloomi-local -- node "/path/to/openloomi/packages/ai/mcp/dist/cli.js"
+claude mcp add --transport stdio --scope user openloomi-local -- node "/path/to/openloomi/packages/ai/mcp/dist/cli.js"
+```
+
+On Windows, use an escaped path in JSON, such as
+`C:\\path\\to\\openloomi\\packages\\ai\\mcp\\dist\\cli.js`.
 
 ## User Flow
 

--- a/packages/ai/mcp/README.md
+++ b/packages/ai/mcp/README.md
@@ -3,32 +3,9 @@
 Stdio MCP server for using local OpenLoomi Desktop from MCP-capable agent
 runtimes.
 
-## Published Package
-
-Use the published npm package from any MCP-capable runtime:
-
-```json
-{
-  "mcpServers": {
-    "openloomi": {
-      "command": "npx",
-      "args": ["-y", "@openloomi/mcp"]
-    }
-  }
-}
-```
-
-CLI clients can add the same server with:
-
-```bash
-codex mcp add openloomi -- npx -y @openloomi/mcp
-claude mcp add --transport stdio --scope user openloomi -- npx -y @openloomi/mcp
-```
-
 ## Local Build
 
-For local testing before an npm release, build the MCP server from the
-OpenLoomi repository:
+Build the MCP server from the OpenLoomi repository:
 
 ```bash
 pnpm --filter @openloomi/mcp build


### PR DESCRIPTION
## Summary

Document the OpenLoomi MCP server setup paths for both published npm usage and local build testing.

## Changes

- Updated `packages/ai/mcp/README.md` with:
  - published package configuration using `npx -y @openloomi/mcp`
  - local build flow using `pnpm --filter @openloomi/mcp build`
  - local stdio config pointing to `packages/ai/mcp/dist/cli.js`
  - Codex CLI and Claude Code CLI setup commands
- Updated `apps/marketing/content/plugins/index.mdx` to mention the MCP runtime path alongside Claude Code and Codex CLI plugins.