### PR TITLE
feat: wire Whisper STT and Kokoro TTS providers

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -104,12 +104,29 @@ ANTHROPIC_MODEL=****
 # LOCAL_EMBEDDING_DTYPE=fp32
 # LOCAL_EMBEDDING_LOCAL_ONLY=false
 
-# OpenAI Audio API (Whisper + TTS) — OPTIONAL, only required if you use
-# Whisper transcription or TTS. Chat and embeddings do not need this.
-# Get your key at: https://platform.openai.com/api-keys
+# Voice features (STT + TTS) — OPTIONAL.
+# Both features are enabled by default when these flags are unset. Set a flag to
+# false, 0, off, no, or disabled to turn the feature off for both UI and API routes.
+# NEXT_PUBLIC_ENABLE_WHISPER=true
+# NEXT_PUBLIC_ENABLE_KOKORO=true
+#
+# Speech-to-text (Whisper)
+# OpenLoomi sends recorded audio to /api/ai/v1/audio/transcriptions, then proxies
+# it to an OpenAI-compatible /v1/audio/transcriptions endpoint.
+# Use a real OpenAI key for the official API, or "dummy" when pointing
+# OPENAI_AUDIO_BASE_URL at a local OpenAI-compatible Whisper server that ignores auth.
 # OPENAI_API_KEY=****
-# Optional: Custom base URL for OpenAI Audio API (defaults to https://api.openai.com/v1)
 # OPENAI_AUDIO_BASE_URL=https://api.openai.com/v1
+# OPENAI_AUDIO_TRANSCRIPTION_MODEL=whisper-1
+#
+# Text-to-speech (Kokoro)
+# OpenLoomi sends assistant replies to /api/ai/v1/audio/speech, then proxies them
+# to a local OpenAI-compatible Kokoro server. No API key is required by default.
+# KOKORO_TTS_BASE_URL=http://127.0.0.1:8880/v1
+# KOKORO_TTS_MODEL=kokoro
+# KOKORO_TTS_VOICE=af_bella
+# KOKORO_TTS_RESPONSE_FORMAT=mp3
+# KOKORO_TTS_SPEED=1
 
 # Image Generation API (Lifestyle image Day 1 backend)
 # Provider selection: openai | openrouter | nano-banana

