### PR TITLE
fix(connectors): preserve Composio accounts across probe failures

### DIFF
--- a/apps/web/components/personalization/personalization-linked-accounts.tsx
+++ b/apps/web/components/personalization/personalization-linked-accounts.tsx
@@ -117,17 +117,48 @@ export function PersonalizationLinkedAccounts({
    * counterpart. Mirrors `ComposioConnectorList`'s dedup rule so the
    * header count matches what's rendered.
    */
-  const composioOnlyCount = (() => {
-    const nativePlatforms = new Set<IntegrationId>(
-      integrationAccounts.map((a) => a.platform),
-    );
-    return loopConnectors.filter(
-      (e) =>
-        e.connected &&
-        e.probed !== false &&
-        !nativePlatforms.has(e.id as IntegrationId),
-    ).length;
-  })();
+  const nativePlatforms = new Set<IntegrationId>(
+    integrationAccounts.map((account) => account.platform),
+  );
+  const composioOnlyCount = loopConnectors.filter(
+    (entry) =>
+      entry.connected &&
+      entry.probed !== false &&
+      !nativePlatforms.has(entry.id as IntegrationId),
+  ).length;
+  const hasKnownComposioSnapshot = loopConnectors.some(
+    (entry) =>
+      entry.probed === true &&
+      entry.source !== "native" &&
+      !nativePlatforms.has(entry.id as IntegrationId),
+  );
+  const connectedAccountsSummary =
+    lastProbeError && !hasKnownComposioSnapshot
+      ? [
+          integrationAccounts.length > 0
+            ? String(integrationAccounts.length)
+            : null,
+          t("connectors.snapshotUnavailable", "Composio status unavailable"),
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      : [
+          integrationAccounts.length > 0 || !lastProbeError
+            ? String(integrationAccounts.length)
+            : null,
+          composioOnlyCount > 0 || lastProbeError
+            ? `${t(
+                "connectors.sourceComposio",
+                "Composio",
+              )} ${composioOnlyCount}${
+                lastProbeError
+                  ? ` · ${t("connectors.snapshotStale", "last known")}`
+                  : ""
+              }`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" · ");
   const [internalAddConnectorDialogOpen, setInternalAddConnectorDialogOpen] =
     useState(false);
 
@@ -422,14 +453,7 @@ export function PersonalizationLinkedAccounts({
                   <span className="text-sm font-semibold text-foreground truncate">
                     {t("common.connectedAccounts")}{" "}
                     <span className="text-xs font-medium text-muted-foreground">
-                      ({integrationAccounts.length}
-                      {composioOnlyCount > 0
-                        ? ` · ${t(
-                            "connectors.sourceComposio",
-                            "Composio",
-                          )} ${composioOnlyCount}`
-                        : ""}
-                      )
+                      ({connectedAccountsSummary})
                     </span>
                   </span>
                 </AccordionTrigger>

--- a/apps/web/lib/ai/extensions/agent/codex/index.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/index.ts
@@ -423,8 +423,10 @@ export class CodexAgent extends BaseAgent {
     cwd: string,
   ): Promise<string[]> {
     const imageInputs =
-      images?.filter((image) => typeof image.data === "string" && image.data) ??
-      [];
+      images?.filter(
+        (image): image is typeof image & { data: string } =>
+          typeof image.data === "string" && image.data.length > 0,
+      ) ?? [];
     if (imageInputs.length === 0) return [];
 
     const imageDir = join(cwd, ".openloomi-codex-images");
@@ -437,7 +439,7 @@ export class CodexAgent extends BaseAgent {
       const imagePath = join(imageDir, `image_${timestamp}_${index}.${ext}`);
       await writeFile(
         imagePath,
-        Buffer.from(stripDataUrlPrefix(image.data!), "base64"),
+        Buffer.from(stripDataUrlPrefix(image.data), "base64"),
       );
       imagePaths.push(imagePath);
     }

--- a/apps/web/lib/loop/composio-bridge.ts
+++ b/apps/web/lib/loop/composio-bridge.ts
@@ -15,8 +15,8 @@
  * posting a small "probe only" prompt to the same `/api/native/agent`
  * endpoint the tick uses; the agent runs the same §1 of the tick
  * prompt (discover which Composio surfaces are reachable), returns
- * the `connectors` block in its `result` event, and we persist +
- * return it.
+ * the `connectors` block as its final assistant response, and we
+ * persist + return it.
  *
  * The result is shape-compatible with `ConnectorEntry[]` from
  * `types.ts`; persistence is the same `writeConnectorSnapshot` the
@@ -97,8 +97,8 @@ const DEFAULT_TOOLKITS: NonNullable<ProbeConnectorPromptOptions["toolkits"]> = [
  * toolkits via whatever Composio surfaces are reachable in the current
  * session (composio CLI / composio skill / openloomi-memory insights).
  * The prompt is intentionally narrow — no signal pull, no classify, no
- * decision persist. The expected output is a single `result` event whose
- * `content` is a JSON `connectors` block matching `ConnectorEntry[]`.
+ * decision persist. The expected output is one JSON `connectors` block
+ * in the final assistant response, matching `ConnectorEntry[]`.
  *
  * IMPORTANT: the prompt requires the agent to **work through every
  * surface, even after an earlier one errors**. The original wording
@@ -122,7 +122,7 @@ function buildProbePrompt(
     })
     .join("\n");
 
-  return `You are running a **connector probe** for the openloomi Loop. Your job is to inspect active Composio surfaces, identify which of the toolkits below have at least one healthy connected account, and emit a single structured \`result\` event. NO signal pull, NO classify, NO decision persist — just the connector snapshot.
+  return `You are running a **connector probe** for the openloomi Loop. Your job is to inspect active Composio surfaces, identify which of the toolkits below have at least one healthy connected account, and return one structured JSON object as your final assistant response. NO signal pull, NO classify, NO decision persist — just the connector snapshot.
 
 # Available Composio surfaces — work through ALL of them before giving up
 
@@ -144,7 +144,7 @@ ${catalog}
 
 # Output
 
-Emit exactly one SSE \`result\` event with this content:
+Return exactly one JSON object as your final assistant response:
 
 \`\`\`json
 {
@@ -162,7 +162,9 @@ Emit exactly one SSE \`result\` event with this content:
 
 The \`connectors\` array MUST contain one entry per toolkit in the catalog above, in the same order, with the \`id\` and \`label\` matching exactly. Do not omit any toolkit. \`accountCount\` MUST equal \`accounts.length\`, and every \`accounts\` entry carries only the non-secret \`{ id, label, healthy }\` — never tokens or credentials.
 
-Do not pull signals, do not classify, do not write to \`~/.openloomi/loop/\` — the bridge persists the snapshot for you. Just emit the \`result\` event and stop.`;
+The runtime owns SSE framing. Do not emit or describe SSE events. You may return raw JSON or a single \`\`\`json fenced block, with no additional prose.
+
+Do not pull signals, do not classify, do not write to \`~/.openloomi/loop/\` — the bridge persists the snapshot for you. Return the final JSON and stop.`;
 }
 
 interface ConnectorBlockShape {
@@ -321,9 +323,9 @@ function findMatchingBrace(text: string, start: number): number {
 
 /**
  * Fourth extraction pass (#391): walk `res.events` for any event whose
- * `content` (already-parsed object or stringified JSON) carries a
- * `connectors` array. Covers agents that wrap the snapshot inside a
- * `tool_call` / `tool_result` event instead of the final `result` event.
+ * payload (already-parsed object or stringified JSON) carries a
+ * `connectors` array. Most events use `content`; native Codex
+ * `tool_result` events use `output`.
  * Returns the LAST usable block found (agents emit the final payload
  * last), or `null` when no event contains one.
  */
@@ -334,15 +336,23 @@ function extractConnectorsFromEvents(
   let last: ConnectorBlockShape | null = null;
   for (const evt of events) {
     if (!evt || typeof evt !== "object") continue;
-    const content = (evt as { content?: unknown }).content;
-    if (!content) continue;
-    if (typeof content === "object") {
-      const obj = content as ConnectorBlockShape;
-      if (Array.isArray(obj.connectors)) last = obj;
+    const event = evt as {
+      type?: unknown;
+      content?: unknown;
+      output?: unknown;
+    };
+    const payload =
+      event.type === "tool_result"
+        ? (event.output ?? event.content)
+        : event.content;
+    if (!payload) continue;
+    if (typeof payload === "object") {
+      const parsed = extractConnectorsFromResult(payload);
+      if (parsed) last = parsed;
       continue;
     }
-    if (typeof content === "string") {
-      const parsed = tryParseJsonObject(content);
+    if (typeof payload === "string") {
+      const parsed = extractConnectorsFromText(payload);
       if (parsed) last = parsed;
     }
   }
@@ -434,7 +444,7 @@ export async function probeConnectorState(
   }
   if (cliOutcome.kind === "cli_not_found") {
     log(
-      "composio-bridge: CLI fast-path unavailable (composio binary not on $PATH) — falling through to agentic probe",
+      "composio-bridge: CLI fast-path unavailable (composio binary not found) — falling through to agentic probe",
     );
     // Don't write a sticky diagnostic for `cli_not_found` — the CLI
     // install state is unlikely to flip mid-session, but the user
@@ -497,18 +507,17 @@ export async function probeConnectorState(
     return { kind: "agent_http_error", status: res.status, error: msg };
   }
 
-  // The agent has THREE ways to return the snapshot; the prompt asks
-  // for the structured `result` event path. In practice we see all of
-  // them, so we try each in order of reliability:
+  // The agent has THREE ways to return the snapshot; native Codex
+  // normally returns the final assistant response as text. Other
+  // runtimes may still expose a structured result, so try each path:
   //
-  //   - **Preferred**: a `result` SSE event with `content` set to the
-  //     JSON object — `runner.ts` reads `evt.content` into `res.result`.
-  //   - **Text fallback**: the agent prints the JSON in its text output.
+  //   - **Structured result**: a `result` SSE event with `content` set
+  //     to the JSON object.
+  //   - **Final text**: the agent prints the JSON in its text output.
   //     We grep the text tail for a ```json ... ``` block and parse it.
   //   - **Event fallback** (#391): the agent wrapped the snapshot inside
-  //     a `tool_call` / `tool_result` event rather than the final
-  //     `result`. Walk `res.events` for any event whose `content`
-  //     carries a `connectors` array.
+  //     a `tool_call` / `tool_result` event rather than its final text.
+  //     Walk `res.events` and inspect each event's real payload field.
   const fromResult = extractConnectorsFromResult(res.result);
   let raw: ConnectorBlockShape | null = fromResult;
   let path = "result";

--- a/apps/web/lib/loop/composio-cli.ts
+++ b/apps/web/lib/loop/composio-cli.ts
@@ -39,6 +39,9 @@
  */
 
 import { execFile } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 import { writeConnectorSnapshot } from "./connectors";
@@ -140,8 +143,8 @@ export type CliProbeOutcome =
 
 /**
  * Run a single `composio` CLI invocation. Catches `ENOENT` and other
- * spawn-level failures and returns `null` so callers can render a
- * structured `cli_not_found` outcome instead of an exception.
+ * spawn-level failures and returns a structured error so callers can
+ * render a `cli_not_found` outcome instead of throwing.
  *
  * `execImpl` is a test seam — production passes the real
  * `promisify(execFile)`. Tests pass a stub returning `{stdout, stderr}`
@@ -154,7 +157,25 @@ interface ExecResult {
   stderr: string;
 }
 
+/**
+ * Finder/launchd does not inherit shell PATH additions, while the Composio
+ * installer places the CLI at `~/.composio/composio`. Prefer that documented
+ * user install location when it is executable, then retain the existing
+ * PATH lookup as the fallback for every other installation layout.
+ */
+function resolveComposioExecutable(env: NodeJS.ProcessEnv): string {
+  const home = env.HOME || env.USERPROFILE || homedir();
+  const userInstall = join(home, ".composio", "composio");
+  try {
+    accessSync(userInstall, constants.X_OK);
+    return userInstall;
+  } catch {
+    return "composio";
+  }
+}
+
 async function runCli(
+  executable: string,
   args: string[],
   execImpl: (
     cmd: string,
@@ -165,15 +186,16 @@ async function runCli(
     args: string[],
     opts: unknown,
   ) => Promise<ExecResult>,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ ok: true; result: ExecResult } | { ok: false; error: string }> {
   try {
-    const result = await execImpl("composio", args, {
+    const result = await execImpl(executable, args, {
       timeout: CLI_CALL_TIMEOUT_MS,
       maxBuffer: 8 * 1024 * 1024,
       // `whoami` and `connections list` both print JSON to stdout.
       // Don't ask for human-readable output — we want the raw shape so
       // the parser can stay stable across CLI versions.
-      env: { ...process.env, NO_COLOR: "1" },
+      env: { ...env, NO_COLOR: "1" },
     });
     return { ok: true, result };
   } catch (e: unknown) {
@@ -183,10 +205,13 @@ async function runCli(
       killed?: boolean;
       signal?: string;
     };
-    // ENOENT = the `composio` binary isn't on `$PATH`. Surface it
+    // ENOENT = the resolved executable couldn't be spawned. Surface it
     // distinctly so the agentic fallback isn't blamed for the gap.
     if (err?.code === "ENOENT") {
-      return { ok: false, error: "composio CLI not on $PATH" };
+      return {
+        ok: false,
+        error: "composio CLI not found at ~/.composio/composio or on $PATH",
+      };
     }
     // Spawn-level timeout — the CLI didn't return within
     // `CLI_CALL_TIMEOUT_MS`. The agentic fallback will retry.
@@ -210,15 +235,17 @@ async function runCli(
  * (something else went wrong, e.g. unexpected JSON shape).
  */
 async function probeWhoami(
+  executable: string,
   execImpl?: (
     cmd: string,
     args: string[],
     opts: unknown,
   ) => Promise<ExecResult>,
+  env?: NodeJS.ProcessEnv,
 ): Promise<
   { ok: true; whoami: WhoamiResult } | { ok: false; outcome: CliProbeOutcome }
 > {
-  const r = await runCli(["whoami"], execImpl);
+  const r = await runCli(executable, ["whoami"], execImpl, env);
   if (!r.ok) {
     return {
       ok: false,
@@ -279,16 +306,18 @@ async function probeWhoami(
  * `dev init` required.
  */
 async function probeConnectedAccounts(
+  executable: string,
   execImpl?: (
     cmd: string,
     args: string[],
     opts: unknown,
   ) => Promise<ExecResult>,
+  env?: NodeJS.ProcessEnv,
 ): Promise<
   | { ok: true; accounts: Record<string, ConnectedAccountRaw[]> }
   | { ok: false; outcome: CliProbeOutcome }
 > {
-  const r = await runCli(["connections", "list"], execImpl);
+  const r = await runCli(executable, ["connections", "list"], execImpl, env);
   if (!r.ok) {
     return {
       ok: false,
@@ -452,9 +481,13 @@ export async function probeViaCli(
       args: string[],
       opts: unknown,
     ) => Promise<ExecResult>;
+    /** Environment used for CLI discovery/execution; exposed for regression tests. */
+    env?: NodeJS.ProcessEnv;
   } = {},
 ): Promise<CliProbeOutcome> {
   const toolkits = opts.toolkits ?? DEFAULT_TOOLKITS;
+  const env = opts.env ?? process.env;
+  const executable = resolveComposioExecutable(env);
   const t0 = Date.now();
   log("composio-cli: probing via local composio CLI");
 
@@ -470,7 +503,7 @@ export async function probeViaCli(
   // do. So the CLI diagnostic is dead weight; the caller's
   // `probeConnectorState` gets the full picture and decides what to
   // persist.
-  const whoami = await probeWhoami(opts.execImpl);
+  const whoami = await probeWhoami(executable, opts.execImpl, env);
   if (!whoami.ok) {
     log(`composio-cli: whoami outcome=${whoami.outcome.kind}`);
     return whoami.outcome;
@@ -480,7 +513,7 @@ export async function probeViaCli(
   // installed and auth works, but we can't enumerate accounts (most
   // commonly the JSON shape changed). Same persistence rationale as
   // above — caller decides.
-  const list = await probeConnectedAccounts(opts.execImpl);
+  const list = await probeConnectedAccounts(executable, opts.execImpl, env);
   if (!list.ok) {
     log(`composio-cli: list outcome=${list.outcome.kind}`);
     return list.outcome;

--- a/apps/web/lib/loop/connectors.ts
+++ b/apps/web/lib/loop/connectors.ts
@@ -78,7 +78,7 @@ interface ConnectorCache {
   lastProbeError?: ProbeErrorInfo;
 }
 
-function readCache(): ConnectorCache | null {
+function readCache(opts: { allowStale?: boolean } = {}): ConnectorCache | null {
   try {
     if (!existsSync(LOOP_PATHS.connectors)) return null;
     // The on-disk shape can carry the top-level stamp under either
@@ -117,7 +117,21 @@ function readCache(): ConnectorCache | null {
     }, null);
     const stamp = topLevel ?? entryMax;
     if (!stamp) return null;
-    if (Date.now() - new Date(stamp).getTime() > CACHE_TTL_MS) return null;
+    const stampMs = new Date(stamp).getTime();
+    if (!Number.isFinite(stampMs)) return null;
+    const probeError = parseProbeError(raw.lastProbeError);
+    // A failed refresh must not turn a healthy, older snapshot into the
+    // all-disconnected fallback. Keep serving the last-known-good rows
+    // while the persisted error tells callers that they are stale.
+    // Explicit refresh still bypasses this read, and the next successful
+    // snapshot rewrite clears `lastProbeError`.
+    if (
+      !opts.allowStale &&
+      !probeError &&
+      Date.now() - stampMs > CACHE_TTL_MS
+    ) {
+      return null;
+    }
     // Defensively treat any cache entry that lacks `probed` as
     // probed: true. Cron-executor and other external writers may have
     // written the snapshot before the field existed; if it's in the
@@ -134,7 +148,6 @@ function readCache(): ConnectorCache | null {
           : { ...c, probed: true };
       return withConnectorCapability(probed as ConnectorEntry);
     });
-    const probeError = parseProbeError(raw.lastProbeError);
     return {
       fetchedAt: stamp,
       connectors,
@@ -485,12 +498,11 @@ export function getLastProbeError(): ProbeErrorInfo | null {
  *
  *   1. Probe succeeded → return + persist the entries.
  *   2. Probe failed (transport / timeout / malformed result) but the
- *      cache is fresh (within CACHE_TTL_MS) → return the cache. The
- *      pill row stays accurate to the last good agent report; we just
- *      can't give the user a live update.
- *   3. Probe failed AND cache is stale / missing → return FALLBACK so
- *      the UI can still render the row. Caller should surface a
- *      "stale" hint to the user.
+ *      cache exists → return it even when older than CACHE_TTL_MS. The
+ *      pill row stays accurate to the last good agent report while the
+ *      persisted `lastProbeError` tells the UI that refresh failed.
+ *   3. Probe failed AND no valid cache exists → return FALLBACK so the
+ *      UI can still render the row.
  */
 export async function refreshConnectors(
   opts: { silent?: boolean } = {},
@@ -500,7 +512,7 @@ export async function refreshConnectors(
   // return whatever the cache (or FALLBACK) has. This prevents a stuck
   // or slow agent from being hammered on rapid card re-opens.
   if (opts.silent && Date.now() < readProbeCooldown()) {
-    const cached = readCache();
+    const cached = readCache({ allowStale: true });
     if (cached) return appendCustomChannels(cached.connectors);
     return appendCustomChannels(FALLBACK_CONNECTORS);
   }
@@ -536,7 +548,7 @@ export async function refreshConnectors(
     if (raced === TIMED_OUT) {
       writeProbeError("timeout", `probe exceeded ${PROBE_TIMEOUT_MS}ms`);
       writeProbeCooldownMarker();
-      const cached = readCache();
+      const cached = readCache({ allowStale: true });
       if (cached) return appendCustomChannels(cached.connectors);
       return appendCustomChannels(FALLBACK_CONNECTORS);
     }
@@ -547,7 +559,7 @@ export async function refreshConnectors(
     // ok — treat like a soft failure: leave a cooldown so a rapid re-
     // open doesn't hammer a broken probe, and degrade to cache/FALLBACK.
     writeProbeCooldownMarker();
-    const cached = readCache();
+    const cached = readCache({ allowStale: true });
     if (cached) return appendCustomChannels(cached.connectors);
     return appendCustomChannels(FALLBACK_CONNECTORS);
   }
@@ -558,8 +570,8 @@ export async function refreshConnectors(
   }
   // Probe failed (the diagnostic was already persisted by
   // `probeConnectorState`) — degrade gracefully to the last-known
-  // snapshot, or the FALLBACK sentinel when the cache is stale/missing.
-  const cached = readCache();
+  // snapshot, or the FALLBACK sentinel when no valid snapshot exists.
+  const cached = readCache({ allowStale: true });
   if (cached) {
     return appendCustomChannels(cached.connectors);
   }

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -798,7 +798,9 @@ describe("CodexAgent", () => {
     const imageFlagIndex = args.indexOf("--image");
     expect(imageFlagIndex).toBeGreaterThan(-1);
 
-    const imagePath = args[imageFlagIndex + 1]!;
+    const imagePath = args[imageFlagIndex + 1];
+    expect(imagePath).toBeDefined();
+    if (!imagePath) throw new Error("Codex --image path was not provided");
     expect(imagePath).toContain(".openloomi-codex-images");
     expect(imagePath).toMatch(/\.png$/);
     expect(await readFile(imagePath)).toEqual(imageBytes);

--- a/apps/web/tests/unit/loop/composio-bridge-cli-fast-path.test.ts
+++ b/apps/web/tests/unit/loop/composio-bridge-cli-fast-path.test.ts
@@ -128,11 +128,33 @@ describe("probeConnectorState fallback to agent", () => {
       kind: "cli_not_found",
       error: "composio CLI not on $PATH",
     });
-    invokeAgentPrompt.mockResolvedValueOnce(agentOk([GMAIL_ENTRY]));
+    invokeAgentPrompt.mockResolvedValueOnce({
+      ok: true,
+      result: "success",
+      text: JSON.stringify({
+        surfaces_used: ["skill"],
+        connectors: [GMAIL_ENTRY],
+      }),
+      reasoning: "",
+      events: [
+        { type: "session", content: "started" },
+        {
+          type: "text",
+          content: JSON.stringify({ connectors: [GMAIL_ENTRY] }),
+        },
+        { type: "done", content: "success" },
+      ],
+    });
 
     const outcome = await probeConnectorState({ toolkits: TOOLKITS });
     expect(outcome.kind).toBe("ok");
     expect(invokeAgentPrompt).toHaveBeenCalledTimes(1);
+    const prompt = invokeAgentPrompt.mock.calls[0][0] as string;
+    expect(prompt).toContain(
+      "structured JSON object as your final assistant response",
+    );
+    expect(prompt).toContain("runtime owns SSE framing");
+    expect(prompt).not.toContain("Emit exactly one SSE");
   });
 
   it("falls through when CLI returns cli_no_dev_project (most common prod failure)", async () => {
@@ -222,5 +244,34 @@ describe("probeConnectorState when both surfaces fail", () => {
 
     const outcome = await probeConnectorState({ toolkits: TOOLKITS });
     expect(outcome.kind).toBe("empty_response");
+  });
+
+  it("reports the hollow three-event Codex response as malformed without replacing the snapshot", async () => {
+    probeViaCli.mockResolvedValueOnce({
+      kind: "cli_not_found",
+      error: "composio CLI not on $PATH",
+    });
+    invokeAgentPrompt.mockResolvedValueOnce({
+      ok: true,
+      result: "success",
+      text: "",
+      reasoning: "",
+      events: [
+        { type: "session", content: "started" },
+        { type: "result", content: "success" },
+        { type: "done", content: "success" },
+      ],
+    });
+
+    const outcome = await probeConnectorState({ toolkits: TOOLKITS });
+
+    expect(outcome.kind).toBe("malformed_response");
+    if (outcome.kind !== "malformed_response") return;
+    expect(outcome.diagnostic).toContain('events=3 text-head=""');
+    expect(writeProbeError).toHaveBeenCalledWith(
+      "malformed_response",
+      expect.stringContaining('events=3 text-head=""'),
+    );
+    expect(writeConnectorSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/loop/composio-cli.test.ts
+++ b/apps/web/tests/unit/loop/composio-cli.test.ts
@@ -37,7 +37,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -169,6 +177,80 @@ const enoentError = (args: string[]) => ({
 // Happy path — both calls succeed; entries are persisted
 // ---------------------------------------------------------------------------
 describe("probeViaCli happy path", () => {
+  it("discovers the default ~/.composio/composio install with a Finder-like PATH", async () => {
+    const composioDir = join(tmp, ".composio");
+    const composioBinary = join(composioDir, "composio");
+    mkdirSync(composioDir, { recursive: true });
+    writeFileSync(composioBinary, "");
+    chmodSync(composioBinary, 0o755);
+
+    const calls: Array<ExecCall & { opts: unknown }> = [];
+    const exec = async (cmd: string, args: string[], opts: unknown) => {
+      calls.push({ cmd, args, opts });
+      if (args[0] === "whoami") {
+        return whoamiSuccess.resolve;
+      }
+      if (args[0] === "connections" && args[1] === "list") {
+        return {
+          stdout: JSON.stringify({
+            github: [
+              {
+                status: "ACTIVE",
+                alias: "semiok",
+                word_id: "github_active",
+              },
+            ],
+            linear: [
+              {
+                status: "ACTIVE",
+                alias: "semiok@example.com",
+                word_id: "linear_active",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      throw new Error(`unhandled call: ${cmd} ${args.join(" ")}`);
+    };
+
+    const outcome = await probeViaCli({
+      execImpl: exec,
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      },
+    });
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") return;
+    expect(calls.map((call) => call.cmd)).toEqual([
+      composioBinary,
+      composioBinary,
+    ]);
+    expect(
+      calls.map((call) => (call.opts as { env?: NodeJS.ProcessEnv }).env?.PATH),
+    ).toEqual([
+      "/usr/bin:/bin:/usr/sbin:/sbin",
+      "/usr/bin:/bin:/usr/sbin:/sbin",
+    ]);
+    expect(outcome.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "github",
+          connected: true,
+          accountCount: 1,
+        }),
+        expect.objectContaining({
+          id: "linear",
+          connected: true,
+          accountCount: 1,
+        }),
+      ]),
+    );
+  });
+
   it("returns ok with parsed entries and persists the snapshot", async () => {
     const exec = makeExec([
       whoamiSuccess,

--- a/apps/web/tests/unit/loop/connector-accounts.test.ts
+++ b/apps/web/tests/unit/loop/connector-accounts.test.ts
@@ -320,7 +320,7 @@ describe("probeConnectorState structured outcomes (#391)", () => {
         { type: "tool_call", content: "{}" },
         {
           type: "tool_result",
-          content: {
+          output: JSON.stringify({
             connectors: [
               {
                 id: "gmail",
@@ -330,7 +330,7 @@ describe("probeConnectorState structured outcomes (#391)", () => {
                 accounts: [{ id: "ga_1", label: "me@x.com" }],
               },
             ],
-          },
+          }),
         },
       ],
     });

--- a/apps/web/tests/unit/loop/connector-timeout.test.ts
+++ b/apps/web/tests/unit/loop/connector-timeout.test.ts
@@ -219,17 +219,26 @@ describe("refreshConnectors timeout (#391)", () => {
     // the last-known connector state.
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
-    // Seed a cache with a known snapshot that predates the timeout
-    // (#411: the cache TTL is now 30s, so 5s old is comfortably
-    // within validity and still meaningfully "predates" the probe
-    // call we're about to make).
-    const seededFetchedAt = new Date(Date.now() - 5 * 1000).toISOString();
+    // Seed a cache older than the 30s TTL. A failed refresh must still
+    // return these last-known-good rows instead of replacing them with
+    // the all-disconnected fallback.
+    const seededFetchedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
     const seededConnectors = [
       {
-        id: "gmail",
-        label: "Gmail",
+        id: "github",
+        label: "GitHub",
         connected: true,
         accountCount: 1,
+        accounts: [{ id: "github_active", healthy: true }],
+        probed: true,
+        fetchedAt: seededFetchedAt,
+      },
+      {
+        id: "linear",
+        label: "Linear",
+        connected: true,
+        accountCount: 1,
+        accounts: [{ id: "linear_active", healthy: true }],
         probed: true,
         fetchedAt: seededFetchedAt,
       },
@@ -253,7 +262,8 @@ describe("refreshConnectors timeout (#391)", () => {
     // Snapshot was preserved.
     expect(result).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "gmail", connected: true }),
+        expect.objectContaining({ id: "github", connected: true }),
+        expect.objectContaining({ id: "linear", connected: true }),
       ]),
     );
 
@@ -261,8 +271,11 @@ describe("refreshConnectors timeout (#391)", () => {
     // cooldown marker.
     const raw = JSON.parse(readFileSync(CONNECTORS_PATH, "utf8"));
     expect(raw.fetchedAt).toBe(seededFetchedAt);
-    expect(raw.connectors).toHaveLength(1);
-    expect(raw.connectors[0].id).toBe("gmail");
+    expect(raw.connectors).toHaveLength(2);
+    expect(raw.connectors.map((entry: { id: string }) => entry.id)).toEqual([
+      "github",
+      "linear",
+    ]);
     expect(raw.lastProbeError?.kind).toBe("timeout");
     expect(typeof raw.probeCooldownUntil).toBe("string");
   });

--- a/packages/i18n/src/locales/en-US.ts
+++ b/packages/i18n/src/locales/en-US.ts
@@ -883,6 +883,8 @@ const enUS = {
     sync: "Sync",
     sourceComposio: "Composio",
     sourceComposioHint: "Connected via Composio (agent-managed)",
+    snapshotStale: "last known",
+    snapshotUnavailable: "Composio status unavailable",
     probeError: "Last sync failed",
     // #412 — per-kind callout copy + affordances. Keys live here so the
     // connectors page can render a localized reason + one-click fix

--- a/packages/i18n/src/locales/zh-Hans.ts
+++ b/packages/i18n/src/locales/zh-Hans.ts
@@ -816,6 +816,8 @@ const zhHans = {
     sync: "同步",
     sourceComposio: "Composio",
     sourceComposioHint: "通过 Composio（智能体管理）连接",
+    snapshotStale: "上次已知状态",
+    snapshotUnavailable: "Composio 状态不可用",
     probeError: "最近同步失败",
     // #412 — 每种探测失败类型对应的提示与一键修复。详见
     // `apps/web/components/loop/probe-error-callout.tsx`。


### PR DESCRIPTION
## Summary

- Discover the default `~/.composio/composio` installation when the packaged macOS app starts with a Finder-like PATH.
- Ask the native Codex fallback for final assistant JSON instead of model-generated SSE, and parse connector data from final text and `tool_result.output`.
- Preserve last-known-good connector rows when a refresh fails, including snapshots older than the normal cache TTL.
- Show connector state as “last known” or “Composio status unavailable” instead of implying that authorization was removed.

## Root cause

Finder/launchd does not inherit shell PATH additions, so the packaged Desktop process could not find the Composio CLI installed under `~/.composio`.

The fallback prompt also asked Codex to emit transport-level SSE events. Native Codex could consequently return a hollow three-event response with no parseable connector result.

Finally, failed probes attempted to read the existing snapshot through the normal 30-second TTL, causing older healthy rows to be replaced in the response by the all-disconnected fallback.

## Test plan

- Verify CLI discovery with a minimal Finder-like PATH and the binary present only at `~/.composio/composio`.
- Verify GitHub and Linear ACTIVE accounts are returned through that binary.
- Verify final assistant JSON from the native Codex fallback is parsed.
- Verify connector JSON inside `tool_result.output` is parsed.
- Verify a hollow three-event Codex response remains a probe error and does not write an empty snapshot.
- Verify an expired GitHub/Linear snapshot remains visible after probe failure.
- Run the related connector unit tests: 74 passed.
- Run the web TypeScript check.

Fixes #488