### PR TITLE
feat(agent): add Claude goal runtime observation and evidence

### DIFF
--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -82,6 +82,7 @@ import {
 import {
   claudeAgentSdkTransport,
   ClaudeRuntimeSession,
+  resolveAuthenticatedGoalRuntimeOwnerId,
   startClaudeGoalRuntimeSession,
 } from "./runtime";
 import {
@@ -1763,6 +1764,9 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       settings: settingsConfig,
       agentOptions: options,
       supplementalInput: claudeRuntime.liveInputSource,
+      toolObserver: resolveAuthenticatedGoalRuntimeOwnerId(options?.session)
+        ? claudeRuntime
+        : undefined,
       permissionMode: options?.permissionMode,
       abortController: session.abortController,
       env: envConfig,

--- a/apps/web/lib/ai/extensions/agent/claude/query-options.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/query-options.ts
@@ -12,6 +12,7 @@ import {
 
 import { createCanUseToolOption } from "./permissions";
 import { createClaudeSupplementalInputHooks } from "./runtime";
+import type { ClaudeRuntimeToolHookObserver } from "./runtime/supplemental-hooks";
 import type { ClaudeRuntimeLogger } from "./skills";
 
 // Baseline tool surface for Claude Code sessions. Extra tool groups, such as
@@ -73,6 +74,7 @@ export function createClaudeQueryOptions({
   allowedTools,
   agentOptions,
   supplementalInput,
+  toolObserver,
   abortController,
   env,
   config,
@@ -98,6 +100,7 @@ export function createClaudeQueryOptions({
     "permissionMode" | "onPermissionRequest" | "disallowedTools"
   >;
   supplementalInput?: AgentSupplementalInputSource;
+  toolObserver?: ClaudeRuntimeToolHookObserver;
   abortController: AbortController;
   env: Record<string, string>;
   config: AgentConfig;
@@ -116,6 +119,7 @@ export function createClaudeQueryOptions({
   const effectivePermissionMode = permissionMode || "bypassPermissions";
   const supplementalHooks = createClaudeSupplementalInputHooks({
     supplementalInput,
+    toolObserver,
     sessionId,
     logger,
   });

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/event-observer.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/event-observer.ts
@@ -1,0 +1,276 @@
+import { createHash } from "node:crypto";
+
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+import type {
+  RuntimeObservationContext,
+  RuntimeProviderObservationPort,
+} from "@/lib/ai/runtime-instructions/runtime-observation";
+import { collectClaudeToolEvidence } from "./evidence-collector";
+import { extractClaudeResultUsage } from "./usage";
+
+export interface ClaudeRuntimeToolStart {
+  toolUseId: string;
+  toolName: string;
+  providerSessionId?: string;
+  runEpoch: number;
+}
+
+export interface ClaudeRuntimeToolOutcome extends ClaudeRuntimeToolStart {
+  outcome: "succeeded" | "failed";
+  toolInput: unknown;
+  toolResponse?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface ClaudeRuntimeEventObserverPort {
+  instructionWritten(input: {
+    instructionId: string;
+    runEpoch: number;
+    recordedAt?: string;
+  }): Promise<void>;
+
+  observeSdkMessage(message: SDKMessage, runEpoch: number): Promise<void>;
+
+  captureToolStart(input: ClaudeRuntimeToolStart): Promise<void>;
+
+  observeToolOutcome(input: ClaudeRuntimeToolOutcome): Promise<void>;
+
+  flush(): Promise<void>;
+}
+
+interface CapturedToolContext {
+  runEpoch: number;
+  context: RuntimeObservationContext | null;
+}
+
+/**
+ * Converts Claude-specific SDK messages and tool hooks into the provider-
+ * neutral observation boundary. All callbacks share one async tail so
+ * synchronous SDK input handoff cannot race ahead of later provider output.
+ */
+export class ClaudeRuntimeEventObserver implements ClaudeRuntimeEventObserverPort {
+  private readonly toolContexts = new Map<string, CapturedToolContext>();
+  private tail: Promise<void> = Promise.resolve();
+  private providerSessionId?: string;
+
+  constructor(
+    private readonly ownerId: string,
+    private readonly runtimeSessionId: string,
+    private readonly observations: RuntimeProviderObservationPort,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  instructionWritten(input: {
+    instructionId: string;
+    runEpoch: number;
+    recordedAt?: string;
+  }): Promise<void> {
+    return this.enqueue(async () => {
+      await this.observations.recordInstructionHandoff({
+        ownerId: this.ownerId,
+        runtimeSessionId: this.runtimeSessionId,
+        instructionId: input.instructionId,
+        runEpoch: input.runEpoch,
+        recordedAt: input.recordedAt ?? this.now().toISOString(),
+      });
+    });
+  }
+
+  observeSdkMessage(message: SDKMessage, runEpoch: number): Promise<void> {
+    return this.enqueue(async () => {
+      const identity = sdkMessageIdentity(message);
+      if (identity?.providerSessionId) {
+        this.assertProviderSession(identity.providerSessionId);
+      }
+      if (message.type === "system" && message.subtype === "init") {
+        if (identity?.providerSessionId) {
+          await this.observations.setProviderSession({
+            ownerId: this.ownerId,
+            runtimeSessionId: this.runtimeSessionId,
+            providerSessionId: identity.providerSessionId,
+          });
+        }
+        return;
+      }
+      if (!identity || !isCausalProviderMessage(message)) return;
+
+      const usage = extractClaudeResultUsage(message);
+      await this.observations.observeProviderEvent({
+        ownerId: this.ownerId,
+        runtimeSessionId: this.runtimeSessionId,
+        runEpoch,
+        eventKey: identity.eventKey,
+        providerEventId: identity.providerEventId,
+        ...(identity.providerSessionId === undefined
+          ? {}
+          : { providerSessionId: identity.providerSessionId }),
+        observedAt: sdkTimestamp(message) ?? this.now().toISOString(),
+        terminal: message.type === "result",
+        ...(usage === undefined ? {} : { usage }),
+      });
+    });
+  }
+
+  captureToolStart(input: ClaudeRuntimeToolStart): Promise<void> {
+    return this.enqueue(async () => {
+      if (input.providerSessionId) {
+        this.assertProviderSession(input.providerSessionId);
+      }
+      const key = toolKey(input.providerSessionId, input.toolUseId);
+      if (this.toolContexts.has(key)) return;
+      const context = await this.observations.captureContext({
+        ownerId: this.ownerId,
+        runtimeSessionId: this.runtimeSessionId,
+        runEpoch: input.runEpoch,
+      });
+      this.toolContexts.set(key, { runEpoch: input.runEpoch, context });
+    });
+  }
+
+  observeToolOutcome(input: ClaudeRuntimeToolOutcome): Promise<void> {
+    return this.enqueue(async () => {
+      if (input.providerSessionId) {
+        this.assertProviderSession(input.providerSessionId);
+      }
+      const key = toolKey(input.providerSessionId, input.toolUseId);
+      const captured = this.toolContexts.get(key);
+      if (!captured) return;
+      this.toolContexts.delete(key);
+
+      const providerEventId = boundedProviderEventId(
+        `claude-tool:${input.providerSessionId ?? this.providerSessionId ?? "unknown"}:${input.toolUseId}`,
+      );
+      const providerSessionId =
+        input.providerSessionId ?? this.providerSessionId;
+      const observedAt = this.now().toISOString();
+      const evidence = captured.context
+        ? [
+            collectClaudeToolEvidence({
+              providerEventId,
+              toolUseId: input.toolUseId,
+              toolName: input.toolName,
+              outcome: input.outcome,
+              toolInput: input.toolInput,
+              ...(input.toolResponse === undefined
+                ? {}
+                : { toolResponse: input.toolResponse }),
+              ...(input.error === undefined ? {} : { error: input.error }),
+              ...(input.durationMs === undefined
+                ? {}
+                : { durationMs: input.durationMs }),
+              observedAt,
+            }),
+          ]
+        : undefined;
+
+      await this.observations.observeProviderEvent({
+        ownerId: this.ownerId,
+        runtimeSessionId: this.runtimeSessionId,
+        runEpoch: captured.runEpoch,
+        eventKey: providerEventId,
+        providerEventId,
+        ...(providerSessionId === undefined ? {} : { providerSessionId }),
+        observedAt,
+        ...(captured.context === null ? {} : { context: captured.context }),
+        ...(evidence === undefined ? {} : { evidence }),
+      });
+    });
+  }
+
+  flush(): Promise<void> {
+    return this.tail;
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const pending = this.tail.then(operation);
+    this.tail = pending.catch(() => {});
+    return pending;
+  }
+
+  private assertProviderSession(providerSessionId: string): void {
+    if (
+      this.providerSessionId !== undefined &&
+      this.providerSessionId !== providerSessionId
+    ) {
+      throw new Error(
+        `Claude event belongs to provider session ${providerSessionId}, not ${this.providerSessionId}`,
+      );
+    }
+    this.providerSessionId = providerSessionId;
+  }
+}
+
+interface ClaudeSdkMessageIdentity {
+  eventKey: string;
+  providerEventId: string;
+  providerSessionId?: string;
+}
+
+function sdkMessageIdentity(
+  message: SDKMessage,
+): ClaudeSdkMessageIdentity | null {
+  const candidate = message as SDKMessage & {
+    uuid?: unknown;
+    session_id?: unknown;
+  };
+  if (
+    typeof candidate.uuid !== "string" ||
+    candidate.uuid.length === 0 ||
+    candidate.uuid.length > 256
+  ) {
+    return null;
+  }
+  const providerSessionId =
+    typeof candidate.session_id === "string" &&
+    candidate.session_id.length > 0 &&
+    candidate.session_id.length <= 256
+      ? candidate.session_id
+      : undefined;
+  return {
+    // Claude UUIDs are the provider's event identity. Do not include mutable
+    // wrapper fields such as subtype, or a replay could apply usage twice.
+    eventKey: [
+      "claude-sdk",
+      providerSessionId ?? "unknown",
+      candidate.uuid,
+    ].join(":"),
+    providerEventId: candidate.uuid,
+    ...(providerSessionId === undefined ? {} : { providerSessionId }),
+  };
+}
+
+function isCausalProviderMessage(message: SDKMessage): boolean {
+  if (
+    message.type === "user" &&
+    (message as SDKMessage & { isReplay?: unknown }).isReplay === true
+  ) {
+    return false;
+  }
+  return (
+    message.type === "assistant" ||
+    message.type === "user" ||
+    message.type === "result"
+  );
+}
+
+function sdkTimestamp(message: SDKMessage): string | undefined {
+  const timestamp = (message as SDKMessage & { timestamp?: unknown }).timestamp;
+  return typeof timestamp === "string" && Number.isFinite(Date.parse(timestamp))
+    ? timestamp
+    : undefined;
+}
+
+function toolKey(
+  providerSessionId: string | undefined,
+  toolUseId: string,
+): string {
+  return JSON.stringify([providerSessionId ?? "unknown", toolUseId]);
+}
+
+function boundedProviderEventId(value: string): string {
+  if (value.length <= 256) return value;
+  const digest = createHash("sha256").update(value).digest("hex");
+  return `${value.slice(0, 180)}:${digest}`.slice(0, 256);
+}

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/evidence-collector.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/evidence-collector.ts
@@ -1,0 +1,408 @@
+import { createHash } from "node:crypto";
+
+import type { GoalEvidenceType } from "@openloomi/ai/agent/runtime-instructions";
+import type { RuntimeEvidenceDraft } from "@/lib/ai/runtime-instructions/runtime-observation";
+
+const MAX_SOURCE_EVENT_ID_CHARACTERS = 256;
+const MAX_NAME_CHARACTERS = 256;
+const MAX_SUMMARY_CHARACTERS = 1_000;
+const MAX_COMMAND_CHARACTERS = 4_000;
+const MAX_DETAIL_CHARACTERS = 8_000;
+const MAX_PATH_CHARACTERS = 512;
+const MAX_PATHS = 16;
+const MAX_JSON_DEPTH = 4;
+const MAX_JSON_ENTRIES = 32;
+const MAX_JSON_CHARACTERS = 8_000;
+const SENSITIVE_KEY_PATTERN =
+  /(?:authorization|cookie|credential|password|private[_-]?key|secret|token|api[_-]?key)/i;
+
+const FILE_CHANGE_TOOLS = new Set([
+  "edit",
+  "multiedit",
+  "notebookedit",
+  "write",
+]);
+
+const COMMAND_TOOLS = new Set([
+  "bash",
+  "command",
+  "powershell",
+  "shell",
+  "sandbox_run_command",
+  "sandbox_run_script",
+]);
+
+const TEST_COMMAND_PATTERNS = [
+  /(?:^|\s)(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?test(?=$|\s|:)/i,
+  /(?:^|\s)(?:(?:npx|bunx|pnpm\s+exec|yarn\s+exec)\s+)?(?:ava|cypress|jest|mocha|playwright|pytest|vitest)(?=$|\s)/i,
+  /(?:^|\s)python(?:3)?\s+-m\s+pytest(?=$|\s)/i,
+  /(?:^|\s)(?:cargo|dotnet|go|mix|swift)\s+test(?=$|\s)/i,
+  /(?:^|\s)(?:bundle\s+exec\s+)?rspec(?=$|\s)/i,
+  /(?:^|\s)(?:\.\/[A-Za-z0-9._-]*gradlew|gradle|mvn|ctest)\s+test(?=$|\s)/i,
+];
+
+type RuntimeEvidenceJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | RuntimeEvidenceJsonValue[]
+  | { [key: string]: RuntimeEvidenceJsonValue };
+
+interface ClaudeToolEvidenceInput {
+  providerEventId: string;
+  toolUseId: string;
+  toolName: string;
+  outcome: "succeeded" | "failed";
+  toolInput: unknown;
+  toolResponse?: unknown;
+  error?: string;
+  durationMs?: number;
+  observedAt: string;
+}
+
+interface ExplicitToolOutcome {
+  success: boolean;
+  exitCode?: number;
+}
+
+function truncate(value: string, maximum: number): string {
+  if (value.length <= maximum) return value;
+  return `${value.slice(0, Math.max(0, maximum - 16))}\n...[truncated]`;
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(
+      /(--(?:api[-_]?key|password|secret|token))(?:=|\s+)\S+/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(
+      /\b([A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY))\s*=\s*([^\s;&|]+)/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(
+      /\b(authorization|cookie|credential|password|secret|token|api[_-]?key)\s*[:=]\s*([^\s,;&|]+)/gi,
+      "$1=[REDACTED]",
+    );
+}
+
+function normalizedToolName(toolName: string): string {
+  const segments = toolName.trim().toLowerCase().split("__");
+  return segments.at(-1) ?? "";
+}
+
+function isCommandTool(toolName: string): boolean {
+  const normalized = normalizedToolName(toolName);
+  return (
+    COMMAND_TOOLS.has(normalized) ||
+    (/sandbox/.test(normalized) && /(?:command|script)$/.test(normalized))
+  );
+}
+
+function isTestCommand(command: string | undefined): boolean {
+  return command
+    ? TEST_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
+    : false;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function findRecordValue(
+  value: unknown,
+  keys: readonly string[],
+  depth = 0,
+): unknown {
+  if (depth > 3) return undefined;
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  for (const key of keys) {
+    if (record[key] !== undefined) return record[key];
+  }
+  for (const nested of Object.values(record)) {
+    const found = findRecordValue(nested, keys, depth + 1);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function extractCommand(toolInput: unknown): string | undefined {
+  if (typeof toolInput === "string") {
+    const command = toolInput.trim();
+    return command
+      ? truncate(redactSensitiveText(command), MAX_COMMAND_CHARACTERS)
+      : undefined;
+  }
+  const rawCommand = findRecordValue(toolInput, ["command", "cmd"]);
+  return typeof rawCommand === "string" && rawCommand.trim()
+    ? truncate(redactSensitiveText(rawCommand.trim()), MAX_COMMAND_CHARACTERS)
+    : undefined;
+}
+
+function extractPaths(toolInput: unknown): string[] {
+  const paths: string[] = [];
+  const seen = new Set<unknown>();
+  const pathKeys = new Set([
+    "file",
+    "file_path",
+    "filePath",
+    "notebook_path",
+    "notebookPath",
+    "path",
+  ]);
+
+  const visit = (value: unknown, depth: number): void => {
+    if (depth > MAX_JSON_DEPTH || paths.length >= MAX_PATHS) return;
+    if (value === null || typeof value !== "object" || seen.has(value)) return;
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value.slice(0, MAX_JSON_ENTRIES)) {
+        visit(item, depth + 1);
+      }
+      return;
+    }
+
+    for (const [key, item] of Object.entries(value)) {
+      if (pathKeys.has(key) && typeof item === "string" && item.trim()) {
+        paths.push(truncate(item.trim(), MAX_PATH_CHARACTERS));
+        if (paths.length >= MAX_PATHS) return;
+      } else {
+        visit(item, depth + 1);
+      }
+    }
+  };
+
+  visit(toolInput, 0);
+  return [...new Set(paths)];
+}
+
+function readExitCode(toolResponse: unknown): number | undefined {
+  const value = findRecordValue(toolResponse, ["exit_code", "exitCode"]);
+  return typeof value === "number" && Number.isInteger(value)
+    ? value
+    : undefined;
+}
+
+function explicitOutcome(
+  outcome: "succeeded" | "failed",
+  toolResponse: unknown,
+): ExplicitToolOutcome {
+  const exitCode = readExitCode(toolResponse);
+  return {
+    success: outcome === "succeeded",
+    ...(exitCode === undefined ? {} : { exitCode }),
+  };
+}
+
+function stableSourceEventId(
+  providerEventId: string,
+  toolUseId: string,
+): string {
+  const raw = `${providerEventId}:tool:${toolUseId}`;
+  if (raw.length <= MAX_SOURCE_EVENT_ID_CHARACTERS) return raw;
+
+  const digest = createHash("sha256").update(raw).digest("hex");
+  const prefix = truncate(providerEventId, 170).replace(/\s+/g, "-");
+  return `${prefix}:tool:${digest}`.slice(0, MAX_SOURCE_EVENT_ID_CHARACTERS);
+}
+
+function boundedJsonValue(
+  value: unknown,
+  remaining: { characters: number; nodes: number },
+  seen: Set<unknown>,
+  depth = 0,
+): RuntimeEvidenceJsonValue {
+  if (remaining.nodes <= 0 || remaining.characters <= 0) return "[truncated]";
+  remaining.nodes -= 1;
+
+  if (value === null) {
+    remaining.characters -= 4;
+    return value;
+  }
+  if (typeof value === "boolean") {
+    remaining.characters -= value ? 4 : 5;
+    return value;
+  }
+  if (typeof value === "number") {
+    const bounded = Number.isFinite(value) ? value : null;
+    remaining.characters -= String(bounded).length;
+    return bounded;
+  }
+  if (typeof value === "string") {
+    const available = Math.max(0, remaining.characters);
+    const bounded = truncate(
+      redactSensitiveText(value),
+      Math.min(MAX_DETAIL_CHARACTERS, available),
+    );
+    remaining.characters -= bounded.length;
+    return bounded;
+  }
+  if (typeof value === "bigint") {
+    const bounded = truncate(value.toString(), 128);
+    remaining.characters -= bounded.length;
+    return bounded;
+  }
+  if (typeof value !== "object" || value === null) {
+    const bounded = truncate(String(value), 128);
+    remaining.characters -= bounded.length;
+    return bounded;
+  }
+  if (seen.has(value)) return "[circular]";
+  if (depth >= MAX_JSON_DEPTH || remaining.characters <= 0) {
+    return "[truncated]";
+  }
+
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value
+      .slice(0, MAX_JSON_ENTRIES)
+      .map((item) => boundedJsonValue(item, remaining, seen, depth + 1));
+    seen.delete(value);
+    return result;
+  }
+
+  const result: { [key: string]: RuntimeEvidenceJsonValue } = {};
+  for (const [rawKey, item] of Object.entries(value).slice(
+    0,
+    MAX_JSON_ENTRIES,
+  )) {
+    if (remaining.characters <= 0) break;
+    const key = truncate(rawKey, 128);
+    remaining.characters -= key.length;
+    result[key] = SENSITIVE_KEY_PATTERN.test(rawKey)
+      ? "[REDACTED]"
+      : boundedJsonValue(item, remaining, seen, depth + 1);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function boundedDetail(value: unknown): RuntimeEvidenceJsonValue {
+  return boundedJsonValue(
+    value,
+    { characters: MAX_JSON_CHARACTERS, nodes: 256 },
+    new Set<unknown>(),
+  );
+}
+
+function responsePreview(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") {
+    return truncate(redactSensitiveText(value), MAX_DETAIL_CHARACTERS);
+  }
+  try {
+    return truncate(
+      JSON.stringify(boundedDetail(value)),
+      MAX_DETAIL_CHARACTERS,
+    );
+  } catch {
+    return "[unserializable tool response]";
+  }
+}
+
+function safeDuration(durationMs: number | undefined): number | undefined {
+  return typeof durationMs === "number" &&
+    Number.isFinite(durationMs) &&
+    durationMs >= 0
+    ? durationMs
+    : undefined;
+}
+
+function summaryFor(
+  type: GoalEvidenceType,
+  toolName: string,
+  success: boolean,
+  command: string | undefined,
+  paths: string[],
+): string {
+  const outcome = success ? "succeeded" : "failed";
+  if (type === "test_result") {
+    return truncate(
+      `Test command ${outcome}${command ? `: ${command}` : ""}`,
+      MAX_SUMMARY_CHARACTERS,
+    );
+  }
+  if (type === "command_result") {
+    return truncate(
+      `Command ${outcome}${command ? `: ${command}` : ""}`,
+      MAX_SUMMARY_CHARACTERS,
+    );
+  }
+  if (type === "file_change") {
+    return truncate(
+      `File change ${outcome}${paths.length ? `: ${paths.join(", ")}` : ` via ${toolName}`}`,
+      MAX_SUMMARY_CHARACTERS,
+    );
+  }
+  return truncate(`Tool ${toolName} ${outcome}`, MAX_SUMMARY_CHARACTERS);
+}
+
+/** Extracts a bounded evidence draft from one completed Claude tool hook. */
+export function collectClaudeToolEvidence({
+  providerEventId,
+  toolUseId,
+  toolName,
+  outcome: hookOutcome,
+  toolInput,
+  toolResponse,
+  error,
+  durationMs,
+  observedAt,
+}: ClaudeToolEvidenceInput): RuntimeEvidenceDraft {
+  const normalizedName = normalizedToolName(toolName);
+  const command = isCommandTool(toolName)
+    ? extractCommand(toolInput)
+    : undefined;
+  const outcome = explicitOutcome(hookOutcome, toolResponse);
+  const paths = extractPaths(toolInput);
+  const type: GoalEvidenceType = isCommandTool(toolName)
+    ? isTestCommand(command)
+      ? "test_result"
+      : "command_result"
+    : FILE_CHANGE_TOOLS.has(normalizedName) && outcome.success
+      ? "file_change"
+      : "tool_result";
+
+  const payload: { [key: string]: RuntimeEvidenceJsonValue } = {
+    provider: "claude",
+    toolName: truncate(toolName.trim() || "unknown", MAX_NAME_CHARACTERS),
+    toolUseId: truncate(toolUseId, MAX_NAME_CHARACTERS),
+  };
+  const boundedDuration = safeDuration(durationMs);
+  if (boundedDuration !== undefined) payload.durationMs = boundedDuration;
+  if (command !== undefined) payload.command = command;
+  if (outcome.exitCode !== undefined) payload.exitCode = outcome.exitCode;
+  if (paths.length > 0) payload.paths = paths;
+  if (error?.trim())
+    payload.error = truncate(
+      redactSensitiveText(error.trim()),
+      MAX_DETAIL_CHARACTERS,
+    );
+
+  // File-writing inputs can contain entire files or patches. Store only paths
+  // and execution metadata for those tools, including failed attempts. Tool
+  // responses are omitted too because some providers echo the written body.
+  if (FILE_CHANGE_TOOLS.has(normalizedName)) {
+    payload.inputContentRetained = false;
+  } else {
+    const preview = responsePreview(toolResponse);
+    if (preview !== undefined) payload.outputPreview = preview;
+    if (!isCommandTool(toolName)) payload.input = boundedDetail(toolInput);
+  }
+
+  return {
+    type,
+    sourceEventId: stableSourceEventId(providerEventId, toolUseId),
+    summary: summaryFor(type, toolName, outcome.success, command, paths),
+    success: outcome.success,
+    payload,
+    observedAt,
+  };
+}

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeSessionRegistration,
 } from "@/lib/ai/runtime-instructions";
 import type { ClaudeRuntimeSession } from "./session";
+import { ClaudeRuntimeEventObserver } from "./event-observer";
 
 export interface StartClaudeGoalRuntimeSessionInput {
   session?: unknown;
@@ -65,7 +66,7 @@ export class ClaudeGoalRuntimeRecoveryRequiredError extends Error {
 export async function startClaudeGoalRuntimeSession(
   input: StartClaudeGoalRuntimeSessionInput,
 ): Promise<RuntimeSessionRegistration | undefined> {
-  const ownerId = authenticatedOwnerId(input.session);
+  const ownerId = resolveAuthenticatedGoalRuntimeOwnerId(input.session);
   if (!ownerId) {
     input.runtime.start(input.start);
     return undefined;
@@ -91,6 +92,13 @@ export async function startClaudeGoalRuntimeSession(
         expectedRunEpoch,
       );
     }
+    input.runtime.attachEventObserver(
+      new ClaudeRuntimeEventObserver(
+        ownerId,
+        input.runtime.runtimeSessionId,
+        goalRuntime.observations,
+      ),
+    );
     registration = goalRuntime.sessions.register({
       ownerId,
       transport: input.runtime,
@@ -114,7 +122,9 @@ export async function startClaudeGoalRuntimeSession(
   }
 }
 
-function authenticatedOwnerId(session: unknown): string | undefined {
+export function resolveAuthenticatedGoalRuntimeOwnerId(
+  session: unknown,
+): string | undefined {
   if (!session || typeof session !== "object") return undefined;
 
   const user = (session as { user?: unknown }).user;

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
@@ -29,6 +29,11 @@ import type {
 } from "@openloomi/ai/agent/types";
 
 import type { ClaudeRuntimeLogger } from "../skills";
+import type {
+  ClaudeRuntimeEventObserverPort,
+  ClaudeRuntimeToolOutcome,
+  ClaudeRuntimeToolStart,
+} from "./event-observer";
 import { ClaudeInputMultiplexer } from "./input-multiplexer";
 import { ClaudeOutputMultiplexer } from "./output-multiplexer";
 import type { ClaudeSdkTransport } from "./sdk-transport";
@@ -75,6 +80,7 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
   private terminalSequence = 0;
   private readonly terminalHistory: RuntimeTurnTerminal[] = [];
   private readonly terminalWaiters = new Set<TerminalWaiter>();
+  private eventObserver: ClaudeRuntimeEventObserverPort | null = null;
 
   claudeSessionId?: string;
 
@@ -122,6 +128,22 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
     return this.processedSdkMessages;
   }
 
+  attachEventObserver(observer: ClaudeRuntimeEventObserverPort): void {
+    if (this.query || this.currentState !== "starting") {
+      throw new ClaudeRuntimeSessionError(
+        "already_started",
+        "Claude runtime event observer must be attached before start",
+      );
+    }
+    if (this.eventObserver && this.eventObserver !== observer) {
+      throw new ClaudeRuntimeSessionError(
+        "observer_already_attached",
+        "Claude runtime session already has an event observer",
+      );
+    }
+    this.eventObserver = observer;
+  }
+
   start(input: {
     initialPrompt: string | AsyncIterable<SDKUserMessage>;
     queryOptions?: Options;
@@ -135,6 +157,10 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
 
     this.inputQueue.setHandoffHandler((supplementalInput) => {
       this.observeSupplementalInputHandoff(supplementalInput);
+      void this.observeInstructionWritten(
+        supplementalInput.id,
+        supplementalInput.runEpoch,
+      );
     });
     const multiplexer = new ClaudeInputMultiplexer(
       input.initialPrompt,
@@ -184,6 +210,10 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
       instruction.kind === "goal.pause" ||
       instruction.kind === "goal.cancel"
     ) {
+      await this.observeInstructionWritten(
+        instruction.id,
+        instruction.payload.expectedRunEpoch,
+      );
       if (
         this.runEpoch === instruction.payload.expectedRunEpoch &&
         (this.currentState === "running" || this.currentState === "evaluating")
@@ -389,6 +419,16 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
     }
 
     if (this.outputPump) await this.outputPump;
+    if (this.eventObserver) {
+      try {
+        await this.eventObserver.flush();
+      } catch (error) {
+        this.logger.warn(
+          `[Claude ${this.runtimeSessionId}] Failed to flush Goal observations`,
+          error,
+        );
+      }
+    }
   }
 
   private async pumpQuery(query: Query): Promise<void> {
@@ -397,7 +437,8 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
       for await (const message of query) {
         const observedRunEpoch = this.providerOutputEpoch;
         this.processedSdkMessages++;
-        this.observeSdkMessage(message, observedRunEpoch);
+        this.updateSessionFromSdkMessage(message, observedRunEpoch);
+        await this.recordProviderObservation(message, observedRunEpoch);
         for (const agentMessage of this.outputMultiplexer.convert(message)) {
           await this.output.publish({
             ...agentMessage,
@@ -459,7 +500,7 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
     }
   }
 
-  private observeSdkMessage(
+  private updateSessionFromSdkMessage(
     message: SDKMessage,
     observedRunEpoch: number,
   ): void {
@@ -495,6 +536,64 @@ export class ClaudeRuntimeSession implements RuntimeSessionLifecycleControlPort 
       this.currentState === "interrupted"
     ) {
       this.transition("running");
+    }
+  }
+
+  async captureToolStart(
+    input: Omit<ClaudeRuntimeToolStart, "runEpoch">,
+  ): Promise<void> {
+    if (!this.eventObserver) return;
+    await this.eventObserver.captureToolStart({
+      ...input,
+      runEpoch: this.providerOutputEpoch,
+    });
+  }
+
+  async observeToolOutcome(
+    input: Omit<ClaudeRuntimeToolOutcome, "runEpoch">,
+  ): Promise<void> {
+    if (!this.eventObserver) return;
+    await this.eventObserver.observeToolOutcome({
+      ...input,
+      runEpoch: this.providerOutputEpoch,
+    });
+  }
+
+  private async observeInstructionWritten(
+    instructionId: string,
+    runEpoch: number,
+  ): Promise<void> {
+    await this.recordObservation("record SDK instruction handoff", (observer) =>
+      observer.instructionWritten({
+        instructionId,
+        runEpoch,
+        recordedAt: new Date().toISOString(),
+      }),
+    );
+  }
+
+  private async recordProviderObservation(
+    message: SDKMessage,
+    runEpoch: number,
+  ): Promise<void> {
+    await this.recordObservation("record SDK event", (observer) =>
+      observer.observeSdkMessage(message, runEpoch),
+    );
+  }
+
+  private async recordObservation(
+    operation: string,
+    record: (observer: ClaudeRuntimeEventObserverPort) => Promise<void>,
+  ): Promise<void> {
+    const observer = this.eventObserver;
+    if (!observer) return;
+    try {
+      await record(observer);
+    } catch (error) {
+      this.logger.warn(
+        `[Claude ${this.runtimeSessionId}] Failed to ${operation}`,
+        error,
+      );
     }
   }
 
@@ -563,6 +662,7 @@ export type ClaudeRuntimeSessionErrorCode =
   | "invalid_terminal_boundary"
   | "invalid_run_epoch"
   | "not_started"
+  | "observer_already_attached"
   | "terminal_unavailable"
   | "terminal_wait_aborted"
   | "turn_not_terminal";

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/supplemental-hooks.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/supplemental-hooks.ts
@@ -5,25 +5,39 @@ import type {
 } from "@openloomi/ai/agent/types";
 
 import type { ClaudeRuntimeLogger } from "../skills";
+import type {
+  ClaudeRuntimeToolOutcome,
+  ClaudeRuntimeToolStart,
+} from "./event-observer";
 
-/**
- * Adds non-urgent input once after all tools in the current batch complete.
- * PostToolBatch is intentionally used instead of concurrent per-tool hooks.
- */
+export interface ClaudeRuntimeToolHookObserver {
+  captureToolStart(
+    input: Omit<ClaudeRuntimeToolStart, "runEpoch">,
+  ): Promise<void>;
+  observeToolOutcome(
+    input: Omit<ClaudeRuntimeToolOutcome, "runEpoch">,
+  ): Promise<void>;
+}
+
+/** Adds PostToolBatch input delivery plus per-tool evidence observation. */
 export function createClaudeSupplementalInputHooks({
   supplementalInput,
+  toolObserver,
   sessionId,
   logger,
 }: {
   supplementalInput?: AgentSupplementalInputSource;
+  toolObserver?: ClaudeRuntimeToolHookObserver;
   sessionId: string;
   logger: ClaudeRuntimeLogger;
 }): Options["hooks"] | undefined {
-  if (!supplementalInput?.takePendingInform) return undefined;
+  if (!supplementalInput?.takePendingInform && !toolObserver) return undefined;
+
+  const hooks: NonNullable<Options["hooks"]> = {};
 
   const postToolBatch: HookCallback = async () => {
     try {
-      const inputs = supplementalInput.takePendingInform?.() ?? [];
+      const inputs = supplementalInput?.takePendingInform?.() ?? [];
       if (inputs.length === 0) return {};
       return {
         hookSpecificOutput: {
@@ -40,7 +54,125 @@ export function createClaudeSupplementalInputHooks({
     }
   };
 
-  return { PostToolBatch: [{ hooks: [postToolBatch] }] };
+  if (supplementalInput?.takePendingInform) {
+    hooks.PostToolBatch = [{ hooks: [postToolBatch] }];
+  }
+
+  if (toolObserver) {
+    const preToolUse: HookCallback = async (input, toolUseId) => {
+      if (input.hook_event_name !== "PreToolUse") return {};
+      try {
+        await toolObserver.captureToolStart({
+          toolUseId: input.tool_use_id ?? toolUseId ?? "",
+          toolName: input.tool_name,
+          providerSessionId: input.session_id,
+        });
+      } catch (error) {
+        logger.warn(
+          `[Claude ${sessionId}] Failed to capture Goal context for tool ${input.tool_name}`,
+          error,
+        );
+      }
+      return {};
+    };
+    const postToolUse: HookCallback = async (input, toolUseId) => {
+      if (input.hook_event_name !== "PostToolUse") return {};
+      await observeToolHookSafely({
+        observer: toolObserver,
+        logger,
+        sessionId,
+        outcome: {
+          toolUseId: input.tool_use_id ?? toolUseId ?? "",
+          toolName: input.tool_name,
+          outcome: "succeeded",
+          toolInput: input.tool_input,
+          toolResponse: input.tool_response,
+          providerSessionId: input.session_id,
+          ...(input.duration_ms === undefined
+            ? {}
+            : { durationMs: input.duration_ms }),
+        },
+      });
+      return {};
+    };
+    const postToolUseFailure: HookCallback = async (input, toolUseId) => {
+      if (input.hook_event_name !== "PostToolUseFailure") return {};
+      await observeToolHookSafely({
+        observer: toolObserver,
+        logger,
+        sessionId,
+        outcome: {
+          toolUseId: input.tool_use_id ?? toolUseId ?? "",
+          toolName: input.tool_name,
+          outcome: "failed",
+          toolInput: input.tool_input,
+          error: input.error,
+          providerSessionId: input.session_id,
+          ...(input.duration_ms === undefined
+            ? {}
+            : { durationMs: input.duration_ms }),
+        },
+      });
+      return {};
+    };
+    const permissionDenied: HookCallback = async (input, toolUseId) => {
+      if (input.hook_event_name !== "PermissionDenied") return {};
+      const resolvedToolUseId = input.tool_use_id ?? toolUseId ?? "";
+      try {
+        await toolObserver.captureToolStart({
+          toolUseId: resolvedToolUseId,
+          toolName: input.tool_name,
+          providerSessionId: input.session_id,
+        });
+      } catch (error) {
+        logger.warn(
+          `[Claude ${sessionId}] Failed to capture Goal context for denied tool ${input.tool_name}`,
+          error,
+        );
+      }
+      await observeToolHookSafely({
+        observer: toolObserver,
+        logger,
+        sessionId,
+        outcome: {
+          toolUseId: resolvedToolUseId,
+          toolName: input.tool_name,
+          outcome: "failed",
+          toolInput: input.tool_input,
+          error: input.reason,
+          providerSessionId: input.session_id,
+        },
+      });
+      return {};
+    };
+    hooks.PreToolUse = [{ hooks: [preToolUse] }];
+    hooks.PostToolUse = [{ hooks: [postToolUse] }];
+    hooks.PostToolUseFailure = [{ hooks: [postToolUseFailure] }];
+    hooks.PermissionDenied = [{ hooks: [permissionDenied] }];
+  }
+
+  return hooks;
+}
+
+async function observeToolHookSafely({
+  observer,
+  logger,
+  sessionId,
+  outcome,
+}: {
+  observer: ClaudeRuntimeToolHookObserver;
+  logger: ClaudeRuntimeLogger;
+  sessionId: string;
+  outcome: Omit<ClaudeRuntimeToolOutcome, "runEpoch">;
+}): Promise<void> {
+  try {
+    await observer.observeToolOutcome(outcome);
+  } catch (error) {
+    logger.warn(
+      `[Claude ${sessionId}] Failed to record Goal evidence for tool ${outcome.toolName}`,
+      error,
+    );
+  }
 }
 
 function formatSupplementalInputContext(

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/usage.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/usage.ts
@@ -1,0 +1,45 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { RuntimeUsageDelta } from "@/lib/ai/runtime-instructions/runtime-observation";
+
+interface ClaudeResultUsage {
+  input_tokens: unknown;
+  output_tokens: unknown;
+  cache_creation_input_tokens: unknown;
+  cache_read_input_tokens: unknown;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+/** Normalizes Claude's finalized result roll-up into a Goal Run delta. */
+export function extractClaudeResultUsage(
+  message: SDKMessage,
+): RuntimeUsageDelta | undefined {
+  if (message.type !== "result") return undefined;
+  if (message.usage === null || typeof message.usage !== "object") {
+    return undefined;
+  }
+
+  const usage = message.usage as ClaudeResultUsage;
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  const cacheCreationTokens = usage.cache_creation_input_tokens;
+  const cacheReadTokens = usage.cache_read_input_tokens;
+  const turnsUsed = message.num_turns;
+  if (
+    !isNonNegativeSafeInteger(inputTokens) ||
+    !isNonNegativeSafeInteger(outputTokens) ||
+    !isNonNegativeSafeInteger(cacheCreationTokens) ||
+    !isNonNegativeSafeInteger(cacheReadTokens) ||
+    !isNonNegativeSafeInteger(turnsUsed)
+  ) {
+    return undefined;
+  }
+
+  const tokensUsed =
+    inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+  if (!Number.isSafeInteger(tokensUsed)) return undefined;
+
+  return { tokensUsed, turnsUsed };
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
@@ -29,6 +29,10 @@ import type {
   RuntimeInstructionDispatcher,
 } from "./instruction-dispatcher";
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import {
+  recordRuntimeObservation,
+  type RuntimeLifecycleObservationPort,
+} from "./runtime-observation";
 import type { RuntimeSessionRegistry } from "./runtime-session-registry";
 
 interface GoalLifecycleCommand {
@@ -80,6 +84,7 @@ export class GoalLifecycleService {
     private readonly clock: RuntimeClockPort,
     private readonly ids: RuntimeIdGeneratorPort,
     private readonly terminalTimeoutMs = 30_000,
+    private readonly observations?: RuntimeLifecycleObservationPort,
   ) {
     if (
       !Number.isInteger(terminalTimeoutMs) ||
@@ -200,6 +205,7 @@ export class GoalLifecycleService {
         return lifecycleResult(transition, wasReplay, controlDispatch);
       }
       await this.commitControlBarrier(transition, command.ownerId, transport);
+      await this.finalizeObservation(transition, command.ownerId);
       return lifecycleResult(transition, wasReplay, controlDispatch);
     }
 
@@ -229,7 +235,15 @@ export class GoalLifecycleService {
           transport,
         );
       }
-      this.reconcileCancelEpoch(transition, transport);
+      const discardedInputIds = this.reconcileCancelEpoch(
+        transition,
+        transport,
+      );
+      await this.supersedeDiscardedInputs(
+        transition,
+        command.ownerId,
+        discardedInputIds,
+      );
       stored = await this.state.finalizeLifecycleTransition({
         ownerId: command.ownerId,
         runtimeSessionId: command.runtimeSessionId,
@@ -238,6 +252,7 @@ export class GoalLifecycleService {
         nextRunEpoch: transition.runEpoch,
         command: command.command,
       });
+      await this.finalizeObservation(stored.transition, command.ownerId);
       this.releaseTerminalBarrier(transition.instruction.id);
       return lifecycleResult(stored.transition, wasReplay, controlDispatch);
     }
@@ -295,7 +310,15 @@ export class GoalLifecycleService {
         nextRunEpoch,
         command: command.command,
       });
-      this.advanceAndValidate(stored.transition, transport);
+      const discardedInputIds = this.advanceAndValidate(
+        stored.transition,
+        transport,
+      );
+      await this.supersedeDiscardedInputs(
+        stored.transition,
+        command.ownerId,
+        discardedInputIds,
+      );
     }
     stored = await this.state.finalizeLifecycleTransition({
       ownerId: command.ownerId,
@@ -305,6 +328,7 @@ export class GoalLifecycleService {
       nextRunEpoch,
       command: command.command,
     });
+    await this.finalizeObservation(stored.transition, command.ownerId);
     this.releaseTerminalBarrier(transition.instruction.id);
     return lifecycleResult(stored.transition, wasReplay, controlDispatch);
   }
@@ -499,7 +523,7 @@ export class GoalLifecycleService {
   private advanceAndValidate(
     transition: AgentGoalLifecycleTransition,
     transport: RuntimeSessionLifecycleControlPort,
-  ): void {
+  ): string[] {
     const advanced = transport.advanceRunEpoch({
       expectedRunEpoch: transition.expectedRunEpoch,
       nextRunEpoch: transition.runEpoch,
@@ -515,20 +539,21 @@ export class GoalLifecycleService {
         "Runtime Session returned an invalid cancellation epoch advance",
       );
     }
+    return [...advanced.discardedInputIds];
   }
 
   private reconcileCancelEpoch(
     transition: AgentGoalLifecycleTransition,
     transport: RuntimeSessionLifecycleControlPort,
-  ): void {
-    if (transport.runEpoch === transition.runEpoch) return;
+  ): string[] {
+    if (transport.runEpoch === transition.runEpoch) return [];
     if (transport.runEpoch !== transition.expectedRunEpoch) {
       throw new GoalServiceError(
         "invalid_command",
         `Goal cancellation epoch ${transition.runEpoch} cannot reconcile live Runtime Session epoch ${transport.runEpoch}`,
       );
     }
-    this.advanceAndValidate(transition, transport);
+    return this.advanceAndValidate(transition, transport);
   }
 
   private releaseTerminalBarrier(instructionId: string): void {
@@ -602,6 +627,44 @@ export class GoalLifecycleService {
           ? "preserve_predecessors"
           : "supersede_predecessors",
     });
+  }
+
+  private async finalizeObservation(
+    transition: AgentGoalLifecycleTransition,
+    ownerId: string,
+  ): Promise<void> {
+    const observations = this.observations;
+    if (!observations) return;
+    await recordRuntimeObservation("finalize lifecycle observation", () =>
+      observations.finalizeControlInstruction({
+        ownerId,
+        runtimeSessionId: transition.runtimeSessionId,
+        instructionId: transition.instruction.id,
+        runEpoch: transition.expectedRunEpoch,
+        status: transition.action === "pause" ? "paused" : "cancelled",
+      }),
+    );
+  }
+
+  private async supersedeDiscardedInputs(
+    transition: AgentGoalLifecycleTransition,
+    ownerId: string,
+    instructionIds: string[],
+  ): Promise<void> {
+    const observations = this.observations;
+    if (instructionIds.length === 0 || !observations) {
+      return;
+    }
+    await recordRuntimeObservation(
+      "record lifecycle-discarded deliveries",
+      () =>
+        observations.supersedeDeliveries({
+          ownerId,
+          runtimeSessionId: transition.runtimeSessionId,
+          instructionIds,
+          reason: `Discarded when Goal ${transition.action} crossed runEpoch ${transition.expectedRunEpoch}`,
+        }),
+    );
   }
 }
 

--- a/apps/web/lib/ai/runtime-instructions/goal-replacement-coordinator.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-replacement-coordinator.ts
@@ -33,6 +33,10 @@ import type {
   RuntimeInstructionDispatcher,
 } from "./instruction-dispatcher";
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import {
+  recordRuntimeObservation,
+  type RuntimeLifecycleObservationPort,
+} from "./runtime-observation";
 import type { RuntimeSessionRegistry } from "./runtime-session-registry";
 
 export type GoalReplacementCommandSource =
@@ -117,6 +121,7 @@ export class GoalReplacementCoordinator {
     private readonly clock: RuntimeClockPort,
     private readonly ids: RuntimeIdGeneratorPort,
     private readonly terminalTimeoutMs = 30_000,
+    private readonly observations?: RuntimeLifecycleObservationPort,
   ) {
     if (
       !Number.isInteger(terminalTimeoutMs) ||
@@ -249,6 +254,7 @@ export class GoalReplacementCoordinator {
             requireActivationInstruction(replacement),
             command.ownerId,
           );
+      await this.finalizeControlObservation(replacement, command.ownerId);
       return {
         replacement,
         deduplicated: wasReplay,
@@ -332,6 +338,11 @@ export class GoalReplacementCoordinator {
       });
       replacement = stored.replacement;
       discardedInputIds = this.advanceAndValidate(replacement, transport);
+      await this.supersedeDiscardedInputs(
+        replacement,
+        command.ownerId,
+        discardedInputIds,
+      );
       this.releaseTerminalBarrier(replacement.controlInstruction.id);
     } else {
       if (replacement.phase !== "boundary_observed") {
@@ -365,6 +376,11 @@ export class GoalReplacementCoordinator {
         transport,
       );
       discardedInputIds = this.reconcileLiveEpoch(replacement, transport);
+      await this.supersedeDiscardedInputs(
+        replacement,
+        command.ownerId,
+        discardedInputIds,
+      );
       this.releaseTerminalBarrier(replacement.controlInstruction.id);
     }
 
@@ -391,6 +407,7 @@ export class GoalReplacementCoordinator {
       command: command.identity,
     });
     replacement = stored.replacement;
+    await this.finalizeControlObservation(replacement, command.ownerId);
     const activationDispatch = await this.dispatchOnTransport(
       requireActivationInstruction(replacement),
       command.ownerId,
@@ -642,6 +659,44 @@ export class GoalReplacementCoordinator {
       reason: `Superseded by Goal replacement ${instruction.id}`,
       predecessorPolicy: "supersede_predecessors",
     });
+  }
+
+  private async finalizeControlObservation(
+    replacement: AgentGoalReplacement,
+    ownerId: string,
+  ): Promise<void> {
+    const observations = this.observations;
+    if (!observations) return;
+    await recordRuntimeObservation("finalize replacement observation", () =>
+      observations.finalizeControlInstruction({
+        ownerId,
+        runtimeSessionId: replacement.runtimeSessionId,
+        instructionId: replacement.controlInstruction.id,
+        runEpoch: replacement.expectedRunEpoch,
+        status: "cancelled",
+      }),
+    );
+  }
+
+  private async supersedeDiscardedInputs(
+    replacement: AgentGoalReplacement,
+    ownerId: string,
+    instructionIds: string[],
+  ): Promise<void> {
+    const observations = this.observations;
+    if (instructionIds.length === 0 || !observations) {
+      return;
+    }
+    await recordRuntimeObservation(
+      "record replacement-discarded deliveries",
+      () =>
+        observations.supersedeDeliveries({
+          ownerId,
+          runtimeSessionId: replacement.runtimeSessionId,
+          instructionIds,
+          reason: `Discarded when Goal replacement crossed runEpoch ${replacement.expectedRunEpoch}`,
+        }),
+    );
   }
 
   private dispatch(

--- a/apps/web/lib/ai/runtime-instructions/in-memory-runtime-observation-journal.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-runtime-observation-journal.ts
@@ -1,0 +1,1181 @@
+import {
+  GoalEvidenceSchema,
+  RuntimeInstructionSchema,
+  assertDeliveryStateTransition,
+  assertGoalRunStatusTransition,
+  canonicalJson,
+  type AgentGoalRun,
+  type AgentGoalStatePort,
+  type DeliveryState,
+  type GoalEvidence,
+  type GoalRunStatus,
+  type RuntimeClockPort,
+  type RuntimeDeliveryReceipt,
+  type RuntimeIdGeneratorPort,
+  type RuntimeInstruction,
+  type RuntimeInstructionDelivery,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import type {
+  RuntimeEvidenceDraft,
+  RuntimeObservationContext,
+  RuntimeObservationJournalPort,
+  RuntimeProviderEventObservation,
+  RuntimeUsageDelta,
+} from "./runtime-observation";
+
+interface PreparedInstruction {
+  instruction: RuntimeInstruction;
+  runEpoch: number;
+}
+
+interface StoredDelivery {
+  delivery: RuntimeInstructionDelivery;
+  instruction: RuntimeInstruction;
+  runEpoch: number;
+}
+
+interface RuntimeObservationSession {
+  ownerId: string;
+  runtimeSessionId: string;
+  providerSessionId?: string;
+  preparedInstructions: Map<string, PreparedInstruction>;
+  deliveries: Map<string, StoredDelivery>;
+  runs: Map<string, AgentGoalRun>;
+  runIdsByGoalEpoch: Map<string, string>;
+  evidence: Map<string, GoalEvidence>;
+  processedProviderEvents: Set<string>;
+}
+
+interface MaterializedEvidence {
+  dedupeKey: string;
+  evidence: GoalEvidence;
+}
+
+type RuntimeObservationJournalErrorCode =
+  | "delivery_conflict"
+  | "invalid_observation"
+  | "provider_session_conflict";
+
+class RuntimeObservationJournalError extends Error {
+  constructor(
+    public readonly code: RuntimeObservationJournalErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "RuntimeObservationJournalError";
+  }
+}
+
+/**
+ * Process-local Goal Run, delivery acknowledgement, usage, and evidence
+ * journal. It is deliberately separate from the authoritative Goal/outbox
+ * aggregate: later durable adapters can persist these high-volume observations
+ * without widening the Goal mutation transaction.
+ */
+export class InMemoryRuntimeObservationJournal implements RuntimeObservationJournalPort {
+  private readonly sessions = new Map<string, RuntimeObservationSession>();
+  private readonly mutations = new KeyedSerialExecutor();
+
+  constructor(
+    private readonly goals: AgentGoalStatePort,
+    private readonly clock: RuntimeClockPort,
+    private readonly ids: RuntimeIdGeneratorPort,
+  ) {}
+
+  async prepareDelivery(input: {
+    ownerId: string;
+    instruction: RuntimeInstruction;
+  }): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const instruction = parseInstruction(input.instruction);
+    const runEpoch = await this.goals.getRuntimeSessionRunEpoch(
+      ownerId,
+      instruction.targetSessionId,
+    );
+    const scope = sessionScope(ownerId, instruction.targetSessionId);
+
+    await this.mutations.run(scope, () => {
+      const session = this.getOrCreateSession(
+        ownerId,
+        instruction.targetSessionId,
+      );
+      const existing = session.preparedInstructions.get(instruction.id);
+      if (existing) {
+        assertSameInstruction(existing.instruction, instruction);
+        if (existing.runEpoch !== runEpoch) {
+          throw journalError(
+            "delivery_conflict",
+            `Instruction ${instruction.id} was prepared for runEpoch ${existing.runEpoch}, not ${runEpoch}`,
+          );
+        }
+        return;
+      }
+      session.preparedInstructions.set(instruction.id, {
+        instruction: structuredClone(instruction),
+        runEpoch,
+      });
+    });
+  }
+
+  async recordDeliveryReceipt(input: {
+    ownerId: string;
+    instruction: RuntimeInstruction;
+    receipt: RuntimeDeliveryReceipt;
+  }): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const instruction = parseInstruction(input.instruction);
+    const receipt = parseReceipt(input.receipt, instruction);
+    const scope = sessionScope(ownerId, instruction.targetSessionId);
+
+    await this.mutations.run(scope, async () => {
+      const session = this.getOrCreateSession(
+        ownerId,
+        instruction.targetSessionId,
+      );
+      let prepared = session.preparedInstructions.get(instruction.id);
+      if (!prepared) {
+        const runEpoch = await this.goals.getRuntimeSessionRunEpoch(
+          ownerId,
+          instruction.targetSessionId,
+        );
+        prepared = { instruction: structuredClone(instruction), runEpoch };
+        session.preparedInstructions.set(instruction.id, prepared);
+      } else {
+        assertSameInstruction(prepared.instruction, instruction);
+      }
+
+      const existing = session.deliveries.get(instruction.id);
+      if (existing) {
+        assertSameInstruction(existing.instruction, instruction);
+        if (existing.runEpoch !== prepared.runEpoch) {
+          throw journalError(
+            "delivery_conflict",
+            `Delivery ${instruction.id} changed runEpoch`,
+          );
+        }
+        if (existing.delivery.state !== "rejected") {
+          this.applyReceiptToExisting(session, existing, receipt);
+          return;
+        }
+        if (receipt.state === "rejected") return;
+        this.createDeliveryAttempt(
+          session,
+          prepared,
+          receipt,
+          existing.delivery.attempt + 1,
+        );
+        return;
+      }
+      this.createDeliveryAttempt(session, prepared, receipt, 1);
+    });
+  }
+
+  async recordInstructionHandoff(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+    runEpoch: number;
+    recordedAt?: string;
+  }): Promise<boolean> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const instructionId = requiredIdentifier(
+      input.instructionId,
+      "instructionId",
+    );
+    const runEpoch = nonNegativeInteger(input.runEpoch, "runEpoch");
+    const recordedAt = isoTimestamp(
+      input.recordedAt ?? this.clock.now().toISOString(),
+      "recordedAt",
+    );
+    const scope = sessionScope(ownerId, runtimeSessionId);
+
+    return this.mutations.run(scope, async () => {
+      const session = this.sessions.get(scope);
+      if (!session) return false;
+      const prepared = session.preparedInstructions.get(instructionId);
+      if (!prepared) return false;
+      if (prepared.runEpoch !== runEpoch) return false;
+      const authoritativeEpoch = await this.goals.getRuntimeSessionRunEpoch(
+        ownerId,
+        runtimeSessionId,
+      );
+      if (authoritativeEpoch !== runEpoch) return false;
+
+      const stored = session.deliveries.get(instructionId);
+      if (!stored || stored.delivery.state === "rejected") {
+        this.createDeliveryAttempt(
+          session,
+          prepared,
+          {
+            instructionId,
+            runtimeSessionId,
+            state: "written_to_sdk",
+            recordedAt,
+          },
+          stored ? stored.delivery.attempt + 1 : 1,
+        );
+        return true;
+      }
+      if (!isProviderAcceptedState(stored.delivery.state)) return false;
+      this.markWritten(session, stored, { runEpoch, recordedAt });
+      return true;
+    });
+  }
+
+  async setProviderSession(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    providerSessionId: string;
+  }): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const providerSessionId = requiredIdentifier(
+      input.providerSessionId,
+      "providerSessionId",
+    );
+    const scope = sessionScope(ownerId, runtimeSessionId);
+    await this.mutations.run(scope, () => {
+      const session = this.getOrCreateSession(ownerId, runtimeSessionId);
+      if (
+        session.providerSessionId !== undefined &&
+        session.providerSessionId !== providerSessionId
+      ) {
+        throw journalError(
+          "provider_session_conflict",
+          `Runtime Session ${runtimeSessionId} already observes provider session ${session.providerSessionId}`,
+        );
+      }
+      this.assignProviderSession(session, providerSessionId);
+    });
+  }
+
+  async captureContext(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    runEpoch: number;
+  }): Promise<RuntimeObservationContext | null> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const runEpoch = nonNegativeInteger(input.runEpoch, "runEpoch");
+    const scope = sessionScope(ownerId, runtimeSessionId);
+    return this.mutations.run(scope, async () => {
+      const authoritativeEpoch = await this.goals.getRuntimeSessionRunEpoch(
+        ownerId,
+        runtimeSessionId,
+      );
+      if (authoritativeEpoch !== runEpoch) return null;
+      const session = this.sessions.get(scope);
+      if (!session) return null;
+      return cloneContext(this.latestWrittenContext(session, runEpoch));
+    });
+  }
+
+  async observeProviderEvent(
+    input: RuntimeProviderEventObservation,
+  ): Promise<boolean> {
+    const parsed = parseProviderObservation(input);
+    const scope = sessionScope(parsed.ownerId, parsed.runtimeSessionId);
+
+    return this.mutations.run(scope, async () => {
+      const authoritativeEpoch = await this.goals.getRuntimeSessionRunEpoch(
+        parsed.ownerId,
+        parsed.runtimeSessionId,
+      );
+      if (authoritativeEpoch !== parsed.runEpoch) return false;
+
+      const session = this.sessions.get(scope);
+      if (!session) return false;
+      if (session.processedProviderEvents.has(parsed.eventKey)) return false;
+      this.assertProviderSession(session, parsed.providerSessionId);
+
+      const context = parsed.context
+        ? this.validateContext(session, parsed.context, parsed.runEpoch)
+        : this.latestWrittenContext(session, parsed.runEpoch);
+      const evidence = context
+        ? this.materializeEvidence(session, context, parsed.evidence ?? [])
+        : [];
+      const run = context ? session.runs.get(context.goalRunId) : undefined;
+      if (
+        run &&
+        parsed.usage &&
+        (!Number.isSafeInteger(run.tokensUsed + parsed.usage.tokensUsed) ||
+          !Number.isSafeInteger(run.turnsUsed + parsed.usage.turnsUsed))
+      ) {
+        throw journalError(
+          "invalid_observation",
+          "Provider usage would overflow Goal Run counters",
+        );
+      }
+
+      session.processedProviderEvents.add(parsed.eventKey);
+      if (parsed.providerSessionId) {
+        this.assignProviderSession(session, parsed.providerSessionId);
+      }
+      this.markWrittenDeliveriesObserved(
+        session,
+        parsed.runEpoch,
+        parsed.providerEventId,
+        parsed.observedAt,
+      );
+      if (parsed.terminal) {
+        this.markNormalDeliveriesApplied(
+          session,
+          parsed.runEpoch,
+          parsed.providerEventId,
+          parsed.observedAt,
+        );
+      }
+
+      if (!context || !run) return true;
+      if (!isRunTerminal(run.status)) {
+        if (run.status === "queued") this.transitionRun(run, "running");
+        run.lastActivityAt = latestTimestamp(
+          run.lastActivityAt,
+          parsed.observedAt,
+        );
+        if (parsed.usage) {
+          run.tokensUsed += parsed.usage.tokensUsed;
+          run.turnsUsed += parsed.usage.turnsUsed;
+        }
+      }
+
+      for (const item of evidence) {
+        session.evidence.set(item.dedupeKey, item.evidence);
+      }
+      return true;
+    });
+  }
+
+  async finalizeControlInstruction(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+    runEpoch: number;
+    status: "paused" | "cancelled";
+    recordedAt?: string;
+  }): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const instructionId = requiredIdentifier(
+      input.instructionId,
+      "instructionId",
+    );
+    const runEpoch = nonNegativeInteger(input.runEpoch, "runEpoch");
+    const recordedAt = isoTimestamp(
+      input.recordedAt ?? this.clock.now().toISOString(),
+      "recordedAt",
+    );
+    const scope = sessionScope(ownerId, runtimeSessionId);
+
+    await this.mutations.run(scope, () => {
+      const session = this.sessions.get(scope);
+      const stored = session?.deliveries.get(instructionId);
+      if (!session || !stored) return;
+      if (stored.runEpoch !== runEpoch) {
+        throw journalError(
+          "delivery_conflict",
+          `Control instruction ${instructionId} belongs to runEpoch ${stored.runEpoch}, not ${runEpoch}`,
+        );
+      }
+      if (!isInterruptControl(stored.instruction)) {
+        throw journalError(
+          "delivery_conflict",
+          `Instruction ${instructionId} is not a lifecycle control instruction`,
+        );
+      }
+      if (!isProviderAcceptedState(stored.delivery.state)) {
+        throw journalError(
+          "delivery_conflict",
+          `Control instruction ${instructionId} cannot finalize from ${stored.delivery.state}`,
+        );
+      }
+      if (
+        (input.status === "paused" &&
+          stored.instruction.kind !== "goal.pause") ||
+        (input.status === "cancelled" &&
+          stored.instruction.kind !== "goal.cancel" &&
+          stored.instruction.kind !== "control.interrupt")
+      ) {
+        throw journalError(
+          "delivery_conflict",
+          `Control instruction ${instructionId} cannot finalize as ${input.status}`,
+        );
+      }
+      const run = stored.delivery.goalRunId
+        ? session.runs.get(stored.delivery.goalRunId)
+        : undefined;
+      const next: GoalRunStatus = input.status;
+      if (run && !isRunTerminal(run.status) && run.status !== next) {
+        // Validate the complete operation before changing the delivery. A
+        // failed run transition must never leave a partially applied receipt.
+        assertGoalRunStatusTransition(run.status, next);
+      }
+      const finalizedAt = latestTimestamp(
+        recordedAt,
+        stored.delivery.updatedAt,
+        run?.lastActivityAt,
+      );
+      const syntheticEventId = boundedIdentifier(
+        `runtime-boundary:${instructionId}`,
+      );
+      if (stored.delivery.state === "queued") {
+        this.transitionDelivery(stored.delivery, "written_to_sdk", finalizedAt);
+      }
+      if (stored.delivery.state === "written_to_sdk") {
+        this.transitionDelivery(
+          stored.delivery,
+          "observed",
+          finalizedAt,
+          syntheticEventId,
+        );
+      }
+      if (stored.delivery.state === "observed") {
+        this.transitionDelivery(
+          stored.delivery,
+          "applied",
+          finalizedAt,
+          stored.delivery.providerEventId ?? syntheticEventId,
+        );
+      }
+
+      if (!run || isRunTerminal(run.status)) return;
+      if (run.status !== next) this.transitionRun(run, next);
+      run.goalRevision = Math.max(
+        run.goalRevision,
+        stored.instruction.goalRevision ?? run.goalRevision,
+      );
+      run.lastActivityAt = finalizedAt;
+      if (next === "cancelled") run.completedAt = finalizedAt;
+    });
+  }
+
+  async supersedeDeliveries(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionIds: string[];
+    reason: string;
+  }): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const instructionIds = [
+      ...new Set(
+        input.instructionIds.map((id) =>
+          requiredIdentifier(id, "instructionId"),
+        ),
+      ),
+    ];
+    const reason = requiredText(input.reason, "reason", 8_000);
+    const scope = sessionScope(ownerId, runtimeSessionId);
+    const now = this.clock.now().toISOString();
+
+    await this.mutations.run(scope, () => {
+      const session = this.sessions.get(scope);
+      if (!session) return;
+      const queued: StoredDelivery[] = [];
+      for (const instructionId of instructionIds) {
+        const stored = session.deliveries.get(instructionId);
+        if (!stored || stored.delivery.state === "superseded") continue;
+        if (stored.delivery.state !== "queued") {
+          throw journalError(
+            "delivery_conflict",
+            `Only a queued delivery can be superseded; ${instructionId} is ${stored.delivery.state}`,
+          );
+        }
+        queued.push(stored);
+      }
+
+      // Nothing is mutated until every delivery has passed validation.
+      for (const stored of queued) {
+        this.transitionDelivery(stored.delivery, "superseded", now);
+        stored.delivery.errorCode = "superseded";
+        stored.delivery.errorMessage = reason;
+      }
+    });
+  }
+
+  async listGoalRuns(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<AgentGoalRun[]> {
+    const scope = validatedScope(ownerId, runtimeSessionId);
+    return [...(this.sessions.get(scope)?.runs.values() ?? [])]
+      .sort((left, right) => left.startedAt.localeCompare(right.startedAt))
+      .map((run) => structuredClone(run));
+  }
+
+  async listDeliveries(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeInstructionDelivery[]> {
+    const scope = validatedScope(ownerId, runtimeSessionId);
+    return [...(this.sessions.get(scope)?.deliveries.values() ?? [])]
+      .map(({ delivery }) => structuredClone(delivery))
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  }
+
+  async listEvidence(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<GoalEvidence[]> {
+    const scope = validatedScope(ownerId, runtimeSessionId);
+    return [...(this.sessions.get(scope)?.evidence.values() ?? [])]
+      .sort((left, right) => left.observedAt.localeCompare(right.observedAt))
+      .map((evidence) => structuredClone(evidence));
+  }
+
+  private getOrCreateSession(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): RuntimeObservationSession {
+    const scope = sessionScope(ownerId, runtimeSessionId);
+    const existing = this.sessions.get(scope);
+    if (existing) return existing;
+    const created: RuntimeObservationSession = {
+      ownerId,
+      runtimeSessionId,
+      preparedInstructions: new Map(),
+      deliveries: new Map(),
+      runs: new Map(),
+      runIdsByGoalEpoch: new Map(),
+      evidence: new Map(),
+      processedProviderEvents: new Set(),
+    };
+    this.sessions.set(scope, created);
+    return created;
+  }
+
+  private ensureGoalRun(
+    session: RuntimeObservationSession,
+    prepared: PreparedInstruction,
+    startedAt: string,
+  ): AgentGoalRun | undefined {
+    const { instruction, runEpoch } = prepared;
+    if (
+      instruction.goalId === undefined ||
+      instruction.goalRevision === undefined
+    ) {
+      return undefined;
+    }
+    const runKey = goalRunKey(instruction.goalId, runEpoch);
+    const existingId = session.runIdsByGoalEpoch.get(runKey);
+    if (existingId) {
+      const existing = session.runs.get(existingId);
+      if (!existing) {
+        throw journalError("invalid_observation", "Goal Run index is corrupt");
+      }
+      if (
+        existing.providerSessionId === undefined &&
+        session.providerSessionId !== undefined
+      ) {
+        existing.providerSessionId = session.providerSessionId;
+      }
+      return existing;
+    }
+
+    const run: AgentGoalRun = {
+      id: this.ids.generate(),
+      ownerId: session.ownerId,
+      goalId: instruction.goalId,
+      goalRevision: instruction.goalRevision,
+      runtimeSessionId: session.runtimeSessionId,
+      ...(session.providerSessionId === undefined
+        ? {}
+        : { providerSessionId: session.providerSessionId }),
+      runEpoch,
+      status: "queued",
+      turnsUsed: 0,
+      tokensUsed: 0,
+      startedAt,
+      lastActivityAt: startedAt,
+    };
+    session.runs.set(run.id, run);
+    session.runIdsByGoalEpoch.set(runKey, run.id);
+    return run;
+  }
+
+  private createDeliveryAttempt(
+    session: RuntimeObservationSession,
+    prepared: PreparedInstruction,
+    receipt: RuntimeDeliveryReceipt,
+    attempt: number,
+  ): StoredDelivery {
+    const { instruction } = prepared;
+    const createdAt = receipt.recordedAt;
+    const state = receipt.state;
+    const goalRun =
+      state === "rejected"
+        ? undefined
+        : this.ensureGoalRun(session, prepared, createdAt);
+    const stored: StoredDelivery = {
+      instruction: structuredClone(instruction),
+      runEpoch: prepared.runEpoch,
+      delivery: {
+        id: this.ids.generate(),
+        ownerId: session.ownerId,
+        instructionId: instruction.id,
+        runtimeSessionId: instruction.targetSessionId,
+        ...(goalRun === undefined ? {} : { goalRunId: goalRun.id }),
+        state,
+        attempt,
+        ...(receipt.providerEventId === undefined
+          ? {}
+          : { providerEventId: receipt.providerEventId }),
+        ...(state === "rejected" && receipt.reason
+          ? {
+              errorCode: "transport_rejected",
+              errorMessage: receipt.reason,
+            }
+          : {}),
+        createdAt,
+        updatedAt: createdAt,
+      },
+    };
+    session.deliveries.set(instruction.id, stored);
+
+    if (state === "written_to_sdk") {
+      this.markWritten(session, stored, {
+        runEpoch: prepared.runEpoch,
+        recordedAt: receipt.recordedAt,
+      });
+    }
+    return stored;
+  }
+
+  private markWritten(
+    session: RuntimeObservationSession,
+    stored: StoredDelivery,
+    handoff: { runEpoch: number; recordedAt: string },
+  ): void {
+    if (stored.runEpoch !== handoff.runEpoch) return;
+    if (stored.delivery.state === "queued") {
+      this.transitionDelivery(
+        stored.delivery,
+        "written_to_sdk",
+        handoff.recordedAt,
+      );
+    }
+    if (
+      stored.delivery.state !== "written_to_sdk" &&
+      stored.delivery.state !== "observed" &&
+      stored.delivery.state !== "applied" &&
+      stored.delivery.state !== "completed"
+    ) {
+      return;
+    }
+    const prepared = session.preparedInstructions.get(stored.instruction.id);
+    const run = prepared
+      ? this.ensureGoalRun(session, prepared, handoff.recordedAt)
+      : undefined;
+    if (!run || isInterruptControl(stored.instruction)) return;
+    run.goalRevision = Math.max(
+      run.goalRevision,
+      stored.instruction.goalRevision ?? run.goalRevision,
+    );
+    if (
+      run.status === "queued" ||
+      run.status === "paused" ||
+      run.status === "blocked"
+    ) {
+      this.transitionRun(run, "running");
+    }
+    run.lastActivityAt = latestTimestamp(
+      run.lastActivityAt,
+      handoff.recordedAt,
+    );
+  }
+
+  private latestWrittenContext(
+    session: RuntimeObservationSession,
+    runEpoch: number,
+  ): RuntimeObservationContext | null {
+    let latest: StoredDelivery | undefined;
+    for (const stored of session.deliveries.values()) {
+      if (
+        stored.runEpoch !== runEpoch ||
+        isInterruptControl(stored.instruction) ||
+        stored.delivery.goalRunId === undefined ||
+        stored.instruction.goalId === undefined ||
+        stored.instruction.goalRevision === undefined ||
+        !isProviderVisibleState(stored.delivery.state)
+      ) {
+        continue;
+      }
+      if (
+        latest === undefined ||
+        stored.instruction.sequence > latest.instruction.sequence
+      ) {
+        latest = stored;
+      }
+    }
+    if (
+      !latest?.delivery.goalRunId ||
+      !latest.instruction.goalId ||
+      !latest.instruction.goalRevision
+    ) {
+      return null;
+    }
+    return {
+      ownerId: session.ownerId,
+      runtimeSessionId: session.runtimeSessionId,
+      goalRunId: latest.delivery.goalRunId,
+      goalId: latest.instruction.goalId,
+      goalRevision: latest.instruction.goalRevision,
+      instructionId: latest.instruction.id,
+      runEpoch,
+    };
+  }
+
+  private validateContext(
+    session: RuntimeObservationSession,
+    context: RuntimeObservationContext,
+    runEpoch: number,
+  ): RuntimeObservationContext | null {
+    if (
+      context.ownerId !== session.ownerId ||
+      context.runtimeSessionId !== session.runtimeSessionId ||
+      context.runEpoch !== runEpoch
+    ) {
+      return null;
+    }
+    const run = session.runs.get(context.goalRunId);
+    const delivery = session.deliveries.get(context.instructionId);
+    if (
+      !run ||
+      !delivery ||
+      run.goalId !== context.goalId ||
+      delivery.delivery.goalRunId !== run.id ||
+      delivery.instruction.goalId !== context.goalId ||
+      delivery.instruction.goalRevision !== context.goalRevision
+    ) {
+      return null;
+    }
+    return context;
+  }
+
+  private markWrittenDeliveriesObserved(
+    session: RuntimeObservationSession,
+    runEpoch: number,
+    providerEventId: string,
+    observedAt: string,
+  ): void {
+    // Claude does not echo an OpenLoomi instruction ID in output events. The
+    // first causal provider event therefore acknowledges every instruction
+    // already handed to this provider turn, scoped by the current runEpoch.
+    for (const stored of session.deliveries.values()) {
+      if (
+        stored.runEpoch === runEpoch &&
+        !isInterruptControl(stored.instruction) &&
+        stored.delivery.state === "written_to_sdk"
+      ) {
+        this.transitionDelivery(
+          stored.delivery,
+          "observed",
+          observedAt,
+          providerEventId,
+        );
+      }
+    }
+  }
+
+  private markNormalDeliveriesApplied(
+    session: RuntimeObservationSession,
+    runEpoch: number,
+    providerEventId: string,
+    observedAt: string,
+  ): void {
+    for (const stored of session.deliveries.values()) {
+      if (
+        stored.runEpoch === runEpoch &&
+        stored.delivery.state === "observed" &&
+        !isInterruptControl(stored.instruction)
+      ) {
+        this.transitionDelivery(
+          stored.delivery,
+          "applied",
+          observedAt,
+          providerEventId,
+        );
+      }
+    }
+  }
+
+  private materializeEvidence(
+    session: RuntimeObservationSession,
+    context: RuntimeObservationContext,
+    drafts: RuntimeEvidenceDraft[],
+  ): MaterializedEvidence[] {
+    const result: MaterializedEvidence[] = [];
+    const seen = new Set<string>();
+    for (const draft of drafts) {
+      const dedupeKey = JSON.stringify([
+        context.goalRunId,
+        draft.sourceEventId,
+      ]);
+      if (session.evidence.has(dedupeKey) || seen.has(dedupeKey)) continue;
+      try {
+        result.push({
+          dedupeKey,
+          evidence: GoalEvidenceSchema.parse({
+            id: this.ids.generate(),
+            goalId: context.goalId,
+            goalRunId: context.goalRunId,
+            goalRevision: context.goalRevision,
+            instructionId: context.instructionId,
+            type: draft.type,
+            sourceEventId: draft.sourceEventId,
+            summary: draft.summary,
+            ...(draft.success === undefined ? {} : { success: draft.success }),
+            payload: draft.payload,
+            observedAt: draft.observedAt,
+          }),
+        });
+        seen.add(dedupeKey);
+      } catch (cause) {
+        throw journalError(
+          "invalid_observation",
+          `Provider evidence ${draft.sourceEventId} is invalid`,
+          cause,
+        );
+      }
+    }
+    return result;
+  }
+
+  private applyReceiptToExisting(
+    session: RuntimeObservationSession,
+    stored: StoredDelivery,
+    receipt: RuntimeDeliveryReceipt,
+  ): void {
+    if (receipt.state === "rejected") {
+      if (stored.delivery.state === "queued") {
+        this.transitionDelivery(
+          stored.delivery,
+          "rejected",
+          receipt.recordedAt,
+          receipt.providerEventId,
+        );
+        stored.delivery.errorCode = "transport_rejected";
+        stored.delivery.errorMessage = receipt.reason;
+      } else if (stored.delivery.state !== "rejected") {
+        throw journalError(
+          "delivery_conflict",
+          `Delivery ${stored.instruction.id} cannot regress from ${stored.delivery.state} to rejected`,
+        );
+      }
+      return;
+    }
+    if (stored.delivery.state === "rejected") {
+      throw journalError(
+        "delivery_conflict",
+        `Rejected delivery ${stored.instruction.id} cannot be accepted later`,
+      );
+    }
+    if (
+      receipt.state === "written_to_sdk" &&
+      stored.delivery.state === "queued"
+    ) {
+      this.transitionDelivery(
+        stored.delivery,
+        "written_to_sdk",
+        receipt.recordedAt,
+        receipt.providerEventId,
+      );
+      this.markWritten(session, stored, {
+        runEpoch: stored.runEpoch,
+        recordedAt: receipt.recordedAt,
+      });
+    }
+  }
+
+  private assertProviderSession(
+    session: RuntimeObservationSession,
+    providerSessionId: string | undefined,
+  ): void {
+    if (providerSessionId === undefined) return;
+    if (
+      session.providerSessionId !== undefined &&
+      session.providerSessionId !== providerSessionId
+    ) {
+      throw journalError(
+        "provider_session_conflict",
+        `Provider event belongs to ${providerSessionId}, not ${session.providerSessionId}`,
+      );
+    }
+  }
+
+  private assignProviderSession(
+    session: RuntimeObservationSession,
+    providerSessionId: string,
+  ): void {
+    session.providerSessionId = providerSessionId;
+    for (const run of session.runs.values()) {
+      if (run.providerSessionId === undefined) {
+        run.providerSessionId = providerSessionId;
+      }
+    }
+  }
+
+  private transitionDelivery(
+    delivery: RuntimeInstructionDelivery,
+    next: DeliveryState,
+    updatedAt: string,
+    providerEventId?: string,
+  ): void {
+    if (delivery.state === next) return;
+    assertDeliveryStateTransition(delivery.state, next);
+    delivery.state = next;
+    delivery.updatedAt = latestTimestamp(delivery.updatedAt, updatedAt);
+    if (providerEventId !== undefined)
+      delivery.providerEventId = providerEventId;
+  }
+
+  private transitionRun(run: AgentGoalRun, next: GoalRunStatus): void {
+    if (run.status === next) return;
+    assertGoalRunStatusTransition(run.status, next);
+    run.status = next;
+  }
+}
+
+function parseInstruction(candidate: RuntimeInstruction): RuntimeInstruction {
+  try {
+    return RuntimeInstructionSchema.parse(candidate);
+  } catch (cause) {
+    throw journalError(
+      "invalid_observation",
+      "Runtime delivery references an invalid instruction",
+      cause,
+    );
+  }
+}
+
+function parseReceipt(
+  candidate: RuntimeDeliveryReceipt,
+  instruction: RuntimeInstruction,
+): RuntimeDeliveryReceipt {
+  if (
+    !candidate ||
+    typeof candidate !== "object" ||
+    candidate.instructionId !== instruction.id ||
+    candidate.runtimeSessionId !== instruction.targetSessionId ||
+    (candidate.state !== "queued" &&
+      candidate.state !== "written_to_sdk" &&
+      candidate.state !== "rejected")
+  ) {
+    throw journalError(
+      "invalid_observation",
+      "Runtime delivery receipt does not match its instruction",
+    );
+  }
+  isoTimestamp(candidate.recordedAt, "receipt.recordedAt");
+  return structuredClone(candidate);
+}
+
+function parseProviderObservation(
+  input: RuntimeProviderEventObservation,
+): RuntimeProviderEventObservation {
+  const parsed: RuntimeProviderEventObservation = {
+    ownerId: requiredIdentifier(input.ownerId, "ownerId"),
+    runtimeSessionId: requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    ),
+    runEpoch: nonNegativeInteger(input.runEpoch, "runEpoch"),
+    eventKey: requiredText(input.eventKey, "eventKey", 1_024),
+    providerEventId: requiredIdentifier(
+      input.providerEventId,
+      "providerEventId",
+    ),
+    observedAt: isoTimestamp(input.observedAt, "observedAt"),
+    ...(input.providerSessionId === undefined
+      ? {}
+      : {
+          providerSessionId: requiredIdentifier(
+            input.providerSessionId,
+            "providerSessionId",
+          ),
+        }),
+    ...(input.terminal === undefined ? {} : { terminal: input.terminal }),
+    ...(input.usage === undefined ? {} : { usage: parseUsage(input.usage) }),
+    ...(input.context === undefined
+      ? {}
+      : { context: structuredClone(input.context) }),
+    ...(input.evidence === undefined
+      ? {}
+      : { evidence: structuredClone(input.evidence) }),
+  };
+  return parsed;
+}
+
+function parseUsage(usage: RuntimeUsageDelta): RuntimeUsageDelta {
+  return {
+    tokensUsed: nonNegativeInteger(usage.tokensUsed, "usage.tokensUsed"),
+    turnsUsed: nonNegativeInteger(usage.turnsUsed, "usage.turnsUsed"),
+  };
+}
+
+function assertSameInstruction(
+  left: RuntimeInstruction,
+  right: RuntimeInstruction,
+): void {
+  if (canonicalJson(left) !== canonicalJson(right)) {
+    throw journalError(
+      "delivery_conflict",
+      `Instruction ID ${right.id} was reused with different content`,
+    );
+  }
+}
+
+function isInterruptControl(instruction: RuntimeInstruction): boolean {
+  return (
+    instruction.kind === "control.interrupt" ||
+    instruction.kind === "goal.pause" ||
+    instruction.kind === "goal.cancel"
+  );
+}
+
+function isProviderVisibleState(state: DeliveryState): boolean {
+  return (
+    state === "written_to_sdk" ||
+    state === "observed" ||
+    state === "applied" ||
+    state === "completed"
+  );
+}
+
+function isProviderAcceptedState(state: DeliveryState): boolean {
+  return state === "queued" || isProviderVisibleState(state);
+}
+
+function isRunTerminal(status: GoalRunStatus): boolean {
+  return (
+    status === "completed" ||
+    status === "cancelled" ||
+    status === "budget_limited" ||
+    status === "failed"
+  );
+}
+
+function cloneContext(
+  context: RuntimeObservationContext | null,
+): RuntimeObservationContext | null {
+  return context === null ? null : structuredClone(context);
+}
+
+function goalRunKey(goalId: string, runEpoch: number): string {
+  return JSON.stringify([goalId, runEpoch]);
+}
+
+function validatedScope(ownerId: string, runtimeSessionId: string): string {
+  return sessionScope(
+    requiredIdentifier(ownerId, "ownerId"),
+    requiredIdentifier(runtimeSessionId, "runtimeSessionId"),
+  );
+}
+
+function sessionScope(ownerId: string, runtimeSessionId: string): string {
+  return JSON.stringify([ownerId, runtimeSessionId]);
+}
+
+function requiredIdentifier(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw journalError("invalid_observation", `${field} must be a string`);
+  }
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    normalized.length > 256 ||
+    normalized !== value
+  ) {
+    throw journalError(
+      "invalid_observation",
+      `${field} must contain 1 to 256 characters without surrounding whitespace`,
+    );
+  }
+  return value;
+}
+
+function boundedIdentifier(value: string): string {
+  return value.length <= 256 ? value : value.slice(0, 256);
+}
+
+function requiredText(value: unknown, field: string, maximum: number): string {
+  if (typeof value !== "string") {
+    throw journalError("invalid_observation", `${field} must be a string`);
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > maximum) {
+    throw journalError(
+      "invalid_observation",
+      `${field} must contain 1 to ${maximum} characters`,
+    );
+  }
+  return normalized;
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw journalError(
+      "invalid_observation",
+      `${field} must be a non-negative integer`,
+    );
+  }
+  return value as number;
+}
+
+function isoTimestamp(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw journalError(
+      "invalid_observation",
+      `${field} must be an ISO date-time`,
+    );
+  }
+  return value;
+}
+
+function latestTimestamp(...values: Array<string | undefined>): string {
+  let latest: string | undefined;
+  let latestTime = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (value === undefined) continue;
+    const time = Date.parse(value);
+    if (time > latestTime) {
+      latest = value;
+      latestTime = time;
+    }
+  }
+  if (latest === undefined) {
+    throw journalError("invalid_observation", "A timestamp is required");
+  }
+  return latest;
+}
+
+function journalError(
+  code: RuntimeObservationJournalErrorCode,
+  message: string,
+  cause?: unknown,
+): RuntimeObservationJournalError {
+  return new RuntimeObservationJournalError(code, message, cause);
+}

--- a/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
+++ b/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
@@ -8,6 +8,10 @@ import {
 } from "@openloomi/ai/agent/runtime-instructions";
 
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
+import {
+  recordRuntimeObservation,
+  type RuntimeDeliveryJournalPort,
+} from "./runtime-observation";
 
 export interface RuntimeInstructionDrainInput {
   ownerId: string;
@@ -137,6 +141,7 @@ export class RuntimeInstructionDispatcher {
   constructor(
     private readonly sessions: RuntimeSessionResolverPort,
     private readonly outbox: RuntimeInstructionOutboxReader,
+    private readonly deliveryJournal?: RuntimeDeliveryJournalPort,
   ) {}
 
   drain(
@@ -233,7 +238,11 @@ export class RuntimeInstructionDispatcher {
         return accepted(sequential.receipt);
       }
 
-      const result = await this.deliverOne(transport, parsed.target);
+      const result = await this.deliverOne(
+        parsed.ownerId,
+        transport,
+        parsed.target,
+      );
       if (result.status === "accepted") {
         progress.directlyAcceptedById.set(parsed.target.id, {
           instructionId: parsed.target.id,
@@ -309,6 +318,16 @@ export class RuntimeInstructionDispatcher {
         }
       }
       advanceSettledPrefix(progress, parsed.instructions);
+      if (supersededInstructionIds.length > 0) {
+        await recordRuntimeObservation("record superseded deliveries", () =>
+          this.deliveryJournal?.supersedeDeliveries({
+            ownerId: parsed.ownerId,
+            runtimeSessionId: parsed.runtimeSessionId,
+            instructionIds: supersededInstructionIds,
+            reason,
+          }),
+        );
+      }
       return supersededInstructionIds;
     });
   }
@@ -404,7 +423,11 @@ export class RuntimeInstructionDispatcher {
         );
       }
 
-      const result = await this.deliverOne(transport, instruction);
+      const result = await this.deliverOne(
+        input.ownerId,
+        transport,
+        instruction,
+      );
       if (result.status !== "accepted") {
         const acceptedTarget = progress.acceptedBySequence.get(
           input.target.sequence,
@@ -495,6 +518,7 @@ export class RuntimeInstructionDispatcher {
   }
 
   private async deliverOne(
+    ownerId: string,
     transport: RuntimeInstructionTransportPort,
     instruction: RuntimeInstruction,
   ): Promise<
@@ -502,9 +526,21 @@ export class RuntimeInstructionDispatcher {
     | RuntimeInstructionDispatchFailure
   > {
     try {
+      await recordRuntimeObservation("prepare instruction delivery", () =>
+        this.deliveryJournal?.prepareDelivery({ ownerId, instruction }),
+      );
       const receipt = validateReceipt(
         await transport.deliver(instruction),
         instruction,
+      );
+      await recordRuntimeObservation(
+        "record instruction delivery receipt",
+        () =>
+          this.deliveryJournal?.recordDeliveryReceipt({
+            ownerId,
+            instruction,
+            receipt,
+          }),
       );
       return receipt.state === "rejected"
         ? {

--- a/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
@@ -1,0 +1,123 @@
+import type {
+  GoalEvidenceType,
+  RuntimeDeliveryReceipt,
+  RuntimeInstruction,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+export interface RuntimeEvidenceDraft {
+  type: GoalEvidenceType;
+  sourceEventId: string;
+  summary: string;
+  success?: boolean;
+  payload: unknown;
+  observedAt: string;
+}
+
+export interface RuntimeObservationContext {
+  ownerId: string;
+  runtimeSessionId: string;
+  goalRunId: string;
+  goalId: string;
+  goalRevision: number;
+  instructionId: string;
+  runEpoch: number;
+}
+
+export interface RuntimeUsageDelta {
+  tokensUsed: number;
+  turnsUsed: number;
+}
+
+export interface RuntimeProviderEventObservation {
+  ownerId: string;
+  runtimeSessionId: string;
+  runEpoch: number;
+  eventKey: string;
+  providerEventId: string;
+  providerSessionId?: string;
+  observedAt: string;
+  terminal?: boolean;
+  usage?: RuntimeUsageDelta;
+  context?: RuntimeObservationContext;
+  evidence?: RuntimeEvidenceDraft[];
+}
+
+export interface RuntimeDeliveryJournalPort {
+  prepareDelivery(input: {
+    ownerId: string;
+    instruction: RuntimeInstruction;
+  }): Promise<void>;
+
+  recordDeliveryReceipt(input: {
+    ownerId: string;
+    instruction: RuntimeInstruction;
+    receipt: RuntimeDeliveryReceipt;
+  }): Promise<void>;
+
+  supersedeDeliveries(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionIds: string[];
+    reason: string;
+  }): Promise<void>;
+}
+
+export interface RuntimeLifecycleObservationPort extends Pick<
+  RuntimeDeliveryJournalPort,
+  "supersedeDeliveries"
+> {
+  finalizeControlInstruction(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+    runEpoch: number;
+    status: "paused" | "cancelled";
+    recordedAt?: string;
+  }): Promise<void>;
+}
+
+/** Provider-facing observation boundary used by runtime adapters. */
+export interface RuntimeProviderObservationPort {
+  recordInstructionHandoff(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+    runEpoch: number;
+    recordedAt?: string;
+  }): Promise<boolean>;
+
+  setProviderSession(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    providerSessionId: string;
+  }): Promise<void>;
+
+  captureContext(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    runEpoch: number;
+  }): Promise<RuntimeObservationContext | null>;
+
+  observeProviderEvent(
+    input: RuntimeProviderEventObservation,
+  ): Promise<boolean>;
+}
+
+/** Complete boundary implemented by process-local and future durable journals. */
+export interface RuntimeObservationJournalPort
+  extends
+    RuntimeDeliveryJournalPort,
+    RuntimeLifecycleObservationPort,
+    RuntimeProviderObservationPort {}
+
+/** Observation recording is best effort and must not undo Goal commands. */
+export async function recordRuntimeObservation(
+  operation: string,
+  record: () => Promise<unknown> | undefined,
+): Promise<void> {
+  try {
+    await record();
+  } catch (error) {
+    console.error(`[Agent Goal Runtime] Failed to ${operation}`, error);
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/runtime.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime.ts
@@ -7,41 +7,61 @@ import { GoalService } from "./goal-service";
 import { GoalLifecycleService } from "./goal-lifecycle-service";
 import { GoalReplacementCoordinator } from "./goal-replacement-coordinator";
 import { InMemoryAgentGoalState } from "./in-memory-goal-state";
+import { InMemoryRuntimeObservationJournal } from "./in-memory-runtime-observation-journal";
 import { RuntimeInstructionDispatcher } from "./instruction-dispatcher";
+import type { RuntimeProviderObservationPort } from "./runtime-observation";
 import { RuntimeSessionRegistry } from "./runtime-session-registry";
 
 export interface InMemoryAgentGoalRuntime {
   readonly state: InMemoryAgentGoalState;
+  readonly observations: InMemoryRuntimeObservationJournal;
   readonly sessions: RuntimeSessionRegistry;
   readonly dispatcher: RuntimeInstructionDispatcher;
   readonly goals: GoalService;
   readonly replacements: GoalReplacementCoordinator;
 }
 
-export type AgentGoalRuntime = Pick<
-  InMemoryAgentGoalRuntime,
-  "sessions" | "goals" | "replacements"
->;
+export interface AgentGoalRuntime {
+  readonly sessions: RuntimeSessionRegistry;
+  readonly goals: GoalService;
+  readonly observations: RuntimeProviderObservationPort;
+  readonly replacements: GoalReplacementCoordinator;
+}
 
 export function createInMemoryAgentGoalRuntime(
   options: {
     clock?: RuntimeClockPort;
     idGenerator?: RuntimeIdGeneratorPort;
+    observationIdGenerator?: RuntimeIdGeneratorPort;
   } = {},
 ): InMemoryAgentGoalRuntime {
   const state = new InMemoryAgentGoalState();
   const sessions = new RuntimeSessionRegistry();
-  const dispatcher = new RuntimeInstructionDispatcher(sessions, state);
   const clock = options.clock ?? { now: () => new Date() };
   const idGenerator = options.idGenerator ?? {
     generate: () => crypto.randomUUID(),
   };
+  const observationIdGenerator = options.observationIdGenerator ?? {
+    generate: () => crypto.randomUUID(),
+  };
+  const observations = new InMemoryRuntimeObservationJournal(
+    state,
+    clock,
+    observationIdGenerator,
+  );
+  const dispatcher = new RuntimeInstructionDispatcher(
+    sessions,
+    state,
+    observations,
+  );
   const lifecycle = new GoalLifecycleService(
     state,
     dispatcher,
     sessions,
     clock,
     idGenerator,
+    30_000,
+    observations,
   );
   const goals = new GoalService(
     state,
@@ -56,8 +76,17 @@ export function createInMemoryAgentGoalRuntime(
     sessions,
     clock,
     idGenerator,
+    30_000,
+    observations,
   );
-  return { state, sessions, dispatcher, goals, replacements };
+  return {
+    state,
+    observations,
+    sessions,
+    dispatcher,
+    goals,
+    replacements,
+  };
 }
 
 let agentGoalRuntime: InMemoryAgentGoalRuntime | undefined;

--- a/apps/web/tests/unit/runtime-instructions/claude-runtime-observation.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/claude-runtime-observation.test.ts
@@ -1,0 +1,638 @@
+import type {
+  HookCallback,
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { CreateAgentGoalInput } from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it, vi } from "vitest";
+
+import { collectClaudeToolEvidence } from "@/lib/ai/extensions/agent/claude/runtime/evidence-collector";
+import {
+  ClaudeRuntimeSession,
+  createClaudeSupplementalInputHooks,
+  startClaudeGoalRuntimeSession,
+} from "@/lib/ai/extensions/agent/claude/runtime";
+import { createInMemoryAgentGoalRuntime } from "@/lib/ai/runtime-instructions/runtime";
+import {
+  createControlledClaudeQuery,
+  createFakeClaudeSdkTransport,
+} from "../../helpers/claude-runtime";
+import {
+  DeterministicRuntimeIds,
+  FixedRuntimeClock,
+} from "../../helpers/goal-runtime";
+
+const OWNER_ID = "owner-runtime-observation";
+const SESSION_ID = "claude-runtime-observation-session";
+const PROVIDER_SESSION_ID = "claude-provider-session";
+const NOW = new Date("2026-08-01T09:00:00.000Z");
+
+const INIT_EVENT_ID = "10000000-0000-4000-8000-000000000001";
+const ASSISTANT_EVENT_ID = "10000000-0000-4000-8000-000000000002";
+const RESULT_EVENT_ID = "10000000-0000-4000-8000-000000000003";
+
+function goalInput(objective: string): CreateAgentGoalInput {
+  return {
+    objective,
+    successCriteria: [
+      {
+        id: "runtime-observed",
+        description: "Claude observes and applies the runtime instruction",
+        verification: { type: "model_evidence" },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 80,
+    maxTurns: 5,
+    completionPolicy: "model_evaluator",
+    source: { type: "user" },
+  };
+}
+
+function initMessage(): SDKMessage {
+  return {
+    type: "system",
+    subtype: "init",
+    uuid: INIT_EVENT_ID,
+    session_id: PROVIDER_SESSION_ID,
+  } as unknown as SDKMessage;
+}
+
+function assistantMessage(): SDKMessage {
+  return {
+    type: "assistant",
+    uuid: ASSISTANT_EVENT_ID,
+    session_id: PROVIDER_SESSION_ID,
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "I am applying the active Goal." }],
+    },
+  } as unknown as SDKMessage;
+}
+
+function resultMessage(uuid = RESULT_EVENT_ID): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    uuid,
+    session_id: PROVIDER_SESSION_ID,
+    duration_ms: 10,
+    duration_api_ms: 8,
+    is_error: false,
+    num_turns: 2,
+    result: "Goal turn complete",
+    total_cost_usd: 0.01,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 3,
+      cache_creation_input_tokens: 4,
+      cache_read_input_tokens: 5,
+    },
+  } as SDKMessage;
+}
+
+async function createHarness(idPrefix: string) {
+  const handle = createControlledClaudeQuery();
+  const sdk = createFakeClaudeSdkTransport(handle);
+  const claude = new ClaudeRuntimeSession({
+    runtimeSessionId: SESSION_ID,
+    runEpoch: 0,
+    sdkTransport: sdk.transport,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    createMessageId: () => `${idPrefix}-agent-message`,
+  });
+  const runtime = createInMemoryAgentGoalRuntime({
+    clock: new FixedRuntimeClock(NOW),
+    idGenerator: new DeterministicRuntimeIds(idPrefix),
+    observationIdGenerator: new DeterministicRuntimeIds("90000000"),
+  });
+  const registration = await startClaudeGoalRuntimeSession({
+    session: { user: { id: OWNER_ID } },
+    runtime: claude,
+    start: { initialPrompt: "Start the observed Goal runtime" },
+    goalRuntime: runtime,
+  });
+  const sdkInput = (sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>)[
+    Symbol.asyncIterator
+  ]();
+
+  return { claude, handle, registration, runtime, sdkInput };
+}
+
+async function deliveryState(
+  runtime: ReturnType<typeof createInMemoryAgentGoalRuntime>,
+  instructionId: string,
+) {
+  const deliveries = await runtime.observations.listDeliveries(
+    OWNER_ID,
+    SESSION_ID,
+  );
+  return deliveries.find(
+    (delivery) => delivery.instructionId === instructionId,
+  );
+}
+
+describe("Claude runtime Goal observations", () => {
+  it("separates queued, written, observed, and applied delivery while deduplicating final usage", async () => {
+    const harness = await createHarness("60000000");
+    const activated = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "observe-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Track the Claude delivery lifecycle"),
+    });
+
+    expect(activated.dispatch.status).toBe("accepted");
+    await expect(
+      deliveryState(harness.runtime, activated.instruction.id),
+    ).resolves.toMatchObject({ state: "queued" });
+
+    await harness.sdkInput.next();
+    await harness.sdkInput.next();
+    await vi.waitFor(async () => {
+      await expect(
+        deliveryState(harness.runtime, activated.instruction.id),
+      ).resolves.toMatchObject({ state: "written_to_sdk" });
+    });
+
+    harness.handle.push(initMessage());
+    await vi.waitFor(() => expect(harness.claude.sdkMessageCount).toBe(1));
+    await expect(
+      deliveryState(harness.runtime, activated.instruction.id),
+    ).resolves.toMatchObject({ state: "written_to_sdk" });
+
+    harness.handle.push(assistantMessage());
+    await vi.waitFor(async () => {
+      await expect(
+        deliveryState(harness.runtime, activated.instruction.id),
+      ).resolves.toMatchObject({
+        state: "observed",
+        providerEventId: ASSISTANT_EVENT_ID,
+      });
+    });
+
+    const result = resultMessage();
+    harness.handle.push(result);
+    await vi.waitFor(async () => {
+      await expect(
+        deliveryState(harness.runtime, activated.instruction.id),
+      ).resolves.toMatchObject({
+        state: "applied",
+        providerEventId: RESULT_EVENT_ID,
+      });
+    });
+    await expect(
+      harness.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID),
+    ).resolves.toMatchObject([
+      {
+        goalId: activated.goal.goal.id,
+        providerSessionId: PROVIDER_SESSION_ID,
+        runEpoch: 0,
+        status: "running",
+        tokensUsed: 22,
+        turnsUsed: 2,
+      },
+    ]);
+
+    harness.handle.push({
+      ...result,
+      subtype: "error_max_turns",
+    } as unknown as SDKMessage);
+    await vi.waitFor(() => expect(harness.claude.sdkMessageCount).toBe(4));
+    const runs = await harness.runtime.observations.listGoalRuns(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ tokensUsed: 22, turnsUsed: 2 });
+
+    harness.registration?.release();
+    await harness.claude.close();
+  });
+
+  it("reconciles provider handoff before its receipt and a rejected retry", async () => {
+    const runtime = createInMemoryAgentGoalRuntime({
+      clock: new FixedRuntimeClock(NOW),
+      idGenerator: new DeterministicRuntimeIds("30000000"),
+      observationIdGenerator: new DeterministicRuntimeIds("31000000"),
+    });
+    const activated = await runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "race-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Observe output that races ahead of its receipt"),
+    });
+
+    await runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: activated.instruction,
+    });
+    await expect(
+      runtime.observations.recordInstructionHandoff({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        instructionId: activated.instruction.id,
+        runEpoch: 0,
+        recordedAt: "2026-08-01T09:00:01.000Z",
+      }),
+    ).resolves.toBe(true);
+    await runtime.observations.observeProviderEvent({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      eventKey: "terminal-before-receipt",
+      providerEventId: "terminal-before-receipt",
+      terminal: true,
+      observedAt: "2026-08-01T09:00:02.000Z",
+      usage: { tokensUsed: 3, turnsUsed: 1 },
+    });
+    await runtime.observations.recordDeliveryReceipt({
+      ownerId: OWNER_ID,
+      instruction: activated.instruction,
+      receipt: {
+        instructionId: activated.instruction.id,
+        runtimeSessionId: SESSION_ID,
+        state: "queued",
+        recordedAt: "2026-08-01T09:00:03.000Z",
+      },
+    });
+    await expect(
+      deliveryState(runtime, activated.instruction.id),
+    ).resolves.toMatchObject({ state: "applied", attempt: 1 });
+
+    const updated = await runtime.goals.update({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 1,
+      idempotencyKey: "race-retry-update",
+      source: { type: "user", authority: "user" },
+      update: { priority: 90 },
+    });
+    await runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: updated.instruction,
+    });
+    await runtime.observations.recordDeliveryReceipt({
+      ownerId: OWNER_ID,
+      instruction: updated.instruction,
+      receipt: {
+        instructionId: updated.instruction.id,
+        runtimeSessionId: SESSION_ID,
+        state: "rejected",
+        reason: "transient transport rejection",
+        recordedAt: "2026-08-01T09:00:04.000Z",
+      },
+    });
+    await runtime.observations.recordInstructionHandoff({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      instructionId: updated.instruction.id,
+      runEpoch: 0,
+      recordedAt: "2026-08-01T09:00:05.000Z",
+    });
+    await runtime.observations.recordDeliveryReceipt({
+      ownerId: OWNER_ID,
+      instruction: updated.instruction,
+      receipt: {
+        instructionId: updated.instruction.id,
+        runtimeSessionId: SESSION_ID,
+        state: "queued",
+        recordedAt: "2026-08-01T09:00:06.000Z",
+      },
+    });
+    const retry = (
+      await runtime.observations.listDeliveries(OWNER_ID, SESSION_ID)
+    ).find(({ instructionId }) => instructionId === updated.instruction.id);
+    expect(retry).toMatchObject({ state: "written_to_sdk", attempt: 2 });
+  });
+
+  it("records next-boundary context as written when PostToolBatch consumes it", async () => {
+    const harness = await createHarness("70000000");
+    await harness.sdkInput.next();
+    const activated = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "boundary-activate",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Consume context at the next tool boundary"),
+    });
+    await harness.sdkInput.next();
+
+    const context = await harness.runtime.goals.upsertContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 1,
+      idempotencyKey: "boundary-context",
+      source: {
+        type: "connector",
+        authority: "untrusted_data",
+        sourceRef: "jira:JIRA-176",
+      },
+      contextRef: {
+        id: "jira-176-runtime-context",
+        kind: "connector_record",
+        refId: "JIRA-176",
+        origin: "connector",
+        sourceRef: "jira:JIRA-176",
+        summary: "Context delivered at the next tool boundary",
+      },
+    });
+    await expect(
+      deliveryState(harness.runtime, context.instruction.id),
+    ).resolves.toMatchObject({ state: "queued" });
+    await expect(
+      harness.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID),
+    ).resolves.toMatchObject([{ goalRevision: 1 }]);
+
+    const hooks = createClaudeSupplementalInputHooks({
+      supplementalInput: harness.claude.liveInputSource,
+      toolObserver: harness.claude,
+      sessionId: SESSION_ID,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const postToolBatch = hooks?.PostToolBatch?.[0]?.hooks[0] as HookCallback;
+    await expect(
+      postToolBatch({} as never, undefined, {
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PostToolBatch",
+        additionalContext: expect.stringContaining(
+          'context_id="jira-176-runtime-context"',
+        ),
+      },
+    });
+    await vi.waitFor(async () => {
+      await expect(
+        deliveryState(harness.runtime, context.instruction.id),
+      ).resolves.toMatchObject({ state: "written_to_sdk" });
+    });
+
+    const preToolUse = hooks?.PreToolUse?.[0]?.hooks[0] as HookCallback;
+    const postToolUse = hooks?.PostToolUse?.[0]?.hooks[0] as HookCallback;
+    const toolUseId = "tool-boundary-test";
+    const hookBase = {
+      session_id: PROVIDER_SESSION_ID,
+      transcript_path: "transcript.jsonl",
+      cwd: "D:/workspace",
+      tool_name: "Bash",
+      tool_input: { command: "pnpm test" },
+      tool_use_id: toolUseId,
+    };
+    await preToolUse(
+      { ...hookBase, hook_event_name: "PreToolUse" } as never,
+      toolUseId,
+      { signal: new AbortController().signal },
+    );
+    await postToolUse(
+      {
+        ...hookBase,
+        hook_event_name: "PostToolUse",
+        tool_response: {
+          stdout: "tests passed",
+          stderr: "",
+          interrupted: false,
+          isImage: false,
+        },
+      } as never,
+      toolUseId,
+      { signal: new AbortController().signal },
+    );
+    const permissionDenied = hooks?.PermissionDenied?.[0]
+      ?.hooks[0] as HookCallback;
+    await permissionDenied(
+      {
+        ...hookBase,
+        hook_event_name: "PermissionDenied",
+        tool_name: "Write",
+        tool_input: { file_path: "src/denied.ts", content: "private" },
+        tool_use_id: "tool-denied-write",
+        reason: "permission policy denied the write",
+      } as never,
+      "tool-denied-write",
+      { signal: new AbortController().signal },
+    );
+    await expect(
+      harness.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID),
+    ).resolves.toMatchObject([{ goalRevision: 2 }]);
+    await expect(
+      harness.runtime.observations.listEvidence(OWNER_ID, SESSION_ID),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          goalId: activated.goal.goal.id,
+          goalRevision: 2,
+          instructionId: context.instruction.id,
+          type: "test_result",
+          sourceEventId: expect.stringContaining(toolUseId),
+          success: true,
+        }),
+        expect.objectContaining({
+          instructionId: context.instruction.id,
+          type: "tool_result",
+          sourceEventId: expect.stringContaining("tool-denied-write"),
+          success: false,
+        }),
+      ]),
+    );
+
+    harness.registration?.release();
+    await harness.claude.close();
+  });
+
+  it("classifies bounded command, test, file, generic, and failed tool evidence", () => {
+    const privateWriteBody = "PRIVATE_WRITE_BODY_SHOULD_NOT_BE_RETAINED";
+    const privateToken = "PRIVATE_TOKEN_SHOULD_NOT_BE_RETAINED";
+    const observedAt = NOW.toISOString();
+    const evidence = [
+      collectClaudeToolEvidence({
+        providerEventId: "provider-command",
+        toolUseId: "tool-command",
+        toolName: "Bash",
+        outcome: "succeeded",
+        toolInput: { command: `API_TOKEN=${privateToken} echo ready` },
+        toolResponse: {
+          stdout: "ready",
+          stderr: "",
+          interrupted: false,
+          isImage: false,
+        },
+        observedAt,
+      }),
+      collectClaudeToolEvidence({
+        providerEventId: "provider-test",
+        toolUseId: "tool-test",
+        toolName: "Bash",
+        outcome: "failed",
+        toolInput: { command: "pnpm test" },
+        error: "Command failed with exit code 1",
+        observedAt,
+      }),
+      collectClaudeToolEvidence({
+        providerEventId: "provider-write",
+        toolUseId: "tool-write",
+        toolName: "Write",
+        outcome: "succeeded",
+        toolInput: {
+          file_path: "src/runtime.ts",
+          content: privateWriteBody.repeat(100),
+        },
+        toolResponse: { success: true },
+        observedAt,
+      }),
+      collectClaudeToolEvidence({
+        providerEventId: "provider-generic",
+        toolUseId: "tool-generic",
+        toolName: "Read",
+        outcome: "succeeded",
+        toolInput: { file_path: "README.md" },
+        toolResponse: { success: false, lines: 20 },
+        observedAt,
+      }),
+      collectClaudeToolEvidence({
+        providerEventId: "provider-failure",
+        toolUseId: "tool-failure",
+        toolName: "WebFetch",
+        outcome: "failed",
+        toolInput: { url: "https://example.com" },
+        error: "network denied",
+        observedAt,
+      }),
+    ];
+
+    expect(
+      evidence.map(({ type, success, sourceEventId }) => ({
+        type,
+        success,
+        sourceEventId,
+      })),
+    ).toEqual([
+      {
+        type: "command_result",
+        success: true,
+        sourceEventId: "provider-command:tool:tool-command",
+      },
+      {
+        type: "test_result",
+        success: false,
+        sourceEventId: "provider-test:tool:tool-test",
+      },
+      {
+        type: "file_change",
+        success: true,
+        sourceEventId: "provider-write:tool:tool-write",
+      },
+      {
+        type: "tool_result",
+        success: true,
+        sourceEventId: "provider-generic:tool:tool-generic",
+      },
+      {
+        type: "tool_result",
+        success: false,
+        sourceEventId: "provider-failure:tool:tool-failure",
+      },
+    ]);
+    expect(evidence[2]?.payload).toMatchObject({
+      paths: ["src/runtime.ts"],
+      inputContentRetained: false,
+    });
+    expect(JSON.stringify(evidence[2])).not.toContain(privateWriteBody);
+    expect(JSON.stringify(evidence)).not.toContain(privateToken);
+  });
+
+  it("rejects stale provider observations after cancellation advances the real runtime epoch", async () => {
+    const harness = await createHarness("80000000");
+    await harness.sdkInput.next();
+    const activated = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "stale-activate-old",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Cancel this Goal before observing stale output"),
+    });
+    await harness.sdkInput.next();
+
+    const cancelling = harness.runtime.goals.cancel({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activated.goal.goal.id,
+      expectedRevision: 1,
+      idempotencyKey: "stale-cancel",
+      source: { type: "user", authority: "user" },
+      reason: "Advance the epoch before delayed output arrives",
+    });
+    await vi.waitFor(() => {
+      expect(harness.handle.interrupt).toHaveBeenCalledTimes(2);
+    });
+    harness.handle.push(resultMessage("20000000-0000-4000-8000-000000000001"));
+    const cancelled = await cancelling;
+    expect(harness.claude.runEpoch).toBe(1);
+
+    const replacement = await harness.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "stale-activate-new",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Keep the new Goal isolated from stale output"),
+    });
+    await harness.sdkInput.next();
+    await vi.waitFor(async () => {
+      const runs = await harness.runtime.observations.listGoalRuns(
+        OWNER_ID,
+        SESSION_ID,
+      );
+      expect(
+        runs.find(({ goalId }) => goalId === replacement.goal.goal.id),
+      ).toMatchObject({
+        runEpoch: 1,
+        status: "running",
+      });
+    });
+
+    const before = (
+      await harness.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID)
+    ).find(({ goalId }) => goalId === replacement.goal.goal.id);
+    await expect(
+      harness.runtime.observations.observeProviderEvent({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 0,
+        eventKey: "stale-provider-result",
+        providerEventId: "stale-provider-result",
+        observedAt: "2026-08-01T09:01:00.000Z",
+        terminal: true,
+        usage: {
+          tokensUsed: 4_000,
+          turnsUsed: 100,
+        },
+      }),
+    ).resolves.toBe(false);
+    const after = (
+      await harness.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID)
+    ).find(({ goalId }) => goalId === replacement.goal.goal.id);
+    expect(after).toEqual(before);
+
+    const runs = await harness.runtime.observations.listGoalRuns(
+      OWNER_ID,
+      SESSION_ID,
+    );
+    expect(
+      runs.find(({ goalId }) => goalId === activated.goal.goal.id),
+    ).toMatchObject({ status: "cancelled", runEpoch: 0 });
+    await expect(
+      deliveryState(harness.runtime, cancelled.instruction.id),
+    ).resolves.toMatchObject({ state: "applied" });
+
+    harness.registration?.release();
+    await harness.claude.close();
+  });
+});