--- a/apps/web/app/api/ai/v1/audio/speech/route.ts
+++ b/apps/web/app/api/ai/v1/audio/speech/route.ts
@@ -1,0 +1,341 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/app/(auth)/auth";
+import { isTauriMode } from "@/lib/env/constants";
+import { AppError } from "@openloomi/shared/errors";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_KOKORO_TTS_BASE_URL = "http://127.0.0.1:8880/v1";
+const DEFAULT_KOKORO_TTS_MODEL = "kokoro";
+const DEFAULT_KOKORO_TTS_VOICE = "af_bella";
+const DEFAULT_KOKORO_TTS_RESPONSE_FORMAT = "mp3";
+const DEFAULT_KOKORO_TTS_SPEED = 1;
+const HEALTH_TIMEOUT_MS = 5_000;
+const SPEECH_TIMEOUT_MS = 600_000;
+
+const supportedResponseFormats = new Set([
+  "mp3",
+  "wav",
+  "opus",
+  "flac",
+  "m4a",
+  "pcm",
+]);
+
+type KokoroResponseFormat = "mp3" | "wav" | "opus" | "flac" | "m4a" | "pcm";
+
+type SpeechPayload = {
+  input: string;
+  model: string;
+  voice: string;
+  responseFormat: KokoroResponseFormat;
+  speed: number;
+};
+
+async function authorize() {
+  const session = await auth().catch(() => null);
+  if (!session?.user?.id && !isTauriMode()) {
+    return false;
+  }
+  return true;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeKokoroBaseUrl(baseUrl?: string): string {
+  const normalized = (baseUrl || DEFAULT_KOKORO_TTS_BASE_URL)
+    .trim()
+    .replace(/\/+$/, "");
+  if (!normalized) {
+    return DEFAULT_KOKORO_TTS_BASE_URL;
+  }
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}
+
+function readResponseFormat(value: unknown): KokoroResponseFormat | undefined {
+  const format = readString(value);
+  if (!format) return undefined;
+  return supportedResponseFormats.has(format)
+    ? (format as KokoroResponseFormat)
+    : undefined;
+}
+
+function readPayloadResponseFormat(
+  value: unknown,
+): KokoroResponseFormat | undefined {
+  const format = readString(value);
+  if (!format) return undefined;
+  const responseFormat = readResponseFormat(format);
+  if (!responseFormat) {
+    throw new AppError(
+      "bad_request:api",
+      "Unsupported Kokoro response_format.",
+    );
+  }
+  return responseFormat;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const numberValue =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value.trim())
+        : Number.NaN;
+  if (!Number.isFinite(numberValue) || numberValue <= 0) {
+    throw new AppError("bad_request:api", "speed must be a positive number.");
+  }
+  return numberValue;
+}
+
+async function readSpeechPayload(request: Request): Promise<SpeechPayload> {
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  if (!body) {
+    throw new AppError("bad_request:api", "Invalid TTS payload.");
+  }
+
+  const input = readString(body.input) ?? readString(body.text);
+  if (!input) {
+    throw new AppError("bad_request:api", "input is required.");
+  }
+
+  return {
+    input,
+    model:
+      readString(body.model) ??
+      readString(process.env.KOKORO_TTS_MODEL) ??
+      DEFAULT_KOKORO_TTS_MODEL,
+    voice:
+      readString(body.voice) ??
+      readString(process.env.KOKORO_TTS_VOICE) ??
+      DEFAULT_KOKORO_TTS_VOICE,
+    responseFormat:
+      readPayloadResponseFormat(body.response_format ?? body.responseFormat) ??
+      readResponseFormat(process.env.KOKORO_TTS_RESPONSE_FORMAT) ??
+      DEFAULT_KOKORO_TTS_RESPONSE_FORMAT,
+    speed: readPositiveNumber(body.speed) ?? DEFAULT_KOKORO_TTS_SPEED,
+  };
+}
+
+function createRequestSignal(signal: AbortSignal, timeoutMs: number) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const abortFromInput = () => controller.abort();
+
+  if (signal.aborted) {
+    controller.abort();
+  } else {
+    signal.addEventListener("abort", abortFromInput, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener("abort", abortFromInput);
+    },
+  };
+}
+
+async function readProviderError(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (!text.trim()) {
+    return `Kokoro returned HTTP ${response.status.toString()}`;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { message?: unknown };
+      message?: unknown;
+      detail?: unknown;
+    };
+    const message =
+      typeof parsed.error?.message === "string"
+        ? parsed.error.message
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : typeof parsed.detail === "string"
+            ? parsed.detail
+            : null;
+    return message ?? text.trim().slice(0, 400);
+  } catch {
+    return text.trim().slice(0, 400);
+  }
+}
+
+function extractVoiceIds(data: unknown): string[] {
+  if (!data || typeof data !== "object") return [];
+  const voices = (data as { voices?: unknown }).voices;
+  if (!Array.isArray(voices)) return [];
+
+  return voices
+    .map((voice) => {
+      if (typeof voice === "string") return voice;
+      if (voice && typeof voice === "object") {
+        const id = (voice as { id?: unknown }).id;
+        return typeof id === "string" ? id : null;
+      }
+      return null;
+    })
+    .filter((voice): voice is string => Boolean(voice));
+}
+
+function createForwardedAudioHeaders(upstreamHeaders: Headers): Headers {
+  const headers = new Headers({
+    "Cache-Control": "no-store",
+  });
+
+  for (const header of [
+    "content-type",
+    "content-length",
+    "content-disposition",
+    "accept-ranges",
+  ]) {
+    const value = upstreamHeaders.get(header);
+    if (value) {
+      headers.set(header, value);
+    }
+  }
+
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "audio/mpeg");
+  }
+
+  return headers;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+export async function GET(request: Request) {
+  if (!(await authorize())) {
+    return new AppError("unauthorized:auth").toResponse();
+  }
+
+  const baseUrl = normalizeKokoroBaseUrl(process.env.KOKORO_TTS_BASE_URL);
+  const { signal, cleanup } = createRequestSignal(
+    request.signal,
+    HEALTH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(`${baseUrl}/audio/voices`, {
+      method: "GET",
+      signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await readProviderError(response));
+    }
+
+    const data = (await response.json().catch(() => null)) as unknown;
+    return NextResponse.json(
+      {
+        ready: true,
+        baseUrl,
+        model:
+          readString(process.env.KOKORO_TTS_MODEL) ?? DEFAULT_KOKORO_TTS_MODEL,
+        voice:
+          readString(process.env.KOKORO_TTS_VOICE) ?? DEFAULT_KOKORO_TTS_VOICE,
+        voices: extractVoiceIds(data),
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("[Audio Speech] Kokoro health check failed", error);
+    if (isAbortError(error)) {
+      return new AppError(
+        "offline:api",
+        "Kokoro TTS health check timed out.",
+      ).toResponse();
+    }
+    return new AppError(
+      "offline:api",
+      error instanceof Error
+        ? error.message
+        : "Kokoro TTS service is not reachable.",
+    ).toResponse();
+  } finally {
+    cleanup();
+  }
+}
+
+export async function POST(request: Request) {
+  if (!(await authorize())) {
+    return new AppError("unauthorized:auth").toResponse();
+  }
+
+  try {
+    const payload = await readSpeechPayload(request);
+    const baseUrl = normalizeKokoroBaseUrl(process.env.KOKORO_TTS_BASE_URL);
+    const { signal, cleanup } = createRequestSignal(
+      request.signal,
+      SPEECH_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(`${baseUrl}/audio/speech`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: payload.model,
+          input: payload.input,
+          voice: payload.voice,
+          response_format: payload.responseFormat,
+          speed: payload.speed,
+        }),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(await readProviderError(response));
+      }
+
+      if (!response.body) {
+        throw new Error("Kokoro TTS response did not include audio.");
+      }
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: createForwardedAudioHeaders(response.headers),
+      });
+    } finally {
+      cleanup();
+    }
+  } catch (error) {
+    console.error("[Audio Speech] Failed to generate speech", error);
+    if (error instanceof AppError) {
+      return error.toResponse();
+    }
+    if (isAbortError(error)) {
+      return new AppError(
+        "offline:api",
+        "Kokoro TTS request was aborted.",
+      ).toResponse();
+    }
+    return new AppError(
+      "offline:api",
+      error instanceof Error ? error.message : "Kokoro TTS request failed.",
+    ).toResponse();
+  }
+}

--- a/apps/web/app/api/ai/v1/audio/speech/route.ts
+++ b/apps/web/app/api/ai/v1/audio/speech/route.ts
@@ -34,12 +34,20 @@ type SpeechPayload = {
   speed: number;
 };
 
