### PR TITLE
fix: make memory file writes atomic

### DIFF
--- a/apps/web/lib/ai/memory/fs-sync.ts
+++ b/apps/web/lib/ai/memory/fs-sync.ts
@@ -13,6 +13,7 @@
  */
 
 import { isTauriMode } from "@/lib/env";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAppDataDir, joinPath } from "@/lib/utils/path";
@@ -51,5 +52,24 @@ export async function writeFile(
   const dirPath = path.dirname(fsPath);
   await createDirectory(dirPath);
 
-  await fs.promises.writeFile(fsPath, content, "utf-8");
+  const tempPath = path.join(
+    dirPath,
+    `.${path.basename(fsPath)}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    const tempFile = await fs.promises.open(tempPath, "w");
+    try {
+      await tempFile.writeFile(content, "utf8");
+      await tempFile.sync();
+    } finally {
+      await tempFile.close();
+    }
+    await fs.promises.rename(tempPath, fsPath);
+  } catch (error) {
+    await fs.promises.rm(tempPath, { force: true }).catch((cleanupError) => {
+      console.error("[MemoryFsSync] Failed to remove temp file:", cleanupError);
+    });
+    throw error;
+  }
 }

--- a/apps/web/tests/unit/memory-fs-sync.test.ts
+++ b/apps/web/tests/unit/memory-fs-sync.test.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({ isTauriMode: () => true }));
+
+import { writeFile } from "@/lib/ai/memory/fs-sync";
+
+describe("memory filesystem sync", () => {
+  let directory: string;
+
+  beforeEach(async () => {
+    directory = await fs.mkdtemp(join(tmpdir(), "openloomi-memory-fs-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(directory, { force: true, recursive: true });
+  });
+
+  it("atomically replaces an existing memory file", async () => {
+    const target = join(directory, "project.md");
+    await fs.writeFile(target, "old memory", "utf8");
+
+    await writeFile(target, "new memory");
+
+    expect(await fs.readFile(target, "utf8")).toBe("new memory");
+    expect(await fs.readdir(directory)).toEqual(["project.md"]);
+  });
+
+  it("preserves the previous memory when the atomic rename fails", async () => {
+    const target = join(directory, "project.md");
+    await fs.writeFile(target, "old memory", "utf8");
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(new Error("rename failed"));
+
+    await expect(writeFile(target, "new memory")).rejects.toThrow(
+      "rename failed",
+    );
+
+    expect(await fs.readFile(target, "utf8")).toBe("old memory");
+    expect(await fs.readdir(directory)).toEqual(["project.md"]);
+  });
+});


### PR DESCRIPTION
## Summary\n\n- write memory files through a same-directory temporary file\n- flush and close the temporary file before an atomic rename\n- remove temporary artifacts after failures while preserving the previous target\n- add regression coverage for successful replacement and rename failure\n\nThis addresses the atomic-write portion of #416 without expanding the workflow UI scope.\n\n## Verification\n\n- 
 RUN  v4.1.5 /private/tmp/openloomi-goodmemory-contrib-20260803/apps/web


 Test Files  2 passed (2)
      Tests  29 passed (29)
   Start at  03:16:35
   Duration  482ms (transform 331ms, setup 46ms, import 399ms, tests 69ms, environment 0ms) (29 tests passed)\n- 
> web@0.8.8 tsc /private/tmp/openloomi-goodmemory-contrib-20260803/apps/web
> node ./scripts/run-cross-env.cjs NODE_OPTIONS=--max-old-space-size=16384 node ../../node_modules/typescript/bin/tsc\n- Checked 2 files in 10ms. No fixes applied.\n- Checking formatting...
All matched files use Prettier code style!