### PR TITLE
fix: send local image uploads to agents as base64

### DIFF
--- a/apps/web/components/agent/chat-panel.tsx
+++ b/apps/web/components/agent/chat-panel.tsx
@@ -569,9 +569,14 @@ export function AgentChatPanel({
                 onSubmit={async ({ text, attachments: submitAttachments }) => {
                   type UploadingAttachment = Attachment & {
                     isUploading?: boolean;
+                    file?: File;
                   };
                   const supportedAttachments = submitAttachments.filter(
-                    (att: UploadingAttachment) => att.url && !att.isUploading,
+                    (att: UploadingAttachment) =>
+                      !att.isUploading &&
+                      Boolean(
+                        att.file || att.url || att.downloadUrl || att.blobPath,
+                      ),
                   );
 
                   const messageObj = {
@@ -586,11 +591,6 @@ export function AgentChatPanel({
                         blobPath: attachment.blobPath,
                         downloadUrl: attachment.downloadUrl,
                         file: (attachment as Attachment & { file?: File }).file,
-                        serverImageTUSUrl: (
-                          attachment as Attachment & {
-                            serverImageTUSUrl?: string;
-                          }
-                        ).serverImageTUSUrl,
                       })),
                       {
                         type: "text" as const,

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -343,6 +343,180 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
     return mediaType?.startsWith("image/") ?? false;
   }
 
+  type ImageMessagePart = {
+    name?: unknown;
+    mediaType?: unknown;
+    file?: unknown;
+    downloadUrl?: unknown;
+    url?: unknown;
+    blobPath?: unknown;
+  };
+
+  function isBrowserFile(value: unknown): value is File {
+    return typeof File !== "undefined" && value instanceof File;
+  }
+
+  function normalizeImageMimeType(
+    value: unknown,
+    fallback = "image/png",
+  ): string {
+    return typeof value === "string" && value.startsWith("image/")
+      ? value
+      : fallback;
+  }
+
+  function base64FromDataUrl(dataUrl: string): string | undefined {
+    const commaIndex = dataUrl.indexOf(",");
+    if (commaIndex === -1) return undefined;
+    const data = dataUrl.slice(commaIndex + 1);
+    return data.length > 0 ? data : undefined;
+  }
+
+  function mimeTypeFromDataUrl(dataUrl: string): string | undefined {
+    const match = dataUrl.match(/^data:([^;,]+)[;,]/);
+    return match?.[1]?.startsWith("image/") ? match[1] : undefined;
+  }
+
+  async function readBlobAsBase64(blob: Blob): Promise<string | undefined> {
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        if (typeof reader.result === "string") {
+          resolve(reader.result);
+          return;
+        }
+        reject(new Error("Failed to read image data"));
+      };
+      reader.onerror = () =>
+        reject(reader.error ?? new Error("Failed to read image data"));
+      reader.readAsDataURL(blob);
+    });
+
+    return base64FromDataUrl(dataUrl);
+  }
+
+  function localDownloadUrlFromBlobPath(blobPath: unknown): string | undefined {
+    if (typeof blobPath !== "string") return undefined;
+    const trimmed = blobPath.trim();
+    if (!trimmed) return undefined;
+    if (
+      trimmed.startsWith("http://") ||
+      trimmed.startsWith("https://") ||
+      trimmed.startsWith("/")
+    ) {
+      return trimmed;
+    }
+    return `/api/files/download?path=${encodeURIComponent(trimmed)}`;
+  }
+
+  function stringSource(value: unknown): string | undefined {
+    if (typeof value !== "string") return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  async function fetchImageSourceAsBase64(
+    source: string,
+    fallbackMimeType: string,
+  ): Promise<ImageAttachment | undefined> {
+    if (source.startsWith("data:image/")) {
+      const data = base64FromDataUrl(source);
+      if (!data) return undefined;
+      return {
+        data,
+        mimeType: mimeTypeFromDataUrl(source) ?? fallbackMimeType,
+      };
+    }
+
+    try {
+      const response = await fetch(source);
+      if (!response.ok) {
+        console.error("[safeSendMessage] image fetch failed:", {
+          source,
+          status: response.status,
+        });
+        return undefined;
+      }
+
+      const contentType = response.headers.get("content-type");
+      if (contentType && !contentType.startsWith("image/")) {
+        console.error("[safeSendMessage] source did not return image:", {
+          source,
+          contentType,
+        });
+        return undefined;
+      }
+
+      const blob = await response.blob();
+      const data = await readBlobAsBase64(blob);
+      if (!data) return undefined;
+
+      return {
+        data,
+        mimeType: contentType?.startsWith("image/")
+          ? contentType
+          : fallbackMimeType,
+      };
+    } catch (error) {
+      console.error("[safeSendMessage] image fetch error:", {
+        source,
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  async function resolveImagePartToBase64(
+    part: ImageMessagePart,
+    messageObject: unknown,
+  ): Promise<ImageAttachment | undefined> {
+    const fallbackMimeType = normalizeImageMimeType(part.mediaType);
+
+    if (isBrowserFile(part.file)) {
+      const data = await readBlobAsBase64(part.file);
+      if (data) {
+        return {
+          data,
+          mimeType: normalizeImageMimeType(part.file.type, fallbackMimeType),
+        };
+      }
+    }
+
+    const messageFiles =
+      messageObject &&
+      typeof messageObject === "object" &&
+      Array.isArray((messageObject as { files?: unknown }).files)
+        ? ((messageObject as { files: unknown[] }).files ?? [])
+        : [];
+    const matchingFile = messageFiles.find(
+      (file) =>
+        isBrowserFile(file) &&
+        (typeof part.name !== "string" || file.name === part.name),
+    );
+    if (isBrowserFile(matchingFile)) {
+      const data = await readBlobAsBase64(matchingFile);
+      if (data) {
+        return {
+          data,
+          mimeType: normalizeImageMimeType(matchingFile.type, fallbackMimeType),
+        };
+      }
+    }
+
+    const candidates = [
+      stringSource(part.downloadUrl),
+      stringSource(part.url),
+      localDownloadUrlFromBlobPath(part.blobPath),
+    ].filter((value): value is string => Boolean(value));
+
+    for (const source of [...new Set(candidates)]) {
+      const resolved = await fetchImageSourceAsBase64(source, fallbackMimeType);
+      if (resolved) return resolved;
+    }
+
+    return undefined;
+  }
+
   // Set isAgentRunning for a specific chatId (used by stream callbacks to clear lock for correct chat)
   // Defined early to avoid initialization order issues with sendMessage
   const setIsAgentRunningForChatFn = useCallback(
@@ -859,132 +1033,11 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             if (part.type === "file" && part.mediaType?.startsWith("image/")) {
               // Image attachment - check if there is an original file object
               try {
-                let base64Data: string | undefined;
-
-                // Method 1: If imageUrl is set (TUS-uploaded to cloud), use it directly as image URL
-                if ((part as any).serverImageTUSUrl) {
-                  images.push({
-                    url: (part as any).serverImageTUSUrl,
-                    mimeType: part.mediaType,
-                  });
-                }
-                // Method 2: If blobPath is set (local path), fetch and convert to base64
-                else if (part.blobPath) {
-                  try {
-                    const resp = await fetch(part.blobPath);
-                    if (!resp.ok) {
-                      console.error(
-                        "[safeSendMessage] ✗ blobPath fetch failed:",
-                        resp.status,
-                      );
-                    } else {
-                      const blob = await resp.blob();
-                      const base64 = await new Promise<string>((resolve) => {
-                        const reader = new FileReader();
-                        reader.onloadend = () =>
-                          resolve(reader.result as string);
-                        reader.readAsDataURL(blob);
-                      });
-                      base64Data = base64.split(",")[1];
-                    }
-                  } catch (err) {
-                    console.error(
-                      "[safeSendMessage] ✗ blobPath fetch error:",
-                      err,
-                    );
-                  }
-                }
-                // Method 2: Prefer checking if part has original file object (fallback upload)
-                else if (part.file && part.file instanceof File) {
-                  // All images are processed locally via FileReader → base64.
-                  // We previously routed large files through uploadImageTUS(),
-                  // but /api/ai/v1/upload does not exist and we no longer need
-                  // a separate server hop just to read the bytes back.
-                  const file = part.file as File;
-                  const base64 = await new Promise<string>(
-                    (resolve, reject) => {
-                      const reader = new FileReader();
-                      reader.onloadend = () => resolve(reader.result as string);
-                      reader.onerror = reject;
-                      reader.readAsDataURL(file);
-                    },
-                  );
-                  base64Data = base64.split(",")[1];
-                }
-                // Method 2: Check message.files array
-                else if (
-                  (message as any).files &&
-                  Array.isArray((message as any).files)
-                ) {
-                  const file = (message as any).files.find(
-                    (f: any) => f.name === part.name,
-                  );
-                  if (file && file instanceof File) {
-                    // Read directly as base64 — see sibling block above for rationale.
-                    const base64 = await new Promise<string>(
-                      (resolve, reject) => {
-                        const reader = new FileReader();
-                        reader.onloadend = () =>
-                          resolve(reader.result as string);
-                        reader.onerror = reject;
-                        reader.readAsDataURL(file);
-                      },
-                    );
-                    base64Data = base64.split(",")[1];
-                  }
-                }
-                // Method 3: Get via downloadUrl (with validation)
-                else if (part.downloadUrl) {
-                  const response = await fetch(part.downloadUrl);
-
-                  const contentType = response.headers.get("content-type");
-                  if (!contentType?.startsWith("image/")) {
-                    console.error(
-                      "[safeSendMessage] ✗ downloadUrl did not return image:",
-                      contentType,
-                    );
-                    continue; // Skip this image
-                  }
-
-                  const blob = await response.blob();
-                  const base64 = await new Promise<string>((resolve) => {
-                    const reader = new FileReader();
-                    reader.onloadend = () => resolve(reader.result as string);
-                    reader.readAsDataURL(blob);
-                  });
-                  base64Data = base64.split(",")[1];
-                }
-                // Method 4: Try normal URL (last resort)
-                else if (part.url) {
-                  const response = await fetch(part.url);
-
-                  const contentType = response.headers.get("content-type");
-                  if (!contentType?.startsWith("image/")) {
-                    console.error(
-                      "[safeSendMessage] ✗ url did not return image:",
-                      contentType,
-                    );
-                    continue; // Skip this image
-                  }
-
-                  const blob = await response.blob();
-                  const base64 = await new Promise<string>((resolve) => {
-                    const reader = new FileReader();
-                    reader.onloadend = () => resolve(reader.result as string);
-                    reader.readAsDataURL(blob);
-                  });
-                  base64Data = base64.split(",")[1];
-                }
-
-                if (base64Data) {
-                  images.push({
-                    data: base64Data,
-                    mimeType: part.mediaType,
-                  });
-                }
+                const image = await resolveImagePartToBase64(part, message);
+                if (image) images.push(image);
               } catch (error) {
                 console.error(
-                  "[safeSendMessage] ✗ Exception loading image:",
+                  "[safeSendMessage] 閴?Exception loading image:",
                   part.name,
                   error,
                 );
@@ -1121,7 +1174,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 }
               } catch (error) {
                 console.error(
-                  "[safeSendMessage] ✗ Exception loading file attachment:",
+                  "[safeSendMessage] 閴?Exception loading file attachment:",
                   part.name,
                   error,
                 );
@@ -1707,7 +1760,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               // informational notice.
               if (!handledCodexTransportStatus) {
                 const retryMessage =
-                  data.content || data.message || "Agent is retrying…";
+                  data.content || data.message || "Agent is retrying...";
                 toast({
                   type: "info",
                   description: retryMessage,
@@ -1735,7 +1788,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               // so the chat UI can render an explicit Continue action that
               // reuses the preserved workspace. We deliberately skip the
               // stream-level auto-retry path (handled in onError) by tagging
-              // the part with an interruption payload — see issue #356.
+              // the part with an interruption payload 閳?see issue #356.
               const interruption = parseCodexInterruptedError(errorMessage);
               if (interruption?.canResume) {
                 parts.push({

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -31,7 +31,7 @@ import { useTranslation } from "react-i18next";
 import { saveMessagesToDatabase } from "@/lib/ai/chat/save-messages";
 import { getAuthToken } from "@/lib/auth/token-manager";
 import { uploadImageTUS } from "@/lib/files/tus-upload";
-import type { ImageAttachment } from "@openloomi/ai/agent/types";
+import type { ImageAttachment as AgentImageAttachment } from "@openloomi/ai/agent/types";
 import { DEFAULT_AI_MODEL, AI_PROXY_BASE_URL } from "@/lib/env/constants";
 import {
   artifactPathBasename,
@@ -352,6 +352,11 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
     blobPath?: unknown;
   };
 
+  type AgentImageDataInput = Pick<AgentImageAttachment, "mimeType"> & {
+    data: string;
+    url?: never;
+  };
+
   function isBrowserFile(value: unknown): value is File {
     return typeof File !== "undefined" && value instanceof File;
   }
@@ -418,7 +423,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   async function fetchImageSourceAsBase64(
     source: string,
     fallbackMimeType: string,
-  ): Promise<ImageAttachment | undefined> {
+  ): Promise<AgentImageDataInput | undefined> {
     if (source.startsWith("data:image/")) {
       const data = base64FromDataUrl(source);
       if (!data) return undefined;
@@ -469,7 +474,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   async function resolveImagePartToBase64(
     part: ImageMessagePart,
     messageObject: unknown,
-  ): Promise<ImageAttachment | undefined> {
+  ): Promise<AgentImageDataInput | undefined> {
     const fallbackMimeType = normalizeImageMimeType(part.mediaType);
 
     if (isBrowserFile(part.file)) {
@@ -1009,7 +1014,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       }
 
       // Extract image attachments, file attachments, RAG documents and focused insights from message
-      const images: ImageAttachment[] = [];
+      const images: AgentImageDataInput[] = [];
       const fileAttachments: Array<{
         name: string;
         data: string;
@@ -1027,7 +1032,8 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       }> = [];
 
       if (message && typeof message === "object") {
-        // Extract image attachments - read directly from local file, not via URL
+        // Extract image attachments as base64-only agent inputs. URLs remain
+        // UI/download references and are resolved before crossing this boundary.
         if ((message as any).parts && Array.isArray((message as any).parts)) {
           for (const part of (message as any).parts) {
             if (part.type === "file" && part.mediaType?.startsWith("image/")) {
@@ -1037,7 +1043,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 if (image) images.push(image);
               } catch (error) {
                 console.error(
-                  "[safeSendMessage] 閴?Exception loading image:",
+                  "[safeSendMessage] Exception loading image:",
                   part.name,
                   error,
                 );

--- a/apps/web/components/multimodal-input.tsx
+++ b/apps/web/components/multimodal-input.tsx
@@ -1612,27 +1612,15 @@ function PureMultimodalInput({
           )?.id;
 
           const result = await uploadFile(file, { createRecord: false });
-          // Reuse the local URL returned by uploadFile — no TUS hop needed.
-          const blobUrl = result.url || result.downloadUrl;
-          if (!blobUrl) {
-            throw new Error(
-              t(
-                "chat.imageUploadFailed",
-                "Image upload failed (no URL returned)",
-              ),
-            );
-          }
 
           const newAttachment: Attachment & {
             file?: File;
-            serverImageTUSUrl?: string;
           } = {
             name: result.name || file.name,
             url: result.url,
             contentType: result.contentType,
             sizeBytes: result.size,
             blobPath: result.blobPath, // local path for display
-            serverImageTUSUrl: blobUrl || undefined, // cloud URL for agent
             downloadUrl: result.downloadUrl,
             // Save original file object for native agent to read directly
             file: file,
@@ -1979,10 +1967,6 @@ function PureMultimodalInput({
           downloadUrl: attachment.downloadUrl,
           // Include original file object (if any) - used by Native Agent to extract files
           file: (attachment as Attachment & { file?: File }).file,
-          // Include TUS upload URL for large images (>400KB)
-          serverImageTUSUrl: (
-            attachment as Attachment & { serverImageTUSUrl?: string }
-          ).serverImageTUSUrl,
         })),
         {
           type: "text",

--- a/apps/web/components/task-composer/task-composer.tsx
+++ b/apps/web/components/task-composer/task-composer.tsx
@@ -34,7 +34,7 @@ const MAX_TEXTAREA_HEIGHT_PX = TEXTAREA_LINE_HEIGHT_PX * MAX_VISIBLE_LINES;
 const MAX_TEXT_LENGTH = 5000;
 const TASK_COMPOSER_MAX_WIDTH_CLASS = "max-w-[730px]";
 
-function isImageAttachmentMissingServerUpload(attachment: Attachment): boolean {
+function isImageAttachmentMissingLocalSource(attachment: Attachment): boolean {
   const file =
     typeof File !== "undefined" && (attachment as any).file instanceof File
       ? ((attachment as any).file as File)
@@ -42,8 +42,10 @@ function isImageAttachmentMissingServerUpload(attachment: Attachment): boolean {
 
   return (
     attachment.contentType.startsWith("image/") &&
-    Boolean(file) &&
-    !(attachment as any).serverImageTUSUrl &&
+    !file &&
+    !attachment.downloadUrl &&
+    !attachment.blobPath &&
+    !attachment.url &&
     !(attachment as any).isUploading
   );
 }
@@ -147,8 +149,8 @@ function PureTaskComposer({
   const hasUploadingAttachment = attachments.some(
     (att) => (att as any).isUploading,
   );
-  const hasImageMissingServerUpload = attachments.some(
-    isImageAttachmentMissingServerUpload,
+  const hasImageMissingLocalSource = attachments.some(
+    isImageAttachmentMissingLocalSource,
   );
   const hasComposerContent = value.trim().length > 0 || attachments.length > 0;
   const sendDisabled =
@@ -156,13 +158,13 @@ function PureTaskComposer({
     isLocked ||
     !hasComposerContent ||
     hasUploadingAttachment ||
-    hasImageMissingServerUpload;
+    hasImageMissingLocalSource;
   const sendButtonMuted =
     !hasComposerContent &&
     !composerBusy &&
     !isLocked &&
     !hasUploadingAttachment &&
-    !hasImageMissingServerUpload;
+    !hasImageMissingLocalSource;
 
   const adjustHeight = useCallback(() => {
     const el = textareaRef.current;
@@ -220,7 +222,7 @@ function PureTaskComposer({
   const handleSubmit = useCallback(() => {
     if (composerBusy || isLocked || hasUploadingAttachment) return;
     if (!hasComposerContent) return;
-    if (hasImageMissingServerUpload) {
+    if (hasImageMissingLocalSource) {
       toast.error(t("chat.imageUploadFailed", "Image upload failed"));
       return;
     }
@@ -234,7 +236,7 @@ function PureTaskComposer({
     attachments,
     composerBusy,
     hasComposerContent,
-    hasImageMissingServerUpload,
+    hasImageMissingLocalSource,
     hasUploadingAttachment,
     isLocked,
     onSubmit,
@@ -358,17 +360,9 @@ function PureTaskComposer({
       const fileName = `screenshot-${Date.now()}.png`;
       const file = new File([blob], fileName, { type: "image/png" });
       const result = await uploadFile(file, { createRecord: false });
-      // Reuse the local URL from uploadFile — no TUS hop needed.
-      const serverImageTUSUrl = result.url || result.downloadUrl;
-      if (!serverImageTUSUrl) {
-        throw new Error(
-          t("chat.imageUploadFailed", "Image upload failed (no URL returned)"),
-        );
-      }
 
       const attachment: Attachment & {
         file?: File;
-        serverImageTUSUrl?: string;
       } = {
         name: result.name || fileName,
         url: result.url,
@@ -377,7 +371,6 @@ function PureTaskComposer({
         contentType: result.contentType,
         sizeBytes: result.size,
         file,
-        serverImageTUSUrl,
       };
 
       setAttachments((prev) => [...prev, attachment]);

--- a/apps/web/components/task-composer/use-attachment-upload.ts
+++ b/apps/web/components/task-composer/use-attachment-upload.ts
@@ -67,7 +67,6 @@ async function readDroppedTauriFiles(paths: string[]) {
 interface UploadingAttachment extends Attachment {
   isUploading?: boolean;
   file?: File;
-  serverImageTUSUrl?: string;
 }
 
 function isPendingAttachmentForUpload(
@@ -193,23 +192,7 @@ export function useAttachmentUpload({
         try {
           const result = await uploadFile(file, { createRecord: false });
 
-          // For images, reuse the local URL returned by uploadFile so the
-          // selected AI model can fetch the attachment via the same origin.
-          // We do NOT call uploadImageTUS here — that route (/api/ai/v1/upload)
-          // does not exist in this app and any fallback would be redundant.
-          let serverImageTUSUrl: string | undefined;
-          if (file.type.startsWith("image/")) {
-            serverImageTUSUrl = result.url || result.downloadUrl;
-            if (!serverImageTUSUrl) {
-              throw new Error(
-                t(
-                  "chat.imageUploadFailed",
-                  "Image upload failed (no URL returned)",
-                ),
-              );
-            }
-          }
-
+          // Keep local URLs for UI only; images are converted to base64 when sent.
           // Update the attachment with upload results and mark as complete
           setAttachments((prev) =>
             prev.map((att) => {
@@ -222,7 +205,6 @@ export function useAttachmentUpload({
                   downloadUrl: result.downloadUrl,
                   blobPath: result.blobPath,
                   isUploading: false,
-                  serverImageTUSUrl,
                 };
               }
               return att;

--- a/apps/web/lib/ai/extensions/agent/codex/command.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/command.ts
@@ -47,6 +47,7 @@ export interface CodexRunCommandOptions {
   prompt: string;
   cwd: string;
   model?: string;
+  imagePaths?: string[];
   permissionMode?: AgentOptions["permissionMode"];
   /**
    * Planning-mode callers pass `plan` to force `read-only` sandbox and disable
@@ -200,6 +201,9 @@ export function buildCodexRunCommand(
   if (providerConfig.skipGitRepoCheck) {
     args.push("--skip-git-repo-check");
   }
+  for (const imagePath of normalizeImagePaths(options.imagePaths)) {
+    args.push("--image", imagePath);
+  }
   if (
     mode !== "plan" &&
     options.permissionMode === "bypassPermissions" &&
@@ -217,6 +221,11 @@ export function buildCodexRunCommand(
     args,
     stdin: options.prompt,
   };
+}
+
+function normalizeImagePaths(value: string[] | undefined): string[] {
+  if (!value) return [];
+  return value.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
 }
 
 export async function* runCodexCli(

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
@@ -263,11 +263,16 @@ export class CodexAgent extends BaseAgent {
     const providerConfig = normalizeCodexProviderConfig(
       this.config.providerConfig,
     );
+    const imagePaths = await this.materializeImagesForCodex(
+      options?.images,
+      cwd,
+    );
 
     const command = buildCodexRunCommand({
       prompt: addConversationContext(prompt, options),
       cwd,
       model: this.config.model,
+      imagePaths,
       permissionMode: options?.permissionMode,
       mode,
       providerConfig: this.config.providerConfig,
@@ -413,6 +418,33 @@ export class CodexAgent extends BaseAgent {
     };
   }
 
+  private async materializeImagesForCodex(
+    images: AgentOptions["images"] | undefined,
+    cwd: string,
+  ): Promise<string[]> {
+    const imageInputs =
+      images?.filter((image) => typeof image.data === "string" && image.data) ??
+      [];
+    if (imageInputs.length === 0) return [];
+
+    const imageDir = join(cwd, ".openloomi-codex-images");
+    await mkdir(imageDir, { recursive: true });
+
+    const timestamp = Date.now();
+    const imagePaths: string[] = [];
+    for (const [index, image] of imageInputs.entries()) {
+      const ext = codexImageExtension(image.mimeType);
+      const imagePath = join(imageDir, `image_${timestamp}_${index}.${ext}`);
+      await writeFile(
+        imagePath,
+        Buffer.from(stripDataUrlPrefix(image.data!), "base64"),
+      );
+      imagePaths.push(imagePath);
+    }
+
+    return imagePaths;
+  }
+
   private withMessageId(message: AgentMessage): AgentMessage {
     return message.messageId
       ? message
@@ -471,6 +503,27 @@ function resolveHome(filePath: string) {
     return join(homedir(), filePath.slice(2));
   }
   return isAbsolute(filePath) ? filePath : join(process.cwd(), filePath);
+}
+
+function stripDataUrlPrefix(data: string): string {
+  const commaIndex = data.indexOf(",");
+  return commaIndex === -1 ? data : data.slice(commaIndex + 1);
+}
+
+function codexImageExtension(mimeType: string): string {
+  switch (mimeType.toLowerCase()) {
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
+  }
 }
 
 export function createCodexAgent(config: AgentConfig): CodexAgent {

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -128,6 +128,24 @@ describe("Codex command builder", () => {
     expect(command.args).not.toContain("--full-auto");
   });
 
+  it("passes image paths as Codex CLI attachments", () => {
+    const command = buildCodexRunCommand({
+      prompt: "describe the attached image",
+      cwd: "/workspace/project",
+      imagePaths: [" /tmp/one.png ", "/tmp/two.jpg"],
+    });
+
+    expect(command.args).toEqual(
+      expect.arrayContaining([
+        "--image",
+        "/tmp/one.png",
+        "--image",
+        "/tmp/two.jpg",
+      ]),
+    );
+    expect(command.stdin).toBe("describe the attached image");
+  });
+
   it("rejects unsafe sandbox/approval values and ignores unsafe extraArgs", () => {
     const command = buildCodexRunCommand({
       prompt: "validate input",
@@ -751,6 +769,41 @@ describe("CodexAgent", () => {
     expect(args).not.toContain("hello codex");
     expect(await readFile(join(workDir, "stdin.txt"), "utf8")).toBe(
       "hello codex",
+    );
+  });
+
+  it("materializes image inputs and passes them to codex exec", async () => {
+    const workDir = await createFakeCodexWorkDir(defaultFakeCodexScript());
+    const agent = new CodexAgent({
+      provider: "codex",
+      workDir,
+      providerConfig: { codexPath: process.execPath },
+    });
+    const imageBytes = Buffer.from("fake-png-bytes");
+
+    await collectMessages(
+      agent.run("what is in this image?", {
+        images: [
+          {
+            data: imageBytes.toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    );
+
+    const args = JSON.parse(
+      await readFile(join(workDir, "args.json"), "utf8"),
+    ) as string[];
+    const imageFlagIndex = args.indexOf("--image");
+    expect(imageFlagIndex).toBeGreaterThan(-1);
+
+    const imagePath = args[imageFlagIndex + 1]!;
+    expect(imagePath).toContain(".openloomi-codex-images");
+    expect(imagePath).toMatch(/\.png$/);
+    expect(await readFile(imagePath)).toEqual(imageBytes);
+    expect(await readFile(join(workDir, "stdin.txt"), "utf8")).toBe(
+      "what is in this image?",
     );
   });
 

--- a/apps/web/tests/unit/image-upload-no-tus.test.ts
+++ b/apps/web/tests/unit/image-upload-no-tus.test.ts
@@ -6,9 +6,10 @@
  * (TUS chunked upload) — that route does not exist, so the second call
  * returned 404 and the user saw "Image upload failed".
  *
- * The fix routes images through `/api/files/upload` only and reuses the
- * returned URL so the selected AI model can fetch the attachment via the
- * same origin. These tests guard against re-introducing the broken call.
+ * The fix routes images through `/api/files/upload` only. Local URLs remain
+ * UI/download references; images are converted to base64 when sent to agents.
+ * These tests guard against re-introducing the broken call or URL-as-model-input
+ * behavior.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
@@ -95,7 +96,7 @@ describe("issue #380 source regressions", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Behavior check: hook delegates to uploadFile and reuses its URL
+// Behavior check: hook delegates to uploadFile and keeps URLs UI-only
 // ---------------------------------------------------------------------------
 
 describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
@@ -120,7 +121,7 @@ describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
     );
   });
 
-  it("uploads the image exactly once via /api/files/upload and reuses the URL", async () => {
+  it("uploads the image exactly once via /api/files/upload without setting a model URL", async () => {
     const localUrl = "/api/files/download?path=user-1/img.png";
     uploadFileMock.mockResolvedValueOnce({
       url: localUrl,
@@ -139,7 +140,8 @@ describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
     type CapturedAttachment = {
       name?: string;
       url?: string;
-      serverImageTUSUrl?: string;
+      downloadUrl?: string;
+      blobPath?: string;
       isUploading?: boolean;
     };
 
@@ -180,10 +182,13 @@ describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
       (a) =>
         a && typeof a === "object" && a.name === "img.png" && !a.isUploading,
     );
-    expect(finished?.serverImageTUSUrl).toBe(localUrl);
+    expect(finished?.url).toBe(localUrl);
+    expect(finished?.downloadUrl).toBe(localUrl);
+    expect(finished?.blobPath).toBe("user-1/img.png");
+    expect(finished).not.toHaveProperty("serverImageTUSUrl");
   });
 
-  it("surfaces a clear error when uploadFile returns no URL", async () => {
+  it("keeps the attachment when uploadFile returns only a blobPath", async () => {
     uploadFileMock.mockResolvedValueOnce({
       url: "",
       downloadUrl: "",
@@ -197,7 +202,7 @@ describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
     const { useAttachmentUpload } =
       await import("@/components/task-composer/use-attachment-upload");
 
-    type CapturedAttachment = { name?: string };
+    type CapturedAttachment = { name?: string; isUploading?: boolean };
     let capturedAttachments: CapturedAttachment[] = [];
     const setAttachments = ((updater: unknown) => {
       capturedAttachments =
@@ -216,8 +221,15 @@ describe("issue #380 behavior — image uploads skip /api/ai/v1/upload", () => {
     await hook.handleFileUpload([file]);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(toastMock.error).toHaveBeenCalledTimes(1);
-    const message = toastMock.error.mock.calls[0]?.[0] as string;
-    expect(message).toMatch(/no URL returned|upload failed/i);
+    expect(toastMock.error).not.toHaveBeenCalled();
+    const finished = capturedAttachments.find(
+      (a) =>
+        a && typeof a === "object" && a.name === "img.png" && !a.isUploading,
+    );
+    expect(finished).toMatchObject({
+      url: "",
+      downloadUrl: "",
+      blobPath: "user-1/img.png",
+    });
   });
 });

--- a/apps/web/tests/unit/image-upload-no-tus.test.ts
+++ b/apps/web/tests/unit/image-upload-no-tus.test.ts
@@ -102,6 +102,9 @@ describe("issue #380 source regressions", () => {
     expect(end).toBeGreaterThan(start);
 
     const imageBlock = source.slice(start, end);
+    expect(source).toContain("type AgentImageDataInput");
+    expect(source).toContain("url?: never");
+    expect(source).toContain("const images: AgentImageDataInput[] = [];");
     expect(imageBlock).toContain("resolveImagePartToBase64");
     expect(imageBlock).not.toContain("serverImageTUSUrl");
     expect(imageBlock).not.toMatch(/images\.push\(\s*{\s*url:/s);

--- a/apps/web/tests/unit/image-upload-no-tus.test.ts
+++ b/apps/web/tests/unit/image-upload-no-tus.test.ts
@@ -93,6 +93,39 @@ describe("issue #380 source regressions", () => {
     expect(imageBlock).toBeDefined();
     expect(imageBlock).not.toMatch(/await\s+uploadImageTUS\s*\(/);
   });
+
+  it("chat-context.tsx resolves local image parts to base64-only agent inputs", () => {
+    const source = readSource("components/chat-context.tsx");
+    const start = source.indexOf("Extract image attachments");
+    const end = source.indexOf("Handle all file attachments", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const imageBlock = source.slice(start, end);
+    expect(imageBlock).toContain("resolveImagePartToBase64");
+    expect(imageBlock).not.toContain("serverImageTUSUrl");
+    expect(imageBlock).not.toMatch(/images\.push\(\s*{\s*url:/s);
+  });
+
+  it("chat-context.tsx converts blobPath references through the local download endpoint", () => {
+    const source = readSource("components/chat-context.tsx");
+    expect(source).toContain("function localDownloadUrlFromBlobPath");
+    expect(source).toContain("/api/files/download?path=");
+    expect(source).toContain("localDownloadUrlFromBlobPath(part.blobPath)");
+  });
+
+  it("input surfaces no longer forward serverImageTUSUrl", () => {
+    const files = [
+      "components/task-composer/use-attachment-upload.ts",
+      "components/task-composer/task-composer.tsx",
+      "components/multimodal-input.tsx",
+      "components/agent/chat-panel.tsx",
+    ];
+
+    for (const file of files) {
+      expect(readSource(file)).not.toContain("serverImageTUSUrl");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -289,8 +289,10 @@ export interface AgentSupplementalInputSource extends AsyncIterable<AgentSupplem
 }
 
 /**
- * Image attachment for vision capabilities
- * Either data (base64) or url (cloud-accessible) must be provided.
+ * Image attachment for vision capabilities.
+ * Local uploads should prefer `data` (base64) so the payload stays
+ * self-contained; `url` remains available for runtimes that can fetch a
+ * reachable image source.
  */
 export interface ImageAttachment {
   /** Base64 encoded image data */


### PR DESCRIPTION
### What changed
- Local image attachments are now converted to base64 before crossing the agent boundary.
- `url`, `downloadUrl`, and `blobPath` stay as UI/download references only.
- Removed the broken `serverImageTUSUrl` path from image input surfaces.
- Codex runtime now materializes base64 images to local files and passes them to `codex exec --image`.
- Added regression coverage for the base64-only agent contract and Codex image attachment flow.

### Approach
- Local image uploads now use base64 as the primary transport into the agent boundary.
- The UI still keeps local download references for preview/history/download behavior.
- Claude already consumes these base64 image blocks correctly, so the existing multimodal path stays intact.
- For Codex, images are written to a temporary session directory and attached with the CLI’s native `--image` flag.
- Non-image file handling stays unchanged.

### Manual verification
  - `POST /api/files/upload 200`
  - `GET /api/files/download?... 200`
  - `POST /api/native/agent 200`
  - Claude read the uploaded image correctly
  - Codex read the uploaded image correctly after `--image` support landed
- No `POST /api/ai/v1/upload` 404 during the flow