+const DISABLED_ENV_VALUES = new Set(["0", "false", "off", "no", "disabled"]);
+
 async function authorize() {
   const session = await auth().catch(() => null);
   if (!session?.user?.id && !isTauriMode()) {
     return false;
   }
   return true;
+}
+
+function isEnabledByEnv(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return true;
+  return !DISABLED_ENV_VALUES.has(normalized);
 }
 
 function readString(value: unknown): string | undefined {
@@ -226,6 +234,22 @@ export async function GET(request: Request) {
     return new AppError("unauthorized:auth").toResponse();
   }
 
+  if (!isEnabledByEnv(process.env.NEXT_PUBLIC_ENABLE_KOKORO)) {
+    return NextResponse.json(
+      {
+        ready: false,
+        enabled: false,
+        message: "Kokoro text-to-speech is disabled.",
+      },
+      {
+        status: 503,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
   const baseUrl = normalizeKokoroBaseUrl(process.env.KOKORO_TTS_BASE_URL);
   const { signal, cleanup } = createRequestSignal(
     request.signal,
@@ -281,6 +305,13 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   if (!(await authorize())) {
     return new AppError("unauthorized:auth").toResponse();
+  }
+
+  if (!isEnabledByEnv(process.env.NEXT_PUBLIC_ENABLE_KOKORO)) {
+    return new AppError(
+      "offline:api",
+      "Kokoro text-to-speech is disabled.",
+    ).toResponse();
   }
 
   try {

--- a/apps/web/app/api/ai/v1/audio/transcriptions/route.ts
+++ b/apps/web/app/api/ai/v1/audio/transcriptions/route.ts
@@ -1,0 +1,218 @@
+import { NextResponse } from "next/server";
+import { WhisperPlugin } from "@openloomi/voice-whisper";
+
+import { auth } from "@/app/(auth)/auth";
+import { isTauriMode } from "@/lib/env/constants";
+import { MAX_VOICE_UPLOAD_BYTES } from "@/lib/audio/voice-input";
+import { AppError } from "@openloomi/shared/errors";
+
+export const runtime = "nodejs";
+
+type TranscriptionPayload = {
+  file: Blob;
+  filename: string;
+  model?: string;
+  responseFormat?: "json" | "text" | "verbose_json" | "srt" | "vtt";
+  language?: string;
+  prompt?: string;
+  temperature?: number;
+};
+
+async function authorize() {
+  const session = await auth().catch(() => null);
+  if (!session?.user?.id && !isTauriMode()) {
+    return false;
+  }
+  return true;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readResponseFormat(
+  value: unknown,
+): TranscriptionPayload["responseFormat"] | undefined {
+  const format = readString(value);
+  if (
+    format === "json" ||
+    format === "text" ||
+    format === "verbose_json" ||
+    format === "srt" ||
+    format === "vtt"
+  ) {
+    return format;
+  }
+  return undefined;
+}
+
+function readTemperature(value: unknown): number | undefined {
+  const raw = readString(value);
+  if (!raw) return undefined;
+  const temperature = Number(raw);
+  return Number.isFinite(temperature) ? temperature : undefined;
+}
+
+function inferFilenameFromUrl(audioUrl: string): string {
+  try {
+    const pathname = new URL(audioUrl).pathname;
+    const lastSegment = pathname.split("/").filter(Boolean).at(-1);
+    return lastSegment || "voice-input.wav";
+  } catch {
+    return "voice-input.wav";
+  }
+}
+
+async function fileFromAudioUrl(
+  audioUrl: string,
+  request: Request,
+): Promise<Pick<TranscriptionPayload, "file" | "filename">> {
+  const url = new URL(audioUrl, request.url);
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Unable to fetch audio_url: HTTP ${response.status.toString()}`,
+    );
+  }
+
+  const contentType = response.headers.get("content-type") || "audio/wav";
+  const arrayBuffer = await response.arrayBuffer();
+  return {
+    file: new Blob([arrayBuffer], { type: contentType }),
+    filename: inferFilenameFromUrl(url.toString()),
+  };
+}
+
+async function parseMultipartPayload(
+  request: Request,
+): Promise<TranscriptionPayload> {
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof Blob)) {
+    throw new AppError("bad_request:api", "Audio file is missing.");
+  }
+
+  return {
+    file,
+    filename:
+      file instanceof File && typeof file.name === "string"
+        ? file.name
+        : "voice-input.wav",
+    model: readString(formData.get("model")),
+    responseFormat: readResponseFormat(formData.get("response_format")),
+    language: readString(formData.get("language")),
+    prompt: readString(formData.get("prompt")),
+    temperature: readTemperature(formData.get("temperature")),
+  };
+}
+
+async function parseJsonPayload(request: Request): Promise<TranscriptionPayload> {
+  const body = (await request.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null;
+  if (!body) {
+    throw new AppError("bad_request:api", "Invalid transcription payload.");
+  }
+
+  const audioUrl = readString(body.audio_url);
+  if (!audioUrl) {
+    throw new AppError("bad_request:api", "audio_url is required.");
+  }
+
+  const audio = await fileFromAudioUrl(audioUrl, request);
+  return {
+    ...audio,
+    model: readString(body.model),
+    responseFormat: readResponseFormat(body.response_format),
+    language: readString(body.language),
+    prompt: readString(body.prompt),
+    temperature:
+      typeof body.temperature === "number"
+        ? body.temperature
+        : readTemperature(body.temperature),
+  };
+}
+
+async function parsePayload(request: Request): Promise<TranscriptionPayload> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return parseJsonPayload(request);
+  }
+  return parseMultipartPayload(request);
+}
+
+export async function POST(request: Request) {
+  if (!(await authorize())) {
+    return new AppError("unauthorized:auth").toResponse();
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    return new AppError(
+      "offline:api",
+      "OPENAI_API_KEY is not configured for audio transcription.",
+    ).toResponse();
+  }
+
+  try {
+    const payload = await parsePayload(request);
+    if (payload.file.size <= 0) {
+      return new AppError("bad_request:api", "Audio file is empty.").toResponse();
+    }
+    if (payload.file.size > MAX_VOICE_UPLOAD_BYTES) {
+      return new AppError(
+        "bad_request:api",
+        "Audio file exceeds the 50MB limit.",
+      ).toResponse();
+    }
+
+    const model =
+      payload.model?.trim() ||
+      process.env.OPENAI_AUDIO_TRANSCRIPTION_MODEL?.trim() ||
+      "whisper-1";
+    const baseUrl =
+      process.env.OPENAI_AUDIO_BASE_URL?.trim() || "https://api.openai.com/v1";
+    const whisper = new WhisperPlugin({
+      enabled: true,
+      model,
+      apiKey,
+      baseUrl,
+    });
+
+    const result = await whisper.transcribe({
+      file: payload.file,
+      filename: payload.filename,
+      model,
+      responseFormat: payload.responseFormat || "json",
+      language: payload.language,
+      prompt: payload.prompt,
+      temperature: payload.temperature,
+      signal: request.signal,
+    });
+
+    return NextResponse.json({ text: result.text });
+  } catch (error) {
+    console.error("[Audio Transcriptions] Failed to transcribe audio", error);
+    if (error instanceof AppError) {
+      return error.toResponse();
+    }
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return new AppError(
+        "offline:api",
+        "Audio transcription request was aborted.",
+      ).toResponse();
+    }
+    return new AppError(
+      "bad_request:api",
+      error instanceof Error
+        ? error.message
+        : "Audio transcription failed.",
+    ).toResponse();
+  }
+}

--- a/apps/web/app/api/ai/v1/audio/transcriptions/route.ts
+++ b/apps/web/app/api/ai/v1/audio/transcriptions/route.ts
@@ -18,12 +18,20 @@ type TranscriptionPayload = {
   temperature?: number;
 };
 
+const DISABLED_ENV_VALUES = new Set(["0", "false", "off", "no", "disabled"]);
+
 async function authorize() {
   const session = await auth().catch(() => null);
   if (!session?.user?.id && !isTauriMode()) {
     return false;
   }
   return true;
+}
+
+function isEnabledByEnv(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return true;
+  return !DISABLED_ENV_VALUES.has(normalized);
 }
 
 function readString(value: unknown): string | undefined {
@@ -112,10 +120,13 @@ async function parseMultipartPayload(
   };
 }
 
-async function parseJsonPayload(request: Request): Promise<TranscriptionPayload> {
-  const body = (await request.json().catch(() => null)) as
-    | Record<string, unknown>
-    | null;
+async function parseJsonPayload(
+  request: Request,
+): Promise<TranscriptionPayload> {
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
   if (!body) {
     throw new AppError("bad_request:api", "Invalid transcription payload.");
   }
@@ -152,6 +163,13 @@ export async function POST(request: Request) {
     return new AppError("unauthorized:auth").toResponse();
   }
 
+  if (!isEnabledByEnv(process.env.NEXT_PUBLIC_ENABLE_WHISPER)) {
+    return new AppError(
+      "offline:api",
+      "Whisper speech-to-text is disabled.",
+    ).toResponse();
+  }
+
   const apiKey = process.env.OPENAI_API_KEY?.trim();
   if (!apiKey) {
     return new AppError(
@@ -163,7 +181,10 @@ export async function POST(request: Request) {
   try {
     const payload = await parsePayload(request);
     if (payload.file.size <= 0) {
-      return new AppError("bad_request:api", "Audio file is empty.").toResponse();
+      return new AppError(
+        "bad_request:api",
+        "Audio file is empty.",
+      ).toResponse();
     }
     if (payload.file.size > MAX_VOICE_UPLOAD_BYTES) {
       return new AppError(
@@ -210,9 +231,7 @@ export async function POST(request: Request) {
     }
     return new AppError(
       "bad_request:api",
-      error instanceof Error
-        ? error.message
-        : "Audio transcription failed.",
+      error instanceof Error ? error.message : "Audio transcription failed.",
     ).toResponse();
   }
 }

--- a/apps/web/components/agent/chat-panel.tsx
+++ b/apps/web/components/agent/chat-panel.tsx
@@ -21,6 +21,8 @@ import { useGlobalInsightDrawer } from "@/components/global-insight-drawer";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { useConversationApiConfiguration } from "@/components/conversation-api-onboarding-guard";
 import { ConversationApiSetup } from "@/components/conversation-api-setup";
+import { useVoice } from "@/components/audio/voice-provider";
+import { getTextFromMessage } from "@/lib/utils";
 
 interface AgentChatPanelProps {
   chatId?: string | null; // External chatId; if null, creates a new chat
@@ -51,6 +53,7 @@ export function AgentChatPanel({
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
   const apiConfigurationState = useConversationApiConfiguration();
   const requiresApiSetup = apiConfigurationState === "missing";
+  const { kokoro } = useVoice();
 
   // Note: previousChatIdRef is not needed because the component gets the latest messages from context
   // When chatId changes, useChat in parent AgentPageClient handles the message switch automatically
@@ -63,6 +66,9 @@ export function AgentChatPanel({
   const scrollButtonTimerRef = useRef<NodeJS.Timeout | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const lastSpokenAssistantMessageIdRef = useRef<string | null>(null);
+  const wasAgentRunningRef = useRef(false);
+  const lastTtsChatIdRef = useRef<string | null>(null);
 
   // Get chat context (must be called before using status)
   const {
@@ -95,6 +101,40 @@ export function AgentChatPanel({
   // Get isAgentRunning for THIS chat panel's chatId (not the activeChatId)
   // This ensures the side panel shows correct status even when activeChatId changes
   const isAgentRunningForChat = getIsAgentRunningByChatId(chatId);
+
+  useEffect(() => {
+    if (lastTtsChatIdRef.current !== chatId) {
+      lastTtsChatIdRef.current = chatId;
+      wasAgentRunningRef.current = isAgentRunningForChat;
+      lastSpokenAssistantMessageIdRef.current = null;
+      return;
+    }
+
+    const wasRunning = wasAgentRunningRef.current;
+    wasAgentRunningRef.current = isAgentRunningForChat;
+
+    if (!wasRunning || isAgentRunningForChat || !kokoro.enabled) {
+      return;
+    }
+
+    const latestAssistantMessage = [...messages]
+      .reverse()
+      .find((message) => message.role === "assistant" && message.id);
+    if (!latestAssistantMessage?.id) return;
+    if (
+      lastSpokenAssistantMessageIdRef.current === latestAssistantMessage.id
+    ) {
+      return;
+    }
+
+    const text = getTextFromMessage(latestAssistantMessage).trim();
+    if (!text) return;
+
+    lastSpokenAssistantMessageIdRef.current = latestAssistantMessage.id;
+    void kokoro.speak(text).catch((error) => {
+      console.error("[AgentChatPanel] Failed to play TTS:", error);
+    });
+  }, [isAgentRunningForChat, kokoro, messages]);
 
   // Per-chat input persistence: track previous chat for saving input on switch
   const prevChatIdForInputRef = useRef<string | null>(null);

--- a/apps/web/components/agent/chat-panel.tsx
+++ b/apps/web/components/agent/chat-panel.tsx
@@ -121,9 +121,7 @@ export function AgentChatPanel({
       .reverse()
       .find((message) => message.role === "assistant" && message.id);
     if (!latestAssistantMessage?.id) return;
-    if (
-      lastSpokenAssistantMessageIdRef.current === latestAssistantMessage.id
-    ) {
+    if (lastSpokenAssistantMessageIdRef.current === latestAssistantMessage.id) {
       return;
     }
 

--- a/apps/web/components/audio/voice-provider.tsx
+++ b/apps/web/components/audio/voice-provider.tsx
@@ -12,11 +12,29 @@ interface VoiceContextValue {
 }
 
 const VoiceContext = createContext<VoiceContextValue | undefined>(undefined);
+const DISABLED_ENV_VALUES = new Set(["0", "false", "off", "no", "disabled"]);
+
+function isEnabledByEnv(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return true;
+  return !DISABLED_ENV_VALUES.has(normalized);
+}
+
+const isKokoroEnabledByEnv = isEnabledByEnv(
+  process.env.NEXT_PUBLIC_ENABLE_KOKORO,
+);
+const isWhisperEnabledByEnv = isEnabledByEnv(
+  process.env.NEXT_PUBLIC_ENABLE_WHISPER,
+);
 
 export function VoiceProvider({ children }: { children: React.ReactNode }) {
   // We initialize the plugins and allow toggling them dynamically via state
-  const [kokoro] = useState(() => new KokoroPlugin({ enabled: true }));
-  const [whisper] = useState(() => new WhisperPlugin({ enabled: true }));
+  const [kokoro] = useState(
+    () => new KokoroPlugin({ enabled: isKokoroEnabledByEnv }),
+  );
+  const [whisper] = useState(
+    () => new WhisperPlugin({ enabled: isWhisperEnabledByEnv }),
+  );
 
   // Dummy state updates to force re-renders if enabled flags change
   const [, setTick] = useState(0);
@@ -26,11 +44,11 @@ export function VoiceProvider({ children }: { children: React.ReactNode }) {
       kokoro,
       whisper,
       setKokoroEnabled: (enabled: boolean) => {
-        kokoro.enabled = enabled;
+        kokoro.enabled = isKokoroEnabledByEnv && enabled;
         setTick((t) => t + 1);
       },
       setWhisperEnabled: (enabled: boolean) => {
-        whisper.enabled = enabled;
+        whisper.enabled = isWhisperEnabledByEnv && enabled;
         setTick((t) => t + 1);
       },
     }),

--- a/apps/web/hooks/use-audio-recording.ts
+++ b/apps/web/hooks/use-audio-recording.ts
@@ -4,7 +4,6 @@ import { useRef, useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { fetchWithAuth } from "@/lib/utils";
-import { uploadImageTUS } from "@/lib/files/tus-upload";
 import {
   formatVoiceDuration,
   isVoiceProcessingPhase,
@@ -14,11 +13,6 @@ import {
   type VoiceInputPhase,
   type WaveformSample,
 } from "@/lib/audio/voice-input";
-
-/**
- * Detect if running in Tauri environment
- */
-const isTauriEnv = typeof window !== "undefined" && "__TAURI__" in window;
 
 function getSupportedAudioMimeType(): string {
   if (typeof MediaRecorder === "undefined") {
@@ -33,9 +27,8 @@ function getSupportedAudioMimeType(): string {
   return candidates.find((type) => MediaRecorder.isTypeSupported(type)) || "";
 }
 
-const DEFAULT_AUDIO_TRANSCRIPTION_MODEL = "gemini-2.5-flash-lite";
-
 /** Reject trivially empty recordings before upload */
+const DEFAULT_AUDIO_TRANSCRIPTION_MODEL = "whisper-1";
 const MIN_VOICE_UPLOAD_BYTES = 256;
 const VOICE_ACTIVITY_THRESHOLD = 0.12;
 const MIN_VOICE_ACTIVITY_FRAMES = 4;
@@ -111,6 +104,8 @@ async function convertWebmToWav(webmBlob: Blob): Promise<Blob> {
 interface UseAudioRecordingOptions {
   /** Called when transcription completes with the transcribed text */
   onTranscriptionComplete: (text: string) => void;
+  /** STT model to request from the backend transcription provider */
+  transcriptionModel?: string;
 }
 
 interface UseAudioRecordingReturn {
@@ -136,6 +131,7 @@ interface UseAudioRecordingReturn {
  */
 export function useAudioRecording({
   onTranscriptionComplete,
+  transcriptionModel = DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
 }: UseAudioRecordingOptions): UseAudioRecordingReturn {
   const { t } = useTranslation();
   const [phase, setPhase] = useState<VoiceInputPhase>("idle");
@@ -155,10 +151,8 @@ export function useAudioRecording({
   );
   /** Store MediaStreamSourceNode so we can disconnect it on cleanup */
   const mediaStreamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
-  const uploadAbortControllerRef = useRef<AbortController | null>(null);
   const transcriptionAbortControllerRef = useRef<AbortController | null>(null);
   const activeRequestIdRef = useRef<string | null>(null);
-  const currentUploadIdRef = useRef<string | null>(null);
   const hasDetectedSpeechRef = useRef(false);
   const voiceActivityFramesRef = useRef(0);
   const lastVoiceActivityAtRef = useRef<number | null>(null);
@@ -299,17 +293,6 @@ export function useAudioRecording({
     t,
   ]);
 
-  const cleanupUploadSession = useCallback(async (uploadId: string | null) => {
-    if (!uploadId) return;
-    try {
-      await fetchWithAuth(`/api/ai/v1/upload?uploadId=${uploadId}`, {
-        method: "DELETE",
-      });
-    } catch (error) {
-      console.warn("[AudioRecording] Failed to cleanup upload session:", error);
-    }
-  }, []);
-
   const startAudioLevelMonitor = useCallback(
     (stream: MediaStream) => {
       if (typeof window === "undefined") return;
@@ -388,8 +371,6 @@ export function useAudioRecording({
   }, []);
 
   const abortProcessingControllers = useCallback(() => {
-    uploadAbortControllerRef.current?.abort();
-    uploadAbortControllerRef.current = null;
     transcriptionAbortControllerRef.current?.abort();
     transcriptionAbortControllerRef.current = null;
   }, []);
@@ -454,55 +435,30 @@ export function useAudioRecording({
           type: audioType,
         });
 
-        let response: Response;
+        setPhaseState("uploading");
+        const controller = new AbortController();
+        transcriptionAbortControllerRef.current = controller;
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append(
+          "model",
+          transcriptionModel.trim() || DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
+        );
+        formData.append("response_format", "json");
 
-        if (isTauriEnv) {
-          setPhaseState("transcribing");
-          const controller = new AbortController();
-          transcriptionAbortControllerRef.current = controller;
-          const formData = new FormData();
-          formData.append("file", file);
-          formData.append("model", DEFAULT_AUDIO_TRANSCRIPTION_MODEL);
-          formData.append("response_format", "json");
+        if (!isRequestCurrent(requestId)) {
+          return;
+        }
 
-          response = await fetchWithAuth("/api/ai/v1/audio/transcriptions", {
+        setPhaseState("transcribing");
+        const response = await fetchWithAuth(
+          "/api/ai/v1/audio/transcriptions",
+          {
             method: "POST",
             body: formData,
             signal: controller.signal,
-          });
-        } else {
-          setPhaseState("uploading");
-          const uploadController = new AbortController();
-          uploadAbortControllerRef.current = uploadController;
-          const audioUrl = await uploadImageTUS(file, {
-            signal: uploadController.signal,
-            onUploadCreated: (uploadId: string) => {
-              currentUploadIdRef.current = uploadId;
-            },
-          });
-          uploadAbortControllerRef.current = null;
-          currentUploadIdRef.current = null;
-          if (!isRequestCurrent(requestId)) {
-            return;
-          }
-          if (!audioUrl) {
-            throw new Error("Audio upload failed");
-          }
-
-          setPhaseState("transcribing");
-          const controller = new AbortController();
-          transcriptionAbortControllerRef.current = controller;
-          response = await fetchWithAuth("/api/ai/v1/audio/transcriptions", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              audio_url: audioUrl,
-              model: DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
-              response_format: "json",
-            }),
-            signal: controller.signal,
-          });
-        }
+          },
+        );
         transcriptionAbortControllerRef.current = null;
 
         if (!response.ok) {
@@ -584,25 +540,17 @@ export function useAudioRecording({
           resetVoiceActivityState();
         }
       } finally {
-        uploadAbortControllerRef.current = null;
         transcriptionAbortControllerRef.current = null;
-        if (
-          currentUploadIdRef.current &&
-          activeRequestIdRef.current !== requestId
-        ) {
-          void cleanupUploadSession(currentUploadIdRef.current);
-          currentUploadIdRef.current = null;
-        }
       }
     },
     [
-      cleanupUploadSession,
       isAbortError,
       isRequestCurrent,
       resetVisualState,
       resetVoiceActivityState,
       setPhaseState,
       t,
+      transcriptionModel,
     ],
   );
 
@@ -766,20 +714,14 @@ export function useAudioRecording({
 
   const cancelProcessing = useCallback(() => {
     if (!isVoiceProcessingPhase(phase)) return;
-    const uploadId = currentUploadIdRef.current;
     activeRequestIdRef.current = null;
-    currentUploadIdRef.current = null;
     abortProcessingControllers();
     stopDurationTimer();
     setPhaseState("idle");
     resetVisualState();
     resetVoiceActivityState();
-    if (uploadId) {
-      void cleanupUploadSession(uploadId);
-    }
   }, [
     abortProcessingControllers,
-    cleanupUploadSession,
     phase,
     resetVisualState,
     resetVoiceActivityState,
@@ -802,10 +744,6 @@ export function useAudioRecording({
       resetVoiceActivityState();
       stopDurationTimer();
       abortProcessingControllers();
-      if (currentUploadIdRef.current) {
-        void cleanupUploadSession(currentUploadIdRef.current);
-        currentUploadIdRef.current = null;
-      }
       if (
         mediaRecorderRef.current &&
         mediaRecorderRef.current.state !== "inactive"
@@ -817,7 +755,6 @@ export function useAudioRecording({
     };
   }, [
     abortProcessingControllers,
-    cleanupUploadSession,
     resetVoiceActivityState,
     stopAudioLevelMonitor,
     stopAudioStreamTracks,

--- a/packages/voice-kokoro/src/index.ts
+++ b/packages/voice-kokoro/src/index.ts
@@ -15,6 +15,9 @@ export class KokoroPlugin {
 
     // Defaulting to fallback since Kokoro backend isn't integrated yet.
     if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+        window.speechSynthesis.cancel();
+      }
       const utterance = new SpeechSynthesisUtterance(text);
       window.speechSynthesis.speak(utterance);
     } else {

--- a/packages/voice-kokoro/src/index.ts
+++ b/packages/voice-kokoro/src/index.ts
@@ -1,10 +1,57 @@
+const DEFAULT_SPEECH_ENDPOINT = "/api/ai/v1/audio/speech";
+const DEFAULT_FALLBACK_VOICE = "af_bella";
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function getBrowserSpeechSynthesis(): SpeechSynthesis | null {
+  if (typeof window === "undefined") return null;
+  if (!("speechSynthesis" in window)) return null;
+  return window.speechSynthesis;
+}
+
 export class KokoroPlugin {
   public enabled: boolean;
   public voice: string;
 
+  private speechEndpoint: string;
+  private currentRequestController: AbortController | null;
+  private currentAudio: HTMLAudioElement | null;
+  private currentObjectUrl: string | null;
+
   constructor(options?: { enabled?: boolean; voice?: string }) {
     this.enabled = options?.enabled ?? true;
-    this.voice = options?.voice ?? "default";
+    this.voice = options?.voice ?? DEFAULT_FALLBACK_VOICE;
+    this.speechEndpoint = DEFAULT_SPEECH_ENDPOINT;
+    this.currentRequestController = null;
+    this.currentAudio = null;
+    this.currentObjectUrl = null;
+  }
+
+  public stop(): void {
+    this.currentRequestController?.abort();
+    this.currentRequestController = null;
+
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.removeAttribute("src");
+      this.currentAudio.load();
+      this.currentAudio = null;
+    }
+
+    if (this.currentObjectUrl) {
+      URL.revokeObjectURL(this.currentObjectUrl);
+      this.currentObjectUrl = null;
+    }
+
+    const synthesis = getBrowserSpeechSynthesis();
+    if (synthesis) {
+      synthesis.cancel();
+    }
   }
 
   public async speak(text: string): Promise<void> {
@@ -13,15 +60,155 @@ export class KokoroPlugin {
       return;
     }
 
-    // Defaulting to fallback since Kokoro backend isn't integrated yet.
-    if (typeof window !== "undefined" && "speechSynthesis" in window) {
-      if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
-        window.speechSynthesis.cancel();
+    const input = text.trim();
+    if (!input) return;
+
+    if (typeof window === "undefined") {
+      console.warn("[KokoroPlugin] Browser APIs are unavailable.");
+      return;
+    }
+
+    this.stop();
+
+    try {
+      await this.speakViaRemoteService(input);
+      return;
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
       }
-      const utterance = new SpeechSynthesisUtterance(text);
-      window.speechSynthesis.speak(utterance);
-    } else {
+
+      console.warn("[KokoroPlugin] Remote TTS unavailable:", error);
+      if (this.speakViaBrowser(input)) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private async speakViaRemoteService(text: string): Promise<void> {
+    if (typeof fetch !== "function") {
+      throw new Error("Fetch is not available for Kokoro TTS.");
+    }
+
+    const controller = new AbortController();
+    this.currentRequestController = controller;
+
+    try {
+      const response = await fetch(this.speechEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          input: text,
+          voice: this.voice === DEFAULT_FALLBACK_VOICE ? undefined : this.voice,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(await this.readProviderError(response));
+      }
+
+      const audioBlob = await response.blob();
+      if (audioBlob.size <= 0) {
+        throw new Error("Kokoro TTS response was empty.");
+      }
+
+      await this.playAudioBlob(audioBlob);
+    } finally {
+      if (this.currentRequestController === controller) {
+        this.currentRequestController = null;
+      }
+    }
+  }
+
+  private async playAudioBlob(audioBlob: Blob): Promise<void> {
+    if (typeof Audio === "undefined") {
+      throw new Error("Browser audio playback is not available.");
+    }
+
+    const objectUrl = URL.createObjectURL(audioBlob);
+    const audio = new Audio(objectUrl);
+    audio.preload = "auto";
+    audio.autoplay = true;
+    audio.onended = () => {
+      if (this.currentAudio === audio) {
+        this.currentAudio = null;
+      }
+      if (this.currentObjectUrl === objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        this.currentObjectUrl = null;
+      }
+    };
+    audio.onerror = () => {
+      if (this.currentAudio === audio) {
+        this.currentAudio = null;
+      }
+      if (this.currentObjectUrl === objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        this.currentObjectUrl = null;
+      }
+    };
+
+    this.currentAudio = audio;
+    this.currentObjectUrl = objectUrl;
+
+    try {
+      await audio.play();
+    } catch (error) {
+      if (this.currentAudio === audio) {
+        this.currentAudio = null;
+      }
+      if (this.currentObjectUrl === objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        this.currentObjectUrl = null;
+      }
+      throw error;
+    }
+  }
+
+  private speakViaBrowser(text: string): boolean {
+    const synthesis = getBrowserSpeechSynthesis();
+    if (!synthesis) {
       console.warn("[KokoroPlugin] No Web Speech API available for fallback.");
+      return false;
+    }
+
+    if (synthesis.speaking || synthesis.pending) {
+      synthesis.cancel();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    synthesis.speak(utterance);
+    return true;
+  }
+
+  private async readProviderError(response: Response): Promise<string> {
+    const text = await response.text().catch(() => "");
+    if (!text.trim()) {
+      return `Kokoro returned HTTP ${response.status.toString()}`;
+    }
+
+    try {
+      const parsed = JSON.parse(text) as {
+        error?: { message?: unknown };
+        message?: unknown;
+        detail?: unknown;
+      };
+      const message =
+        typeof parsed.error?.message === "string"
+          ? parsed.error.message
+          : typeof parsed.message === "string"
+            ? parsed.message
+            : typeof parsed.detail === "string"
+              ? parsed.detail
+              : null;
+      return message ?? text.trim().slice(0, 400);
+    } catch {
+      return text.trim().slice(0, 400);
     }
   }
 }

--- a/packages/voice-whisper/src/index.ts
+++ b/packages/voice-whisper/src/index.ts
@@ -1,9 +1,175 @@
+const DEFAULT_OPENAI_AUDIO_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_TRANSCRIPTION_MODEL = "whisper-1";
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+export interface WhisperPluginOptions {
+  enabled?: boolean;
+  model?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  timeoutMs?: number;
+}
+
+export interface WhisperTranscriptionInput {
+  file: Blob;
+  filename?: string;
+  model?: string;
+  language?: string;
+  prompt?: string;
+  responseFormat?: "json" | "text" | "verbose_json" | "srt" | "vtt";
+  temperature?: number;
+  signal?: AbortSignal;
+}
+
+export interface WhisperTranscriptionResult {
+  text: string;
+  raw?: unknown;
+}
+
+function normalizeAudioBaseUrl(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) {
+    return DEFAULT_OPENAI_AUDIO_BASE_URL;
+  }
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}
+
+async function readProviderError(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (!text.trim()) {
+    return `Provider returned HTTP ${response.status.toString()}`;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { message?: unknown };
+      message?: unknown;
+    };
+    const message =
+      typeof parsed.error?.message === "string"
+        ? parsed.error.message
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : null;
+    return message ?? text.trim().slice(0, 400);
+  } catch {
+    return text.trim().slice(0, 400);
+  }
+}
+
+function createRequestSignal(signal: AbortSignal | undefined, timeoutMs: number) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const abortFromInput = () => controller.abort();
+
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", abortFromInput, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", abortFromInput);
+    },
+  };
+}
+
 export class WhisperPlugin {
   public enabled: boolean;
   public model: string;
+  public apiKey?: string;
+  public baseUrl: string;
+  public timeoutMs: number;
 
-  constructor(options?: { enabled?: boolean; model?: string }) {
+  constructor(options?: WhisperPluginOptions) {
     this.enabled = options?.enabled ?? true;
-    this.model = options?.model ?? "whisper-1";
+    this.model = options?.model ?? DEFAULT_TRANSCRIPTION_MODEL;
+    this.apiKey = options?.apiKey;
+    this.baseUrl = options?.baseUrl ?? DEFAULT_OPENAI_AUDIO_BASE_URL;
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  public get ready(): boolean {
+    return this.enabled && Boolean(this.apiKey?.trim());
+  }
+
+  public async transcribe(
+    input: WhisperTranscriptionInput,
+  ): Promise<WhisperTranscriptionResult> {
+    if (!this.enabled) {
+      throw new Error("Speech-to-text is disabled.");
+    }
+
+    const apiKey = this.apiKey?.trim();
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY is not configured for audio APIs.");
+    }
+
+    const model = input.model?.trim() || this.model || DEFAULT_TRANSCRIPTION_MODEL;
+    const formData = new FormData();
+    formData.append("file", input.file, input.filename || "voice-input.wav");
+    formData.append("model", model);
+    formData.append("response_format", input.responseFormat || "json");
+
+    if (input.language?.trim()) {
+      formData.append("language", input.language.trim());
+    }
+    if (input.prompt?.trim()) {
+      formData.append("prompt", input.prompt.trim());
+    }
+    if (
+      typeof input.temperature === "number" &&
+      Number.isFinite(input.temperature)
+    ) {
+      formData.append("temperature", input.temperature.toString());
+    }
+
+    const { signal, cleanup } = createRequestSignal(
+      input.signal,
+      this.timeoutMs,
+    );
+
+    try {
+      const response = await fetch(
+        `${normalizeAudioBaseUrl(this.baseUrl)}/audio/transcriptions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: formData,
+          signal,
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(await readProviderError(response));
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("application/json")) {
+        const data = (await response.json().catch(() => null)) as {
+          text?: unknown;
+        } | null;
+        const text = typeof data?.text === "string" ? data.text.trim() : "";
+        if (!text) {
+          throw new Error("Transcription response did not include text.");
+        }
+        return { text, raw: data };
+      }
+
+      const text = (await response.text()).trim();
+      if (!text) {
+        throw new Error("Transcription response was empty.");
+      }
+      return { text };
+    } finally {
+      cleanup();
+    }
   }
 }

--- a/packages/voice-whisper/src/index.ts
+++ b/packages/voice-whisper/src/index.ts
@@ -57,7 +57,10 @@ async function readProviderError(response: Response): Promise<string> {
   }
 }
 
-function createRequestSignal(signal: AbortSignal | undefined, timeoutMs: number) {
+function createRequestSignal(
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   const abortFromInput = () => controller.abort();
@@ -110,7 +113,8 @@ export class WhisperPlugin {
       throw new Error("OPENAI_API_KEY is not configured for audio APIs.");
     }
 
-    const model = input.model?.trim() || this.model || DEFAULT_TRANSCRIPTION_MODEL;
+    const model =
+      input.model?.trim() || this.model || DEFAULT_TRANSCRIPTION_MODEL;
     const formData = new FormData();
     formData.append("file", input.file, input.filename || "voice-input.wav");
     formData.append("model", model);


### PR DESCRIPTION
Fixes #204.

## Summary

This PR wires the existing voice UI and provider packages to real provider-backed flows:

- microphone recording -> Whisper-compatible STT -> insert transcription into chat input
- assistant response completed -> Kokoro-compatible TTS -> play generated speech
- env-based feature gates for enabling/disabling STT and TTS
- documentation for the related voice environment variables

## Changes

### STT / Whisper

- Added `/api/ai/v1/audio/transcriptions`.
- The route accepts recorded audio as `multipart/form-data`.
- The route calls `@openloomi/voice-whisper`.
- `WhisperPlugin` now sends audio to an OpenAI-compatible `/v1/audio/transcriptions` endpoint.
- Supports:
  - `OPENAI_API_KEY`
  - `OPENAI_AUDIO_BASE_URL`
  - `OPENAI_AUDIO_TRANSCRIPTION_MODEL`
- The chat input microphone flow now inserts transcription text into the composer without auto-sending.

### TTS / Kokoro

- Added `/api/ai/v1/audio/speech`.
- The route proxies text-to-speech requests to a local OpenAI-compatible Kokoro service.
- `KokoroPlugin` now prefers the local speech proxy and falls back to browser `speechSynthesis` when remote TTS is unavailable.
- Assistant replies trigger TTS only after generation completes.
- The same assistant message is only spoken once.

### Feature Gates

- Added env-controlled voice feature flags:
  - `NEXT_PUBLIC_ENABLE_WHISPER`
  - `NEXT_PUBLIC_ENABLE_KOKORO`
- Both are enabled by default when unset.
- Values such as `false`, `0`, `off`, `no`, and `disabled` disable the feature.
- Whisper disabled:
  - hides/disables the microphone UI
  - blocks the transcription API route
- Kokoro disabled:
  - prevents automatic TTS playback
  - blocks the speech API route

### Documentation

- Updated `apps/web/.env.example` with STT/TTS env examples and provider notes.

## Current Scope / Boundaries

This PR intentionally focuses on the minimal provider integration path.

It does not implement:

- settings UI for STT/TTS
- persistent user voice preferences
- automatic installation/startup of Whisper or Kokoro runtimes
- full local runtime lifecycle management
- stop/pause/resume controls for TTS playback
- streaming or chunked TTS playback
- model/voice/speed selection UI

For now, Whisper and Kokoro services are expected to be provided externally through OpenAI-compatible endpoints.

## User Flow

### STT

1. User enables Whisper through env or leaves it enabled by default.
2. User starts OpenLoomi.
3. User opens chat.
4. User clicks the microphone button.
5. User records speech and confirms.
6. OpenLoomi sends audio to `/api/ai/v1/audio/transcriptions`.
7. The route forwards the audio to the configured Whisper-compatible endpoint.
8. Transcribed text is inserted into the chat input.
9. User can edit and manually send the message.

### TTS

1. User enables Kokoro through env or leaves it enabled by default.
2. User starts a local Kokoro-compatible service.
3. User sends a chat message.
4. Assistant response streams normally.
5. Once the assistant response is complete, OpenLoomi sends the final text to `/api/ai/v1/audio/speech`.
6. The route forwards the request to the configured Kokoro service.
7. Returned audio is played in the client.
8. If Kokoro is unavailable, playback falls back to browser `speechSynthesis`.

## Manual Testing

Tested locally in the desktop app.

### STT

- Started a local OpenAI-compatible Whisper service.
- Configured OpenLoomi with:
  - `OPENAI_API_KEY=dummy`
  - `OPENAI_AUDIO_BASE_URL=<local whisper endpoint>`
  - `OPENAI_AUDIO_TRANSCRIPTION_MODEL=whisper-1`
- Recorded speech through the microphone UI.
- Confirmed `/api/ai/v1/audio/transcriptions` returned `200`.
- Confirmed recognized text was inserted into the chat input.
- Verified the transcription was not auto-sent.

Observed route timings included:
- first request around `7.1s`, including Next route compilation
- later request around `1.2s`
- another request around `5.1s`, depending on audio length/model runtime

### TTS

- Started a local Kokoro-compatible service.
- Verified `GET /api/ai/v1/audio/speech` returned `ready: true`.
- Sent a chat message and waited for assistant completion.
- Confirmed TTS playback triggered after the assistant response completed.
- Confirmed Kokoro speech proxy path was usable locally.

## Known Issues / Follow-up

1. Whisper and Kokoro service management is still manual.

   Currently both services need to be configured and started by the user/developer. For real users, this is inconvenient. A future improvement should clarify whether these runtimes should be bundled, auto-started, or managed by plugin/runtime installation flows.

2. STT/TTS controls are env-based for now.

   The feature switches are currently controlled through env variables. This is enough for development and provider validation, but a better user experience needs dedicated settings UI and persistence.

3. Kokoro TTS latency can be high.

   Local text-to-speech latency currently varies from around 5 seconds to over 10 seconds depending on text length, voice, speed, and model warmup. Future optimization may include voice/speed defaults, warmup, text chunking, streaming playback, or limiting spoken text length.