### PR TITLE
feat: add lifestyle image skill routing and reference image support

### DIFF
--- a/apps/web/app/api/ai/v1/images/lifestyle/intent/route.ts
+++ b/apps/web/app/api/ai/v1/images/lifestyle/intent/route.ts
@@ -1,0 +1,180 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { auth } from "@/app/(auth)/auth";
+import { resolveLlmProvider } from "@/lib/ai/provider-resolver";
+import {
+  createLifestyleImageSkillFallbackRoute,
+  resolveLifestyleImageSkillRoute,
+  type LifestyleImageSkillRouteResult,
+} from "@/lib/ai/image-generation/lifestyle-skill-router";
+import { isTauriMode } from "@/lib/env/constants";
+import { AppError } from "@openloomi/shared/errors";
+
+export const runtime = "nodejs";
+
+const LIFESTYLE_IMAGE_SKILL_NAME = "openloomi-lifestyle-image";
+const CLASSIFIER_TIMEOUT_MS = 45_000;
+
+type LifestyleImageIntentRequestBody = {
+  message?: unknown;
+  hasReferenceImage?: unknown;
+  model?: unknown;
+};
+
+type LifestyleImageIntentResponseBody = {
+  success: true;
+  route: LifestyleImageSkillRouteResult;
+  model?: string;
+};
+
+export async function POST(request: Request) {
+  const session = await auth().catch(() => null);
+  if (!session?.user?.id && !isTauriMode()) {
+    return new AppError("unauthorized:auth").toResponse();
+  }
+
+  const body = (await request.json().catch((error) => {
+    console.error("[LifestyleImageIntent] Invalid request payload", error);
+    return null;
+  })) as LifestyleImageIntentRequestBody | null;
+
+  const message = normalizeMessage(body?.message);
+  if (!message) {
+    return Response.json({
+      success: true,
+      route: createLifestyleImageSkillFallbackRoute("empty_output"),
+    } satisfies LifestyleImageIntentResponseBody);
+  }
+
+  const hasReferenceImage = body?.hasReferenceImage === true;
+  const skillInstructions = await readLifestyleImageSkillInstructions().catch(
+    (error) => {
+      console.error(
+        "[LifestyleImageIntent] Failed to load lifestyle image skill",
+        error,
+      );
+      return null;
+    },
+  );
+  if (!skillInstructions) {
+    return Response.json({
+      success: true,
+      route: createLifestyleImageSkillFallbackRoute("classifier_unavailable"),
+    } satisfies LifestyleImageIntentResponseBody);
+  }
+
+  const provider = await resolveLlmProvider({
+    userId: session?.user?.id,
+    prefer: "chat_completions",
+  });
+
+  if (!provider) {
+    return Response.json({
+      success: true,
+      route: createLifestyleImageSkillFallbackRoute("classifier_unavailable"),
+    } satisfies LifestyleImageIntentResponseBody);
+  }
+
+  try {
+    const response = await provider.complete({
+      system: buildLifestyleImageIntentSystemPrompt(skillInstructions),
+      userContent: buildLifestyleImageIntentUserContent({
+        message,
+        hasReferenceImage,
+      }),
+      model: resolveModelOverride(body?.model, provider.flavor),
+      maxTokens: 300,
+      timeoutMs: CLASSIFIER_TIMEOUT_MS,
+    });
+    const route = normalizeReferenceImageFlag(
+      resolveLifestyleImageSkillRoute(response.text),
+      hasReferenceImage,
+    );
+
+    return Response.json({
+      success: true,
+      route,
+      model: response.model,
+    } satisfies LifestyleImageIntentResponseBody);
+  } catch (error) {
+    console.error("[LifestyleImageIntent] Classifier request failed", error);
+    return Response.json({
+      success: true,
+      route: createLifestyleImageSkillFallbackRoute("classifier_error"),
+    } satisfies LifestyleImageIntentResponseBody);
+  }
+}
+
+function normalizeMessage(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveModelOverride(
+  model: unknown,
+  providerFlavor: "anthropic_http" | "openai_http" | "agent_runtime",
+): string | undefined {
+  if (providerFlavor === "agent_runtime") return undefined;
+  return typeof model === "string" && model.trim() ? model.trim() : undefined;
+}
+
+function buildLifestyleImageIntentSystemPrompt(
+  skillInstructions: string,
+): string {
+  return [
+    skillInstructions,
+    "You are OpenLoomi's lifestyle image intent classifier.",
+    "Return only JSON matching the skill's Output Contract.",
+    "Do not include Markdown, prose, code fences, or tool calls.",
+    "If the intent is unclear, invalid, negated, or only asks for image understanding, return matched false with confidence low.",
+  ].join("\n\n");
+}
+
+function buildLifestyleImageIntentUserContent(input: {
+  message: string;
+  hasReferenceImage: boolean;
+}): string {
+  return [
+    `Reference image uploaded: ${input.hasReferenceImage ? "true" : "false"}`,
+    "Set hasReferenceImage to exactly the value above.",
+    "",
+    "User message:",
+    input.message,
+  ].join("\n");
+}
+
+function normalizeReferenceImageFlag(
+  route: LifestyleImageSkillRouteResult,
+  hasReferenceImage: boolean,
+): LifestyleImageSkillRouteResult {
+  if (!route.decision) return route;
+  return {
+    ...route,
+    decision: {
+      ...route.decision,
+      hasReferenceImage,
+    },
+  };
+}
+
+async function readLifestyleImageSkillInstructions(): Promise<string> {
+  const cwd = process.cwd();
+  const parent = dirname(cwd);
+  const grandParent = dirname(parent);
+  const candidates = [
+    join(cwd, "skills", LIFESTYLE_IMAGE_SKILL_NAME, "SKILL.md"),
+    join(parent, "skills", LIFESTYLE_IMAGE_SKILL_NAME, "SKILL.md"),
+    join(grandParent, "skills", LIFESTYLE_IMAGE_SKILL_NAME, "SKILL.md"),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const content = await readFile(candidate, "utf8");
+      if (content.trim()) return content;
+    } catch {
+      // Try the next dev/prod candidate path.
+    }
+  }
+
+  throw new Error(`Unable to locate ${LIFESTYLE_IMAGE_SKILL_NAME}/SKILL.md`);
+}

--- a/apps/web/app/api/ai/v1/images/lifestyle/intent/route.ts
+++ b/apps/web/app/api/ai/v1/images/lifestyle/intent/route.ts
@@ -76,6 +76,13 @@ export async function POST(request: Request) {
     } satisfies LifestyleImageIntentResponseBody);
   }
 
+  if (provider.flavor === "agent_runtime") {
+    return Response.json({
+      success: true,
+      route: createLifestyleImageSkillFallbackRoute("classifier_unavailable"),
+    } satisfies LifestyleImageIntentResponseBody);
+  }
+
   try {
     const response = await provider.complete({
       system: buildLifestyleImageIntentSystemPrompt(skillInstructions),

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -46,6 +46,10 @@ import {
   isLifestyleImageSkillRouteResult,
   type LifestyleImageSkillRouteResult,
 } from "@/lib/ai/image-generation/lifestyle-skill-router";
+import {
+  buildLifestyleReferenceImages,
+  type LifestyleReferenceImagePayload,
+} from "@/lib/ai/image-generation/lifestyle-reference-images";
 
 // Max retry attempts for stream errors
 const MAX_STREAM_RETRY_ATTEMPTS = 3;
@@ -401,11 +405,12 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   // 400KB stays well under Vercel's 4.5MB body limit and protects small images too.
   const TUS_SIZE_THRESHOLD = 400 * 1024;
 
-  function isImageFile(mediaType?: string): boolean {
-    return mediaType?.startsWith("image/") ?? false;
+  function isImageFile(mediaType?: unknown): boolean {
+    return typeof mediaType === "string" && mediaType.startsWith("image/");
   }
 
   type ImageMessagePart = {
+    type?: unknown;
     name?: unknown;
     mediaType?: unknown;
     file?: unknown;
@@ -584,6 +589,47 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
     return undefined;
   }
 
+  async function collectLifestyleReferenceImages(
+    messageObject: unknown,
+  ): Promise<LifestyleReferenceImagePayload[]> {
+    const parts =
+      messageObject &&
+      typeof messageObject === "object" &&
+      Array.isArray((messageObject as { parts?: unknown }).parts)
+        ? ((messageObject as { parts: unknown[] }).parts ?? [])
+        : [];
+    if (parts.length === 0) return [];
+
+    const sources: Array<{ data: string; mimeType: string; role: "style" }> =
+      [];
+    for (const part of parts) {
+      if (!part || typeof part !== "object") continue;
+      const imagePart = part as ImageMessagePart;
+      if (imagePart.type !== "file" || !isImageFile(imagePart.mediaType)) {
+        continue;
+      }
+
+      try {
+        const image = await resolveImagePartToBase64(imagePart, messageObject);
+        if (image) {
+          sources.push({
+            data: image.data,
+            mimeType: image.mimeType,
+            role: "style",
+          });
+        }
+      } catch (error) {
+        console.error(
+          "[LifestyleImage] Failed to resolve reference image:",
+          imagePart.name,
+          error,
+        );
+      }
+    }
+
+    return buildLifestyleReferenceImages(sources);
+  }
+
   // Set isAgentRunning for a specific chatId (used by stream callbacks to clear lock for correct chat)
   // Defined early to avoid initialization order issues with sendMessage
   const setIsAgentRunningForChatFn = useCallback(
@@ -671,11 +717,13 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
       prompt,
       assistantMessageId,
       sourceUserMessageId,
+      referenceImages,
     }: {
       chatId: string;
       prompt: string;
       assistantMessageId?: string;
       sourceUserMessageId?: string;
+      referenceImages?: LifestyleReferenceImagePayload[];
     }) => {
       const replyId = assistantMessageId || generateUUID();
       const replyCreatedAt = new Date();
@@ -737,6 +785,12 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             outputFormat: "png",
             responseFormat: "data_url",
             imageCount: 1,
+            ...(referenceImages?.length
+              ? {
+                  referenceImages,
+                  passReferenceImagesToProvider: true,
+                }
+              : {}),
           }),
         });
         const data = (await response
@@ -1079,10 +1133,14 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           return Promise.resolve();
         }
 