--- a/packages/ai/src/agent/supplemental-input/queue.ts
+++ b/packages/ai/src/agent/supplemental-input/queue.ts
@@ -258,8 +258,11 @@ export class AgentSupplementalInputQueue implements AgentSupplementalInputSource
 
     const informs: NormalizedAgentSupplementalInput[] = [];
     while (this.pending[0]?.input.intent === "inform") {
-      const entry = this.pending.shift();
-      if (entry !== undefined) informs.push(entry.input);
+      const entry = this.pending[0];
+      if (entry === undefined) break;
+      this.handoffHandler?.(entry.input);
+      this.pending.shift();
+      informs.push(entry.input);
     }
 
     this.drainReleasableInputs();


### PR DESCRIPTION
## Summary

Add runtime observation, delivery tracking, usage accounting, and evidence collection to the Claude Goal Runtime.

This completes the feedback path from delivering an OpenLoomi instruction to observing how Claude processes it.

Related to #176.

## What Changed

### Delivery Tracking

- Track instructions through `queued`, `written_to_sdk`, `observed`, and `applied`.
- Distinguish transport acceptance from the actual Claude SDK input handoff.
- Handle early handoff, delayed receipt, rejected retry, and duplicate-event races.
- Mark discarded pending instructions as `superseded` during cancellation and Goal replacement.

### Goal Runs and Usage

- Create and update in-memory Goal Runs from Claude runtime activity.
- Associate runs with the Goal, revision, runtime session, provider session, and `runEpoch`.
- Accumulate input, output, cache, and turn usage from Claude result events.
- Prevent replayed SDK events from applying usage more than once.

### Runtime Evidence

- Capture Goal context before tool execution and associate the outcome with the correct Goal revision.
- Record command, test, file-change, generic tool, failed-tool, and permission-denied evidence.
- Preserve useful metadata such as command, exit code, affected paths, duration, and outcome.
- Redact secret-like values and avoid retaining file bodies or patches.
- Bound evidence payload size and deduplicate evidence by provider event.

### Lifecycle Safety

- Synchronize Goal Run and delivery state across pause, cancellation, resume, and replacement.
- Reject delayed provider events from stale `runEpoch` values.
- Keep observation failures isolated so they cannot roll back authoritative Goal commands.
- Attach Goal observation only to authenticated Claude sessions.

## Validation

- 11 related test files passed.
- 85 related tests passed.