+        const referenceImages = hasLifestyleReferenceImage
+          ? await collectLifestyleReferenceImages(triggerMessageObject)
+          : [];
         await generateLifestyleImageReply({
           chatId: chatIdForMessages,
           prompt: generationPrompt,
           sourceUserMessageId: userMessage.id,
+          referenceImages,
         });
         return Promise.resolve();
       }

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -41,7 +41,11 @@ import {
 import { formatAgentStreamErrorForUser } from "@/lib/ai/runtime/format-error";
 import { parseCodexInterruptedError } from "@/lib/ai/extensions/agent/codex/interrupt-marker";
 import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/codex/transport-status";
-import { detectLifestyleImageTrigger } from "@/lib/ai/image-generation/lifestyle-trigger";
+import {
+  createLifestyleImageSkillFallbackRoute,
+  isLifestyleImageSkillRouteResult,
+  type LifestyleImageSkillRouteResult,
+} from "@/lib/ai/image-generation/lifestyle-skill-router";
 
 // Max retry attempts for stream errors
 const MAX_STREAM_RETRY_ATTEMPTS = 3;
@@ -214,6 +218,64 @@ function getLifestyleImageUrl(
     (response.b64Json ? `data:${mimeType};base64,${response.b64Json}` : null);
 
   return url ? { url, mediaType: mimeType } : null;
+}
+
+function messageHasImageAttachment(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const parts = (message as { parts?: unknown }).parts;
+  if (!Array.isArray(parts)) return false;
+
+  return parts.some((part) => {
+    if (!part || typeof part !== "object") return false;
+    const mediaType = (part as { mediaType?: unknown }).mediaType;
+    return typeof mediaType === "string" && mediaType.startsWith("image/");
+  });
+}
+
+async function requestLifestyleImageSkillRoute(input: {
+  message: string;
+  hasReferenceImage: boolean;
+  model: string;
+}): Promise<LifestyleImageSkillRouteResult> {
+  try {
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+    };
+    let authToken: string | null = null;
+    try {
+      authToken = getAuthToken();
+    } catch (error) {
+      console.error("[LifestyleImageIntent] Failed to read auth token", error);
+    }
+    if (authToken) {
+      headers.Authorization = `Bearer ${authToken}`;
+    }
+
+    const response = await fetch("/api/ai/v1/images/lifestyle/intent", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(input),
+    });
+
+    if (!response.ok) {
+      return createLifestyleImageSkillFallbackRoute("classifier_error");
+    }
+
+    const data = (await response.json().catch(() => null)) as {
+      route?: unknown;
+    } | null;
+    if (!isLifestyleImageSkillRouteResult(data?.route)) {
+      return createLifestyleImageSkillFallbackRoute("invalid_schema");
+    }
+
+    return data.route;
+  } catch (error) {
+    console.error(
+      "[LifestyleImageIntent] Failed to resolve skill route",
+      error,
+    );
+    return createLifestyleImageSkillFallbackRoute("classifier_error");
+  }
 }
 
 export function ChatContextProvider({ children }: { children: ReactNode }) {
@@ -945,12 +1007,22 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               metadata?: Record<string, unknown>;
             })
           : null;
-      const lifestyleTrigger = detectLifestyleImageTrigger(messageContent);
-      if (
-        lifestyleTrigger.matched &&
-        lifestyleTrigger.confidence === "high" &&
-        triggerMessageObject?.metadata?.skipLifestyleImageTrigger !== true
-      ) {
+      const hasLifestyleReferenceImage =
+        messageHasImageAttachment(triggerMessageObject);
+      const shouldSkipLifestyleImageSkill =
+        triggerMessageObject?.metadata?.skipLifestyleImageTrigger === true;
+      const lifestyleSkillRoute = shouldSkipLifestyleImageSkill
+        ? createLifestyleImageSkillFallbackRoute("intent_not_matched")
+        : await requestLifestyleImageSkillRoute({
+            message: messageContent,
+            hasReferenceImage: hasLifestyleReferenceImage,
+            model:
+              selectedModel === "default" ? DEFAULT_AI_MODEL : selectedModel,
+          });
+      const lifestyleSkillDecision = lifestyleSkillRoute.decision;
+      if (lifestyleSkillRoute.shouldGenerate && lifestyleSkillDecision) {
+        const generationPrompt =
+          lifestyleSkillDecision.refinedPrompt || messageContent;
         const userMessageCreatedAt = new Date();
         const userMessage = {
           role: "user" as const,
@@ -963,8 +1035,10 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             ...triggerMessageObject?.metadata,
             createdAt: userMessageCreatedAt.toISOString(),
             lifestyleImageTrigger: {
-              kind: lifestyleTrigger.kind,
-              reason: lifestyleTrigger.reason,
+              kind: "skill_lifestyle_image_request",
+              reason: lifestyleSkillDecision.reason,
+              confidence: lifestyleSkillDecision.confidence,
+              hasReferenceImage: hasLifestyleReferenceImage,
             },
           },
           id: generateUUID(),
@@ -985,8 +1059,8 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 type: "data-lifestyleImageConsent" as const,
                 data: {
                   id: consentMessageId,
-                  prompt: messageContent,
-                  reason: lifestyleTrigger.reason,
+                  prompt: generationPrompt,
+                  reason: lifestyleSkillDecision.reason,
                   createdAt: new Date().toISOString(),
                 },
               },
@@ -1007,7 +1081,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
 
         await generateLifestyleImageReply({
           chatId: chatIdForMessages,
-          prompt: messageContent,
+          prompt: generationPrompt,
           sourceUserMessageId: userMessage.id,
         });
         return Promise.resolve();

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -44,7 +44,7 @@ import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/
 import {
   createLifestyleImageSkillFallbackRoute,
   isLifestyleImageSkillRouteResult,
-  shouldBlockLifestyleImageClassifierFallback,
+  shouldGenerateLifestyleImageFromClassifierFallback,
   type LifestyleImageSkillRouteResult,
 } from "@/lib/ai/image-generation/lifestyle-skill-router";
 import {
@@ -1077,74 +1077,18 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               selectedModel === "default" ? DEFAULT_AI_MODEL : selectedModel,
           });
       const lifestyleSkillDecision = lifestyleSkillRoute.decision;
-      if (
-        shouldBlockLifestyleImageClassifierFallback({
+      const shouldGenerateFromClassifierFallback =
+        shouldGenerateLifestyleImageFromClassifierFallback({
           route: lifestyleSkillRoute,
           message: messageContent,
           hasReferenceImage: hasLifestyleReferenceImage,
-        })
-      ) {
-        const userMessageCreatedAt = new Date();
-        const userMessage = {
-          role: "user" as const,
-          content: messageContent,
-          createdAt: userMessageCreatedAt,
-          parts: triggerMessageObject?.parts || [
-            { type: "text" as const, text: messageContent },
-          ],
-          metadata: {
-            ...triggerMessageObject?.metadata,
-            createdAt: userMessageCreatedAt.toISOString(),
-            lifestyleImageTrigger: {
-              kind: "skill_lifestyle_image_request",
-              reason: "classifier_unavailable",
-              confidence: "low",
-              hasReferenceImage: hasLifestyleReferenceImage,
-            },
-          },
-          id: generateUUID(),
-        } as ChatMessage;
-        setMessages((prev) => [...prev, userMessage], chatIdForMessages);
-        await saveUserMessageAndUpdateHistory(userMessage, chatIdForMessages);
-
-        const errorMessage =
-          "Lifestyle image generation is temporarily unavailable. Please try again with a chat provider that supports lifestyle image intent routing.";
-        const assistantMessageId = generateUUID();
-        const assistantMessageCreatedAt = new Date(
-          userMessageCreatedAt.getTime() + 1,
-        );
-        const assistantMessage = {
-          role: "assistant" as const,
-          content: errorMessage,
-          id: assistantMessageId,
-          createdAt: assistantMessageCreatedAt,
-          parts: [
-            {
-              type: "error" as const,
-              content: errorMessage,
-            },
-          ],
-          metadata: {
-            createdAt: assistantMessageCreatedAt.toISOString(),
-            lifestyleImage: {
-              status: "error",
-              error: errorMessage,
-              sourceUserMessageId: userMessage.id,
-            },
-          },
-        } as ChatMessage;
-        setMessages((prev) => [...prev, assistantMessage], chatIdForMessages);
-        saveChatMessageImmediately(assistantMessage, chatIdForMessages);
-        toast({
-          type: "error",
-          description: errorMessage,
         });
-        setIsSending(false);
-        return Promise.resolve();
-      }
-      if (lifestyleSkillRoute.shouldGenerate && lifestyleSkillDecision) {
+      if (
+        (lifestyleSkillRoute.shouldGenerate && lifestyleSkillDecision) ||
+        shouldGenerateFromClassifierFallback
+      ) {
         const generationPrompt =
-          lifestyleSkillDecision.refinedPrompt || messageContent;
+          lifestyleSkillDecision?.refinedPrompt || messageContent;
         const userMessageCreatedAt = new Date();
         const userMessage = {
           role: "user" as const,
@@ -1157,9 +1101,13 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             ...triggerMessageObject?.metadata,
             createdAt: userMessageCreatedAt.toISOString(),
             lifestyleImageTrigger: {
-              kind: "skill_lifestyle_image_request",
-              reason: lifestyleSkillDecision.reason,
-              confidence: lifestyleSkillDecision.confidence,
+              kind: lifestyleSkillDecision
+                ? "skill_lifestyle_image_request"
+                : "classifier_fallback_lifestyle_image_request",
+              reason:
+                lifestyleSkillDecision?.reason ||
+                lifestyleSkillRoute.fallbackReason,
+              confidence: lifestyleSkillDecision?.confidence || "low",
               hasReferenceImage: hasLifestyleReferenceImage,
             },
           },

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -44,6 +44,7 @@ import { createCodexTransportStatusController } from "@/lib/ai/extensions/agent/
 import {
   createLifestyleImageSkillFallbackRoute,
   isLifestyleImageSkillRouteResult,
+  shouldBlockLifestyleImageClassifierFallback,
   type LifestyleImageSkillRouteResult,
 } from "@/lib/ai/image-generation/lifestyle-skill-router";
 import {
@@ -1076,6 +1077,71 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
               selectedModel === "default" ? DEFAULT_AI_MODEL : selectedModel,
           });
       const lifestyleSkillDecision = lifestyleSkillRoute.decision;
+      if (
+        shouldBlockLifestyleImageClassifierFallback({
+          route: lifestyleSkillRoute,
+          message: messageContent,
+          hasReferenceImage: hasLifestyleReferenceImage,
+        })
+      ) {
+        const userMessageCreatedAt = new Date();
+        const userMessage = {
+          role: "user" as const,
+          content: messageContent,
+          createdAt: userMessageCreatedAt,
+          parts: triggerMessageObject?.parts || [
+            { type: "text" as const, text: messageContent },
+          ],
+          metadata: {
+            ...triggerMessageObject?.metadata,
+            createdAt: userMessageCreatedAt.toISOString(),
+            lifestyleImageTrigger: {
+              kind: "skill_lifestyle_image_request",
+              reason: "classifier_unavailable",
+              confidence: "low",
+              hasReferenceImage: hasLifestyleReferenceImage,
+            },
+          },
+          id: generateUUID(),
+        } as ChatMessage;
+        setMessages((prev) => [...prev, userMessage], chatIdForMessages);
+        await saveUserMessageAndUpdateHistory(userMessage, chatIdForMessages);
+
+        const errorMessage =
+          "Lifestyle image generation is temporarily unavailable. Please try again with a chat provider that supports lifestyle image intent routing.";
+        const assistantMessageId = generateUUID();
+        const assistantMessageCreatedAt = new Date(
+          userMessageCreatedAt.getTime() + 1,
+        );
+        const assistantMessage = {
+          role: "assistant" as const,
+          content: errorMessage,
+          id: assistantMessageId,
+          createdAt: assistantMessageCreatedAt,
+          parts: [
+            {
+              type: "error" as const,
+              content: errorMessage,
+            },
+          ],
+          metadata: {
+            createdAt: assistantMessageCreatedAt.toISOString(),
+            lifestyleImage: {
+              status: "error",
+              error: errorMessage,
+              sourceUserMessageId: userMessage.id,
+            },
+          },
+        } as ChatMessage;
+        setMessages((prev) => [...prev, assistantMessage], chatIdForMessages);
+        saveChatMessageImmediately(assistantMessage, chatIdForMessages);
+        toast({
+          type: "error",
+          description: errorMessage,
+        });
+        setIsSending(false);
+        return Promise.resolve();
+      }
       if (lifestyleSkillRoute.shouldGenerate && lifestyleSkillDecision) {
         const generationPrompt =
           lifestyleSkillDecision.refinedPrompt || messageContent;

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -124,6 +124,7 @@ export interface ChatContextValue {
     chatId: string;
     assistantMessageId: string;
     prompt: string;
+    referenceImages?: LifestyleReferenceImagePayload[];
   }) => Promise<void>;
   declineLifestyleImageGeneration: (input: {
     chatId: string;
@@ -932,12 +933,13 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   const confirmLifestyleImageGeneration = useCallback<
     ChatContextValue["confirmLifestyleImageGeneration"]
   >(
-    async ({ chatId, assistantMessageId, prompt }) => {
+    async ({ chatId, assistantMessageId, prompt, referenceImages }) => {
       acceptLifestyleImageConsent();
       await generateLifestyleImageReply({
         chatId,
         prompt,
         assistantMessageId,
+        referenceImages,
       });
     },
     [generateLifestyleImageReply],
@@ -1100,6 +1102,9 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
         setMessages((prev) => [...prev, userMessage], chatIdForMessages);
         await saveUserMessageAndUpdateHistory(userMessage, chatIdForMessages);
 
+        const referenceImages = hasLifestyleReferenceImage
+          ? await collectLifestyleReferenceImages(triggerMessageObject)
+          : [];
         if (!hasAcceptedLifestyleImageConsent()) {
           const consentMessageId = generateUUID();
           const consentCreatedAt = new Date(userMessageCreatedAt.getTime() + 1);
@@ -1116,6 +1121,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                   prompt: generationPrompt,
                   reason: lifestyleSkillDecision.reason,
                   createdAt: new Date().toISOString(),
+                  ...(referenceImages.length ? { referenceImages } : {}),
                 },
               },
             ],
@@ -1133,9 +1139,6 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
           return Promise.resolve();
         }
 
-        const referenceImages = hasLifestyleReferenceImage
-          ? await collectLifestyleReferenceImages(triggerMessageObject)
-          : [];
         await generateLifestyleImageReply({
           chatId: chatIdForMessages,
           prompt: generationPrompt,

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -1133,7 +1133,9 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
                 data: {
                   id: consentMessageId,
                   prompt: generationPrompt,
-                  reason: lifestyleSkillDecision.reason,
+                  reason:
+                    lifestyleSkillDecision?.reason ||
+                    lifestyleSkillRoute.fallbackReason,
                   createdAt: new Date().toISOString(),
                   ...(referenceImages.length ? { referenceImages } : {}),
                 },

--- a/apps/web/components/message/index.tsx
+++ b/apps/web/components/message/index.tsx
@@ -44,6 +44,7 @@ import { NativeToolCall } from "./native-tool-call";
 import { RawMessagesResult } from "./raw-messages-result";
 import { LifestyleImageConsent } from "./lifestyle-image-consent";
 import { ToolCallAccordion, type ToolCallPart } from "./tool-call-accordion";
+import { buildLifestyleReferenceImages } from "@/lib/ai/image-generation/lifestyle-reference-images";
 import {
   LibraryItemRow,
   type LibraryItem,
@@ -1056,10 +1057,16 @@ const PurePreviewMessage = ({
                       const consentPart = part as {
                         data?: {
                           prompt?: string;
+                          referenceImages?: unknown;
                         };
                       };
                       const prompt = consentPart.data?.prompt?.trim();
                       if (!prompt) return null;
+                      const referenceImages = buildLifestyleReferenceImages(
+                        Array.isArray(consentPart.data?.referenceImages)
+                          ? consentPart.data.referenceImages
+                          : [],
+                      );
 
                       return (
                         <LifestyleImageConsent
@@ -1069,6 +1076,7 @@ const PurePreviewMessage = ({
                               chatId,
                               assistantMessageId: message.id,
                               prompt,
+                              referenceImages,
                             })
                           }
                           onDecline={() =>

--- a/apps/web/lib/ai/image-generation/lifestyle-reference-images.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-reference-images.ts
@@ -1,0 +1,157 @@
+export type LifestyleReferenceImageRole = "style" | "subject";
+
+export interface LifestyleReferenceImagePayload {
+  b64Json: string;
+  mimeType: string;
+  role: LifestyleReferenceImageRole;
+  note?: string;
+}
+
+export interface LifestyleReferenceImageSource {
+  data?: unknown;
+  dataUrl?: unknown;
+  b64Json?: unknown;
+  mimeType?: unknown;
+  role?: unknown;
+  note?: unknown;
+}
+
+export interface BuildLifestyleReferenceImagesOptions {
+  maxImages?: number;
+  defaultRole?: LifestyleReferenceImageRole;
+}
+
+export const MAX_LIFESTYLE_REFERENCE_IMAGES = 4;
+
+const MAX_REFERENCE_NOTE_LENGTH = 160;
+const SUPPORTED_REFERENCE_IMAGE_MIME_TYPES = new Set<string>([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
+
+export function buildLifestyleReferenceImages(
+  sources: LifestyleReferenceImageSource[] | null | undefined,
+  options: BuildLifestyleReferenceImagesOptions = {},
+): LifestyleReferenceImagePayload[] {
+  if (!sources?.length) return [];
+
+  const maxImages = normalizeMaxImages(options.maxImages);
+  const defaultRole = normalizeRole(options.defaultRole) ?? "style";
+  const images: LifestyleReferenceImagePayload[] = [];
+
+  for (const source of sources) {
+    if (images.length >= maxImages) break;
+    const image = normalizeLifestyleReferenceImage(source, { defaultRole });
+    if (image) {
+      images.push(image);
+    }
+  }
+
+  return images;
+}
+
+export function normalizeLifestyleReferenceImage(
+  source: LifestyleReferenceImageSource | null | undefined,
+  options: { defaultRole?: LifestyleReferenceImageRole } = {},
+): LifestyleReferenceImagePayload | null {
+  if (!source) return null;
+
+  const encodedImage = extractEncodedImage(source);
+  if (!encodedImage) return null;
+
+  const mimeType = normalizeMimeType(source.mimeType, encodedImage.mimeType);
+  if (!mimeType || !SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(mimeType)) {
+    return null;
+  }
+
+  const b64Json = stripDataUrlPrefix(encodedImage.b64Json).trim();
+  if (!b64Json) return null;
+
+  const role = normalizeRole(source.role) ?? options.defaultRole ?? "style";
+  const note = normalizeReferenceNote(source.note);
+
+  return {
+    b64Json,
+    mimeType,
+    role,
+    ...(note ? { note } : {}),
+  };
+}
+
+export function isSupportedLifestyleReferenceImageMimeType(
+  mimeType: unknown,
+): mimeType is string {
+  const normalized = normalizeMimeType(mimeType);
+  return Boolean(
+    normalized && SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(normalized),
+  );
+}
+
+function extractEncodedImage(
+  source: LifestyleReferenceImageSource,
+): { b64Json: string; mimeType?: string } | null {
+  const dataUrl = firstString(source.dataUrl);
+  if (dataUrl) {
+    const parsed = parseDataUrl(dataUrl);
+    if (parsed) return parsed;
+  }
+
+  const b64Json = firstString(source.b64Json, source.data);
+  return b64Json ? { b64Json } : null;
+}
+
+function parseDataUrl(
+  value: string,
+): { b64Json: string; mimeType: string } | null {
+  const match = value.trim().match(/^data:([^;,]+);base64,(.+)$/i);
+  if (!match) return null;
+  return {
+    mimeType: match[1].toLowerCase(),
+    b64Json: match[2],
+  };
+}
+
+function stripDataUrlPrefix(value: string): string {
+  const parsed = parseDataUrl(value);
+  return parsed?.b64Json ?? value;
+}
+
+function normalizeMimeType(
+  value: unknown,
+  fallback?: string,
+): string | undefined {
+  const raw = firstString(value) ?? fallback;
+  const normalized = raw?.trim().toLowerCase();
+  return normalized?.startsWith("image/") ? normalized : undefined;
+}
+
+function normalizeRole(
+  value: unknown,
+): LifestyleReferenceImageRole | undefined {
+  return value === "subject" || value === "style" ? value : undefined;
+}
+
+function normalizeReferenceNote(value: unknown): string | undefined {
+  const note = firstString(value);
+  if (!note) return undefined;
+  return note.length > MAX_REFERENCE_NOTE_LENGTH
+    ? `${note.slice(0, MAX_REFERENCE_NOTE_LENGTH - 3)}...`
+    : note;
+}
+
+function normalizeMaxImages(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : MAX_LIFESTYLE_REFERENCE_IMAGES;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}

--- a/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
@@ -106,6 +106,24 @@ export function createLifestyleImageSkillFallbackRoute(
   };
 }
 
+export function shouldBlockLifestyleImageClassifierFallback(input: {
+  route: LifestyleImageSkillRouteResult;
+  message: string;
+  hasReferenceImage: boolean;
+}): boolean {
+  if (
+    input.route.fallbackReason !== "classifier_unavailable" &&
+    input.route.fallbackReason !== "classifier_error"
+  ) {
+    return false;
+  }
+
+  return isLikelyLifestyleImageGenerationRequest(
+    input.message,
+    input.hasReferenceImage,
+  );
+}
+
 export function isLifestyleImageSkillRouteResult(
   value: unknown,
 ): value is LifestyleImageSkillRouteResult {
@@ -206,4 +224,34 @@ function isEmptySkillOutput(rawOutput: unknown): boolean {
   return (
     rawOutput == null || (typeof rawOutput === "string" && !rawOutput.trim())
   );
+}
+
+function isLikelyLifestyleImageGenerationRequest(
+  message: string,
+  hasReferenceImage: boolean,
+): boolean {
+  const normalized = message.toLowerCase();
+  if (!normalized.trim()) return false;
+
+  const wantsGeneration =
+    /\b(generate|create|make|render|produce|design|compose)\b/.test(
+      normalized,
+    ) || /生成|生图|出图|做图|制图|画一张|画个|制作/.test(normalized);
+  if (!wantsGeneration) return false;
+
+  const mentionsImage =
+    /\b(image|picture|photo|visual|mockup|render|png|jpg|jpeg)\b/.test(
+      normalized,
+    ) || /图片|照片|图像|视觉|效果图|渲染图/.test(normalized);
+
+  const mentionsLifestyle =
+    /\b(lifestyle|scene|setup|desk|room|interior|product|reference|style)\b/.test(
+      normalized,
+    ) || /生活方式|场景|桌面|室内|产品|参考图|风格/.test(normalized);
+
+  if (hasReferenceImage) {
+    return mentionsImage || mentionsLifestyle;
+  }
+
+  return mentionsImage && mentionsLifestyle;
 }

--- a/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
@@ -1,0 +1,161 @@
+export type LifestyleImageSkillConfidence = "high" | "medium" | "low";
+
+export interface LifestyleImageSkillDecision {
+  matched: boolean;
+  confidence: LifestyleImageSkillConfidence;
+  hasReferenceImage: boolean;
+  reason?: string;
+  refinedPrompt?: string;
+}
+
+export type LifestyleImageSkillFallbackReason =
+  | "empty_output"
+  | "invalid_json"
+  | "invalid_schema"
+  | "intent_not_matched"
+  | "confidence_not_high";
+
+export interface LifestyleImageSkillRouteResult {
+  shouldGenerate: boolean;
+  decision: LifestyleImageSkillDecision | null;
+  fallbackReason?: LifestyleImageSkillFallbackReason;
+}
+
+const CONFIDENCE_VALUES = new Set<LifestyleImageSkillConfidence>([
+  "high",
+  "medium",
+  "low",
+]);
+
+export function parseLifestyleImageSkillDecision(
+  rawOutput: unknown,
+): LifestyleImageSkillDecision | null {
+  const parsed = parseJsonObject(rawOutput);
+  if (!parsed) return null;
+
+  return coerceLifestyleImageSkillDecision(parsed);
+}
+
+export function resolveLifestyleImageSkillRoute(
+  rawOutput: unknown,
+): LifestyleImageSkillRouteResult {
+  if (isEmptySkillOutput(rawOutput)) {
+    return {
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "empty_output",
+    };
+  }
+
+  const parsed = parseJsonObject(rawOutput);
+  if (!parsed) {
+    return {
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason:
+        typeof rawOutput === "string" ? "invalid_json" : "invalid_schema",
+    };
+  }
+
+  const decision = coerceLifestyleImageSkillDecision(parsed);
+  if (!decision) {
+    return {
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "invalid_schema",
+    };
+  }
+
+  if (!decision.matched) {
+    return {
+      shouldGenerate: false,
+      decision,
+      fallbackReason: "intent_not_matched",
+    };
+  }
+
+  if (decision.confidence !== "high") {
+    return {
+      shouldGenerate: false,
+      decision,
+      fallbackReason: "confidence_not_high",
+    };
+  }
+
+  return {
+    shouldGenerate: true,
+    decision,
+  };
+}
+
+function coerceLifestyleImageSkillDecision(
+  parsed: Record<string, unknown>,
+): LifestyleImageSkillDecision | null {
+  if (typeof parsed.matched !== "boolean") return null;
+  if (!isLifestyleImageSkillConfidence(parsed.confidence)) return null;
+  if (typeof parsed.hasReferenceImage !== "boolean") return null;
+
+  const decision: LifestyleImageSkillDecision = {
+    matched: parsed.matched,
+    confidence: parsed.confidence,
+    hasReferenceImage: parsed.hasReferenceImage,
+  };
+
+  if (typeof parsed.reason === "string") {
+    const reason = parsed.reason.trim();
+    if (reason) {
+      decision.reason = reason;
+    }
+  } else if (parsed.reason !== undefined) {
+    return null;
+  }
+
+  if (typeof parsed.refinedPrompt === "string") {
+    const refinedPrompt = parsed.refinedPrompt.trim();
+    if (refinedPrompt) {
+      decision.refinedPrompt = refinedPrompt;
+    }
+  } else if (parsed.refinedPrompt !== undefined) {
+    return null;
+  }
+
+  return decision;
+}
+
+function parseJsonObject(rawOutput: unknown): Record<string, unknown> | null {
+  if (typeof rawOutput === "string") {
+    try {
+      return asPlainObject(JSON.parse(normalizeJsonOutput(rawOutput)));
+    } catch {
+      return null;
+    }
+  }
+
+  return asPlainObject(rawOutput);
+}
+
+function normalizeJsonOutput(rawOutput: string): string {
+  const trimmed = rawOutput.trim();
+  const fencedJson = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fencedJson ? fencedJson[1].trim() : trimmed;
+}
+
+function asPlainObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function isLifestyleImageSkillConfidence(
+  value: unknown,
+): value is LifestyleImageSkillConfidence {
+  return typeof value === "string" && CONFIDENCE_VALUES.has(value);
+}
+
+function isEmptySkillOutput(rawOutput: unknown): boolean {
+  return (
+    rawOutput == null || (typeof rawOutput === "string" && !rawOutput.trim())
+  );
+}

--- a/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
@@ -106,7 +106,7 @@ export function createLifestyleImageSkillFallbackRoute(
   };
 }
 
-export function shouldBlockLifestyleImageClassifierFallback(input: {
+export function shouldGenerateLifestyleImageFromClassifierFallback(input: {
   route: LifestyleImageSkillRouteResult;
   message: string;
   hasReferenceImage: boolean;

--- a/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
+++ b/apps/web/lib/ai/image-generation/lifestyle-skill-router.ts
@@ -13,7 +13,9 @@ export type LifestyleImageSkillFallbackReason =
   | "invalid_json"
   | "invalid_schema"
   | "intent_not_matched"
-  | "confidence_not_high";
+  | "confidence_not_high"
+  | "classifier_unavailable"
+  | "classifier_error";
 
 export interface LifestyleImageSkillRouteResult {
   shouldGenerate: boolean;
@@ -21,10 +23,16 @@ export interface LifestyleImageSkillRouteResult {
   fallbackReason?: LifestyleImageSkillFallbackReason;
 }
 
-const CONFIDENCE_VALUES = new Set<LifestyleImageSkillConfidence>([
-  "high",
-  "medium",
-  "low",
+const CONFIDENCE_VALUES = new Set<string>(["high", "medium", "low"]);
+
+const FALLBACK_REASON_VALUES = new Set<string>([
+  "empty_output",
+  "invalid_json",
+  "invalid_schema",
+  "intent_not_matched",
+  "confidence_not_high",
+  "classifier_unavailable",
+  "classifier_error",
 ]);
 
 export function parseLifestyleImageSkillDecision(
@@ -86,6 +94,40 @@ export function resolveLifestyleImageSkillRoute(
     shouldGenerate: true,
     decision,
   };
+}
+
+export function createLifestyleImageSkillFallbackRoute(
+  fallbackReason: LifestyleImageSkillFallbackReason,
+): LifestyleImageSkillRouteResult {
+  return {
+    shouldGenerate: false,
+    decision: null,
+    fallbackReason,
+  };
+}
+
+export function isLifestyleImageSkillRouteResult(
+  value: unknown,
+): value is LifestyleImageSkillRouteResult {
+  const route = asPlainObject(value);
+  if (!route) return false;
+  if (typeof route.shouldGenerate !== "boolean") return false;
+
+  const decision =
+    route.decision === null
+      ? null
+      : parseLifestyleImageSkillDecision(route.decision);
+  if (route.decision !== null && !decision) return false;
+  if (route.shouldGenerate && !decision) return false;
+
+  if (
+    route.fallbackReason !== undefined &&
+    !isLifestyleImageSkillFallbackReason(route.fallbackReason)
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function coerceLifestyleImageSkillDecision(
@@ -152,6 +194,12 @@ function isLifestyleImageSkillConfidence(
   value: unknown,
 ): value is LifestyleImageSkillConfidence {
   return typeof value === "string" && CONFIDENCE_VALUES.has(value);
+}
+
+function isLifestyleImageSkillFallbackReason(
+  value: unknown,
+): value is LifestyleImageSkillFallbackReason {
+  return typeof value === "string" && FALLBACK_REASON_VALUES.has(value);
 }
 
 function isEmptySkillOutput(rawOutput: unknown): boolean {

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -331,7 +331,12 @@ describe("POST /api/ai/v1/images/generations", () => {
     const [, options] = fetchMock.mock.calls[0];
     const payload = JSON.parse((options as RequestInit).body as string);
     expect(payload.input_references).toEqual([
-      "data:image/png;base64,cmVmLWltYWdl",
+      {
+        type: "image_url",
+        image_url: {
+          url: "data:image/png;base64,cmVmLWltYWdl",
+        },
+      },
     ]);
   });
 

--- a/apps/web/tests/api/image-generation.route.test.ts
+++ b/apps/web/tests/api/image-generation.route.test.ts
@@ -205,6 +205,46 @@ describe("POST /api/ai/v1/images/generations", () => {
     );
   });
 
+  test("uses OpenAI edits payload when reference images are provided", async () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: "aGVsbG8=" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "openai",
+        prompt: "a lifestyle image",
+        referenceImages: [{ b64Json: "cmVmLWltYWdl", mimeType: "image/png" }],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/images/edits",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          "Content-Type": expect.any(String),
+        }),
+      }),
+    );
+    const [, options] = fetchMock.mock.calls[0];
+    const payload = (options as RequestInit).body as FormData;
+    expect(payload).toBeInstanceOf(FormData);
+    expect(payload.get("model")).toBe("gpt-image-2");
+    expect(payload.get("prompt")).toBe("a lifestyle image");
+    expect(payload.getAll("image[]")).toHaveLength(1);
+    const image = payload.getAll("image[]")[0] as File;
+    expect(image.type).toBe("image/png");
+    expect(image.name).toBe("reference-1.png");
+  });
+
   test("uses OpenRouter image API shape with aspect_ratio output", async () => {
     process.env.OPENROUTER_API_KEY = "test-openrouter-key";
     process.env.OPENROUTER_IMAGE_MODEL = "bytedance-seed/seedream-4.5";
@@ -267,6 +307,34 @@ describe("POST /api/ai/v1/images/generations", () => {
     });
   });
 
+  test("passes reference images to the OpenRouter image API", async () => {
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+    process.env.OPENROUTER_IMAGE_MODEL = "bytedance-seed/seedream-4.5";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: "aGVsbG8=" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "openrouter",
+        prompt: "a lifestyle image",
+        referenceImages: [{ b64Json: "cmVmLWltYWdl", mimeType: "image/png" }],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const [, options] = fetchMock.mock.calls[0];
+    const payload = JSON.parse((options as RequestInit).body as string);
+    expect(payload.input_references).toEqual([
+      "data:image/png;base64,cmVmLWltYWdl",
+    ]);
+  });
+
   test("uses request provider over env default and accepts Nano Banana url output", async () => {
     process.env.IMAGE_GENERATION_PROVIDER = "openai";
     process.env.NANO_BANANA_API_KEY = "test-nano-key";
@@ -308,5 +376,35 @@ describe("POST /api/ai/v1/images/generations", () => {
       provider: "nano-banana",
       imageUrl: "https://cdn.example/generated.png",
     });
+  });
+
+  test("passes reference images to Nano Banana", async () => {
+    process.env.NANO_BANANA_API_KEY = "test-nano-key";
+    process.env.NANO_BANANA_IMAGE_GENERATION_URL =
+      "https://nano.example/images";
+    process.env.NANO_BANANA_MODEL = "nano-banana";
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [{ url: "https://cdn.example/generated.png" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(
+      request({
+        provider: "nano-banana",
+        prompt: "a lifestyle image",
+        referenceImages: [{ b64Json: "cmVmLWltYWdl", mimeType: "image/png" }],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const [, options] = fetchMock.mock.calls[0];
+    const payload = JSON.parse((options as RequestInit).body as string);
+    expect(payload.referenceImageUrls).toEqual([
+      "data:image/png;base64,cmVmLWltYWdl",
+    ]);
   });
 });

--- a/apps/web/tests/unit/lifestyle-image-intent-route.test.ts
+++ b/apps/web/tests/unit/lifestyle-image-intent-route.test.ts
@@ -110,32 +110,27 @@ describe("lifestyle image intent route", () => {
     expect(mocks.complete).not.toHaveBeenCalled();
   });
 
-  test("does not pass selected chat model overrides to agent runtimes", async () => {
+  test("falls back when the provider resolves to an agent runtime", async () => {
     mocks.resolveLlmProvider.mockResolvedValue({
       flavor: "agent_runtime",
       model: "agent-runtime",
       complete: mocks.complete,
     });
-    mocks.complete.mockResolvedValue({
-      text: JSON.stringify({
-        matched: false,
-        confidence: "low",
-        hasReferenceImage: false,
-      }),
-      model: "agent-runtime",
-    });
 
-    await postIntent({
+    const response = await postIntent({
       message: "Let's talk about lifestyle design.",
       hasReferenceImage: false,
       model: "deepseek/deepseek-v4-pro",
     });
+    const body = await response.json();
 
-    expect(mocks.complete).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: undefined,
-      }),
-    );
+    expect(response.status).toBe(200);
+    expect(body.route).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "classifier_unavailable",
+    });
+    expect(mocks.complete).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/tests/unit/lifestyle-image-intent-route.test.ts
+++ b/apps/web/tests/unit/lifestyle-image-intent-route.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  isTauriMode: vi.fn(),
+  resolveLlmProvider: vi.fn(),
+  complete: vi.fn(),
+}));
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: mocks.auth,
+}));
+
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: mocks.isTauriMode,
+}));
+
+vi.mock("@/lib/ai/provider-resolver", () => ({
+  resolveLlmProvider: mocks.resolveLlmProvider,
+}));
+
+describe("lifestyle image intent route", () => {
+  beforeEach(() => {
+    mocks.auth.mockReset();
+    mocks.isTauriMode.mockReset();
+    mocks.resolveLlmProvider.mockReset();
+    mocks.complete.mockReset();
+
+    mocks.auth.mockResolvedValue({ user: { id: "user-1" } });
+    mocks.isTauriMode.mockReturnValue(false);
+    mocks.resolveLlmProvider.mockResolvedValue({
+      flavor: "openai_http",
+      model: "classifier-model",
+      complete: mocks.complete,
+    });
+  });
+
+  test("returns a generation route for valid high-confidence intent JSON", async () => {
+    mocks.complete.mockResolvedValue({
+      text: JSON.stringify({
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: false,
+        reason: "explicit_lifestyle_image_generation_request",
+      }),
+      model: "classifier-model",
+    });
+
+    const response = await postIntent({
+      message: "Generate a lifestyle image for my profile.",
+      hasReferenceImage: true,
+      model: "openai/gpt-5.4",
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.route).toMatchObject({
+      shouldGenerate: true,
+      decision: {
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: true,
+      },
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "openai/gpt-5.4",
+        maxTokens: 300,
+      }),
+    );
+    const request = mocks.complete.mock.calls[0][0];
+    expect(request.system).toContain("OpenLoomi Lifestyle Image");
+    expect(request.userContent).toContain("Reference image uploaded: true");
+  });
+
+  test("falls back when the model returns natural language", async () => {
+    mocks.complete.mockResolvedValue({
+      text: "The user probably wants a lifestyle image.",
+      model: "classifier-model",
+    });
+
+    const response = await postIntent({
+      message: "Generate a lifestyle image for my profile.",
+      hasReferenceImage: false,
+    });
+    const body = await response.json();
+
+    expect(body.route).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "invalid_json",
+    });
+  });
+
+  test("falls back when the provider is unavailable", async () => {
+    mocks.resolveLlmProvider.mockResolvedValue(null);
+
+    const response = await postIntent({
+      message: "Generate a lifestyle image.",
+      hasReferenceImage: false,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.route).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "classifier_unavailable",
+    });
+    expect(mocks.complete).not.toHaveBeenCalled();
+  });
+
+  test("does not pass selected chat model overrides to agent runtimes", async () => {
+    mocks.resolveLlmProvider.mockResolvedValue({
+      flavor: "agent_runtime",
+      model: "agent-runtime",
+      complete: mocks.complete,
+    });
+    mocks.complete.mockResolvedValue({
+      text: JSON.stringify({
+        matched: false,
+        confidence: "low",
+        hasReferenceImage: false,
+      }),
+      model: "agent-runtime",
+    });
+
+    await postIntent({
+      message: "Let's talk about lifestyle design.",
+      hasReferenceImage: false,
+      model: "deepseek/deepseek-v4-pro",
+    });
+
+    expect(mocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: undefined,
+      }),
+    );
+  });
+});
+
+async function postIntent(body: Record<string, unknown>): Promise<Response> {
+  const { POST } =
+    await import("@/app/api/ai/v1/images/lifestyle/intent/route");
+  return POST(
+    new Request("http://localhost/api/ai/v1/images/lifestyle/intent", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+}

--- a/apps/web/tests/unit/lifestyle-reference-images.test.ts
+++ b/apps/web/tests/unit/lifestyle-reference-images.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildLifestyleReferenceImages,
+  isSupportedLifestyleReferenceImageMimeType,
+  MAX_LIFESTYLE_REFERENCE_IMAGES,
+  normalizeLifestyleReferenceImage,
+} from "@/lib/ai/image-generation/lifestyle-reference-images";
+
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB";
+
+describe("normalizeLifestyleReferenceImage", () => {
+  test("normalizes bare base64 image data", () => {
+    expect(
+      normalizeLifestyleReferenceImage({
+        data: PNG_BASE64,
+        mimeType: "image/png",
+      }),
+    ).toEqual({
+      b64Json: PNG_BASE64,
+      mimeType: "image/png",
+      role: "style",
+    });
+  });
+
+  test("normalizes data URLs and lowercases MIME type", () => {
+    expect(
+      normalizeLifestyleReferenceImage({
+        dataUrl: `data:IMAGE/JPEG;base64,${PNG_BASE64}`,
+        role: "subject",
+      }),
+    ).toEqual({
+      b64Json: PNG_BASE64,
+      mimeType: "image/jpeg",
+      role: "subject",
+    });
+  });
+
+  test("strips a data URL prefix from b64Json when MIME type is supplied", () => {
+    expect(
+      normalizeLifestyleReferenceImage({
+        b64Json: `data:image/webp;base64,${PNG_BASE64}`,
+        mimeType: "image/webp",
+      }),
+    ).toEqual({
+      b64Json: PNG_BASE64,
+      mimeType: "image/webp",
+      role: "style",
+    });
+  });
+
+  test("uses the configured default role and trims notes", () => {
+    expect(
+      normalizeLifestyleReferenceImage(
+        {
+          data: PNG_BASE64,
+          mimeType: "image/png",
+          note: "  use the jacket color  ",
+        },
+        { defaultRole: "subject" },
+      ),
+    ).toEqual({
+      b64Json: PNG_BASE64,
+      mimeType: "image/png",
+      role: "subject",
+      note: "use the jacket color",
+    });
+  });
+
+  test("rejects unsupported MIME types", () => {
+    expect(
+      normalizeLifestyleReferenceImage({
+        data: PNG_BASE64,
+        mimeType: "application/pdf",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects empty image payloads", () => {
+    expect(
+      normalizeLifestyleReferenceImage({
+        data: "   ",
+        mimeType: "image/png",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildLifestyleReferenceImages", () => {
+  test("filters invalid images and caps the result at four references by default", () => {
+    const sources = Array.from({ length: 6 }, (_, index) => ({
+      data: `${PNG_BASE64}-${index}`,
+      mimeType: index === 2 ? "text/plain" : "image/png",
+    }));
+
+    const images = buildLifestyleReferenceImages(sources);
+
+    expect(images).toHaveLength(MAX_LIFESTYLE_REFERENCE_IMAGES);
+    expect(images.map((image) => image.b64Json)).toEqual([
+      `${PNG_BASE64}-0`,
+      `${PNG_BASE64}-1`,
+      `${PNG_BASE64}-3`,
+      `${PNG_BASE64}-4`,
+    ]);
+  });
+
+  test("supports a custom max image count", () => {
+    expect(
+      buildLifestyleReferenceImages(
+        [
+          { data: "one", mimeType: "image/png" },
+          { data: "two", mimeType: "image/png" },
+        ],
+        { maxImages: 1 },
+      ),
+    ).toEqual([
+      {
+        b64Json: "one",
+        mimeType: "image/png",
+        role: "style",
+      },
+    ]);
+  });
+});
+
+describe("isSupportedLifestyleReferenceImageMimeType", () => {
+  test("accepts supported image MIME types", () => {
+    expect(isSupportedLifestyleReferenceImageMimeType("image/png")).toBe(true);
+    expect(isSupportedLifestyleReferenceImageMimeType("IMAGE/WEBP")).toBe(true);
+  });
+
+  test("rejects unsupported or non-image MIME types", () => {
+    expect(isSupportedLifestyleReferenceImageMimeType("image/svg+xml")).toBe(
+      false,
+    );
+    expect(isSupportedLifestyleReferenceImageMimeType("text/plain")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/tests/unit/lifestyle-skill-router.test.ts
+++ b/apps/web/tests/unit/lifestyle-skill-router.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "vitest";
+import {
+  parseLifestyleImageSkillDecision,
+  resolveLifestyleImageSkillRoute,
+} from "@/lib/ai/image-generation/lifestyle-skill-router";
+
+describe("parseLifestyleImageSkillDecision", () => {
+  test("accepts a valid structured decision", () => {
+    expect(
+      parseLifestyleImageSkillDecision({
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: true,
+        reason: " explicit_lifestyle_image_generation_request ",
+        refinedPrompt: " create a lifestyle portrait ",
+      }),
+    ).toEqual({
+      matched: true,
+      confidence: "high",
+      hasReferenceImage: true,
+      reason: "explicit_lifestyle_image_generation_request",
+      refinedPrompt: "create a lifestyle portrait",
+    });
+  });
+
+  test("accepts a JSON string decision", () => {
+    expect(
+      parseLifestyleImageSkillDecision(
+        '{"matched":false,"confidence":"low","hasReferenceImage":false}',
+      ),
+    ).toEqual({
+      matched: false,
+      confidence: "low",
+      hasReferenceImage: false,
+    });
+  });
+
+  test("accepts a fenced JSON decision", () => {
+    expect(
+      parseLifestyleImageSkillDecision(
+        '```json\n{"matched":true,"confidence":"high","hasReferenceImage":false}\n```',
+      ),
+    ).toEqual({
+      matched: true,
+      confidence: "high",
+      hasReferenceImage: false,
+    });
+  });
+
+  test("rejects natural language output", () => {
+    expect(
+      parseLifestyleImageSkillDecision(
+        "The user probably wants a lifestyle image.",
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects missing required fields", () => {
+    expect(
+      parseLifestyleImageSkillDecision({
+        matched: true,
+        confidence: "high",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects invalid confidence values", () => {
+    expect(
+      parseLifestyleImageSkillDecision({
+        matched: true,
+        confidence: "certain",
+        hasReferenceImage: false,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects invalid optional field types", () => {
+    expect(
+      parseLifestyleImageSkillDecision({
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: false,
+        refinedPrompt: ["portrait"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveLifestyleImageSkillRoute", () => {
+  test("routes high-confidence matched decisions to generation", () => {
+    expect(
+      resolveLifestyleImageSkillRoute({
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: false,
+      }),
+    ).toEqual({
+      shouldGenerate: true,
+      decision: {
+        matched: true,
+        confidence: "high",
+        hasReferenceImage: false,
+      },
+    });
+  });
+
+  test("falls back when intent is not matched", () => {
+    expect(
+      resolveLifestyleImageSkillRoute({
+        matched: false,
+        confidence: "low",
+        hasReferenceImage: false,
+      }),
+    ).toMatchObject({
+      shouldGenerate: false,
+      fallbackReason: "intent_not_matched",
+    });
+  });
+
+  test("falls back when confidence is below high", () => {
+    expect(
+      resolveLifestyleImageSkillRoute({
+        matched: true,
+        confidence: "medium",
+        hasReferenceImage: false,
+      }),
+    ).toMatchObject({
+      shouldGenerate: false,
+      fallbackReason: "confidence_not_high",
+    });
+  });
+
+  test("falls back on malformed JSON", () => {
+    expect(resolveLifestyleImageSkillRoute("{not-json")).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "invalid_json",
+    });
+  });
+
+  test("falls back on invalid schema", () => {
+    expect(
+      resolveLifestyleImageSkillRoute({
+        matched: true,
+        confidence: "high",
+      }),
+    ).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "invalid_schema",
+    });
+  });
+
+  test("falls back on empty output", () => {
+    expect(resolveLifestyleImageSkillRoute("  ")).toEqual({
+      shouldGenerate: false,
+      decision: null,
+      fallbackReason: "empty_output",
+    });
+  });
+});

--- a/apps/web/tests/unit/lifestyle-skill-router.test.ts
+++ b/apps/web/tests/unit/lifestyle-skill-router.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   parseLifestyleImageSkillDecision,
   resolveLifestyleImageSkillRoute,
-  shouldBlockLifestyleImageClassifierFallback,
+  shouldGenerateLifestyleImageFromClassifierFallback,
 } from "@/lib/ai/image-generation/lifestyle-skill-router";
 
 describe("parseLifestyleImageSkillDecision", () => {
@@ -161,10 +161,10 @@ describe("resolveLifestyleImageSkillRoute", () => {
   });
 });
 
-describe("shouldBlockLifestyleImageClassifierFallback", () => {
-  test("blocks explicit lifestyle generation requests when the classifier is unavailable", () => {
+describe("shouldGenerateLifestyleImageFromClassifierFallback", () => {
+  test("allows explicit lifestyle generation requests when the classifier is unavailable", () => {
     expect(
-      shouldBlockLifestyleImageClassifierFallback({
+      shouldGenerateLifestyleImageFromClassifierFallback({
         route: {
           shouldGenerate: false,
           decision: null,
@@ -177,9 +177,9 @@ describe("shouldBlockLifestyleImageClassifierFallback", () => {
     ).toBe(true);
   });
 
-  test("does not block ordinary image understanding when the classifier is unavailable", () => {
+  test("does not route ordinary image understanding when the classifier is unavailable", () => {
     expect(
-      shouldBlockLifestyleImageClassifierFallback({
+      shouldGenerateLifestyleImageFromClassifierFallback({
         route: {
           shouldGenerate: false,
           decision: null,
@@ -191,9 +191,9 @@ describe("shouldBlockLifestyleImageClassifierFallback", () => {
     ).toBe(false);
   });
 
-  test("does not block non-classifier fallbacks", () => {
+  test("does not route non-classifier fallbacks", () => {
     expect(
-      shouldBlockLifestyleImageClassifierFallback({
+      shouldGenerateLifestyleImageFromClassifierFallback({
         route: {
           shouldGenerate: false,
           decision: null,

--- a/apps/web/tests/unit/lifestyle-skill-router.test.ts
+++ b/apps/web/tests/unit/lifestyle-skill-router.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   parseLifestyleImageSkillDecision,
   resolveLifestyleImageSkillRoute,
+  shouldBlockLifestyleImageClassifierFallback,
 } from "@/lib/ai/image-generation/lifestyle-skill-router";
 
 describe("parseLifestyleImageSkillDecision", () => {
@@ -157,5 +158,50 @@ describe("resolveLifestyleImageSkillRoute", () => {
       decision: null,
       fallbackReason: "empty_output",
     });
+  });
+});
+
+describe("shouldBlockLifestyleImageClassifierFallback", () => {
+  test("blocks explicit lifestyle generation requests when the classifier is unavailable", () => {
+    expect(
+      shouldBlockLifestyleImageClassifierFallback({
+        route: {
+          shouldGenerate: false,
+          decision: null,
+          fallbackReason: "classifier_unavailable",
+        },
+        message:
+          "Use this uploaded image as a style reference and generate a lifestyle image.",
+        hasReferenceImage: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not block ordinary image understanding when the classifier is unavailable", () => {
+    expect(
+      shouldBlockLifestyleImageClassifierFallback({
+        route: {
+          shouldGenerate: false,
+          decision: null,
+          fallbackReason: "classifier_unavailable",
+        },
+        message: "What is in this uploaded image?",
+        hasReferenceImage: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not block non-classifier fallbacks", () => {
+    expect(
+      shouldBlockLifestyleImageClassifierFallback({
+        route: {
+          shouldGenerate: false,
+          decision: null,
+          fallbackReason: "invalid_json",
+        },
+        message: "Generate a lifestyle image.",
+        hasReferenceImage: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/ai/src/agent/image-gen/base.ts
+++ b/packages/ai/src/agent/image-gen/base.ts
@@ -35,6 +35,27 @@ export abstract class ImageGenProvider {
     return `data:${mimeType};base64,${stripped}`;
   }
 
+  protected referenceImageDataUrls(request: ImageGenerationRequest): string[] {
+    const urls = request.referenceImageUrls
+      ?.map((url) => url.trim())
+      .filter(Boolean);
+    const images = request.referenceImages
+      ?.map((image) => this.referenceImageToDataUrl(image))
+      .filter((image): image is string => Boolean(image));
+    return [...(urls ?? []), ...(images ?? [])];
+  }
+
+  protected referenceImageFiles(request: ImageGenerationRequest): Array<{
+    blob: Blob;
+    filename: string;
+  }> {
+    return this.referenceImageDataUrls(request)
+      .map((value, index) => this.dataUrlToFile(value, index))
+      .filter(
+        (file): file is { blob: Blob; filename: string } => file !== null,
+      );
+  }
+
   protected stripDataUrlPrefix(value: string): string {
     const trimmed = value.trim();
     const marker = ";base64,";
@@ -46,5 +67,53 @@ export abstract class ImageGenProvider {
 
   protected async sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private referenceImageToDataUrl(
+    image: NonNullable<ImageGenerationRequest["referenceImages"]>[number],
+  ): string | null {
+    if (image.dataUrl?.trim()) return image.dataUrl.trim();
+    const encoded = image.b64Json?.trim();
+    if (!encoded) return null;
+    return this.dataUrlFromBase64(encoded, image.mimeType || "image/png");
+  }
+
+  private dataUrlToFile(
+    value: string,
+    index: number,
+  ): { blob: Blob; filename: string } | null {
+    const parsed = parseDataUrl(value);
+    if (!parsed) return null;
+    const bytes = Buffer.from(parsed.b64Json, "base64");
+    return {
+      blob: new Blob([bytes], { type: parsed.mimeType }),
+      filename: `reference-${index + 1}.${extensionForMimeType(
+        parsed.mimeType,
+      )}`,
+    };
+  }
+}
+
+function parseDataUrl(
+  value: string,
+): { mimeType: string; b64Json: string } | null {
+  const match = value.trim().match(/^data:([^;,]+);base64,(.+)$/i);
+  if (!match) return null;
+  return {
+    mimeType: match[1].toLowerCase(),
+    b64Json: match[2],
+  };
+}
+
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType.toLowerCase()) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
   }
 }

--- a/packages/ai/src/agent/image-gen/providers/nano-banana.ts
+++ b/packages/ai/src/agent/image-gen/providers/nano-banana.ts
@@ -18,7 +18,7 @@ const NANO_BANANA_MODELS: ImageModelInfo[] = [
     id: "nano-banana",
     name: "nano-banana",
     displayName: "Nano Banana",
-    supportedModality: ["text"],
+    supportedModality: ["text", "image"],
     supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
     supportedQualities: ["auto", "low", "medium", "high"],
     supportedOutputFormats: ["png", "jpeg", "webp"],
@@ -27,7 +27,7 @@ const NANO_BANANA_MODELS: ImageModelInfo[] = [
 
 const NANO_BANANA_CAPABILITIES: ImageGenerationCapabilities = {
   supportsTextToImage: true,
-  supportsImageReference: false,
+  supportsImageReference: true,
   supportsUrlOutput: true,
   supportsBase64Output: true,
   supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
@@ -119,19 +119,6 @@ export class NanoBananaImageGenProvider extends ImageGenProvider {
       });
     }
 
-    if (modality === "image") {
-      return failure({
-        model,
-        prompt: request.prompt,
-        imageCount,
-        modality,
-        creditsUsed,
-        error:
-          "Reference images are not supported by the Day 1 Nano Banana text-to-image provider.",
-        errorType: "validation_error",
-      });
-    }
-
     try {
       const response = await fetch(endpoint, {
         method: "POST",
@@ -140,7 +127,14 @@ export class NanoBananaImageGenProvider extends ImageGenProvider {
           "x-api-key": this.apiKey,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(buildPayload(request, model, imageCount)),
+        body: JSON.stringify(
+          buildPayload(
+            request,
+            model,
+            imageCount,
+            this.referenceImageDataUrls(request),
+          ),
+        ),
         signal: AbortSignal.timeout(this.timeoutMs),
       });
 
@@ -224,6 +218,7 @@ function buildPayload(
   request: ImageGenerationRequest,
   model: string,
   imageCount: number,
+  referenceImages: string[] = [],
 ): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     model,
@@ -239,6 +234,9 @@ function buildPayload(
       request.responseFormat === "data_url"
         ? "b64_json"
         : request.responseFormat;
+  }
+  if (referenceImages.length > 0) {
+    payload.referenceImageUrls = referenceImages;
   }
 
   return payload;

--- a/packages/ai/src/agent/image-gen/providers/openai.ts
+++ b/packages/ai/src/agent/image-gen/providers/openai.ts
@@ -19,7 +19,7 @@ const OPENAI_IMAGE_MODELS: ImageModelInfo[] = [
     id: "gpt-image-2",
     name: "gpt-image-2",
     displayName: "GPT-Image-2",
-    supportedModality: ["text"],
+    supportedModality: ["text", "image"],
     supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
     supportedQualities: ["auto", "low", "medium", "high"],
     supportedOutputFormats: ["png", "jpeg", "webp"],
@@ -28,7 +28,7 @@ const OPENAI_IMAGE_MODELS: ImageModelInfo[] = [
 
 const OPENAI_CAPABILITIES: ImageGenerationCapabilities = {
   supportsTextToImage: true,
-  supportsImageReference: false,
+  supportsImageReference: true,
   supportsUrlOutput: false,
   supportsBase64Output: true,
   supportedSizes: ["1024x1024", "1024x1536", "1536x1024", "auto"],
@@ -121,7 +121,9 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
       });
     }
 
-    if (modality === "image") {
+    const referenceFiles =
+      modality === "image" ? this.referenceImageFiles(request) : [];
+    if (modality === "image" && referenceFiles.length === 0) {
       return failure({
         model,
         prompt: request.prompt,
@@ -129,21 +131,31 @@ export class OpenAIImageGenProvider extends ImageGenProvider {
         modality,
         creditsUsed,
         error:
-          "Reference images are not supported by the Day 1 OpenAI text-to-image provider.",
+          "OpenAI reference image generation requires base64/data URL reference images.",
         errorType: "validation_error",
       });
     }
 
     try {
       const response = await fetch(
-        buildImagesUrl(this.baseUrl, this.imageGenerationUrl),
+        modality === "image"
+          ? buildImageEditsUrl(this.baseUrl, this.imageGenerationUrl)
+          : buildImagesUrl(this.baseUrl, this.imageGenerationUrl),
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${this.apiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(buildPayload(request, model, imageCount)),
+          headers:
+            modality === "image"
+              ? {
+                  Authorization: `Bearer ${this.apiKey}`,
+                }
+              : {
+                  Authorization: `Bearer ${this.apiKey}`,
+                  "Content-Type": "application/json",
+                },
+          body:
+            modality === "image"
+              ? buildEditFormData(request, model, imageCount, referenceFiles)
+              : JSON.stringify(buildPayload(request, model, imageCount)),
           signal: AbortSignal.timeout(this.timeoutMs),
         },
       );
@@ -242,6 +254,33 @@ function buildPayload(
   return payload;
 }
 
+function buildEditFormData(
+  request: ImageGenerationRequest,
+  model: string,
+  imageCount: number,
+  referenceFiles: Array<{ blob: Blob; filename: string }>,
+): FormData {
+  const form = new FormData();
+  form.set("model", model);
+  form.set("prompt", request.prompt);
+  form.set("n", String(imageCount));
+  form.set("size", request.size || DEFAULT_SIZE);
+
+  if (request.quality) {
+    form.set("quality", request.quality);
+  }
+
+  if (request.outputFormat) {
+    form.set("output_format", request.outputFormat);
+  }
+
+  for (const file of referenceFiles) {
+    form.append("image[]", file.blob, file.filename);
+  }
+
+  return form;
+}
+
 function buildImagesUrl(baseUrl: string, imageGenerationUrl?: string): string {
   const direct = normalizeOptionalString(imageGenerationUrl);
   if (direct) return direct;
@@ -250,6 +289,19 @@ function buildImagesUrl(baseUrl: string, imageGenerationUrl?: string): string {
   return normalized.endsWith("/v1")
     ? `${normalized}/images/generations`
     : `${normalized}/v1/images/generations`;
+}
+
+function buildImageEditsUrl(
+  baseUrl: string,
+  imageGenerationUrl?: string,
+): string {
+  const direct = normalizeOptionalString(imageGenerationUrl);
+  if (direct) return direct;
+
+  const normalized = baseUrl.replace(/\/+$/, "");
+  return normalized.endsWith("/v1")
+    ? `${normalized}/images/edits`
+    : `${normalized}/v1/images/edits`;
 }
 
 function usesLegacyImageResponseFormat(model: string): boolean {

--- a/packages/ai/src/agent/image-gen/providers/openrouter.ts
+++ b/packages/ai/src/agent/image-gen/providers/openrouter.ts
@@ -18,7 +18,7 @@ const OPENROUTER_IMAGE_MODELS: ImageModelInfo[] = [
     id: "bytedance-seed/seedream-4.5",
     name: "bytedance-seed/seedream-4.5",
     displayName: "Seedream 4.5 (OpenRouter)",
-    supportedModality: ["text"],
+    supportedModality: ["text", "image"],
     supportedSizes: ["1:1", "16:9", "9:16", "4:3", "3:4"],
     supportedQualities: ["auto", "low", "medium", "high"],
     supportedOutputFormats: ["png", "jpeg", "webp"],
@@ -27,7 +27,7 @@ const OPENROUTER_IMAGE_MODELS: ImageModelInfo[] = [
 
 const OPENROUTER_CAPABILITIES: ImageGenerationCapabilities = {
   supportsTextToImage: true,
-  supportsImageReference: false,
+  supportsImageReference: true,
   supportsUrlOutput: false,
   supportsBase64Output: true,
   supportedSizes: ["1:1", "16:9", "9:16", "4:3", "3:4"],
@@ -126,19 +126,6 @@ export class OpenRouterImageGenProvider extends ImageGenProvider {
       });
     }
 
-    if (modality === "image") {
-      return failure({
-        model,
-        prompt: request.prompt,
-        imageCount,
-        modality,
-        creditsUsed,
-        error:
-          "Reference images are not supported by the Day 1 OpenRouter text-to-image provider.",
-        errorType: "validation_error",
-      });
-    }
-
     try {
       const response = await fetch(
         buildImagesUrl(this.baseUrl, this.imageGenerationUrl),
@@ -149,7 +136,14 @@ export class OpenRouterImageGenProvider extends ImageGenProvider {
             referer: this.referer,
             title: this.title,
           }),
-          body: JSON.stringify(buildPayload(request, model, imageCount)),
+          body: JSON.stringify(
+            buildPayload(
+              request,
+              model,
+              imageCount,
+              this.referenceImageDataUrls(request),
+            ),
+          ),
           signal: AbortSignal.timeout(this.timeoutMs),
         },
       );
@@ -238,6 +232,7 @@ function buildPayload(
   request: ImageGenerationRequest,
   model: string,
   imageCount: number,
+  referenceImages: string[] = [],
 ): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     model,
@@ -249,6 +244,9 @@ function buildPayload(
   if (aspectRatio) payload.aspect_ratio = aspectRatio;
   if (request.quality) payload.quality = request.quality;
   if (request.outputFormat) payload.output_format = request.outputFormat;
+  if (referenceImages.length > 0) {
+    payload.input_references = referenceImages;
+  }
 
   return payload;
 }

--- a/packages/ai/src/agent/image-gen/providers/openrouter.ts
+++ b/packages/ai/src/agent/image-gen/providers/openrouter.ts
@@ -245,7 +245,10 @@ function buildPayload(
   if (request.quality) payload.quality = request.quality;
   if (request.outputFormat) payload.output_format = request.outputFormat;
   if (referenceImages.length > 0) {
-    payload.input_references = referenceImages;
+    payload.input_references = referenceImages.map((url) => ({
+      type: "image_url",
+      image_url: { url },
+    }));
   }
 
   return payload;

--- a/skills/openloomi-lifestyle-image/SKILL.md
+++ b/skills/openloomi-lifestyle-image/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: openloomi-lifestyle-image
+description: Identify whether a user is asking OpenLoomi to generate a lifestyle image, portrait, personal visual, or lifestyle scene. Use this skill for chat messages that may request image generation for a user's lifestyle, identity, persona, personal brand, social profile, memories, interests, or real-life scene; distinguish true generation intent from ordinary image understanding, prompt-writing, editing, or negated requests.
+---
+
+# OpenLoomi Lifestyle Image
+
+## Purpose
+
+Decide whether the user is asking to generate a lifestyle image through OpenLoomi's existing lifestyle image flow. This skill only judges intent and prepares a decision signal for the host app. Do not call image generation providers from this skill.
+
+## Decision
+
+Return a lifestyle image generation decision only when the user clearly wants OpenLoomi to create or generate a lifestyle-oriented image.
+
+Use `matched: true` when the request asks to generate, create, make, draw, design, render, or produce a lifestyle image, personal visual, avatar-like lifestyle scene, personal brand image, social profile visual, or life-scene image based on the user's profile, memory, interests, chat context, or uploaded reference image.
+
+Use `matched: false` when the user is only asking to:
+
+- Analyze, identify, describe, OCR, classify, or understand an uploaded image.
+- Write or improve a prompt without asking to generate the image now.
+- Edit an existing image without asking for lifestyle generation.
+- Discuss image generation conceptually.
+- Say not to generate an image, or says image generation is unnecessary.
+- Ask an unrelated design, document, code, or chat question.
+
+## Reference Images
+
+Set `hasReferenceImage: true` when the current user message includes an uploaded image that appears intended as style, subject, persona, or visual reference for generation.
+
+Do not set `matched: true` only because an image was uploaded. If the user asks what the image shows, who the character is, or asks for image understanding, return `matched: false`.
+
+If the user uploads a reference image and also asks to generate a lifestyle image from or inspired by it, return `matched: true` and `hasReferenceImage: true`.
+
+## Output Contract
+
+When the host requests a structured decision, return only JSON with this shape:
+
+```json
+{
+  "matched": true,
+  "confidence": "high",
+  "reason": "explicit_lifestyle_image_generation_request",
+  "hasReferenceImage": false,
+  "refinedPrompt": "optional concise generation intent"
+}
+```
+
+Rules:
+
+- `matched` must be boolean.
+- `confidence` must be `high`, `medium`, or `low`.
+- Use `confidence: "high"` only when the user clearly wants generation now.
+- Use `confidence: "medium"` when lifestyle generation is plausible but underspecified.
+- Use `confidence: "low"` with `matched: false` for ordinary chat or image understanding.
+- `reason` should be a short snake_case string.
+- `hasReferenceImage` must be boolean.
+- `refinedPrompt` is optional and should preserve the user's intent without inventing new identity details.
+
+## Examples
+
+User: "Generate a lifestyle image for my LinkedIn profile based on my interests."
+
+Decision: `matched: true`, `confidence: "high"`, `hasReferenceImage: false`.
+
+User: "Use this photo as a style reference and create a lifestyle portrait."
+
+Decision: `matched: true`, `confidence: "high"`, `hasReferenceImage: true`.
+
+User: "What character is in this image?"
+
+Decision: `matched: false`, `confidence: "low"`, `hasReferenceImage: false`.
+
+User: "Help me write a prompt for a lifestyle image."
+
+Decision: `matched: false`, `confidence: "low"`, `hasReferenceImage: false`.
+
+User: "Do not generate an image, just describe the idea."
+
+Decision: `matched: false`, `confidence: "low"`, `hasReferenceImage: false`.

--- a/skills/openloomi-lifestyle-image/agents/openai.yaml
+++ b/skills/openloomi-lifestyle-image/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Lifestyle Image Intent"
+  short_description: "Decide when a user wants OpenLoomi to generate a lifestyle image."


### PR DESCRIPTION
## Summary

This PR moves lifestyle image generation from the previous chat-side rule trigger toward a skill-routed flow, while also adding uploaded reference image support through the local image generation pipeline.

The implementation keeps image generation provider calls separate from the selected chat/agent runtime. Lifestyle image generation continues to use the locally configured image generation APIs from env, while the skill/router layer is only responsible for deciding whether the user intends to generate a lifestyle image.

## Changes

- Added a new `openloomi-lifestyle-image` skill with a structured JSON intent contract.
- Added a lifestyle image intent route at `/api/ai/v1/images/lifestyle/intent`.
- Added strict parsing and fallback handling for malformed or low-confidence classifier output.
- Updated chat routing to call the lifestyle intent route before ordinary chat.
- Preserved normal chat fallback for non-matching or malformed skill output.
- Avoided using Codex agent runtime as the intent classifier, since the agent runtime can take over the request with its own tools/skills instead of returning strict routing JSON.
- Added a narrow classifier-unavailable fallback so explicit lifestyle image generation still uses the OpenLoomi local image generation pipeline instead of falling through to Codex `imagegen` / shell / Pillow.
- Added reference image extraction from uploaded chat image attachments.
- Preserved reference images through the consent flow.
- Passed `referenceImages` and `passReferenceImagesToProvider` into lifestyle image generation.
- Added reference image support for existing image providers:
  - OpenAI / GPT Image via image edit multipart payload
  - OpenRouter via `input_references`
  - Nano Banana via `referenceImageUrls`
- Fixed OpenRouter reference image schema to send object references instead of raw string values.
- Added/updated unit and API tests for routing, fallback behavior, reference image normalization, and provider payloads.

## Approach

The final flow is:

1. User sends a chat message.
2. OpenLoomi calls the lifestyle image intent route.
3. If the skill classifier returns valid high-confidence JSON, the request enters the lifestyle image generation flow.
4. If classifier output is invalid or intent is not matched, the message continues as normal chat.
5. If the classifier is unavailable but the request is clearly an explicit lifestyle image generation request, OpenLoomi uses a controlled fallback into the existing local lifestyle image generation flow.
6. If generation is accepted, existing consent, prompt composition, and env-configured image provider APIs are reused.
7. Uploaded reference images are normalized to base64 payloads and passed to the image provider when requested.

This avoids using the selected chat provider as the image generation backend. The chat/intent layer only decides routing; the image generation layer still uses the local env-configured provider.

## Implemented Functionality

- Basic lifestyle image generation continues to work.
- Uploaded images can be used as lifestyle image references.
- Reference images are preserved through consent and generation.
- OpenRouter no longer fails with `input_references[0]: expected object, received string`.
- Codex agent runtime no longer hijacks lifestyle image requests with its own `imagegen` / shell / Pillow path.
- The generated image is rendered back into the chat as before.

## Manual Testing

Tested locally in Tauri dev mode.

- The returned image was displayed successfully in chat.
- The generated image appeared to include visual/reference elements from the uploaded image.
<img width="975" height="611" alt="80b94885860e7dd0b70c34c6eabb3306" src="https://github.com/user-attachments/assets/6f241431-f506-40ee-a877-48e1df5ec10f" />

## Known UX Follow-ups

The backend/functionality is now working, but the user experience still needs improvement:

- The UI does not clearly indicate when a reference image is being used for lifestyle generation.
- The classifier/fallback behavior should be surfaced more clearly to users and developers.
- Some unrelated asset/icon 404s appear in local logs and should be polished separately.