### PR TITLE
Feat/desktop agent runtime settings

### DIFF
--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -218,13 +218,13 @@ _The onboarding screen — pick your AI agent and complete sign-in in a few clic
   />
 </div>
 
-_The API Settings panel — enter your provider's base URL, auth token, and model name. These map to the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_MODEL` environment variables shown below._
+_The API Settings panel — enter your provider's base URL, credential, and model name. OpenLoomi passes that per-user configuration to the selected runtime._
 
-OpenLoomi uses your existing AI agent configuration to work. To get started, set up your agent's environment variables in `~/.claude/settings.json`.
+For the desktop app, complete runtime and model setup in **Settings → Agent runtime** and **Settings → Conversation models**. You do not need to edit Claude configuration files manually.
 
 **Default: Claude**
 
-OpenLoomi automatically detects an existing Claude Code configuration. For server deployments and shared installations, configure a Claude API key or an Anthropic-compatible endpoint in OpenLoomi instead of relying on a personal Claude login.
+OpenLoomi Desktop includes the Claude Agent SDK runtime, so users do not install a separate Claude CLI. Authenticate it with a complete Anthropic-compatible configuration saved in OpenLoomi, or reuse supported Claude authentication already available to the same OS account. For server deployments and shared installations, prefer an API configuration over a personal Claude login.
 
 **Supported Agents**
 
@@ -237,7 +237,7 @@ OpenLoomi automatically detects an existing Claude Code configuration. For serve
 | OpenClaw   | ✅ Supported   | Gateway-backed `openclaw acp` bridge                    |
 | DeepAgents | 🔜 Coming Soon | Metadata exists; a production adapter is not registered |
 
-In the desktop app, open **Settings → Agent runtime** to choose Claude Code or Codex CLI. OpenLoomi checks whether the selected CLI is installed and authenticated, then enables the switch once it is ready. Claude can authenticate through its CLI login or a complete Anthropic-compatible configuration saved in API Settings; Codex uses its CLI login. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted.
+In the desktop app, open **Settings → Agent runtime** to choose **Claude** or **Codex CLI**. Claude uses the runtime bundled with OpenLoomi and a saved Anthropic-compatible configuration or existing Claude authentication. Codex requires a local CLI installation and `codex login`. OpenLoomi performs read-only version and authentication checks before enabling a switch; it does not start a model request. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted. Use **Use environment/default** to remove that override.
 
 Server/headless deployments—and the OpenCode, Hermes, and OpenClaw runtimes—remain environment-controlled. Claude is used when neither a desktop preference nor `OPENLOOMI_AGENT_PROVIDER` is set; supported environment values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
 
@@ -265,30 +265,21 @@ OPENLOOMI_AGENT_CODEX_COMMAND=codex
 OPENLOOMI_AGENT_CODEX_SANDBOX=workspace-write
 ```
 
-OpenLoomi guides desktop users to the official installer and CLI login flow, but does not run either one automatically. CLI subprocesses receive a restricted environment; use `OPENLOOMI_AGENT_ENV_ALLOWLIST` only when a runtime needs an additional named variable. Executable paths, runtime models, profiles, Gateway targets, and approval policy cannot be overridden by chat/API request bodies.
+For Codex, OpenLoomi links to the official installer and shows the login command, but does not run either one automatically. Claude is already bundled with the desktop app. External CLI runtimes receive a restricted environment; use `OPENLOOMI_AGENT_ENV_ALLOWLIST` only when one needs an additional named variable. Executable paths, runtime models, profiles, Gateway targets, and approval policy cannot be overridden by chat/API request bodies.
 
 Agent runtimes and sandboxes are separate layers: OpenCode, Hermes, OpenClaw, and Codex are registered through `AgentPlugin` and do not pretend to be sandbox providers. Filesystem or process isolation must still be selected and enforced independently by the host.
 
 See the **[Agent Runtimes reference](/docs/reference/agent-runtimes)** for detailed runtime setup and security behavior.
 
-**Configuring Your Agent**
+**Configure Claude in the desktop app**
 
-Edit `~/.claude/settings.json` to customize your environment:
-
-```json
-{
-  "skipWebFetchPreflight": true,
-  "env": {
-    "ANTHROPIC_AUTH_TOKEN": "your-auth-token-here",
-    "ANTHROPIC_BASE_URL": "your-base-url-here",
-    "ANTHROPIC_MODEL": "your-model-here"
-  }
-}
-```
+In **Settings → Conversation models**, save the API key or gateway token, base URL, and model under **Anthropic compatible**. Return to **Agent runtime**, select **Check again**, and choose Claude when its status is **Ready**. Use **Test connection** as an endpoint check, then start a new task to confirm the complete Agent SDK path.
 
 <Callout type="warning">
-  **Security:** Your API keys are stored locally in `~/.claude/settings.json`.
-  Always keep your settings file private.
+  **Security:** OpenLoomi stores the saved credential as an encrypted user
+  setting and only passes it to that user's Claude runtime request. Keep
+  deployment environment files and any external Claude configuration private as
+  well.
 </Callout>
 
 ---
@@ -306,7 +297,7 @@ If you're on the plugin path, confirm the readiness table lands on `READY` and `
 ## Troubleshooting
 
 - **App doesn't open on macOS** — confirm the binary is in `/Applications` (not quarantined in `~/Downloads`). Re-run `brew install --cask openloomi` to repair.
-- **API key rejected** — verify the key in `~/.claude/settings.json`, then restart the desktop app so the helper binary picks up the new env.
+- **API key rejected** — verify the credential, base URL, and model in **Settings → Conversation models**, run **Test connection**, then retry the task.
 - **Loop is silent** — make sure at least one connector is enabled; otherwise there's nothing to surface.
 - **Plugin says `OPENLOOMI_NOT_INSTALLED`** — re-run `/openloomi:setup` or `@OpenLoomi Run first-use setup.` to mint a guest session.
 

--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -237,7 +237,9 @@ OpenLoomi automatically detects an existing Claude Code configuration. For serve
 | OpenClaw   | ✅ Supported   | Gateway-backed `openclaw acp` bridge                    |
 | DeepAgents | 🔜 Coming Soon | Metadata exists; a production adapter is not registered |
 
-Runtime selection is intentionally server-controlled and is not shown as an in-app setting yet. Claude is used when `OPENLOOMI_AGENT_PROVIDER` is unset; supported explicit values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
+In the desktop app, open **Settings → Agent runtime** to choose Claude Code or Codex CLI. OpenLoomi checks whether the selected CLI is installed and signed in, then enables the switch once it is ready. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted.
+
+Server/headless deployments—and the OpenCode, Hermes, and OpenClaw runtimes—remain environment-controlled. Claude is used when neither a desktop preference nor `OPENLOOMI_AGENT_PROVIDER` is set; supported environment values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
 
 ```bash
 # OpenCode
@@ -263,7 +265,7 @@ OPENLOOMI_AGENT_CODEX_COMMAND=codex
 OPENLOOMI_AGENT_CODEX_SANDBOX=workspace-write
 ```
 
-OpenLoomi does not install or authenticate these CLIs. CLI subprocesses receive a restricted environment; use `OPENLOOMI_AGENT_ENV_ALLOWLIST` only when a runtime needs an additional named variable. Executable paths, runtime models, profiles, Gateway targets, and approval policy cannot be overridden by chat/API request bodies.
+OpenLoomi guides desktop users to the official installer and CLI login flow, but does not run either one automatically. CLI subprocesses receive a restricted environment; use `OPENLOOMI_AGENT_ENV_ALLOWLIST` only when a runtime needs an additional named variable. Executable paths, runtime models, profiles, Gateway targets, and approval policy cannot be overridden by chat/API request bodies.
 
 Agent runtimes and sandboxes are separate layers: OpenCode, Hermes, OpenClaw, and Codex are registered through `AgentPlugin` and do not pretend to be sandbox providers. Filesystem or process isolation must still be selected and enforced independently by the host.
 

--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -237,7 +237,7 @@ OpenLoomi automatically detects an existing Claude Code configuration. For serve
 | OpenClaw   | ✅ Supported   | Gateway-backed `openclaw acp` bridge                    |
 | DeepAgents | 🔜 Coming Soon | Metadata exists; a production adapter is not registered |
 
-In the desktop app, open **Settings → Agent runtime** to choose Claude Code or Codex CLI. OpenLoomi checks whether the selected CLI is installed and signed in, then enables the switch once it is ready. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted.
+In the desktop app, open **Settings → Agent runtime** to choose Claude Code or Codex CLI. OpenLoomi checks whether the selected CLI is installed and authenticated, then enables the switch once it is ready. Claude can authenticate through its CLI login or a complete Anthropic-compatible configuration saved in API Settings; Codex uses its CLI login. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted.
 
 Server/headless deployments—and the OpenCode, Hermes, and OpenClaw runtimes—remain environment-controlled. Claude is used when neither a desktop preference nor `OPENLOOMI_AGENT_PROVIDER` is set; supported environment values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
 

--- a/apps/marketing/content/reference/agent-runtimes/claude.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/claude.mdx
@@ -42,6 +42,10 @@ claude doctor
 
 See the official [Claude Code installation guide](https://code.claude.com/docs/en/installation) for current system requirements, Homebrew, WinGet, package-manager, and platform-specific instructions.
 
+### Select it in the desktop app
+
+Open **Settings → Agent runtime** and choose **Claude Code**. If the runtime is missing or signed out, follow the installation or login guidance and select **Check again**. Once the status is **Ready**, use it for new tasks. Packaged builds can satisfy the installation check with their bundled Claude runtime.
+
 ## Authentication and model configuration
 
 For normal OpenLoomi use, configure the model in the application's API Settings. A saved `anthropic_compatible` setting supplies the endpoint, credential, and model for that user and takes precedence over request defaults.

--- a/apps/marketing/content/reference/agent-runtimes/claude.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/claude.mdx
@@ -44,7 +44,7 @@ See the official [Claude Code installation guide](https://code.claude.com/docs/e
 
 ### Select it in the desktop app
 
-Open **Settings → Agent runtime** and choose **Claude Code**. If the runtime is missing or signed out, follow the installation or login guidance and select **Check again**. Once the status is **Ready**, use it for new tasks. Packaged builds can satisfy the installation check with their bundled Claude runtime.
+Open **Settings → Agent runtime** and choose **Claude Code**. If the runtime is missing, follow the installation guidance. Then either sign in to Claude Code or save a complete Anthropic-compatible configuration in API Settings and select **Check again**. Once the status is **Ready**, use it for new tasks. Packaged builds can satisfy the installation check with their bundled Claude runtime.
 
 ## Authentication and model configuration
 

--- a/apps/marketing/content/reference/agent-runtimes/claude.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/claude.mdx
@@ -11,13 +11,15 @@ Unlike the direct OpenCode and Codex CLI adapters, the Claude integration is an 
 
 ## Runtime availability
 
-Packaged OpenLoomi builds can include a bundled Claude runtime. When resolving the executable, OpenLoomi checks these sources in order:
+OpenLoomi Desktop builds include a bundled Claude runtime. When resolving the executable, OpenLoomi checks these sources in order:
 
 1. The Claude runtime bundled with OpenLoomi
 2. `CLAUDE_CODE_PATH`
 3. A user-installed `claude` executable
 
-If the packaged runtime is present, no separate Claude Code installation is required. Development checkouts and server deployments without the bundle must make Claude Code available to the operating-system user that starts OpenLoomi.
+Desktop users do not install Claude Code separately. Development checkouts and server deployments without the bundle must make Claude Code available to the operating-system user that starts OpenLoomi.
+
+The following installation steps are only for development or server builds that do not contain the desktop runtime bundle.
 
 Official native installation:
 
@@ -44,11 +46,11 @@ See the official [Claude Code installation guide](https://code.claude.com/docs/e
 
 ### Select it in the desktop app
 
-Open **Settings → Agent runtime** and choose **Claude Code**. If the runtime is missing, follow the installation guidance. Then either sign in to Claude Code or save a complete Anthropic-compatible configuration in API Settings and select **Check again**. Once the status is **Ready**, use it for new tasks. Packaged builds can satisfy the installation check with their bundled Claude runtime.
+Open **Settings → Agent runtime** and choose **Claude**. Save a complete Anthropic-compatible configuration in **Conversation models**, or reuse supported Claude authentication already available to the same OS account, then select **Check again**. Once the status is **Ready**, use it for new tasks. If the built-in runtime is unavailable, update or repair OpenLoomi Desktop rather than installing a second copy of Claude Code.
 
 ## Authentication and model configuration
 
-For normal OpenLoomi use, configure the model in the application's API Settings. A saved `anthropic_compatible` setting supplies the endpoint, credential, and model for that user and takes precedence over request defaults.
+For normal OpenLoomi use, configure the model in the application's Conversation models settings. A saved `anthropic_compatible` setting supplies the endpoint, credential, and model for that user and takes precedence over existing Claude authentication. Use the connection test as an endpoint check, then start a new task to confirm that the provider supports the complete Agent SDK request and tool-use path.
 
 Server deployments can provide the same configuration through environment variables. For direct Anthropic API access:
 
@@ -113,19 +115,19 @@ See the official [Agent SDK permissions documentation](https://code.claude.com/d
 
 ## Verify the integration
 
-For a development or server installation, first verify the same operating-system user can authenticate and run a non-interactive Claude request:
+For a development or server installation without the bundled runtime, first verify the same operating-system user can authenticate and run a non-interactive Claude request:
 
 ```bash
 claude -p "Reply with exactly: CLAUDE_READY"
 ```
 
-Then leave `OPENLOOMI_AGENT_PROVIDER` unset—or set it to `claude`—start OpenLoomi, and submit a read-only prompt. A healthy run emits a session, streamed text and reasoning where available, tool events when used, a result containing usage information, and a final done event.
+For OpenLoomi Desktop, select Claude in Settings and submit a small read-only prompt; no standalone CLI verification is required. A healthy run emits a session, streamed text and reasoning where available, tool events when used, a result containing usage information, and a final done event.
 
 To verify a custom Anthropic-compatible provider, use the same endpoint, token, and model in both the direct command environment and OpenLoomi API Settings. The provider must support the Anthropic Messages behavior required by the Claude Agent SDK and the tools used by the task.
 
 ## Troubleshooting
 
-- **Claude runtime not found:** run `claude --version` as the OpenLoomi service user, set `CLAUDE_CODE_PATH` to an absolute executable path, or rebuild/package OpenLoomi with its Claude runtime bundle.
+- **Built-in runtime unavailable in OpenLoomi Desktop:** update or repair the desktop installation, then select **Check again**. For a development/server build only, run `claude --version` as the service user, set `CLAUDE_CODE_PATH` to an absolute executable path, or build with the runtime bundle.
 - **Authentication fails:** check the saved OpenLoomi API setting and environment for conflicting credentials. `ANTHROPIC_AUTH_TOKEN` takes precedence over `ANTHROPIC_API_KEY`; use `/status` inside Claude Code or the official authentication guide to confirm the active method.
 - **Model not found:** verify the saved model or `ANTHROPIC_MODEL` is valid for the selected endpoint. Custom gateways may use model identifiers that differ from Anthropic's public IDs.
 - **Compatible endpoint rejects a request:** confirm it implements the Anthropic Messages and tool-use behavior required by the Agent SDK. Some text-only compatibility layers cannot run the Claude agent loop.

--- a/apps/marketing/content/reference/agent-runtimes/codex.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/codex.mdx
@@ -30,7 +30,7 @@ See the official [Codex non-interactive mode documentation](https://learn.chatgp
 
 ### Select it in the desktop app
 
-Open **Settings → Agent runtime** and choose **Codex CLI**. The page checks `codex --version` and `codex login status` without starting a model request. Follow the installation or login guidance, select **Check again**, and switch once the status is **Ready**. The change applies to new tasks.
+Open **Settings → Agent runtime** and choose **Codex CLI**. The page checks `codex --version` and `codex login status` without starting a model request. Follow the installation or login guidance, select **Check again**, and switch once the status is **Ready**. The change applies to new tasks. **Ready** confirms discovery and authentication, not that a model override or network path can complete a request; use the verification command above for that stronger check. Select **Use environment/default** to remove the desktop override later.
 
 ## Configure OpenLoomi
 

--- a/apps/marketing/content/reference/agent-runtimes/codex.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/codex.mdx
@@ -28,6 +28,10 @@ codex exec --json --sandbox read-only --skip-git-repo-check \
 
 See the official [Codex non-interactive mode documentation](https://learn.chatgpt.com/docs/non-interactive-mode) for `codex exec`, JSONL output, authentication, and sandbox behavior.
 
+### Select it in the desktop app
+
+Open **Settings → Agent runtime** and choose **Codex CLI**. The page checks `codex --version` and `codex login status` without starting a model request. Follow the installation or login guidance, select **Check again**, and switch once the status is **Ready**. The change applies to new tasks.
+
 ## Configure OpenLoomi
 
 Set environment variables before starting OpenLoomi:

--- a/apps/marketing/content/reference/agent-runtimes/index.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/index.mdx
@@ -5,7 +5,7 @@ description: "Choose and configure the agent runtime used for OpenLoomi native a
 
 # Agent Runtimes
 
-OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude Code or Codex CLI under **Settings → Agent runtime**; the app verifies installation and sign-in before enabling a switch. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
+OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude Code or Codex CLI under **Settings → Agent runtime**; the app verifies installation and authentication before enabling a switch. Claude accepts either its CLI login or a complete saved Anthropic-compatible API configuration; Codex uses its CLI login. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
 
 ## Overview
 

--- a/apps/marketing/content/reference/agent-runtimes/index.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/index.mdx
@@ -5,7 +5,7 @@ description: "Choose and configure the agent runtime used for OpenLoomi native a
 
 # Agent Runtimes
 
-OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Runtime selection is deployment configuration: set `OPENLOOMI_AGENT_PROVIDER` before starting OpenLoomi, then restart the process after changing it. The runtime cannot be selected or reconfigured from a chat/API request.
+OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude Code or Codex CLI under **Settings → Agent runtime**; the app verifies installation and sign-in before enabling a switch. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
 
 ## Overview
 
@@ -19,13 +19,13 @@ The supported runtimes sit at different layers:
 
 Selecting a runtime chooses the `AgentPlugin`/`IAgent` implementation that executes a task; it does not turn that runtime into an OpenLoomi sandbox provider. The host and selected runtime still enforce their own filesystem, process, network, and approval boundaries.
 
-| Provider                                            | Role      | Runtime path                          | Configuration source         |
-| --------------------------------------------------- | --------- | ------------------------------------- | ---------------------------- |
-| [Claude](/docs/reference/agent-runtimes/claude)     | Default   | Claude Agent SDK `query()`            | OpenLoomi API settings / env |
-| [Codex](/docs/reference/agent-runtimes/codex)       | Secondary | `codex exec --json`                   | Environment and Codex CLI    |
-| [OpenCode](/docs/reference/agent-runtimes/opencode) | Optional  | `opencode run --format json`          | Environment and OpenCode     |
-| [Hermes](/docs/reference/agent-runtimes/hermes)     | Optional  | `hermes acp`                          | Environment and Hermes       |
-| [OpenClaw](/docs/reference/agent-runtimes/openclaw) | Optional  | `openclaw acp` plus a running Gateway | Environment and OpenClaw     |
+| Provider                                            | Role      | Runtime path                          | Configuration source        |
+| --------------------------------------------------- | --------- | ------------------------------------- | --------------------------- |
+| [Claude](/docs/reference/agent-runtimes/claude)     | Default   | Claude Agent SDK `query()`            | Desktop setting / API / env |
+| [Codex](/docs/reference/agent-runtimes/codex)       | Secondary | `codex exec --json`                   | Desktop setting / Codex CLI |
+| [OpenCode](/docs/reference/agent-runtimes/opencode) | Optional  | `opencode run --format json`          | Environment and OpenCode    |
+| [Hermes](/docs/reference/agent-runtimes/hermes)     | Optional  | `hermes acp`                          | Environment and Hermes      |
+| [OpenClaw](/docs/reference/agent-runtimes/openclaw) | Optional  | `openclaw acp` plus a running Gateway | Environment and OpenClaw    |
 
 Each runtime guide covers installation, authentication, OpenLoomi environment variables, permission behavior, verification, and troubleshooting:
 
@@ -34,6 +34,14 @@ Each runtime guide covers installation, authentication, OpenLoomi environment va
 - **[OpenCode CLI runtime](/docs/reference/agent-runtimes/opencode)** — Direct non-interactive CLI integration with JSON events.
 - **[Hermes ACP runtime](/docs/reference/agent-runtimes/hermes)** — Local ACP server integration with profile and model selection.
 - **[OpenClaw ACP runtime](/docs/reference/agent-runtimes/openclaw)** — Gateway-backed ACP integration with session and device pairing.
+
+Desktop runtime selection resolves in this order:
+
+1. The device preference saved from Settings (Claude or Codex)
+2. `OPENLOOMI_AGENT_PROVIDER`
+3. Claude as the default
+
+The device preference is local to that desktop installation. It does not alter deployment environment variables and only affects tasks started after the change.
 
 Agent runtimes and sandboxes are separate layers. Selecting a runtime chooses the `AgentPlugin`/`IAgent` implementation that executes a task; it does not turn that runtime into an OpenLoomi sandbox provider. The host and selected runtime still enforce their own filesystem, process, network, and approval boundaries.
 

--- a/apps/marketing/content/reference/agent-runtimes/index.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/index.mdx
@@ -5,7 +5,7 @@ description: "Choose and configure the agent runtime used for OpenLoomi native a
 
 # Agent Runtimes
 
-OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude Code or Codex CLI under **Settings → Agent runtime**; the app verifies installation and authentication before enabling a switch. Claude accepts either its CLI login or a complete saved Anthropic-compatible API configuration; Codex uses its CLI login. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
+OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude or Codex CLI under **Settings → Agent runtime**. Claude's runtime is bundled with the desktop app and accepts a complete saved Anthropic-compatible API configuration or supported existing Claude authentication; Codex requires a local installation and CLI login. The app performs read-only version and authentication checks before enabling a switch. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
 
 ## Overview
 
@@ -13,7 +13,7 @@ OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runti
 
 The supported runtimes sit at different layers:
 
-- **Claude** runs in-process via the Agent SDK — OpenLoomi owns the lifecycle.
+- **Claude** is controlled through the Agent SDK, which launches the Claude runtime bundled with OpenLoomi Desktop as a child process.
 - **Codex, OpenCode, Hermes** are CLI subprocesses that OpenLoomi spawns per task and reads a JSON event stream from.
 - **OpenClaw** adds a Gateway that brokers sessions and device pairing.
 
@@ -21,7 +21,7 @@ Selecting a runtime chooses the `AgentPlugin`/`IAgent` implementation that execu
 
 | Provider                                            | Role      | Runtime path                          | Configuration source        |
 | --------------------------------------------------- | --------- | ------------------------------------- | --------------------------- |
-| [Claude](/docs/reference/agent-runtimes/claude)     | Default   | Claude Agent SDK `query()`            | Desktop setting / API / env |
+| [Claude](/docs/reference/agent-runtimes/claude)     | Default   | Agent SDK + bundled Claude runtime    | Desktop setting / API / env |
 | [Codex](/docs/reference/agent-runtimes/codex)       | Secondary | `codex exec --json`                   | Desktop setting / Codex CLI |
 | [OpenCode](/docs/reference/agent-runtimes/opencode) | Optional  | `opencode run --format json`          | Environment and OpenCode    |
 | [Hermes](/docs/reference/agent-runtimes/hermes)     | Optional  | `hermes acp`                          | Environment and Hermes      |
@@ -41,7 +41,7 @@ Desktop runtime selection resolves in this order:
 2. `OPENLOOMI_AGENT_PROVIDER`
 3. Claude as the default
 
-The device preference is local to that desktop installation. It does not alter deployment environment variables and only affects tasks started after the change.
+The device preference is local to that desktop installation. It does not alter deployment environment variables and only affects tasks started after the change. Select **Use environment/default** in Settings to delete the desktop override and return to the environment/default resolution path.
 
 Agent runtimes and sandboxes are separate layers. Selecting a runtime chooses the `AgentPlugin`/`IAgent` implementation that executes a task; it does not turn that runtime into an OpenLoomi sandbox provider. The host and selected runtime still enforce their own filesystem, process, network, and approval boundaries.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,7 +10,9 @@ ANTHROPIC_API_KEY=****
 ANTHROPIC_AUTH_TOKEN=****
 ANTHROPIC_MODEL=****
 
-# Agent runtime provider (optional)
+# Agent runtime provider (optional). Server/headless deployments use this
+# value directly. In the desktop app, a runtime selected under Settings is
+# stored on that device and takes precedence over this environment fallback.
 # CLI processes receive a restricted environment by default. Add any extra
 # variable names they require as a comma-separated, server-controlled allowlist.
 # OPENLOOMI_AGENT_ENV_ALLOWLIST=MY_CORPORATE_CA_BUNDLE,HTTPS_PROXY

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { getAuthUser } from "@/lib/auth/dual-auth";
-import { getAgentRuntimeSettings } from "@/lib/ai/native-agent/runtime-settings";
 import { writeAgentRuntimePreference } from "@/lib/ai/native-agent/runtime-preference";
+import { getAgentRuntimeSettings } from "@/lib/ai/native-agent/runtime-settings";
+import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
+import { getAuthUser } from "@/lib/auth/dual-auth";
 import { isTauriMode } from "@/lib/env/constants";
 
 const runtimePreferenceSchema = z
@@ -14,6 +15,15 @@ const runtimePreferenceSchema = z
 
 const noStoreHeaders = { "Cache-Control": "no-store" };
 
+async function hasUsableClaudeApiConfiguration(userId: string) {
+  return Boolean(
+    await getUserLlmProviderConfig({
+      userId,
+      providerType: "anthropic_compatible",
+    }),
+  );
+}
+
 export async function GET(request: Request) {
   const user = await getAuthUser(request).catch(() => null);
   if (!user) {
@@ -23,7 +33,11 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const forceRefresh = url.searchParams.get("refresh") === "1";
-    const settings = await getAgentRuntimeSettings({ forceRefresh });
+    const claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
+    const settings = await getAgentRuntimeSettings({
+      forceRefresh,
+      claudeApiConfigured,
+    });
     return NextResponse.json(settings, { headers: noStoreHeaders });
   } catch (error) {
     console.error("[Agent Runtime Preferences] Failed to load state", error);
@@ -56,8 +70,20 @@ export async function PUT(request: Request) {
   }
 
   try {
+    const claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
+    const readiness = await getAgentRuntimeSettings({
+      forceRefresh: true,
+      claudeApiConfigured,
+    });
+    if (!readiness.runtimes?.[parsed.data.provider].ready) {
+      return NextResponse.json(
+        { error: "runtime_not_ready", settings: readiness },
+        { status: 409, headers: noStoreHeaders },
+      );
+    }
+
     writeAgentRuntimePreference(parsed.data.provider);
-    const settings = await getAgentRuntimeSettings();
+    const settings = await getAgentRuntimeSettings({ claudeApiConfigured });
     return NextResponse.json(settings, { headers: noStoreHeaders });
   } catch (error) {
     console.error("[Agent Runtime Preferences] Failed to save state", error);

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { writeAgentRuntimePreference } from "@/lib/ai/native-agent/runtime-preference";
+import {
+  clearAgentRuntimePreference,
+  readAgentRuntimePreference,
+  writeAgentRuntimePreference,
+} from "@/lib/ai/native-agent/runtime-preference";
 import { getAgentRuntimeSettings } from "@/lib/ai/native-agent/runtime-settings";
 import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
 import { getAuthUser } from "@/lib/auth/dual-auth";
@@ -70,11 +74,25 @@ export async function PUT(request: Request) {
   }
 
   try {
-    const claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
-    const readiness = await getAgentRuntimeSettings({
+    let claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
+    let readiness = await getAgentRuntimeSettings({
       forceRefresh: true,
       claudeApiConfigured,
     });
+
+    // The runtime probe can take several seconds. If the user saves or removes
+    // the Claude API configuration while it is running, remap readiness against
+    // the latest setting before persisting the choice.
+    if (parsed.data.provider === "claude") {
+      const latestClaudeApiConfigured = await hasUsableClaudeApiConfiguration(
+        user.id,
+      );
+      if (latestClaudeApiConfigured !== claudeApiConfigured) {
+        claudeApiConfigured = latestClaudeApiConfigured;
+        readiness = await getAgentRuntimeSettings({ claudeApiConfigured });
+      }
+    }
+
     if (!readiness.runtimes?.[parsed.data.provider].ready) {
       return NextResponse.json(
         { error: "runtime_not_ready", settings: readiness },
@@ -83,12 +101,63 @@ export async function PUT(request: Request) {
     }
 
     writeAgentRuntimePreference(parsed.data.provider);
-    const settings = await getAgentRuntimeSettings({ claudeApiConfigured });
+    const settings = {
+      ...readiness,
+      preference: parsed.data.provider,
+      effective: {
+        provider: parsed.data.provider,
+        source: "preference" as const,
+      },
+    };
     return NextResponse.json(settings, { headers: noStoreHeaders });
   } catch (error) {
     console.error("[Agent Runtime Preferences] Failed to save state", error);
     return NextResponse.json(
       { error: "runtime_preference_save_failed" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  if (!isTauriMode()) {
+    return NextResponse.json(
+      { error: "runtime_selection_not_editable" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const previousPreference = readAgentRuntimePreference();
+    clearAgentRuntimePreference();
+    try {
+      const claudeApiConfigured = await hasUsableClaudeApiConfiguration(
+        user.id,
+      );
+      const settings = await getAgentRuntimeSettings({
+        forceRefresh: true,
+        claudeApiConfigured,
+      });
+      return NextResponse.json(settings, { headers: noStoreHeaders });
+    } catch (error) {
+      // Keep the API result and the on-disk state consistent. A failed refresh
+      // must not leave the preference cleared while the UI reports failure.
+      if (previousPreference) {
+        writeAgentRuntimePreference(previousPreference);
+      }
+      throw error;
+    }
+  } catch (error) {
+    console.error(
+      "[Agent Runtime Preferences] Failed to clear desktop preference",
+      error,
+    );
+    return NextResponse.json(
+      { error: "runtime_preference_clear_failed" },
       { status: 500 },
     );
   }

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getAuthUser } from "@/lib/auth/dual-auth";
+import { getAgentRuntimeSettings } from "@/lib/ai/native-agent/runtime-settings";
+import { writeAgentRuntimePreference } from "@/lib/ai/native-agent/runtime-preference";
+import { isTauriMode } from "@/lib/env/constants";
+
+const runtimePreferenceSchema = z
+  .object({
+    provider: z.enum(["claude", "codex"]),
+  })
+  .strict();
+
+const noStoreHeaders = { "Cache-Control": "no-store" };
+
+export async function GET(request: Request) {
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const forceRefresh = url.searchParams.get("refresh") === "1";
+    const settings = await getAgentRuntimeSettings({ forceRefresh });
+    return NextResponse.json(settings, { headers: noStoreHeaders });
+  } catch (error) {
+    console.error("[Agent Runtime Preferences] Failed to load state", error);
+    return NextResponse.json(
+      { error: "runtime_state_unavailable" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  if (!isTauriMode()) {
+    return NextResponse.json(
+      { error: "runtime_selection_not_editable" },
+      { status: 403 },
+    );
+  }
+
+  const payload = await request.json().catch(() => null);
+  const parsed = runtimePreferenceSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid_runtime_preference" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    writeAgentRuntimePreference(parsed.data.provider);
+    const settings = await getAgentRuntimeSettings();
+    return NextResponse.json(settings, { headers: noStoreHeaders });
+  } catch (error) {
+    console.error("[Agent Runtime Preferences] Failed to save state", error);
+    return NextResponse.json(
+      { error: "runtime_preference_save_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/components/agent-runtime-settings.tsx
+++ b/apps/web/components/agent-runtime-settings.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
 import { Badge, Button, Separator } from "@openloomi/ui";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { RemixIcon } from "@/components/remix-icon";
 import { toast } from "@/components/toast";
-import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
+import { AI_SETTINGS_CHANGED_EVENT } from "@/lib/ai/conversation-api-configuration";
 import {
-  canSaveAgentRuntime,
   type AgentRuntimePublicProbe,
   type AgentRuntimeSettingsResponse,
   type SelectableAgentRuntime,
+  canSaveAgentRuntime,
 } from "@/lib/ai/native-agent/runtime-contract";
+import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
 import { isTauri, openUrl } from "@/lib/tauri";
 import { cn, fetchWithAuth } from "@/lib/utils";
 
@@ -28,7 +29,8 @@ const runtimeOptions: Array<{
     provider: "claude",
     name: "Claude Code",
     descriptionKey: "settings.agentRuntimeClaudeDescription",
-    descriptionFallback: "Use your local Claude Code installation and account.",
+    descriptionFallback:
+      "Use local Claude Code with its CLI login or your saved API configuration.",
     docsUrl: "https://code.claude.com/docs/en/installation",
     loginCommand: "claude auth login",
   },
@@ -100,6 +102,17 @@ export function AgentRuntimeSettings() {
     if (inDesktop) void loadState();
   }, [loadState]);
 
+  useEffect(() => {
+    if (desktop !== true) return;
+    const handleSettingsChanged = () => void loadState();
+    window.addEventListener(AI_SETTINGS_CHANGED_EVENT, handleSettingsChanged);
+    return () =>
+      window.removeEventListener(
+        AI_SETTINGS_CHANGED_EVENT,
+        handleSettingsChanged,
+      );
+  }, [desktop, loadState]);
+
   const saveSelection = async () => {
     if (!state || !draft || !canSaveAgentRuntime(state, draft)) return;
     setSaving(true);
@@ -108,8 +121,33 @@ export function AgentRuntimeSettings() {
         method: "PUT",
         body: JSON.stringify({ provider: draft }),
       });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const nextState = (await response.json()) as AgentRuntimeSettingsResponse;
+      const payload = (await response.json().catch(() => null)) as
+        | AgentRuntimeSettingsResponse
+        | { error?: string; settings?: AgentRuntimeSettingsResponse }
+        | null;
+      if (!response.ok) {
+        if (
+          response.status === 409 &&
+          payload &&
+          "settings" in payload &&
+          payload.settings
+        ) {
+          setState(payload.settings);
+          toast({
+            type: "error",
+            description: t(
+              "settings.agentRuntimeNotReadyError",
+              "The selected runtime is no longer ready. Complete setup and check again.",
+            ),
+          });
+          return;
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
+      if (!payload || !("editable" in payload)) {
+        throw new Error("Invalid runtime settings response");
+      }
+      const nextState = payload;
       setState(nextState);
       setDraft(draft);
       notifyAiSettingsChanged();
@@ -193,7 +231,11 @@ export function AgentRuntimeSettings() {
                 </p>
               )}
 
-            <div className="grid gap-3 sm:grid-cols-2" role="radiogroup">
+            <div
+              className="grid gap-3 sm:grid-cols-2"
+              role="radiogroup"
+              aria-labelledby="agent-runtime-title"
+            >
               {runtimeOptions.map((option) => {
                 const selected = draft === option.provider;
                 const active = state.effective.provider === option.provider;
@@ -202,7 +244,7 @@ export function AgentRuntimeSettings() {
                   <label
                     key={option.provider}
                     className={cn(
-                      "flex cursor-pointer items-start gap-3 rounded-lg border p-4 text-left transition-colors",
+                      "flex cursor-pointer items-start gap-3 rounded-lg border p-4 text-left transition-colors focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
                       selected
                         ? "border-primary/50 bg-primary/5 ring-1 ring-primary/15"
                         : "border-border bg-background hover:border-foreground/20 hover:bg-muted/30",
@@ -323,11 +365,17 @@ function RuntimeSetupPanel({
       <div className="space-y-3">
         {probe.status === "ready" ? (
           <p className="text-sm text-muted-foreground">
-            {t(
-              "settings.agentRuntimeReadyDescription",
-              "{{runtime}} is installed and signed in. It is ready for new tasks.",
-              { runtime: option.name },
-            )}
+            {probe.readyVia === "api"
+              ? t(
+                  "settings.agentRuntimeApiReadyDescription",
+                  "{{runtime}} is installed and your saved API configuration is ready for new tasks.",
+                  { runtime: option.name },
+                )
+              : t(
+                  "settings.agentRuntimeReadyDescription",
+                  "{{runtime}} is installed and signed in. It is ready for new tasks.",
+                  { runtime: option.name },
+                )}
           </p>
         ) : probe.status === "login_required" ? (
           <div className="space-y-2">
@@ -343,7 +391,7 @@ function RuntimeSetupPanel({
           <p className="text-sm text-muted-foreground">
             {t(
               "settings.agentRuntimeInstallDescription",
-              "Install {{runtime}} from its official guide, sign in, then check again.",
+              "Install {{runtime}} from its official guide, then check again.",
               { runtime: option.name },
             )}
           </p>

--- a/apps/web/components/agent-runtime-settings.tsx
+++ b/apps/web/components/agent-runtime-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Badge, Button, Separator } from "@openloomi/ui";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { RemixIcon } from "@/components/remix-icon";
@@ -13,6 +13,10 @@ import {
   type SelectableAgentRuntime,
   canSaveAgentRuntime,
 } from "@/lib/ai/native-agent/runtime-contract";
+import {
+  CODEX_LOGIN_COMMAND,
+  getCodexInstallCommand,
+} from "@/lib/ai/native-agent/runtime-installation";
 import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
 import { isTauri, openUrl } from "@/lib/tauri";
 import { cn, fetchWithAuth } from "@/lib/utils";
@@ -20,27 +24,29 @@ import { cn, fetchWithAuth } from "@/lib/utils";
 const runtimeOptions: Array<{
   provider: SelectableAgentRuntime;
   name: string;
+  builtIn: boolean;
   descriptionKey: string;
   descriptionFallback: string;
   docsUrl: string;
-  loginCommand: string;
+  loginCommand?: string;
 }> = [
   {
     provider: "claude",
-    name: "Claude Code",
+    name: "Claude",
+    builtIn: true,
     descriptionKey: "settings.agentRuntimeClaudeDescription",
     descriptionFallback:
-      "Use local Claude Code with its CLI login or your saved API configuration.",
-    docsUrl: "https://code.claude.com/docs/en/installation",
-    loginCommand: "claude auth login",
+      "Powered by Claude Agent SDK with its runtime bundled in OpenLoomi—no separate Claude CLI installation required. Use a saved Anthropic-compatible API configuration or existing Claude authentication.",
+    docsUrl: "https://openloomi.ai/docs/reference/agent-runtimes/claude",
   },
   {
     provider: "codex",
     name: "Codex CLI",
+    builtIn: false,
     descriptionKey: "settings.agentRuntimeCodexDescription",
     descriptionFallback: "Use your local Codex CLI installation and account.",
-    docsUrl: "https://developers.openai.com/codex/cli/",
-    loginCommand: "codex login",
+    docsUrl: "https://learn.chatgpt.com/docs/codex/cli",
+    loginCommand: CODEX_LOGIN_COMMAND,
   },
 ];
 
@@ -57,19 +63,36 @@ export function AgentRuntimeSettings() {
   const [refreshing, setRefreshing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
+  const loadRequestId = useRef(0);
+  const loadAbortController = useRef<AbortController | null>(null);
+  const savingRef = useRef(false);
+  const pendingReloadRef = useRef(false);
 
   const loadState = useCallback(
     async (refresh = false) => {
+      if (savingRef.current) {
+        pendingReloadRef.current = true;
+        return;
+      }
+
+      const requestId = ++loadRequestId.current;
+      loadAbortController.current?.abort();
+      const controller = new AbortController();
+      loadAbortController.current = controller;
       if (refresh) setRefreshing(true);
       else setLoading(true);
+      if (refresh) setLoading(false);
+      else setRefreshing(false);
       setLoadFailed(false);
       try {
         const response = await fetchWithAuth(
           `/api/preferences/agent-runtime${refresh ? "?refresh=1" : ""}`,
+          { signal: controller.signal },
         );
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const nextState =
           (await response.json()) as AgentRuntimeSettingsResponse;
+        if (requestId !== loadRequestId.current) return;
         setState(nextState);
         setDraft(
           (current) =>
@@ -79,6 +102,9 @@ export function AgentRuntimeSettings() {
               : null),
         );
       } catch (error) {
+        if (controller.signal.aborted || requestId !== loadRequestId.current) {
+          return;
+        }
         console.error("[Agent Runtime Settings] Failed to load state", error);
         setLoadFailed(true);
         toast({
@@ -89,8 +115,13 @@ export function AgentRuntimeSettings() {
           ),
         });
       } finally {
-        setLoading(false);
-        setRefreshing(false);
+        if (requestId === loadRequestId.current) {
+          setLoading(false);
+          setRefreshing(false);
+          if (loadAbortController.current === controller) {
+            loadAbortController.current = null;
+          }
+        }
       }
     },
     [t],
@@ -113,8 +144,29 @@ export function AgentRuntimeSettings() {
       );
   }, [desktop, loadState]);
 
+  useEffect(
+    () => () => {
+      ++loadRequestId.current;
+      loadAbortController.current?.abort();
+    },
+    [],
+  );
+
   const saveSelection = async () => {
-    if (!state || !draft || !canSaveAgentRuntime(state, draft)) return;
+    if (
+      savingRef.current ||
+      !state ||
+      !draft ||
+      !canSaveAgentRuntime(state, draft)
+    ) {
+      return;
+    }
+    ++loadRequestId.current;
+    loadAbortController.current?.abort();
+    loadAbortController.current = null;
+    setLoading(false);
+    setRefreshing(false);
+    savingRef.current = true;
     setSaving(true);
     try {
       const response = await fetchWithAuth("/api/preferences/agent-runtime", {
@@ -168,7 +220,63 @@ export function AgentRuntimeSettings() {
         ),
       });
     } finally {
+      savingRef.current = false;
       setSaving(false);
+      if (pendingReloadRef.current) {
+        pendingReloadRef.current = false;
+        void loadState();
+      }
+    }
+  };
+
+  const clearSelection = async () => {
+    if (!state?.preference || savingRef.current) return;
+    ++loadRequestId.current;
+    loadAbortController.current?.abort();
+    loadAbortController.current = null;
+    setLoading(false);
+    setRefreshing(false);
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      const response = await fetchWithAuth("/api/preferences/agent-runtime", {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const nextState = (await response.json()) as AgentRuntimeSettingsResponse;
+      setState(nextState);
+      setDraft(
+        isSelectableRuntime(nextState.effective.provider)
+          ? nextState.effective.provider
+          : null,
+      );
+      notifyAiSettingsChanged();
+      toast({
+        type: "success",
+        description: t(
+          "settings.agentRuntimePreferenceCleared",
+          "Desktop runtime preference cleared.",
+        ),
+      });
+    } catch (error) {
+      console.error(
+        "[Agent Runtime Settings] Failed to clear desktop preference",
+        error,
+      );
+      toast({
+        type: "error",
+        description: t(
+          "settings.agentRuntimeClearError",
+          "Failed to restore the managed runtime setting.",
+        ),
+      });
+    } finally {
+      savingRef.current = false;
+      setSaving(false);
+      if (pendingReloadRef.current) {
+        pendingReloadRef.current = false;
+        void loadState();
+      }
     }
   };
 
@@ -191,7 +299,7 @@ export function AgentRuntimeSettings() {
           <p className="max-w-3xl text-sm text-muted-foreground">
             {t(
               "settings.agentRuntimeDescription",
-              "Choose the local CLI OpenLoomi uses for new agent tasks. Running tasks are not interrupted.",
+              "Choose the agent runtime OpenLoomi uses for new tasks. Claude is built in; Codex uses its local CLI. Running tasks are not interrupted.",
             )}
           </p>
         </div>
@@ -231,6 +339,30 @@ export function AgentRuntimeSettings() {
                 </p>
               )}
 
+            {state.preference && (
+              <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs text-muted-foreground">
+                  {t(
+                    "settings.agentRuntimePreferenceOverrideDescription",
+                    "This desktop preference overrides the environment/default runtime for new tasks.",
+                  )}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={saving || loading || refreshing}
+                  onClick={clearSelection}
+                  className="shrink-0"
+                >
+                  {t(
+                    "settings.agentRuntimeUseManagedSetting",
+                    "Use environment/default",
+                  )}
+                </Button>
+              </div>
+            )}
+
             <div
               className="grid gap-3 sm:grid-cols-2"
               role="radiogroup"
@@ -248,7 +380,7 @@ export function AgentRuntimeSettings() {
                       selected
                         ? "border-primary/50 bg-primary/5 ring-1 ring-primary/15"
                         : "border-border bg-background hover:border-foreground/20 hover:bg-muted/30",
-                      (saving || refreshing) &&
+                      (saving || loading || refreshing) &&
                         "pointer-events-none opacity-60",
                     )}
                   >
@@ -257,7 +389,7 @@ export function AgentRuntimeSettings() {
                       name="agent-runtime"
                       value={option.provider}
                       checked={selected}
-                      disabled={saving || refreshing}
+                      disabled={saving || loading || refreshing}
                       onChange={() => setDraft(option.provider)}
                       className="sr-only"
                     />
@@ -274,8 +406,20 @@ export function AgentRuntimeSettings() {
                     <span className="min-w-0 flex-1">
                       <span className="flex flex-wrap items-center gap-2 text-sm font-semibold text-foreground">
                         {option.name}
+                        {option.builtIn && (
+                          <Badge
+                            as="span"
+                            variant="secondary"
+                            className="h-5 rounded-md px-2 text-[11px] font-medium"
+                          >
+                            {t("settings.agentRuntimeBuiltIn", "Built in")}
+                          </Badge>
+                        )}
                         {active && (
-                          <Badge className="h-5 rounded-md px-2 text-[11px] font-medium">
+                          <Badge
+                            as="span"
+                            className="h-5 rounded-md px-2 text-[11px] font-medium"
+                          >
                             {t("settings.agentRuntimeInUse", "In use")}
                           </Badge>
                         )}
@@ -294,8 +438,9 @@ export function AgentRuntimeSettings() {
               <RuntimeSetupPanel
                 option={selectedOption}
                 probe={state.runtimes[draft]}
+                platform={state.platform}
                 active={state.effective.provider === draft}
-                busy={saving || refreshing}
+                busy={saving || loading || refreshing}
                 refreshing={refreshing}
                 canSave={canSaveAgentRuntime(state, draft)}
                 onRefresh={() => loadState(true)}
@@ -312,12 +457,24 @@ export function AgentRuntimeSettings() {
 
 function RuntimeStatusLine({ probe }: { probe: AgentRuntimePublicProbe }) {
   const { t } = useTranslation();
-  const labels = {
-    ready: t("settings.agentRuntimeReady", "Ready"),
-    login_required: t("settings.agentRuntimeLoginRequired", "Sign-in required"),
-    not_installed: t("settings.agentRuntimeNotInstalled", "Not installed"),
-    unverified: t("settings.agentRuntimeUnverifiedShort", "Could not verify"),
-  };
+  const label =
+    probe.status === "ready"
+      ? t("settings.agentRuntimeReady", "Ready")
+      : probe.status === "login_required"
+        ? probe.provider === "claude"
+          ? t(
+              "settings.agentRuntimeAuthenticationRequired",
+              "Authentication required",
+            )
+          : t("settings.agentRuntimeLoginRequired", "Sign-in required")
+        : probe.status === "not_installed"
+          ? probe.provider === "claude"
+            ? t(
+                "settings.agentRuntimeBuiltInUnavailable",
+                "Built-in runtime unavailable",
+              )
+            : t("settings.agentRuntimeNotInstalled", "Not installed")
+          : t("settings.agentRuntimeUnverifiedShort", "Could not verify");
   return (
     <span
       className={cn(
@@ -331,7 +488,7 @@ function RuntimeStatusLine({ probe }: { probe: AgentRuntimePublicProbe }) {
           probe.ready ? "bg-emerald-500" : "bg-muted-foreground/60",
         )}
       />
-      {labels[probe.status]}
+      {label}
       {probe.version ? ` · v${probe.version.replace(/^v/, "")}` : ""}
     </span>
   );
@@ -340,6 +497,7 @@ function RuntimeStatusLine({ probe }: { probe: AgentRuntimePublicProbe }) {
 function RuntimeSetupPanel({
   option,
   probe,
+  platform,
   active,
   busy,
   refreshing,
@@ -349,6 +507,7 @@ function RuntimeSetupPanel({
 }: {
   option: (typeof runtimeOptions)[number];
   probe: AgentRuntimePublicProbe;
+  platform: AgentRuntimeSettingsResponse["platform"];
   active: boolean;
   busy: boolean;
   refreshing: boolean;
@@ -357,55 +516,22 @@ function RuntimeSetupPanel({
   onSave: () => void;
 }) {
   const { t } = useTranslation();
+  const showGuide =
+    probe.status === "not_installed" || probe.status === "unverified";
   return (
     <div
       className="rounded-lg border border-border bg-background p-4 sm:p-5"
       aria-live="polite"
     >
       <div className="space-y-3">
-        {probe.status === "ready" ? (
-          <p className="text-sm text-muted-foreground">
-            {probe.readyVia === "api"
-              ? t(
-                  "settings.agentRuntimeApiReadyDescription",
-                  "{{runtime}} is installed and your saved API configuration is ready for new tasks.",
-                  { runtime: option.name },
-                )
-              : t(
-                  "settings.agentRuntimeReadyDescription",
-                  "{{runtime}} is installed and signed in. It is ready for new tasks.",
-                  { runtime: option.name },
-                )}
-          </p>
-        ) : probe.status === "login_required" ? (
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">
-              {t(
-                "settings.agentRuntimeLoginDescription",
-                "Run this command in a terminal, finish signing in, then check again.",
-              )}
-            </p>
-            <CopyCommand command={option.loginCommand} />
-          </div>
-        ) : probe.status === "not_installed" ? (
-          <p className="text-sm text-muted-foreground">
-            {t(
-              "settings.agentRuntimeInstallDescription",
-              "Install {{runtime}} from its official guide, then check again.",
-              { runtime: option.name },
-            )}
-          </p>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            {t(
-              "settings.agentRuntimeUnverifiedDescription",
-              "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
-            )}
-          </p>
-        )}
+        <RuntimeSetupSummary
+          option={option}
+          probe={probe}
+          platform={platform}
+        />
 
         <div className="flex flex-wrap justify-end gap-2">
-          {probe.status !== "ready" && (
+          {showGuide && (
             <Button
               type="button"
               variant="outline"
@@ -414,7 +540,17 @@ function RuntimeSetupPanel({
               onClick={() => void openUrl(option.docsUrl)}
             >
               <RemixIcon name="external_link" size="size-4" />
-              {t("settings.agentRuntimeInstallGuide", "Installation guide")}
+              {option.provider === "claude"
+                ? t(
+                    "settings.agentRuntimeTroubleshootingGuide",
+                    "Troubleshooting guide",
+                  )
+                : probe.status === "not_installed"
+                  ? t(
+                      "settings.agentRuntimeOfficialInstructions",
+                      "Official instructions",
+                    )
+                  : t("settings.agentRuntimeSetupGuide", "Setup guide")}
             </Button>
           )}
           <Button
@@ -445,6 +581,176 @@ function RuntimeSetupPanel({
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function RuntimeSetupSummary({
+  option,
+  probe,
+  platform,
+}: {
+  option: (typeof runtimeOptions)[number];
+  probe: AgentRuntimePublicProbe;
+  platform: AgentRuntimeSettingsResponse["platform"];
+}) {
+  const { t } = useTranslation();
+  const isClaude = option.provider === "claude";
+
+  if (probe.status === "ready") {
+    if (isClaude) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {probe.readyVia === "api"
+            ? t(
+                "settings.agentRuntimeClaudeApiReadyDescription",
+                "The built-in Claude runtime will use your saved Anthropic-compatible configuration. Test the connection below, then confirm it with a new task.",
+              )
+            : t(
+                "settings.agentRuntimeClaudeAuthReadyDescription",
+                "The built-in Claude runtime found existing Claude authentication. This check does not start a model request.",
+              )}
+        </p>
+      );
+    }
+
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t(
+          "settings.agentRuntimeReadyDescription",
+          "{{runtime}} is installed and signed in. This check does not start a model request.",
+          { runtime: option.name },
+        )}
+      </p>
+    );
+  }
+
+  if (probe.status === "login_required") {
+    if (isClaude) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "settings.agentRuntimeClaudeAuthenticationDescription",
+            "Save an Anthropic-compatible API configuration below. If this OS account already has Claude authentication, check again to reuse it.",
+          )}
+        </p>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "settings.agentRuntimeLoginDescription",
+            "Run this command in a terminal, finish signing in, then check again.",
+          )}
+        </p>
+        {option.loginCommand && <CopyCommand command={option.loginCommand} />}
+      </div>
+    );
+  }
+
+  if (probe.status === "not_installed") {
+    if (!isClaude) {
+      return <CodexInstallSteps platform={platform} />;
+    }
+
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t(
+          "settings.agentRuntimeClaudeUnavailableDescription",
+          "OpenLoomi could not load its built-in Claude runtime. Update or repair the desktop app, then check again.",
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      {isClaude
+        ? t(
+            "settings.agentRuntimeClaudeUnverifiedDescription",
+            "OpenLoomi could not verify the built-in Claude runtime. Open the troubleshooting guide, then check again.",
+          )
+        : t(
+            "settings.agentRuntimeUnverifiedDescription",
+            "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
+          )}
+    </p>
+  );
+}
+
+function CodexInstallSteps({
+  platform,
+}: {
+  platform: AgentRuntimeSettingsResponse["platform"];
+}) {
+  const { t } = useTranslation();
+  const terminal =
+    platform === "windows"
+      ? "PowerShell"
+      : t("settings.agentRuntimeTerminal", "Terminal");
+  const checkAgain = t("settings.agentRuntimeCheckAgain", "Check again");
+  const useCodex = t("settings.agentRuntimeUse", "Use {{runtime}}", {
+    runtime: "Codex CLI",
+  });
+  const inUse = t("settings.agentRuntimeInUse", "In use");
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-foreground">
+        {t(
+          "settings.agentRuntimeCodexInstallTitle",
+          "Install and sign in to Codex CLI",
+        )}
+      </p>
+      <ol className="list-decimal space-y-3 pl-5 text-sm text-muted-foreground">
+        <li>
+          {t(
+            "settings.agentRuntimeCodexInstallOpenTerminal",
+            "Open {{terminal}}.",
+            { terminal },
+          )}
+        </li>
+        <li className="space-y-2 pl-1">
+          <p>
+            {t(
+              "settings.agentRuntimeCodexInstallRunInstaller",
+              "Copy and run the official install command.",
+            )}
+          </p>
+          <CopyCommand command={getCodexInstallCommand(platform)} />
+          <p>
+            {t(
+              "settings.agentRuntimeCodexInstallSkipLaunch",
+              'When "Start Codex now? [y/N]" appears at the end, press Enter to keep the default N. Do not start Codex yet.',
+            )}
+          </p>
+          <p>
+            {t(
+              "settings.agentRuntimeCodexInstallExitAccidentalLaunch",
+              'If you already selected y and see "Hooks need review", select "3. Continue without trusting". After Codex opens, enter /exit or press Ctrl+C to close it.',
+            )}
+          </p>
+        </li>
+        <li className="space-y-2 pl-1">
+          <p>
+            {t(
+              "settings.agentRuntimeCodexInstallSignIn",
+              "After the installer returns to {{terminal}}, close that window and open a new one. Run this command and finish signing in in your browser. When sign-in succeeds, you can close the browser page and {{terminal}}.",
+              { terminal },
+            )}
+          </p>
+          <CopyCommand command={CODEX_LOGIN_COMMAND} />
+        </li>
+        <li>
+          {t(
+            "settings.agentRuntimeCodexInstallReturn",
+            "Return here and select {{checkAction}}. Once Codex CLI is ready, select {{useAction}} if it does not already show {{inUse}}. You do not need to restart OpenLoomi.",
+            { checkAction: checkAgain, useAction: useCodex, inUse },
+          )}
+        </li>
+      </ol>
     </div>
   );
 }

--- a/apps/web/components/agent-runtime-settings.tsx
+++ b/apps/web/components/agent-runtime-settings.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge, Button, Separator } from "@openloomi/ui";
+import { useTranslation } from "react-i18next";
+
+import { RemixIcon } from "@/components/remix-icon";
+import { toast } from "@/components/toast";
+import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
+import {
+  canSaveAgentRuntime,
+  type AgentRuntimePublicProbe,
+  type AgentRuntimeSettingsResponse,
+  type SelectableAgentRuntime,
+} from "@/lib/ai/native-agent/runtime-contract";
+import { isTauri, openUrl } from "@/lib/tauri";
+import { cn, fetchWithAuth } from "@/lib/utils";
+
+const runtimeOptions: Array<{
+  provider: SelectableAgentRuntime;
+  name: string;
+  descriptionKey: string;
+  descriptionFallback: string;
+  docsUrl: string;
+  loginCommand: string;
+}> = [
+  {
+    provider: "claude",
+    name: "Claude Code",
+    descriptionKey: "settings.agentRuntimeClaudeDescription",
+    descriptionFallback: "Use your local Claude Code installation and account.",
+    docsUrl: "https://code.claude.com/docs/en/installation",
+    loginCommand: "claude auth login",
+  },
+  {
+    provider: "codex",
+    name: "Codex CLI",
+    descriptionKey: "settings.agentRuntimeCodexDescription",
+    descriptionFallback: "Use your local Codex CLI installation and account.",
+    docsUrl: "https://developers.openai.com/codex/cli/",
+    loginCommand: "codex login",
+  },
+];
+
+function isSelectableRuntime(value: string): value is SelectableAgentRuntime {
+  return value === "claude" || value === "codex";
+}
+
+export function AgentRuntimeSettings() {
+  const { t } = useTranslation();
+  const [desktop, setDesktop] = useState<boolean | null>(null);
+  const [state, setState] = useState<AgentRuntimeSettingsResponse | null>(null);
+  const [draft, setDraft] = useState<SelectableAgentRuntime | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const loadState = useCallback(
+    async (refresh = false) => {
+      if (refresh) setRefreshing(true);
+      else setLoading(true);
+      setLoadFailed(false);
+      try {
+        const response = await fetchWithAuth(
+          `/api/preferences/agent-runtime${refresh ? "?refresh=1" : ""}`,
+        );
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const nextState =
+          (await response.json()) as AgentRuntimeSettingsResponse;
+        setState(nextState);
+        setDraft(
+          (current) =>
+            current ??
+            (isSelectableRuntime(nextState.effective.provider)
+              ? nextState.effective.provider
+              : null),
+        );
+      } catch (error) {
+        console.error("[Agent Runtime Settings] Failed to load state", error);
+        setLoadFailed(true);
+        toast({
+          type: "error",
+          description: t(
+            "settings.agentRuntimeLoadError",
+            "Failed to check agent runtimes.",
+          ),
+        });
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    const inDesktop = isTauri();
+    setDesktop(inDesktop);
+    if (inDesktop) void loadState();
+  }, [loadState]);
+
+  const saveSelection = async () => {
+    if (!state || !draft || !canSaveAgentRuntime(state, draft)) return;
+    setSaving(true);
+    try {
+      const response = await fetchWithAuth("/api/preferences/agent-runtime", {
+        method: "PUT",
+        body: JSON.stringify({ provider: draft }),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const nextState = (await response.json()) as AgentRuntimeSettingsResponse;
+      setState(nextState);
+      setDraft(draft);
+      notifyAiSettingsChanged();
+      toast({
+        type: "success",
+        description: t(
+          "settings.agentRuntimeSaved",
+          "Agent runtime updated for new tasks.",
+        ),
+      });
+    } catch (error) {
+      console.error("[Agent Runtime Settings] Failed to save state", error);
+      toast({
+        type: "error",
+        description: t(
+          "settings.agentRuntimeSaveError",
+          "Failed to update the agent runtime.",
+        ),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectedOption = draft
+    ? runtimeOptions.find((option) => option.provider === draft)
+    : undefined;
+
+  if (desktop !== true) return null;
+
+  return (
+    <>
+      <section className="space-y-4" aria-labelledby="agent-runtime-title">
+        <div className="flex flex-col gap-2">
+          <p
+            id="agent-runtime-title"
+            className="text-base font-semibold text-foreground-secondary"
+          >
+            {t("settings.agentRuntimeTitle", "Agent runtime")}
+          </p>
+          <p className="max-w-3xl text-sm text-muted-foreground">
+            {t(
+              "settings.agentRuntimeDescription",
+              "Choose the local CLI OpenLoomi uses for new agent tasks. Running tasks are not interrupted.",
+            )}
+          </p>
+        </div>
+
+        {loading && !state ? (
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-background p-4 text-sm text-muted-foreground">
+            <RemixIcon name="loader_2" size="size-4" className="animate-spin" />
+            {t("settings.agentRuntimeChecking", "Checking local runtimes…")}
+          </div>
+        ) : loadFailed && !state ? (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background p-4">
+            <p className="text-sm text-muted-foreground">
+              {t(
+                "settings.agentRuntimeUnverified",
+                "OpenLoomi could not verify the local runtimes.",
+              )}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => loadState()}
+            >
+              {t("settings.agentRuntimeTryAgain", "Try again")}
+            </Button>
+          </div>
+        ) : state?.editable && state.runtimes ? (
+          <>
+            {state.effective.source === "environment" &&
+              !isSelectableRuntime(state.effective.provider) && (
+                <p className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+                  {t(
+                    "settings.agentRuntimeManagedByEnvironment",
+                    "The current runtime is managed by the environment: {{provider}}. Choose Claude or Codex to create a desktop preference.",
+                    { provider: state.effective.provider },
+                  )}
+                </p>
+              )}
+
+            <div className="grid gap-3 sm:grid-cols-2" role="radiogroup">
+              {runtimeOptions.map((option) => {
+                const selected = draft === option.provider;
+                const active = state.effective.provider === option.provider;
+                const probe = state.runtimes?.[option.provider];
+                return (
+                  <label
+                    key={option.provider}
+                    className={cn(
+                      "flex cursor-pointer items-start gap-3 rounded-lg border p-4 text-left transition-colors",
+                      selected
+                        ? "border-primary/50 bg-primary/5 ring-1 ring-primary/15"
+                        : "border-border bg-background hover:border-foreground/20 hover:bg-muted/30",
+                      (saving || refreshing) &&
+                        "pointer-events-none opacity-60",
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="agent-runtime"
+                      value={option.provider}
+                      checked={selected}
+                      disabled={saving || refreshing}
+                      onChange={() => setDraft(option.provider)}
+                      className="sr-only"
+                    />
+                    <span
+                      className={cn(
+                        "flex size-9 shrink-0 items-center justify-center rounded-lg",
+                        selected
+                          ? "bg-primary/10 text-primary"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      <RemixIcon name="terminal" size="size-5" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="flex flex-wrap items-center gap-2 text-sm font-semibold text-foreground">
+                        {option.name}
+                        {active && (
+                          <Badge className="h-5 rounded-md px-2 text-[11px] font-medium">
+                            {t("settings.agentRuntimeInUse", "In use")}
+                          </Badge>
+                        )}
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                        {t(option.descriptionKey, option.descriptionFallback)}
+                      </span>
+                      {probe && <RuntimeStatusLine probe={probe} />}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+
+            {draft && selectedOption && (
+              <RuntimeSetupPanel
+                option={selectedOption}
+                probe={state.runtimes[draft]}
+                active={state.effective.provider === draft}
+                busy={saving || refreshing}
+                refreshing={refreshing}
+                canSave={canSaveAgentRuntime(state, draft)}
+                onRefresh={() => loadState(true)}
+                onSave={saveSelection}
+              />
+            )}
+          </>
+        ) : null}
+      </section>
+      <Separator />
+    </>
+  );
+}
+
+function RuntimeStatusLine({ probe }: { probe: AgentRuntimePublicProbe }) {
+  const { t } = useTranslation();
+  const labels = {
+    ready: t("settings.agentRuntimeReady", "Ready"),
+    login_required: t("settings.agentRuntimeLoginRequired", "Sign-in required"),
+    not_installed: t("settings.agentRuntimeNotInstalled", "Not installed"),
+    unverified: t("settings.agentRuntimeUnverifiedShort", "Could not verify"),
+  };
+  return (
+    <span
+      className={cn(
+        "mt-2 flex items-center gap-1.5 text-xs",
+        probe.ready ? "text-emerald-600" : "text-muted-foreground",
+      )}
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full",
+          probe.ready ? "bg-emerald-500" : "bg-muted-foreground/60",
+        )}
+      />
+      {labels[probe.status]}
+      {probe.version ? ` · v${probe.version.replace(/^v/, "")}` : ""}
+    </span>
+  );
+}
+
+function RuntimeSetupPanel({
+  option,
+  probe,
+  active,
+  busy,
+  refreshing,
+  canSave,
+  onRefresh,
+  onSave,
+}: {
+  option: (typeof runtimeOptions)[number];
+  probe: AgentRuntimePublicProbe;
+  active: boolean;
+  busy: boolean;
+  refreshing: boolean;
+  canSave: boolean;
+  onRefresh: () => void;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="rounded-lg border border-border bg-background p-4 sm:p-5"
+      aria-live="polite"
+    >
+      <div className="space-y-3">
+        {probe.status === "ready" ? (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "settings.agentRuntimeReadyDescription",
+              "{{runtime}} is installed and signed in. It is ready for new tasks.",
+              { runtime: option.name },
+            )}
+          </p>
+        ) : probe.status === "login_required" ? (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              {t(
+                "settings.agentRuntimeLoginDescription",
+                "Run this command in a terminal, finish signing in, then check again.",
+              )}
+            </p>
+            <CopyCommand command={option.loginCommand} />
+          </div>
+        ) : probe.status === "not_installed" ? (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "settings.agentRuntimeInstallDescription",
+              "Install {{runtime}} from its official guide, sign in, then check again.",
+              { runtime: option.name },
+            )}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "settings.agentRuntimeUnverifiedDescription",
+              "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
+            )}
+          </p>
+        )}
+
+        <div className="flex flex-wrap justify-end gap-2">
+          {probe.status !== "ready" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => void openUrl(option.docsUrl)}
+            >
+              <RemixIcon name="external_link" size="size-4" />
+              {t("settings.agentRuntimeInstallGuide", "Installation guide")}
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={onRefresh}
+          >
+            <RemixIcon
+              name={refreshing ? "loader_2" : "refresh"}
+              size="size-4"
+              className={refreshing ? "animate-spin" : undefined}
+            />
+            {t("settings.agentRuntimeCheckAgain", "Check again")}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canSave || busy}
+            onClick={onSave}
+          >
+            {active
+              ? t("settings.agentRuntimeInUse", "In use")
+              : t("settings.agentRuntimeUse", "Use {{runtime}}", {
+                  runtime: option.name,
+                })}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CopyCommand({ command }: { command: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2_000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+    } catch (error) {
+      console.error("[Agent Runtime Settings] Clipboard write failed", error);
+    }
+  };
+
+  return (
+    <div className="inline-flex max-w-full items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-1 font-mono text-xs text-foreground">
+      <code className="select-all truncate">{command}</code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={copy}
+        className="h-6 shrink-0 gap-1 px-1.5 text-[11px]"
+      >
+        <RemixIcon name={copied ? "check" : "file_copy"} size="size-3" />
+        {copied
+          ? t("settings.agentRuntimeCopied", "Copied")
+          : t("settings.agentRuntimeCopy", "Copy")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/ai-api-settings.tsx
+++ b/apps/web/components/ai-api-settings.tsx
@@ -437,7 +437,9 @@ export function AiApiSettings() {
       <div className="w-full px-1 sm:px-0 space-y-8">
         {showMissingApiKeyNotice && (
           <div
+            role="status"
             aria-live="polite"
+            aria-atomic="true"
             className="flex gap-3 rounded-lg border border-primary/25 bg-primary/5 p-4 text-sm"
           >
             <RemixIcon

--- a/apps/web/components/ai-api-settings.tsx
+++ b/apps/web/components/ai-api-settings.tsx
@@ -8,11 +8,10 @@ import { RemixIcon } from "@/components/remix-icon";
 import { toast } from "@/components/toast";
 import { fetchWithAuth } from "@/lib/utils";
 import { cn } from "@/lib/utils";
-import {
-  AI_SETTINGS_CHANGED_EVENT,
-  MISSING_API_KEY_REASON,
-} from "@/lib/ai/conversation-api-configuration";
+import { MISSING_API_KEY_REASON } from "@/lib/ai/conversation-api-configuration";
 import { EmbeddingApiSettings } from "@/components/embedding-api-settings";
+import { AgentRuntimeSettings } from "@/components/agent-runtime-settings";
+import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
 
 type ProviderType = "openai_compatible" | "anthropic_compatible";
 
@@ -301,23 +300,7 @@ export function AiApiSettings() {
         apiKey: "",
       });
       // Notify listeners in the same webview (kept for backwards compat).
-      window.dispatchEvent(new Event(AI_SETTINGS_CHANGED_EVENT));
-      // Mirror as a Tauri event so the pet card webview (separate origin
-      // and therefore a separate window — `window.dispatchEvent` doesn't
-      // cross webviews in Tauri 2.x) re-evaluates its no-api-key layout,
-      // and the Rust watcher re-emits a natural idle/sleeping state so
-      // the pet sprite leaves the "needs-setup" mode. Without this the
-      // pet card kept showing the missing-key CTA even after a
-      // successful save. See loomi-card.html:3789 and
-      // apps/web/src-tauri/src/pet/watcher.rs.
-      const tauriEvent = (
-        window as unknown as {
-          __TAURI__?: { event?: { emit?: (name: string) => unknown } };
-        }
-      ).__TAURI__;
-      if (tauriEvent?.event?.emit) {
-        tauriEvent.event.emit(AI_SETTINGS_CHANGED_EVENT);
-      }
+      notifyAiSettingsChanged();
       if (
         showMissingApiKeyNotice &&
         providerType === "anthropic_compatible" &&
@@ -374,15 +357,7 @@ export function AiApiSettings() {
       // Same rationale as the save path above — fire both the DOM event
       // (legacy listeners in the same webview) and the Tauri event
       // (pet card webview + Rust watcher).
-      window.dispatchEvent(new Event(AI_SETTINGS_CHANGED_EVENT));
-      const tauriEvent = (
-        window as unknown as {
-          __TAURI__?: { event?: { emit?: (name: string) => unknown } };
-        }
-      ).__TAURI__;
-      if (tauriEvent?.event?.emit) {
-        tauriEvent.event.emit(AI_SETTINGS_CHANGED_EVENT);
-      }
+      notifyAiSettingsChanged();
       toast({
         type: "success",
         description: t(
@@ -462,7 +437,7 @@ export function AiApiSettings() {
       <div className="w-full px-1 sm:px-0 space-y-8">
         {showMissingApiKeyNotice && (
           <div
-            role="status"
+            aria-live="polite"
             className="flex gap-3 rounded-lg border border-primary/25 bg-primary/5 p-4 text-sm"
           >
             <RemixIcon
@@ -486,6 +461,7 @@ export function AiApiSettings() {
             </div>
           </div>
         )}
+        <AgentRuntimeSettings />
         <div className="flex flex-col gap-2">
           <p className="text-base font-semibold text-foreground-secondary">
             {t("settings.conversationModelsTitle", "Conversation models")}

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -312,31 +312,60 @@ const en = {
       "Configure per-user API settings for compatible AI providers.",
     agentRuntimeTitle: "Agent runtime",
     agentRuntimeDescription:
-      "Choose the local CLI OpenLoomi uses for new agent tasks. Running tasks are not interrupted.",
+      "Choose the agent runtime OpenLoomi uses for new tasks. Claude is built in; Codex uses its local CLI. Running tasks are not interrupted.",
     agentRuntimeClaudeDescription:
-      "Use local Claude Code with its CLI login or your saved API configuration.",
+      "Powered by Claude Agent SDK with its runtime bundled in OpenLoomi—no separate Claude CLI installation required. Use a saved Anthropic-compatible API configuration or existing Claude authentication.",
     agentRuntimeCodexDescription:
       "Use your local Codex CLI installation and account.",
     agentRuntimeChecking: "Checking local runtimes…",
+    agentRuntimeBuiltIn: "Built in",
     agentRuntimeReady: "Ready",
+    agentRuntimeAuthenticationRequired: "Authentication required",
     agentRuntimeLoginRequired: "Sign-in required",
     agentRuntimeNotInstalled: "Not installed",
+    agentRuntimeBuiltInUnavailable: "Built-in runtime unavailable",
     agentRuntimeUnverifiedShort: "Could not verify",
     agentRuntimeInUse: "In use",
     agentRuntimeReadyDescription:
-      "{{runtime}} is installed and signed in. It is ready for new tasks.",
-    agentRuntimeApiReadyDescription:
-      "{{runtime}} is installed and your saved API configuration is ready for new tasks.",
+      "{{runtime}} is installed and signed in. This check does not start a model request.",
+    agentRuntimeClaudeApiReadyDescription:
+      "The built-in Claude runtime will use your saved Anthropic-compatible configuration. Test the connection below, then confirm it with a new task.",
+    agentRuntimeClaudeAuthReadyDescription:
+      "The built-in Claude runtime found existing Claude authentication. This check does not start a model request.",
+    agentRuntimeClaudeAuthenticationDescription:
+      "Save an Anthropic-compatible API configuration below. If this OS account already has Claude authentication, check again to reuse it.",
     agentRuntimeLoginDescription:
       "Run this command in a terminal, finish signing in, then check again.",
-    agentRuntimeInstallDescription:
-      "Install {{runtime}} from its official guide, then check again.",
+    agentRuntimeCodexInstallTitle: "Install and sign in to Codex CLI",
+    agentRuntimeCodexInstallOpenTerminal: "Open {{terminal}}.",
+    agentRuntimeCodexInstallRunInstaller:
+      "Copy and run the official install command.",
+    agentRuntimeCodexInstallSkipLaunch:
+      'When "Start Codex now? [y/N]" appears at the end, press Enter to keep the default N. Do not start Codex yet.',
+    agentRuntimeCodexInstallExitAccidentalLaunch:
+      'If you already selected y and see "Hooks need review", select "3. Continue without trusting". After Codex opens, enter /exit or press Ctrl+C to close it.',
+    agentRuntimeCodexInstallSignIn:
+      "After the installer returns to {{terminal}}, close that window and open a new one. Run this command and finish signing in in your browser. When sign-in succeeds, you can close the browser page and {{terminal}}.",
+    agentRuntimeCodexInstallReturn:
+      "Return here and select {{checkAction}}. Once Codex CLI is ready, select {{useAction}} if it does not already show {{inUse}}. You do not need to restart OpenLoomi.",
+    agentRuntimeTerminal: "Terminal",
+    agentRuntimeClaudeUnavailableDescription:
+      "OpenLoomi could not load its built-in Claude runtime. Update or repair the desktop app, then check again.",
     agentRuntimeUnverified: "OpenLoomi could not verify the local runtimes.",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
+    agentRuntimeClaudeUnverifiedDescription:
+      "OpenLoomi could not verify the built-in Claude runtime. Open the troubleshooting guide, then check again.",
     agentRuntimeManagedByEnvironment:
       "The current runtime is managed by the environment: {{provider}}. Choose Claude or Codex to create a desktop preference.",
-    agentRuntimeInstallGuide: "Installation guide",
+    agentRuntimePreferenceOverrideDescription:
+      "This desktop preference overrides the environment/default runtime for new tasks.",
+    agentRuntimeUseManagedSetting: "Use environment/default",
+    agentRuntimePreferenceCleared: "Desktop runtime preference cleared.",
+    agentRuntimeClearError: "Failed to restore the managed runtime setting.",
+    agentRuntimeOfficialInstructions: "Official instructions",
+    agentRuntimeSetupGuide: "Setup guide",
+    agentRuntimeTroubleshootingGuide: "Troubleshooting guide",
     agentRuntimeCheckAgain: "Check again",
     agentRuntimeTryAgain: "Try again",
     agentRuntimeUse: "Use {{runtime}}",

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -314,7 +314,7 @@ const en = {
     agentRuntimeDescription:
       "Choose the local CLI OpenLoomi uses for new agent tasks. Running tasks are not interrupted.",
     agentRuntimeClaudeDescription:
-      "Use your local Claude Code installation and account.",
+      "Use local Claude Code with its CLI login or your saved API configuration.",
     agentRuntimeCodexDescription:
       "Use your local Codex CLI installation and account.",
     agentRuntimeChecking: "Checking local runtimes…",
@@ -325,10 +325,12 @@ const en = {
     agentRuntimeInUse: "In use",
     agentRuntimeReadyDescription:
       "{{runtime}} is installed and signed in. It is ready for new tasks.",
+    agentRuntimeApiReadyDescription:
+      "{{runtime}} is installed and your saved API configuration is ready for new tasks.",
     agentRuntimeLoginDescription:
       "Run this command in a terminal, finish signing in, then check again.",
     agentRuntimeInstallDescription:
-      "Install {{runtime}} from its official guide, sign in, then check again.",
+      "Install {{runtime}} from its official guide, then check again.",
     agentRuntimeUnverified: "OpenLoomi could not verify the local runtimes.",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
@@ -343,6 +345,8 @@ const en = {
     agentRuntimeSaved: "Agent runtime updated for new tasks.",
     agentRuntimeLoadError: "Failed to check agent runtimes.",
     agentRuntimeSaveError: "Failed to update the agent runtime.",
+    agentRuntimeNotReadyError:
+      "The selected runtime is no longer ready. Complete setup and check again.",
     conversationModelsTitle: "Conversation models",
     aiSettingsOpenAiTitle: "OpenAI compatible",
     aiSettingsOpenAiDescription:

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -310,6 +310,39 @@ const en = {
       "Loop is on — Loomi reads your mail, calendar, code, and chat through your connectors in the background and combines that with screen memory to fill your morning brief. Toggle off here if you'd rather not.",
     aiSettingsDescription:
       "Configure per-user API settings for compatible AI providers.",
+    agentRuntimeTitle: "Agent runtime",
+    agentRuntimeDescription:
+      "Choose the local CLI OpenLoomi uses for new agent tasks. Running tasks are not interrupted.",
+    agentRuntimeClaudeDescription:
+      "Use your local Claude Code installation and account.",
+    agentRuntimeCodexDescription:
+      "Use your local Codex CLI installation and account.",
+    agentRuntimeChecking: "Checking local runtimes…",
+    agentRuntimeReady: "Ready",
+    agentRuntimeLoginRequired: "Sign-in required",
+    agentRuntimeNotInstalled: "Not installed",
+    agentRuntimeUnverifiedShort: "Could not verify",
+    agentRuntimeInUse: "In use",
+    agentRuntimeReadyDescription:
+      "{{runtime}} is installed and signed in. It is ready for new tasks.",
+    agentRuntimeLoginDescription:
+      "Run this command in a terminal, finish signing in, then check again.",
+    agentRuntimeInstallDescription:
+      "Install {{runtime}} from its official guide, sign in, then check again.",
+    agentRuntimeUnverified: "OpenLoomi could not verify the local runtimes.",
+    agentRuntimeUnverifiedDescription:
+      "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
+    agentRuntimeManagedByEnvironment:
+      "The current runtime is managed by the environment: {{provider}}. Choose Claude or Codex to create a desktop preference.",
+    agentRuntimeInstallGuide: "Installation guide",
+    agentRuntimeCheckAgain: "Check again",
+    agentRuntimeTryAgain: "Try again",
+    agentRuntimeUse: "Use {{runtime}}",
+    agentRuntimeCopy: "Copy",
+    agentRuntimeCopied: "Copied",
+    agentRuntimeSaved: "Agent runtime updated for new tasks.",
+    agentRuntimeLoadError: "Failed to check agent runtimes.",
+    agentRuntimeSaveError: "Failed to update the agent runtime.",
     conversationModelsTitle: "Conversation models",
     aiSettingsOpenAiTitle: "OpenAI compatible",
     aiSettingsOpenAiDescription:

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -298,29 +298,58 @@ const zh = {
       "为当前用户配置兼容的 AI 服务商接口，保存后会优先使用用户配置。",
     agentRuntimeTitle: "Agent 运行时",
     agentRuntimeDescription:
-      "选择 OpenLoomi 在新任务中使用的本地 CLI；正在运行的任务不会被中断。",
+      "选择 OpenLoomi 在新任务中使用的 Agent 运行时。Claude 已内置，Codex 使用本机 CLI；正在运行的任务不会被中断。",
     agentRuntimeClaudeDescription:
-      "使用本机 Claude Code，可通过 CLI 登录或已保存的 API 配置完成认证。",
+      "由 Claude Agent SDK 驱动，运行组件已随 OpenLoomi 内置，无需另装 Claude CLI。可使用已保存的 Anthropic 兼容 API 配置或已有 Claude 认证。",
     agentRuntimeCodexDescription: "使用本机 Codex CLI 及其登录账号。",
     agentRuntimeChecking: "正在检查本地运行时…",
+    agentRuntimeBuiltIn: "内置",
     agentRuntimeReady: "已就绪",
+    agentRuntimeAuthenticationRequired: "需要认证",
     agentRuntimeLoginRequired: "需要登录",
     agentRuntimeNotInstalled: "尚未安装",
+    agentRuntimeBuiltInUnavailable: "内置运行组件不可用",
     agentRuntimeUnverifiedShort: "无法验证",
     agentRuntimeInUse: "使用中",
-    agentRuntimeReadyDescription: "{{runtime}} 已安装并登录，可以用于新任务。",
-    agentRuntimeApiReadyDescription:
-      "{{runtime}} 已安装，且已保存的 API 配置可用于新任务。",
+    agentRuntimeReadyDescription:
+      "{{runtime}} 已安装并登录；此检查不会实际发起模型请求。",
+    agentRuntimeClaudeApiReadyDescription:
+      "内置 Claude 运行时将使用已保存的 Anthropic 兼容配置；请先在下方测试连接，再通过一个新任务确认实际运行。",
+    agentRuntimeClaudeAuthReadyDescription:
+      "内置 Claude 运行时已检测到当前系统账号的 Claude 认证；此检查不会实际发起模型请求。",
+    agentRuntimeClaudeAuthenticationDescription:
+      "请在下方保存 Anthropic 兼容 API 配置；如果当前系统账号已有 Claude 认证，请重新检查以复用它。",
     agentRuntimeLoginDescription:
       "请在终端运行以下命令并完成登录，然后重新检查。",
-    agentRuntimeInstallDescription:
-      "请按官方指南安装 {{runtime}}，然后重新检查。",
+    agentRuntimeCodexInstallTitle: "安装并登录 Codex CLI",
+    agentRuntimeCodexInstallOpenTerminal: "打开 {{terminal}}。",
+    agentRuntimeCodexInstallRunInstaller: "复制并运行以下官方安装命令。",
+    agentRuntimeCodexInstallSkipLaunch:
+      "安装结束时如果出现“Start Codex now? [y/N]”，直接按 Enter，保持默认选项 N；此时不要启动 Codex。",
+    agentRuntimeCodexInstallExitAccidentalLaunch:
+      "如果已经误选 y，并看到“Hooks need review”，请选择“3. Continue without trusting”。进入 Codex 后输入 /exit（或按 Ctrl+C）将其关闭。",
+    agentRuntimeCodexInstallSignIn:
+      "安装程序返回 {{terminal}} 后，关闭这个窗口，再打开一个新的 {{terminal}}。运行以下命令并在浏览器中完成登录；提示登录成功后，可以关闭浏览器页面和 {{terminal}}。",
+    agentRuntimeCodexInstallReturn:
+      "回到这里点击“{{checkAction}}”。确认 Codex CLI 已就绪后，如果尚未显示“{{inUse}}”，再点击“{{useAction}}”。无需重启 OpenLoomi。",
+    agentRuntimeTerminal: "终端",
+    agentRuntimeClaudeUnavailableDescription:
+      "OpenLoomi 无法加载内置 Claude 运行组件。请更新或修复桌面应用，然后重新检查。",
     agentRuntimeUnverified: "OpenLoomi 无法验证本地运行时。",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi 无法验证此 CLI。请确认它能在终端运行，然后重新检查。",
+    agentRuntimeClaudeUnverifiedDescription:
+      "OpenLoomi 无法验证内置 Claude 运行组件。请打开故障排查指南，然后重新检查。",
     agentRuntimeManagedByEnvironment:
       "当前运行时由环境变量管理：{{provider}}。选择 Claude 或 Codex 后将创建桌面偏好。",
-    agentRuntimeInstallGuide: "安装指南",
+    agentRuntimePreferenceOverrideDescription:
+      "此桌面偏好会覆盖环境变量或默认运行时，并用于新任务。",
+    agentRuntimeUseManagedSetting: "使用环境变量/默认值",
+    agentRuntimePreferenceCleared: "已清除桌面运行时偏好。",
+    agentRuntimeClearError: "恢复环境变量或默认运行时失败。",
+    agentRuntimeOfficialInstructions: "查看官方说明",
+    agentRuntimeSetupGuide: "配置指南",
+    agentRuntimeTroubleshootingGuide: "故障排查指南",
     agentRuntimeCheckAgain: "重新检查",
     agentRuntimeTryAgain: "重试",
     agentRuntimeUse: "使用 {{runtime}}",

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -299,7 +299,8 @@ const zh = {
     agentRuntimeTitle: "Agent 运行时",
     agentRuntimeDescription:
       "选择 OpenLoomi 在新任务中使用的本地 CLI；正在运行的任务不会被中断。",
-    agentRuntimeClaudeDescription: "使用本机 Claude Code 及其登录账号。",
+    agentRuntimeClaudeDescription:
+      "使用本机 Claude Code，可通过 CLI 登录或已保存的 API 配置完成认证。",
     agentRuntimeCodexDescription: "使用本机 Codex CLI 及其登录账号。",
     agentRuntimeChecking: "正在检查本地运行时…",
     agentRuntimeReady: "已就绪",
@@ -308,10 +309,12 @@ const zh = {
     agentRuntimeUnverifiedShort: "无法验证",
     agentRuntimeInUse: "使用中",
     agentRuntimeReadyDescription: "{{runtime}} 已安装并登录，可以用于新任务。",
+    agentRuntimeApiReadyDescription:
+      "{{runtime}} 已安装，且已保存的 API 配置可用于新任务。",
     agentRuntimeLoginDescription:
       "请在终端运行以下命令并完成登录，然后重新检查。",
     agentRuntimeInstallDescription:
-      "请按官方指南安装 {{runtime}}，完成登录后重新检查。",
+      "请按官方指南安装 {{runtime}}，然后重新检查。",
     agentRuntimeUnverified: "OpenLoomi 无法验证本地运行时。",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi 无法验证此 CLI。请确认它能在终端运行，然后重新检查。",
@@ -326,6 +329,7 @@ const zh = {
     agentRuntimeSaved: "Agent 运行时已更新，将用于新任务。",
     agentRuntimeLoadError: "Agent 运行时检查失败。",
     agentRuntimeSaveError: "Agent 运行时更新失败。",
+    agentRuntimeNotReadyError: "所选运行时已不再就绪，请完成配置后重新检查。",
     conversationModelsTitle: "对话模型",
     aiSettingsOpenAiTitle: "OpenAI 兼容",
     aiSettingsOpenAiDescription:

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -296,6 +296,36 @@ const zh = {
       "Loop 已开启 —— Loomi 在后台通过连接器读取你的邮件、日历、代码与聊天等来源，并结合屏幕记忆来填你的早安简报。如果你不希望这样，可以在这里关掉。",
     aiSettingsDescription:
       "为当前用户配置兼容的 AI 服务商接口，保存后会优先使用用户配置。",
+    agentRuntimeTitle: "Agent 运行时",
+    agentRuntimeDescription:
+      "选择 OpenLoomi 在新任务中使用的本地 CLI；正在运行的任务不会被中断。",
+    agentRuntimeClaudeDescription: "使用本机 Claude Code 及其登录账号。",
+    agentRuntimeCodexDescription: "使用本机 Codex CLI 及其登录账号。",
+    agentRuntimeChecking: "正在检查本地运行时…",
+    agentRuntimeReady: "已就绪",
+    agentRuntimeLoginRequired: "需要登录",
+    agentRuntimeNotInstalled: "尚未安装",
+    agentRuntimeUnverifiedShort: "无法验证",
+    agentRuntimeInUse: "使用中",
+    agentRuntimeReadyDescription: "{{runtime}} 已安装并登录，可以用于新任务。",
+    agentRuntimeLoginDescription:
+      "请在终端运行以下命令并完成登录，然后重新检查。",
+    agentRuntimeInstallDescription:
+      "请按官方指南安装 {{runtime}}，完成登录后重新检查。",
+    agentRuntimeUnverified: "OpenLoomi 无法验证本地运行时。",
+    agentRuntimeUnverifiedDescription:
+      "OpenLoomi 无法验证此 CLI。请确认它能在终端运行，然后重新检查。",
+    agentRuntimeManagedByEnvironment:
+      "当前运行时由环境变量管理：{{provider}}。选择 Claude 或 Codex 后将创建桌面偏好。",
+    agentRuntimeInstallGuide: "安装指南",
+    agentRuntimeCheckAgain: "重新检查",
+    agentRuntimeTryAgain: "重试",
+    agentRuntimeUse: "使用 {{runtime}}",
+    agentRuntimeCopy: "复制",
+    agentRuntimeCopied: "已复制",
+    agentRuntimeSaved: "Agent 运行时已更新，将用于新任务。",
+    agentRuntimeLoadError: "Agent 运行时检查失败。",
+    agentRuntimeSaveError: "Agent 运行时更新失败。",
     conversationModelsTitle: "对话模型",
     aiSettingsOpenAiTitle: "OpenAI 兼容",
     aiSettingsOpenAiDescription:

--- a/apps/web/lib/ai/conversation-api-configuration.ts
+++ b/apps/web/lib/ai/conversation-api-configuration.ts
@@ -26,10 +26,10 @@ export type ConversationApiSettingsResponse = {
    */
   defaultAgent?: string;
   /**
-   * Probe of the user's local Claude CLI, surfaced by
-   * `/api/preferences/ai`. `authenticated: true` means `claude auth
-   * login` succeeded and the runtime can talk to Anthropic without
-   * any per-user key.
+   * Probe of the Claude runtime bundled with OpenLoomi Desktop, surfaced by
+   * `/api/preferences/ai`. `authenticated: true` means it found supported
+   * Claude authentication for the same OS account, so no per-user API setting
+   * is required.
    */
   nativeRuntime?: { ready?: boolean; authenticated?: boolean } | null;
 };
@@ -60,8 +60,8 @@ export function hasUsableConversationApiConfiguration(
     return true;
   }
 
-  // Built-in Claude agent: if the user's local `claude` CLI is
-  // authenticated (probed server-side), no per-user key is needed.
+  // Built-in Claude agent: if the bundled runtime finds supported existing
+  // authentication (probed server-side), no per-user key is needed.
   // `systemDefaults.anthropic_compatible.hasApiKey` is intentionally
   // NOT consulted here — it was a stale env-var mirror and would
   // falsely mark the user as configured in Tauri builds launched

--- a/apps/web/lib/ai/extensions/agent/claude/cli-locations.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/cli-locations.ts
@@ -1,0 +1,44 @@
+import { dirname, join } from "node:path";
+
+/**
+ * Candidate resource directories shared by Claude execution and readiness
+ * probes. Keeping this list in one place prevents a packaged CLI from working
+ * for tasks while being reported as missing in Settings.
+ */
+export function getClaudeBundleDirectories(
+  cwd = process.cwd(),
+  executablePath = process.execPath,
+): string[] {
+  const executableDirectory = dirname(executablePath);
+  return Array.from(
+    new Set([
+      join(cwd, "apps", "web", "cli-bundle"),
+      join(cwd, "cli-bundle"),
+      join(cwd, "..", "web", "cli-bundle"),
+      join(executableDirectory, "cli-bundle"),
+      join(executableDirectory, "..", "Resources", "cli-bundle"),
+      join(
+        executableDirectory,
+        "..",
+        "Resources",
+        "_up_",
+        "src-api",
+        "dist",
+        "cli-bundle",
+      ),
+      join(executableDirectory, "_up_", "src-api", "dist", "cli-bundle"),
+      join(
+        executableDirectory,
+        "..",
+        "lib",
+        "openloomi",
+        "_up_",
+        "src-api",
+        "dist",
+        "cli-bundle",
+      ),
+      join(executableDirectory, "claude-bundle"),
+      join(executableDirectory, "..", "Resources", "claude-bundle"),
+    ]),
+  );
+}

--- a/apps/web/lib/ai/extensions/agent/claude/env.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/env.ts
@@ -1,11 +1,8 @@
-import { existsSync, readdirSync } from "node:fs";
-import { homedir, platform } from "node:os";
-import { join } from "node:path";
-
 import type { AgentConfig } from "@openloomi/ai/agent/types";
 
 import { DEFAULT_AI_MODEL } from "@/lib/env/constants";
 import { createLogger } from "@/lib/utils/logger";
+import { buildAgentCliSearchPath } from "../cli-process";
 
 import { prepareClaudeCodeTempDirectory } from "./runtime-preflight";
 
@@ -23,45 +20,7 @@ export function isUsingCustomApi(config: AgentConfig): boolean {
  * Build extended PATH that includes common package manager bin locations.
  */
 export function getExtendedPath(): string {
-  const home = homedir();
-  const os = platform();
-  const isWindows = os === "win32";
-  const pathSeparator = isWindows ? ";" : ":";
-
-  const paths = [process.env.PATH || ""];
-
-  if (isWindows) {
-    paths.push(
-      join(home, "AppData", "Roaming", "npm"),
-      join(home, "AppData", "Local", "Programs", "nodejs"),
-      join(home, ".volta", "bin"),
-      "C:\\Program Files\\nodejs",
-      "C:\\Program Files (x86)\\nodejs",
-    );
-  } else {
-    paths.push(
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-      `${home}/.local/bin`,
-      `${home}/.npm-global/bin`,
-      `${home}/.volta/bin`,
-      `${home}/code/node/npm_global/bin`,
-    );
-
-    const nvmDir = join(home, ".nvm", "versions", "node");
-    try {
-      if (existsSync(nvmDir)) {
-        const versions = readdirSync(nvmDir);
-        for (const version of versions) {
-          paths.push(join(nvmDir, version, "bin"));
-        }
-      }
-    } catch {
-      // nvm not installed.
-    }
-  }
-
-  return paths.join(pathSeparator);
+  return buildAgentCliSearchPath();
 }
 
 /**

--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -9,7 +9,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { arch, homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import {
   createSdkMcpServer,
   query,
@@ -67,6 +67,7 @@ import { syncSkillsToClaude } from "@/lib/ai/skills/loader";
 // Logging - uses shared logger (writes to ~/.openloomi/logs/openloomi.log)
 // ============================================================================
 import { createLogger, LOG_FILE_PATH } from "@/lib/utils/logger";
+import { getClaudeBundleDirectories } from "./cli-locations";
 import {
   buildClaudeEnvConfig,
   buildClaudeSettingsConfig,
@@ -343,49 +344,8 @@ export function getTargetTriple(): string {
  */
 function getSidecarClaudeCodePath(): string | undefined {
   const os = platform();
-  const execDir = dirname(process.execPath);
 
-  // Possible locations for the bundled Claude Code (cli-bundle directory)
-  const bundleLocations = [
-    // Dev mode: check apps/web/cli-bundle (monorepo structure)
-    join(process.cwd(), "apps", "web", "cli-bundle"),
-    join(process.cwd(), "cli-bundle"),
-    join(process.cwd(), "..", "web", "cli-bundle"),
-    // Same directory as openloomi-api
-    join(execDir, "cli-bundle"),
-    // macOS: Tauri places resources in Resources
-    join(execDir, "..", "Resources", "cli-bundle"),
-    // macOS: Tauri places resources with preserved path structure
-    join(execDir, "..", "Resources", "_up_", "src-api", "dist", "cli-bundle"),
-    // Windows: Tauri places resources relative to exe
-    join(execDir, "_up_", "src-api", "dist", "cli-bundle"),
-    // Linux: Tauri deb/rpm places resources in /usr/lib/<AppName>/
-    join(
-      execDir,
-      "..",
-      "lib",
-      "openloomi",
-      "_up_",
-      "src-api",
-      "dist",
-      "cli-bundle",
-    ),
-    join(
-      execDir,
-      "..",
-      "lib",
-      "openloomi",
-      "_up_",
-      "src-api",
-      "dist",
-      "cli-bundle",
-    ),
-    // Legacy claude-bundle for backward compatibility
-    join(execDir, "claude-bundle"),
-    join(execDir, "..", "Resources", "claude-bundle"),
-  ];
-
-  for (const bundleDir of bundleLocations) {
+  for (const bundleDir of getClaudeBundleDirectories()) {
     if (!existsSync(bundleDir)) continue;
 
     // Current bundle structure: a platform-native Claude Code executable.

--- a/apps/web/lib/ai/extensions/agent/claude/process-spawner.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/process-spawner.ts
@@ -133,18 +133,16 @@ function spawnClaudeCodeProcess(
     }
     const cliJsPath = join(bundleDir, "cli.js");
 
-    let nodeToUse: string;
-    if (os === "win32") {
+    const bundledNode = join(bundleDir, os === "win32" ? "node.exe" : "node");
+    let nodeToUse = existsSync(bundledNode) ? bundledNode : "node";
+    if (nodeToUse === "node" && os === "win32") {
       const openloomiNode = join(homedir(), ".openloomi", "node", "node.exe");
       nodeToUse = existsSync(openloomiNode) ? openloomiNode : "node";
-    } else {
-      const nodeBinPath = join(bundleDir, "node");
-      nodeToUse = existsSync(nodeBinPath) ? nodeBinPath : "node";
     }
 
     const childProcess = spawnRegistered(
       nodeToUse,
-      [cliJsPath, ...options.args],
+      ["--max-old-space-size=8192", cliJsPath, ...options.args],
       { ...options.env, CLAUDECODE: "" },
     );
 

--- a/apps/web/lib/ai/extensions/agent/cli-process.ts
+++ b/apps/web/lib/ai/extensions/agent/cli-process.ts
@@ -1,7 +1,7 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { platform } from "node:os";
 
-const terminatingProcesses = new WeakSet<ChildProcessWithoutNullStreams>();
+const terminatingProcesses = new WeakSet<ChildProcess>();
 const POSIX_TERMINATION_GRACE_MS = 2_000;
 export const MAX_CLI_PROTOCOL_LINE_CHARS = 16 * 1024 * 1024;
 const MAX_CAPTURED_OUTPUT_CHARS = 1024 * 1024;
@@ -83,9 +83,7 @@ export function appendCapturedCliOutput(
  * Stop the CLI and descendants it launched. POSIX children are spawned as a
  * process-group leader so a disconnect cannot leave tool processes running.
  */
-export function terminateCliProcessTree(
-  proc: ChildProcessWithoutNullStreams,
-): void {
+export function terminateCliProcessTree(proc: ChildProcess): void {
   if (
     terminatingProcesses.has(proc) ||
     proc.exitCode !== null ||
@@ -116,7 +114,7 @@ export function terminateCliProcessTree(
 }
 
 function signalPosixProcessGroup(
-  proc: ChildProcessWithoutNullStreams,
+  proc: ChildProcess,
   signal: NodeJS.Signals,
 ): void {
   try {

--- a/apps/web/lib/ai/extensions/agent/cli-process.ts
+++ b/apps/web/lib/ai/extensions/agent/cli-process.ts
@@ -46,18 +46,29 @@ export function shouldDetachCliProcess(): boolean {
  */
 export function buildAgentCliSearchPath(
   basePath = process.env.PATH ?? "",
+  options: {
+    platform?: NodeJS.Platform;
+    homeDirectory?: string;
+    localAppData?: string;
+  } = {},
 ): string {
-  const home = homedir();
+  const currentPlatform = options.platform ?? platform();
+  const home = options.homeDirectory ?? homedir();
   const paths = basePath
     .split(delimiter)
     .map((entry) => entry.replace(/^"|"$/g, "").trim())
     .filter(Boolean);
 
-  if (platform() === "win32") {
+  if (currentPlatform === "win32") {
+    const localAppData =
+      options.localAppData?.trim() ||
+      process.env.LOCALAPPDATA?.trim() ||
+      join(home, "AppData", "Local");
     paths.push(
       join(home, ".local", "bin"),
       join(home, "AppData", "Roaming", "npm"),
       join(home, "AppData", "Local", "Programs", "nodejs"),
+      join(localAppData, "Programs", "OpenAI", "Codex", "bin"),
       join(home, ".volta", "bin"),
       "C:\\Program Files\\nodejs",
       "C:\\Program Files (x86)\\nodejs",
@@ -88,6 +99,26 @@ export function buildAgentCliSearchPath(
   }
 
   return Array.from(new Set(paths)).join(delimiter);
+}
+
+/** Resolve commands in the same directory-first order used by PATH lookup. */
+export function findCliExecutableOnSearchPath(
+  searchPath: string,
+  candidates: readonly string[],
+): string | null {
+  const directories = searchPath
+    .split(delimiter)
+    .map((directory) => directory.replace(/^"|"$/g, "").trim())
+    .filter(Boolean);
+
+  for (const directory of directories) {
+    for (const candidate of candidates) {
+      const command = join(directory, candidate);
+      if (existsSync(command)) return command;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/apps/web/lib/ai/extensions/agent/cli-process.ts
+++ b/apps/web/lib/ai/extensions/agent/cli-process.ts
@@ -1,5 +1,7 @@
-import { spawn, type ChildProcess } from "node:child_process";
-import { platform } from "node:os";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { delimiter, join } from "node:path";
 
 const terminatingProcesses = new WeakSet<ChildProcess>();
 const POSIX_TERMINATION_GRACE_MS = 2_000;
@@ -35,6 +37,57 @@ const RUNTIME_ENV_PREFIXES = ["OPENCODE_", "HERMES_", "OPENCLAW_", "CODEX_"];
 
 export function shouldDetachCliProcess(): boolean {
   return platform() !== "win32";
+}
+
+/**
+ * Desktop apps inherit a much shorter PATH than an interactive shell. Keep
+ * runtime probes and actual CLI execution on the same search path so a CLI
+ * reported as ready is also launchable when a task starts.
+ */
+export function buildAgentCliSearchPath(
+  basePath = process.env.PATH ?? "",
+): string {
+  const home = homedir();
+  const paths = basePath
+    .split(delimiter)
+    .map((entry) => entry.replace(/^"|"$/g, "").trim())
+    .filter(Boolean);
+
+  if (platform() === "win32") {
+    paths.push(
+      join(home, ".local", "bin"),
+      join(home, "AppData", "Roaming", "npm"),
+      join(home, "AppData", "Local", "Programs", "nodejs"),
+      join(home, ".volta", "bin"),
+      "C:\\Program Files\\nodejs",
+      "C:\\Program Files (x86)\\nodejs",
+    );
+  } else {
+    paths.push(
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+      join(home, ".local", "bin"),
+      join(home, ".npm-global", "bin"),
+      join(home, ".volta", "bin"),
+      join(home, ".bun", "bin"),
+      join(home, "Library", "pnpm"),
+      join(home, ".local", "share", "pnpm"),
+      join(home, "code", "node", "npm_global", "bin"),
+    );
+
+    const nvmDirectory = join(home, ".nvm", "versions", "node");
+    try {
+      if (existsSync(nvmDirectory)) {
+        for (const version of readdirSync(nvmDirectory)) {
+          paths.push(join(nvmDirectory, version, "bin"));
+        }
+      }
+    } catch {
+      // nvm is optional and may be unreadable in hardened desktop installs.
+    }
+  }
+
+  return Array.from(new Set(paths)).join(delimiter);
 }
 
 /**

--- a/apps/web/lib/ai/extensions/agent/codex/command.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/command.ts
@@ -5,9 +5,10 @@ import spawn from "cross-spawn";
 
 import type { AgentOptions } from "@openloomi/ai/agent/types";
 import {
-  appendCapturedCliOutput,
-  buildCliEnvironment,
   MAX_CLI_PROTOCOL_LINE_CHARS,
+  appendCapturedCliOutput,
+  buildAgentCliSearchPath,
+  buildCliEnvironment,
   shouldDetachCliProcess,
   terminateCliProcessTree,
 } from "../cli-process";
@@ -268,7 +269,10 @@ export async function* runCodexCli(
   try {
     proc = spawn(command, args, {
       cwd: options.cwd,
-      env: buildCliEnvironment(options.env),
+      env: buildCliEnvironment({
+        ...options.env,
+        PATH: buildAgentCliSearchPath(options.env?.PATH),
+      }),
       detached: shouldDetachCliProcess(),
       windowsHide: true,
     }) as ChildProcessWithoutNullStreams;

--- a/apps/web/lib/ai/extensions/agent/codex/runtime-preflight.ts
+++ b/apps/web/lib/ai/extensions/agent/codex/runtime-preflight.ts
@@ -5,9 +5,10 @@ import { StringDecoder } from "node:string_decoder";
 import spawn from "cross-spawn";
 
 import {
-  appendCapturedCliOutput,
-  buildCliEnvironment,
   MAX_CLI_PROTOCOL_LINE_CHARS,
+  appendCapturedCliOutput,
+  buildAgentCliSearchPath,
+  buildCliEnvironment,
   shouldDetachCliProcess,
   terminateCliProcessTree,
 } from "../cli-process";
@@ -384,7 +385,10 @@ class CodexAppServerProbeClient {
     try {
       proc = spawn(this.command, this.args, {
         cwd: this.options.cwd,
-        env: buildCliEnvironment(this.options.env),
+        env: buildCliEnvironment({
+          ...this.options.env,
+          PATH: buildAgentCliSearchPath(this.options.env?.PATH),
+        }),
         detached: shouldDetachCliProcess(),
         windowsHide: true,
       }) as ChildProcessWithoutNullStreams;

--- a/apps/web/lib/ai/native-agent/provider-env.ts
+++ b/apps/web/lib/ai/native-agent/provider-env.ts
@@ -3,12 +3,21 @@ import {
   type NativeAgentRequest,
 } from "@openloomi/ai/agent/native-runner";
 import type { AgentProvider } from "@openloomi/ai/agent/types";
-import { readAgentRuntimePreference } from "./runtime-preference";
+import {
+  readAgentRuntimePreference,
+  type SelectableAgentRuntime,
+} from "./runtime-preference";
 
 type EnvSource = Record<string, string | undefined>;
 
 interface ProviderResolutionOptions {
   preferencePath?: string;
+}
+
+export interface ConfiguredAgentProviderResolution {
+  provider: AgentProvider;
+  preference?: SelectableAgentRuntime;
+  source: "preference" | "environment" | "default";
 }
 
 const DEFAULT_AGENT_PROVIDER: AgentProvider = "claude";
@@ -29,14 +38,24 @@ export function getConfiguredDefaultAgentProvider(
   env: EnvSource = process.env,
   options: ProviderResolutionOptions = {},
 ): AgentProvider {
+  return getConfiguredAgentProviderResolution(env, options).provider;
+}
+
+export function getConfiguredAgentProviderResolution(
+  env: EnvSource = process.env,
+  options: ProviderResolutionOptions = {},
+): ConfiguredAgentProviderResolution {
   if (isTauriEnvironment(env)) {
     const preference = readAgentRuntimePreference(options.preferencePath);
     if (preference) {
-      return preference;
+      return { provider: preference, preference, source: "preference" };
     }
   }
 
-  return resolveEnvAgentProvider(env) ?? DEFAULT_AGENT_PROVIDER;
+  const environmentProvider = resolveEnvAgentProvider(env);
+  return environmentProvider
+    ? { provider: environmentProvider, source: "environment" }
+    : { provider: DEFAULT_AGENT_PROVIDER, source: "default" };
 }
 
 export function resolveNativeAgentProviderRequest(

--- a/apps/web/lib/ai/native-agent/provider-env.ts
+++ b/apps/web/lib/ai/native-agent/provider-env.ts
@@ -3,8 +3,13 @@ import {
   type NativeAgentRequest,
 } from "@openloomi/ai/agent/native-runner";
 import type { AgentProvider } from "@openloomi/ai/agent/types";
+import { readAgentRuntimePreference } from "./runtime-preference";
 
 type EnvSource = Record<string, string | undefined>;
+
+interface ProviderResolutionOptions {
+  preferencePath?: string;
+}
 
 const DEFAULT_AGENT_PROVIDER: AgentProvider = "claude";
 const ENV_PROVIDER_KEY = "OPENLOOMI_AGENT_PROVIDER";
@@ -22,18 +27,27 @@ const SUPPORTED_ENV_PROVIDERS = new Set([
 
 export function getConfiguredDefaultAgentProvider(
   env: EnvSource = process.env,
+  options: ProviderResolutionOptions = {},
 ): AgentProvider {
+  if (isTauriEnvironment(env)) {
+    const preference = readAgentRuntimePreference(options.preferencePath);
+    if (preference) {
+      return preference;
+    }
+  }
+
   return resolveEnvAgentProvider(env) ?? DEFAULT_AGENT_PROVIDER;
 }
 
 export function resolveNativeAgentProviderRequest(
   body: NativeAgentRequest,
   env: EnvSource = process.env,
+  options: ProviderResolutionOptions = {},
 ): NativeAgentRequest {
   // Runtime selection is deployment configuration, not an HTTP request
   // option. External CLI agents inherit host credentials and can execute local
   // tools, so allowing callers to switch providers would cross a trust boundary.
-  const provider = getConfiguredDefaultAgentProvider(env);
+  const provider = getConfiguredDefaultAgentProvider(env, options);
 
   if (provider === HERMES_PROVIDER) {
     const hermesEnvConfig = resolveHermesEnvConfig(env);
@@ -90,6 +104,10 @@ export function resolveNativeAgentProviderRequest(
       : undefined,
     providerConfig: opencodeEnvConfig.providerConfig,
   };
+}
+
+function isTauriEnvironment(env: EnvSource): boolean {
+  return typeof env.TAURI_MODE === "string" || env.IS_TAURI === "true";
 }
 
 function resolveEnvAgentProvider(env: EnvSource): AgentProvider | undefined {

--- a/apps/web/lib/ai/native-agent/runner.ts
+++ b/apps/web/lib/ai/native-agent/runner.ts
@@ -18,6 +18,15 @@ import {
   registerNativeAgentPermission,
 } from "./permissions";
 
+// The HTTP route resolves provider selection at its trust boundary before it
+// reaches this wrapper. Do not resolve it again inside the package runner: the
+// desktop preference is mutable, so two reads could select different runtimes
+// for execution and usage attribution within one request.
+const preparedNativeAgentHost = {
+  ...nativeAgentHost,
+  prepareRequest: undefined,
+};
+
 export type { NativeAgentRequest, NativeAgentRun };
 export { NativeAgentRequestError };
 
@@ -40,24 +49,24 @@ export interface NativeAgentRunnerContext extends Omit<
  * @openloomi/ai/agent/native-runner directly with nativeAgentHost.
  */
 export async function runNativeAgentRequest(
-  body: NativeAgentRequest,
+  preparedBody: NativeAgentRequest,
   context: NativeAgentRunnerContext,
 ): Promise<NativeAgentRun> {
   return runPackageNativeAgentRequest(
-    body,
+    preparedBody,
     {
       ...context,
       permissionHandler:
         context.permissionHandler ??
         createNativeAgentPermissionHandler(
-          body.permissionMode,
+          preparedBody.permissionMode,
           context.userId,
           context.abortController.signal,
         ),
       emitPermissionRequestEvents:
         context.emitPermissionRequestEvents ?? !context.permissionHandler,
     },
-    nativeAgentHost,
+    preparedNativeAgentHost,
   );
 }
 

--- a/apps/web/lib/ai/native-agent/runtime-contract.ts
+++ b/apps/web/lib/ai/native-agent/runtime-contract.ts
@@ -13,6 +13,7 @@ export type AgentRuntimePublicProbe = {
   installed: boolean;
   authenticated: boolean | null;
   ready: boolean;
+  readyVia: "cli" | "api" | null;
   status: AgentRuntimeSetupStatus;
   version: string | null;
   reason:

--- a/apps/web/lib/ai/native-agent/runtime-contract.ts
+++ b/apps/web/lib/ai/native-agent/runtime-contract.ts
@@ -36,3 +36,15 @@ export type AgentRuntimeSettingsResponse = {
   platform: "windows" | "macos" | "linux";
   runtimes: Record<SelectableAgentRuntime, AgentRuntimePublicProbe> | null;
 };
+
+export function canSaveAgentRuntime(
+  state: AgentRuntimeSettingsResponse,
+  draft: SelectableAgentRuntime | null,
+): boolean {
+  return Boolean(
+    state.editable &&
+    draft &&
+    draft !== state.effective.provider &&
+    state.runtimes?.[draft].ready,
+  );
+}

--- a/apps/web/lib/ai/native-agent/runtime-contract.ts
+++ b/apps/web/lib/ai/native-agent/runtime-contract.ts
@@ -1,0 +1,38 @@
+export const SELECTABLE_AGENT_RUNTIMES = ["claude", "codex"] as const;
+
+export type SelectableAgentRuntime = (typeof SELECTABLE_AGENT_RUNTIMES)[number];
+
+export type AgentRuntimeSetupStatus =
+  | "ready"
+  | "login_required"
+  | "not_installed"
+  | "unverified";
+
+export type AgentRuntimePublicProbe = {
+  provider: SelectableAgentRuntime;
+  installed: boolean;
+  authenticated: boolean | null;
+  ready: boolean;
+  status: AgentRuntimeSetupStatus;
+  version: string | null;
+  reason:
+    | "READY"
+    | "CLI_UNAVAILABLE"
+    | "VERSION_FAILED"
+    | "VERSION_TIMEOUT"
+    | "AUTH_REQUIRED"
+    | "AUTH_UNAVAILABLE"
+    | "AUTH_TIMEOUT"
+    | "PROBE_FAILED";
+};
+
+export type AgentRuntimeSettingsResponse = {
+  editable: boolean;
+  preference: SelectableAgentRuntime | null;
+  effective: {
+    provider: string;
+    source: "preference" | "environment" | "default";
+  };
+  platform: "windows" | "macos" | "linux";
+  runtimes: Record<SelectableAgentRuntime, AgentRuntimePublicProbe> | null;
+};

--- a/apps/web/lib/ai/native-agent/runtime-installation.ts
+++ b/apps/web/lib/ai/native-agent/runtime-installation.ts
@@ -1,0 +1,16 @@
+import type { AgentRuntimeSettingsResponse } from "./runtime-contract";
+
+type AgentRuntimePlatform = AgentRuntimeSettingsResponse["platform"];
+
+const CODEX_INSTALL_COMMANDS: Record<AgentRuntimePlatform, string> = {
+  windows:
+    'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+  macos: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+  linux: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+};
+
+export const CODEX_LOGIN_COMMAND = "codex login";
+
+export function getCodexInstallCommand(platform: AgentRuntimePlatform): string {
+  return CODEX_INSTALL_COMMANDS[platform];
+}

--- a/apps/web/lib/ai/native-agent/runtime-preference.ts
+++ b/apps/web/lib/ai/native-agent/runtime-preference.ts
@@ -76,6 +76,12 @@ export function writeAgentRuntimePreference(
   }
 }
 
+export function clearAgentRuntimePreference(
+  filePath = getAgentRuntimePreferencePath(),
+): void {
+  rmSync(filePath, { force: true });
+}
+
 function isRuntimePreference(
   value: unknown,
 ): value is { provider: SelectableAgentRuntime } {

--- a/apps/web/lib/ai/native-agent/runtime-preference.ts
+++ b/apps/web/lib/ai/native-agent/runtime-preference.ts
@@ -1,0 +1,86 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+import { getAppDir } from "@/lib/env/config/constants";
+
+export const SELECTABLE_AGENT_RUNTIMES = ["claude", "codex"] as const;
+
+export type SelectableAgentRuntime = (typeof SELECTABLE_AGENT_RUNTIMES)[number];
+
+const RUNTIME_PREFERENCE_FILE_NAME = "agent-runtime.json";
+
+export function getAgentRuntimePreferencePath(): string {
+  return join(getAppDir(), RUNTIME_PREFERENCE_FILE_NAME);
+}
+
+export function readAgentRuntimePreference(
+  filePath = getAgentRuntimePreferencePath(),
+): SelectableAgentRuntime | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+    if (!isRuntimePreference(parsed)) {
+      console.warn(
+        `[agent-runtime] Ignoring invalid runtime preference at ${filePath}`,
+      );
+      return undefined;
+    }
+    return parsed.provider;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(
+        `[agent-runtime] Unable to read runtime preference at ${filePath}`,
+        error,
+      );
+    }
+    return undefined;
+  }
+}
+
+export function writeAgentRuntimePreference(
+  provider: SelectableAgentRuntime,
+  filePath = getAgentRuntimePreferencePath(),
+): void {
+  if (!SELECTABLE_AGENT_RUNTIMES.includes(provider)) {
+    throw new TypeError(`Unsupported agent runtime: ${String(provider)}`);
+  }
+
+  mkdirSync(dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify({ provider }, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      rmSync(temporaryPath, { force: true });
+    } catch {
+      // Preserve the original write/rename error if best-effort cleanup fails.
+    }
+    throw error;
+  }
+}
+
+function isRuntimePreference(
+  value: unknown,
+): value is { provider: SelectableAgentRuntime } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const provider = (value as { provider?: unknown }).provider;
+  return (
+    typeof provider === "string" &&
+    SELECTABLE_AGENT_RUNTIMES.includes(provider as SelectableAgentRuntime)
+  );
+}

--- a/apps/web/lib/ai/native-agent/runtime-preference.ts
+++ b/apps/web/lib/ai/native-agent/runtime-preference.ts
@@ -9,10 +9,15 @@ import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 
 import { getAppDir } from "@/lib/env/config/constants";
+import {
+  SELECTABLE_AGENT_RUNTIMES,
+  type SelectableAgentRuntime,
+} from "./runtime-contract";
 
-export const SELECTABLE_AGENT_RUNTIMES = ["claude", "codex"] as const;
-
-export type SelectableAgentRuntime = (typeof SELECTABLE_AGENT_RUNTIMES)[number];
+export {
+  SELECTABLE_AGENT_RUNTIMES,
+  type SelectableAgentRuntime,
+} from "./runtime-contract";
 
 const RUNTIME_PREFERENCE_FILE_NAME = "agent-runtime.json";
 

--- a/apps/web/lib/ai/native-agent/runtime-probe.ts
+++ b/apps/web/lib/ai/native-agent/runtime-probe.ts
@@ -10,7 +10,7 @@
 import type { ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { delimiter, join, parse } from "node:path";
+import { join, parse } from "node:path";
 import spawn from "cross-spawn";
 
 import { getClaudeBundleDirectories } from "@/lib/ai/extensions/agent/claude/cli-locations";
@@ -18,6 +18,7 @@ import {
   appendCapturedCliOutput,
   buildAgentCliSearchPath,
   buildCliEnvironment,
+  findCliExecutableOnSearchPath,
   shouldDetachCliProcess,
   terminateCliProcessTree,
 } from "@/lib/ai/extensions/agent/cli-process";
@@ -210,22 +211,17 @@ function resolveCliPath(
     }
   }
 
-  const pathDirectories = searchPath
-    .split(delimiter)
-    .map((directory) => directory.replace(/^"|"$/g, ""))
-    .filter(Boolean);
-  for (const binary of candidateBinaries(definition.binary)) {
-    for (const directory of pathDirectories) {
-      const candidate = join(directory, binary);
-      if (existsSync(candidate)) {
-        return {
-          path: candidate,
-          source: "PATH",
-          searchPath,
-          argsPrefix: [],
-        };
-      }
-    }
+  const pathCommand = findCliExecutableOnSearchPath(
+    searchPath,
+    candidateBinaries(definition.binary),
+  );
+  if (pathCommand) {
+    return {
+      path: pathCommand,
+      source: "PATH",
+      searchPath,
+      argsPrefix: [],
+    };
   }
 
   return { path: null, source: null, searchPath, argsPrefix: [] };

--- a/apps/web/lib/ai/native-agent/runtime-probe.ts
+++ b/apps/web/lib/ai/native-agent/runtime-probe.ts
@@ -8,22 +8,39 @@
  */
 
 import type { ChildProcess } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { delimiter, dirname, join, parse } from "node:path";
+import { delimiter, join, parse } from "node:path";
 import spawn from "cross-spawn";
 
+import { getClaudeBundleDirectories } from "@/lib/ai/extensions/agent/claude/cli-locations";
 import {
   appendCapturedCliOutput,
+  buildAgentCliSearchPath,
+  buildCliEnvironment,
   shouldDetachCliProcess,
   terminateCliProcessTree,
 } from "@/lib/ai/extensions/agent/cli-process";
 import { createLogger } from "@/lib/utils/logger";
+import { APP_DIR_NAME } from "@/lib/env/config/constants";
 
 const PROBE_TIMEOUT_MS = 5000;
 const CACHE_TTL_MS = 30_000;
 
 const logger = createLogger("NativeAgentRuntime");
+
+const PROBE_CREDENTIAL_KEYS = new Set([
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "CLAUDE_CONFIG_DIR",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "OPENROUTER_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+]);
+const PROBE_RUNTIME_PREFIXES = ["OPENCODE_", "HERMES_", "OPENCLAW_", "CODEX_"];
 
 export type NativeRuntimeStatus =
   | "CLAUDE_CLI_AUTHENTICATED"
@@ -112,6 +129,13 @@ type RuntimeDefinition<
   };
 };
 
+type ResolvedCliPath = {
+  path: string | null;
+  source: CliPathSource;
+  searchPath: string;
+  argsPrefix: string[];
+};
+
 let claudeCache: { at: number; value: NativeRuntimeProbe } | null = null;
 let codexCache: { at: number; value: CodexRuntimeProbe } | null = null;
 let claudeInFlight: Promise<NativeRuntimeProbe> | null = null;
@@ -124,78 +148,35 @@ function candidateBinaries(binary: string): string[] {
   return [binary];
 }
 
-/**
- * Desktop apps do not inherit the user's interactive shell PATH. Include the
- * common package-manager locations used by both supported runtimes.
- */
-function buildCliSearchPath(): string {
-  const home = homedir();
-  const dirs: string[] = [process.env.PATH || ""];
-
-  if (platform() === "win32") {
-    dirs.push(
-      join(home, "AppData", "Roaming", "npm"),
-      join(home, "AppData", "Local", "Programs", "nodejs"),
-      join(home, ".volta", "bin"),
-      "C:\\Program Files\\nodejs",
-      "C:\\Program Files (x86)\\nodejs",
-    );
-  } else {
-    dirs.push(
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-      join(home, ".local", "bin"),
-      join(home, ".npm-global", "bin"),
-      join(home, ".volta", "bin"),
-      join(home, ".bun", "bin"),
-      join(home, "Library", "pnpm"),
-      join(home, ".local", "share", "pnpm"),
-      join(home, "code", "node", "npm_global", "bin"),
-    );
-  }
-
-  return Array.from(new Set(dirs.filter(Boolean))).join(delimiter);
-}
-
-function listNvmBinaries(binary: string): string[] {
-  try {
-    const nvmBase = join(homedir(), ".nvm", "versions", "node");
-    if (!existsSync(nvmBase)) return [];
-    return readdirSync(nvmBase)
-      .sort()
-      .reverse()
-      .map((version) => join(nvmBase, version, "bin", binary))
-      .filter((candidate) => existsSync(candidate));
-  } catch {
-    return [];
-  }
-}
-
-/** Current desktop bundles include a platform-native Claude executable. */
-function resolveBundledClaudePath(): string | null {
-  const executableDirectory = dirname(process.execPath);
-  const bundleDirectories = [
-    join(process.cwd(), "apps", "web", "cli-bundle"),
-    join(process.cwd(), "cli-bundle"),
-    join(process.cwd(), "..", "web", "cli-bundle"),
-    join(executableDirectory, "cli-bundle"),
-    join(executableDirectory, "..", "Resources", "cli-bundle"),
-    join(
-      executableDirectory,
-      "..",
-      "Resources",
-      "_up_",
-      "src-api",
-      "dist",
-      "cli-bundle",
-    ),
-    join(executableDirectory, "_up_", "src-api", "dist", "cli-bundle"),
-  ];
+/** Resolve both current native bundles and legacy cli.js bundles. */
+function resolveBundledClaudeCommand(): {
+  path: string;
+  argsPrefix: string[];
+} | null {
   const executable = platform() === "win32" ? "claude.exe" : "claude";
 
-  for (const directory of bundleDirectories) {
+  for (const directory of getClaudeBundleDirectories()) {
     const candidate = join(directory, executable);
-    if (existsSync(candidate)) return candidate;
+    if (existsSync(candidate)) return { path: candidate, argsPrefix: [] };
+
+    const cliPath = join(directory, "cli.js");
+    const vendorDirectory = join(directory, "vendor");
+    if (!(existsSync(cliPath) && existsSync(vendorDirectory))) continue;
+
+    const bundledNode = join(
+      directory,
+      platform() === "win32" ? "node.exe" : "node",
+    );
+    const openLoomiNode = join(homedir(), APP_DIR_NAME, "node", "node.exe");
+    const nodePath = existsSync(bundledNode)
+      ? bundledNode
+      : platform() === "win32" && existsSync(openLoomiNode)
+        ? openLoomiNode
+        : "node";
+    return {
+      path: nodePath,
+      argsPrefix: ["--max-old-space-size=8192", cliPath],
+    };
   }
   return null;
 }
@@ -207,13 +188,13 @@ function isBareCommand(command: string): boolean {
 
 function resolveCliPath(
   definition: RuntimeDefinition<"claude" | "codex", string>,
-): { path: string | null; source: CliPathSource; searchPath: string } {
-  const searchPath = buildCliSearchPath();
+): ResolvedCliPath {
+  const searchPath = buildAgentCliSearchPath();
 
   if (definition.provider === "claude") {
-    const bundled = resolveBundledClaudePath();
+    const bundled = resolveBundledClaudeCommand();
     if (bundled) {
-      return { path: bundled, source: "BUNDLED", searchPath };
+      return { ...bundled, source: "BUNDLED", searchPath };
     }
   }
 
@@ -224,6 +205,7 @@ function resolveCliPath(
         path: explicit,
         source: definition.explicitSource,
         searchPath,
+        argsPrefix: [],
       };
     }
   }
@@ -236,24 +218,26 @@ function resolveCliPath(
     for (const directory of pathDirectories) {
       const candidate = join(directory, binary);
       if (existsSync(candidate)) {
-        return { path: candidate, source: "PATH", searchPath };
+        return {
+          path: candidate,
+          source: "PATH",
+          searchPath,
+          argsPrefix: [],
+        };
       }
     }
   }
 
-  const [fallback] = listNvmBinaries(definition.binary);
-  if (fallback) {
-    return { path: fallback, source: "FALLBACK", searchPath };
-  }
-
-  return { path: null, source: null, searchPath };
+  return { path: null, source: null, searchPath, argsPrefix: [] };
 }
 
 function runCli(
+  provider: "claude" | "codex",
   command: string,
   args: readonly string[],
   timeoutMs: number,
   searchPath: string,
+  argsPrefix: readonly string[] = [],
 ): Promise<ProbeResult> {
   const startedAt = Date.now();
   return new Promise((resolve) => {
@@ -270,10 +254,13 @@ function runCli(
 
     let processHandle: ChildProcess;
     try {
-      processHandle = spawn(command, [...args], {
+      processHandle = spawn(command, [...argsPrefix, ...args], {
         stdio: ["ignore", "pipe", "pipe"],
         detached: shouldDetachCliProcess(),
-        env: { ...process.env, PATH: searchPath, CLAUDECODE: "" },
+        env: buildRuntimeProbeEnvironment(provider, {
+          PATH: searchPath,
+          CLAUDECODE: "",
+        }),
         windowsHide: true,
       });
     } catch (error) {
@@ -338,6 +325,44 @@ function runCli(
   });
 }
 
+function buildRuntimeProbeEnvironment(
+  provider: "claude" | "codex",
+  overrides: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const providerOverrides: Record<string, string> = {};
+  if (provider === "claude") {
+    for (const key of [
+      "ANTHROPIC_AUTH_TOKEN",
+      "ANTHROPIC_BASE_URL",
+      "CLAUDE_CONFIG_DIR",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+    ]) {
+      const value = process.env[key];
+      if (value !== undefined) providerOverrides[key] = value;
+    }
+  }
+
+  const env = buildCliEnvironment({ ...providerOverrides, ...overrides });
+  for (const key of Object.keys(env)) {
+    const normalized = key.toUpperCase();
+    const isRuntimeCredential =
+      PROBE_CREDENTIAL_KEYS.has(normalized) ||
+      PROBE_RUNTIME_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+    if (!isRuntimeCredential) continue;
+
+    const isProviderCredential =
+      provider === "claude"
+        ? normalized.startsWith("ANTHROPIC_") ||
+          normalized === "CLAUDE_CONFIG_DIR" ||
+          normalized === "CLAUDE_CODE_OAUTH_TOKEN"
+        : normalized === "OPENAI_API_KEY" || normalized.startsWith("CODEX_");
+    if (!isProviderCredential) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 function cleanVersion(result: ProbeResult): string | null {
   const line = `${result.stdout}\n${result.stderr}`
     .split(/\r?\n/)
@@ -386,10 +411,12 @@ async function probeCliRuntime<
   }
 
   const versionProbe = await runCli(
+    definition.provider,
     resolved.path,
     ["--version"],
     PROBE_TIMEOUT_MS,
     resolved.searchPath,
+    resolved.argsPrefix,
   );
   if (!versionProbe.ok) {
     const result = {
@@ -414,10 +441,12 @@ async function probeCliRuntime<
   }
 
   const authProbe = await runCli(
+    definition.provider,
     resolved.path,
     definition.authArgs,
     PROBE_TIMEOUT_MS,
     resolved.searchPath,
+    resolved.argsPrefix,
   );
   if (!authProbe.ok) {
     const reason = authProbe.timedOut

--- a/apps/web/lib/ai/native-agent/runtime-probe.ts
+++ b/apps/web/lib/ai/native-agent/runtime-probe.ts
@@ -1,28 +1,29 @@
 /**
- * Server-side probe for the user's local Claude Code runtime.
+ * Server-side readiness probes for the local Claude Code and Codex CLIs.
  *
- * Single source of truth for "can the user talk to Claude right now". It
- * replaces the previous reliance on `process.env.ANTHROPIC_*` for
- * AI-provider readiness — the user's host-side `claude auth login` is the
- * actual signal, not whatever env vars happened to be set when the
- * OpenLoomi process started.
- *
- * The plugin (plugins/claude) reads this probe via `/api/preferences/ai`
- * rather than spawning its own copies of `claude --version` /
- * `claude auth status`. One probe per node process, cached briefly.
+ * Probes are deliberately read-only: they check the executable version and
+ * the CLI's own authentication status without starting a model request. Raw
+ * probe output stays server-side; UI routes must translate these structures
+ * into the safe summary exported by `runtime-settings.ts`.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { delimiter, join } from "node:path";
 import { homedir, platform } from "node:os";
+import { delimiter, dirname, join, parse } from "node:path";
+import spawn from "cross-spawn";
 
+import {
+  appendCapturedCliOutput,
+  shouldDetachCliProcess,
+  terminateCliProcessTree,
+} from "@/lib/ai/extensions/agent/cli-process";
 import { createLogger } from "@/lib/utils/logger";
 
 const PROBE_TIMEOUT_MS = 5000;
 const CACHE_TTL_MS = 30_000;
 
-const logger = createLogger("NativeClaudeRuntime");
+const logger = createLogger("NativeAgentRuntime");
 
 export type NativeRuntimeStatus =
   | "CLAUDE_CLI_AUTHENTICATED"
@@ -32,6 +33,15 @@ export type NativeRuntimeStatus =
   | "CLAUDE_CLI_VERSION_FAILED"
   | "CLAUDE_CLI_VERSION_TIMEOUT"
   | "CLAUDE_CLI_UNAVAILABLE";
+
+export type CodexRuntimeStatus =
+  | "CODEX_CLI_AUTHENTICATED"
+  | "CODEX_CLI_AUTH_REQUIRED"
+  | "CODEX_CLI_AUTH_STATUS_TIMEOUT"
+  | "CODEX_CLI_AUTH_STATUS_UNAVAILABLE"
+  | "CODEX_CLI_VERSION_FAILED"
+  | "CODEX_CLI_VERSION_TIMEOUT"
+  | "CODEX_CLI_UNAVAILABLE";
 
 export type ProbeResult = {
   ok: boolean;
@@ -43,46 +53,82 @@ export type ProbeResult = {
   timedOut: boolean;
 };
 
-export type NativeRuntimeProbe = {
+type CliPathSource =
+  | "BUNDLED"
+  | "PATH"
+  | "CLAUDE_CODE_PATH"
+  | "OPENLOOMI_AGENT_CODEX_COMMAND"
+  | "FALLBACK"
+  | null;
+
+type BaseRuntimeProbe<
+  Provider extends "claude" | "codex",
+  Status extends string,
+> = {
   checked: true;
+  provider: Provider;
   available: boolean;
   authenticated: boolean;
   active: boolean;
   ready: boolean;
-  reason: NativeRuntimeStatus;
-  defaultAgent: "claude";
+  reason: Status;
   cliPathPresent: boolean;
-  cliPathSource: "PATH" | "CLAUDE_CODE_PATH" | "FALLBACK" | null;
+  cliPathSource: CliPathSource;
   versionPresent: boolean;
+  version: string | null;
   probes: {
     version?: ProbeResult;
     auth?: ProbeResult;
   };
 };
 
-let cache: { at: number; value: NativeRuntimeProbe | null } | null = null;
+export type NativeRuntimeProbe = BaseRuntimeProbe<
+  "claude",
+  NativeRuntimeStatus
+> & {
+  // Kept for the existing `/api/preferences/ai` plugin contract.
+  defaultAgent: "claude";
+};
 
-function candidateBinaries(): string[] {
-  // On Windows the user's installer can drop `claude.exe` (native) or a
-  // `claude.cmd` shim; npm globals also produce `claude.ps1` + `claude.cmd`
-  // pairs. The portable `.exe` is what we want to spawn, but checking all
-  // three keeps us aligned with how Windows resolves PATH lookups.
+export type CodexRuntimeProbe = BaseRuntimeProbe<"codex", CodexRuntimeStatus>;
+
+type RuntimeDefinition<
+  Provider extends "claude" | "codex",
+  Status extends string,
+> = {
+  provider: Provider;
+  binary: Provider;
+  explicitCommand: string | undefined;
+  explicitSource: Exclude<CliPathSource, null>;
+  authArgs: readonly string[];
+  status: {
+    ready: Status;
+    authRequired: Status;
+    authTimeout: Status;
+    authUnavailable: Status;
+    versionFailed: Status;
+    versionTimeout: Status;
+    unavailable: Status;
+  };
+};
+
+let claudeCache: { at: number; value: NativeRuntimeProbe } | null = null;
+let codexCache: { at: number; value: CodexRuntimeProbe } | null = null;
+let claudeInFlight: Promise<NativeRuntimeProbe> | null = null;
+let codexInFlight: Promise<CodexRuntimeProbe> | null = null;
+
+function candidateBinaries(binary: string): string[] {
   if (platform() === "win32") {
-    return ["claude.exe", "claude.cmd", "claude"];
+    return [`${binary}.exe`, `${binary}.cmd`, binary];
   }
-  return ["claude"];
+  return [binary];
 }
 
-// GUI apps launched via `open -a` (or directly by launchd on macOS) inherit
-// a stripped PATH that usually drops user bin dirs like `~/Library/pnpm`,
-// `~/.nvm/versions/node/*/bin`, `~/.local/bin`, etc. The bridge plugin
-// works around this with its own `getClaudeCliProbePath()` — we mirror
-// that here and additionally glob the nvm versions dir, since nvm can't
-// be expressed as a single PATH entry. Without this, `claude auth status`
-// appears "missing" to the embedded Next.js server even though the user's
-// terminal can run it just fine, which makes the "API key needed" onboarding
-// card falsely appear.
-function buildClaudeSearchPath(): string {
+/**
+ * Desktop apps do not inherit the user's interactive shell PATH. Include the
+ * common package-manager locations used by both supported runtimes.
+ */
+function buildCliSearchPath(): string {
   const home = homedir();
   const dirs: string[] = [process.env.PATH || ""];
 
@@ -111,115 +157,166 @@ function buildClaudeSearchPath(): string {
   return Array.from(new Set(dirs.filter(Boolean))).join(delimiter);
 }
 
-// nvm bins aren't on PATH under launchd and can't be added as a single
-// entry, so we glob `~/.nvm/versions/node/*/bin/claude` and return the
-// newest version's binary. Empty list means no nvm-managed claude (or
-// no nvm at all).
-function listNvmClaudeBinaries(): string[] {
+function listNvmBinaries(binary: string): string[] {
   try {
     const nvmBase = join(homedir(), ".nvm", "versions", "node");
     if (!existsSync(nvmBase)) return [];
     return readdirSync(nvmBase)
       .sort()
-      .reverse() // newest version first
-      .map((version) => join(nvmBase, version, "bin", "claude"))
+      .reverse()
+      .map((version) => join(nvmBase, version, "bin", binary))
       .filter((candidate) => existsSync(candidate));
   } catch {
     return [];
   }
 }
 
-function resolveClaudeCliPath(): {
-  path: string | null;
-  source: "PATH" | "CLAUDE_CODE_PATH" | "FALLBACK" | null;
-} {
-  const explicit = process.env.CLAUDE_CODE_PATH;
-  if (explicit && existsSync(explicit)) {
-    return { path: explicit, source: "CLAUDE_CODE_PATH" };
+/** Current desktop bundles include a platform-native Claude executable. */
+function resolveBundledClaudePath(): string | null {
+  const executableDirectory = dirname(process.execPath);
+  const bundleDirectories = [
+    join(process.cwd(), "apps", "web", "cli-bundle"),
+    join(process.cwd(), "cli-bundle"),
+    join(process.cwd(), "..", "web", "cli-bundle"),
+    join(executableDirectory, "cli-bundle"),
+    join(executableDirectory, "..", "Resources", "cli-bundle"),
+    join(
+      executableDirectory,
+      "..",
+      "Resources",
+      "_up_",
+      "src-api",
+      "dist",
+      "cli-bundle",
+    ),
+    join(executableDirectory, "_up_", "src-api", "dist", "cli-bundle"),
+  ];
+  const executable = platform() === "win32" ? "claude.exe" : "claude";
+
+  for (const directory of bundleDirectories) {
+    const candidate = join(directory, executable);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function isBareCommand(command: string): boolean {
+  const parsed = parse(command);
+  return parsed.dir.length === 0 && parsed.base === command;
+}
+
+function resolveCliPath(
+  definition: RuntimeDefinition<"claude" | "codex", string>,
+): { path: string | null; source: CliPathSource; searchPath: string } {
+  const searchPath = buildCliSearchPath();
+
+  if (definition.provider === "claude") {
+    const bundled = resolveBundledClaudePath();
+    if (bundled) {
+      return { path: bundled, source: "BUNDLED", searchPath };
+    }
   }
 
-  // 1. Standard PATH walk, augmented with the common install dirs above.
-  const pathEnv = buildClaudeSearchPath();
-  const pathDirs = pathEnv.split(delimiter).filter(Boolean);
-  for (const bin of candidateBinaries()) {
-    for (const dir of pathDirs) {
-      const candidate = join(dir, bin);
+  const explicit = definition.explicitCommand?.trim();
+  if (explicit) {
+    if (existsSync(explicit) || isBareCommand(explicit)) {
+      return {
+        path: explicit,
+        source: definition.explicitSource,
+        searchPath,
+      };
+    }
+  }
+
+  const pathDirectories = searchPath
+    .split(delimiter)
+    .map((directory) => directory.replace(/^"|"$/g, ""))
+    .filter(Boolean);
+  for (const binary of candidateBinaries(definition.binary)) {
+    for (const directory of pathDirectories) {
+      const candidate = join(directory, binary);
       if (existsSync(candidate)) {
-        return { path: candidate, source: "PATH" };
+        return { path: candidate, source: "PATH", searchPath };
       }
     }
   }
 
-  // 2. nvm version glob — covers installs under `~/.nvm/versions/node/*`.
-  const nvmBins = listNvmClaudeBinaries();
-  if (nvmBins.length > 0) {
-    return { path: nvmBins[0], source: "FALLBACK" };
+  const [fallback] = listNvmBinaries(definition.binary);
+  if (fallback) {
+    return { path: fallback, source: "FALLBACK", searchPath };
   }
 
-  return { path: null, source: null };
+  return { path: null, source: null, searchPath };
 }
 
 function runCli(
   command: string,
   args: readonly string[],
   timeoutMs: number,
+  searchPath: string,
 ): Promise<ProbeResult> {
   const startedAt = Date.now();
   return new Promise((resolve) => {
-    let timedOut = false;
+    let stdout = "";
+    let stderr = "";
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const settle = (result: ProbeResult) => {
       if (settled) return;
       settled = true;
-      if (timer) {
-        clearTimeout(timer);
-      }
+      if (timer) clearTimeout(timer);
       resolve(result);
     };
 
-    let proc: ChildProcess;
+    let processHandle: ChildProcess;
     try {
-      proc = spawn(command, [...args], {
+      processHandle = spawn(command, [...args], {
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, CLAUDECODE: "" },
+        detached: shouldDetachCliProcess(),
+        env: { ...process.env, PATH: searchPath, CLAUDECODE: "" },
         windowsHide: true,
       });
     } catch (error) {
       settle({
         ok: false,
-        stdout: "",
-        stderr: "",
+        stdout,
+        stderr,
         exitCode: null,
         error: {
           code: "SPAWN_FAILED",
           message: error instanceof Error ? error.message : String(error),
         },
-        elapsedMs: 0,
+        elapsedMs: Date.now() - startedAt,
         timedOut: false,
       });
       return;
     }
 
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    proc.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
-    proc.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    processHandle.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout = appendCapturedCliOutput(stdout, chunk.toString());
+    });
+    processHandle.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr = appendCapturedCliOutput(stderr, chunk.toString());
+    });
 
     timer = setTimeout(() => {
-      timedOut = true;
-      try {
-        proc.kill("SIGKILL");
-      } catch {
-        // already dead
-      }
-    }, timeoutMs);
-
-    proc.on("error", (error) => {
+      terminateCliProcessTree(processHandle);
       settle({
         ok: false,
-        stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
-        stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+        stdout,
+        stderr,
+        exitCode: processHandle.exitCode,
+        error: null,
+        elapsedMs: Date.now() - startedAt,
+        timedOut: true,
+      });
+    }, timeoutMs);
+
+    processHandle.once("error", (error) => {
+      settle({
+        ok: false,
+        stdout,
+        stderr,
         exitCode: null,
         error: { code: "SPAWN_FAILED", message: error.message },
         elapsedMs: Date.now() - startedAt,
@@ -227,135 +324,231 @@ function runCli(
       });
     });
 
-    proc.on("close", (code) => {
+    processHandle.once("close", (code) => {
       settle({
-        ok: code === 0 && !timedOut,
-        stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
-        stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+        ok: code === 0,
+        stdout,
+        stderr,
         exitCode: code,
         error: null,
         elapsedMs: Date.now() - startedAt,
-        timedOut,
+        timedOut: false,
       });
     });
   });
 }
 
-function classifyAuthFailure(result: ProbeResult): NativeRuntimeStatus {
-  if (result.timedOut) return "CLAUDE_CLI_AUTH_STATUS_TIMEOUT";
-  const combined = `${result.stdout}\n${result.stderr}`.toLowerCase();
-  if (
-    combined.includes("not authenticated") ||
-    combined.includes("not logged") ||
-    combined.includes("not signed") ||
-    combined.includes("please login") ||
-    combined.includes("/login")
-  ) {
-    return "CLAUDE_CLI_AUTH_REQUIRED";
-  }
-  if (
-    combined.includes("unknown command") ||
-    combined.includes("invalid command")
-  ) {
-    return "CLAUDE_CLI_AUTH_STATUS_UNAVAILABLE";
-  }
-  return "CLAUDE_CLI_AUTH_REQUIRED";
+function cleanVersion(result: ProbeResult): string | null {
+  const line = `${result.stdout}\n${result.stderr}`
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find(Boolean);
+  if (!line) return null;
+  // Only publish the semantic version token. A CLI can print warnings,
+  // usernames, or local paths around it; those details stay server-side.
+  return (
+    line.match(/\bv?\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?\b/)?.[0] ?? null
+  );
 }
 
-export async function probeNativeClaudeRuntime(): Promise<NativeRuntimeProbe | null> {
-  if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
-    return cache.value;
-  }
+function isAuthCommandUnavailable(result: ProbeResult): boolean {
+  const combined = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  return (
+    combined.includes("unknown command") ||
+    combined.includes("unrecognized subcommand") ||
+    combined.includes("invalid command")
+  );
+}
 
-  const resolved = resolveClaudeCliPath();
+async function probeCliRuntime<
+  Provider extends "claude" | "codex",
+  Status extends string,
+>(definition: RuntimeDefinition<Provider, Status>) {
+  const resolved = resolveCliPath(
+    definition as RuntimeDefinition<"claude" | "codex", string>,
+  );
+  const base = { checked: true as const, provider: definition.provider };
+
   if (!resolved.path) {
-    const probe: NativeRuntimeProbe = {
-      checked: true,
+    return {
+      ...base,
       available: false,
       authenticated: false,
       active: false,
       ready: false,
-      reason: "CLAUDE_CLI_UNAVAILABLE",
-      defaultAgent: "claude",
+      reason: definition.status.unavailable,
       cliPathPresent: false,
       cliPathSource: null,
       versionPresent: false,
+      version: null,
       probes: {},
     };
-    cache = { at: Date.now(), value: probe };
-    return probe;
   }
 
   const versionProbe = await runCli(
     resolved.path,
     ["--version"],
     PROBE_TIMEOUT_MS,
+    resolved.searchPath,
   );
   if (!versionProbe.ok) {
-    const probe: NativeRuntimeProbe = {
-      checked: true,
+    const result = {
+      ...base,
       available: true,
       authenticated: false,
       active: false,
       ready: false,
       reason: versionProbe.timedOut
-        ? "CLAUDE_CLI_VERSION_TIMEOUT"
-        : "CLAUDE_CLI_VERSION_FAILED",
-      defaultAgent: "claude",
+        ? definition.status.versionTimeout
+        : definition.status.versionFailed,
       cliPathPresent: true,
       cliPathSource: resolved.source,
       versionPresent: false,
+      version: null,
       probes: { version: versionProbe },
     };
     logger.warn(
-      `[NativeClaudeRuntime] version probe failed: ${probe.reason} (${resolved.path})`,
+      `[NativeAgentRuntime] ${definition.provider} version probe failed: ${result.reason}`,
     );
-    cache = { at: Date.now(), value: probe };
-    return probe;
+    return result;
   }
 
   const authProbe = await runCli(
     resolved.path,
-    ["auth", "status"],
+    definition.authArgs,
     PROBE_TIMEOUT_MS,
+    resolved.searchPath,
   );
-
   if (!authProbe.ok) {
-    const reason = classifyAuthFailure(authProbe);
-    const probe: NativeRuntimeProbe = {
-      checked: true,
+    const reason = authProbe.timedOut
+      ? definition.status.authTimeout
+      : isAuthCommandUnavailable(authProbe)
+        ? definition.status.authUnavailable
+        : definition.status.authRequired;
+    return {
+      ...base,
       available: true,
       authenticated: false,
       active: false,
       ready: false,
       reason,
-      defaultAgent: "claude",
       cliPathPresent: true,
       cliPathSource: resolved.source,
       versionPresent: true,
+      version: cleanVersion(versionProbe),
       probes: { version: versionProbe, auth: authProbe },
     };
-    cache = { at: Date.now(), value: probe };
-    return probe;
   }
 
-  const probe: NativeRuntimeProbe = {
-    checked: true,
+  return {
+    ...base,
     available: true,
     authenticated: true,
     active: true,
     ready: true,
-    reason: "CLAUDE_CLI_AUTHENTICATED",
-    defaultAgent: "claude",
+    reason: definition.status.ready,
     cliPathPresent: true,
     cliPathSource: resolved.source,
     versionPresent: true,
+    version: cleanVersion(versionProbe),
     probes: { version: versionProbe, auth: authProbe },
   };
-  cache = { at: Date.now(), value: probe };
-  return probe;
+}
+
+export async function probeNativeClaudeRuntime(
+  options: { force?: boolean } = {},
+): Promise<NativeRuntimeProbe | null> {
+  if (
+    !options.force &&
+    claudeCache &&
+    Date.now() - claudeCache.at < CACHE_TTL_MS
+  ) {
+    return claudeCache.value;
+  }
+  if (claudeInFlight) return claudeInFlight;
+
+  const operation = probeCliRuntime({
+    provider: "claude",
+    binary: "claude",
+    explicitCommand: process.env.CLAUDE_CODE_PATH,
+    explicitSource: "CLAUDE_CODE_PATH",
+    authArgs: ["auth", "status"],
+    status: {
+      ready: "CLAUDE_CLI_AUTHENTICATED",
+      authRequired: "CLAUDE_CLI_AUTH_REQUIRED",
+      authTimeout: "CLAUDE_CLI_AUTH_STATUS_TIMEOUT",
+      authUnavailable: "CLAUDE_CLI_AUTH_STATUS_UNAVAILABLE",
+      versionFailed: "CLAUDE_CLI_VERSION_FAILED",
+      versionTimeout: "CLAUDE_CLI_VERSION_TIMEOUT",
+      unavailable: "CLAUDE_CLI_UNAVAILABLE",
+    },
+  }).then((result) => {
+    const probe: NativeRuntimeProbe = { ...result, defaultAgent: "claude" };
+    claudeCache = { at: Date.now(), value: probe };
+    return probe;
+  });
+  claudeInFlight = operation;
+  try {
+    return await operation;
+  } finally {
+    if (claudeInFlight === operation) claudeInFlight = null;
+  }
+}
+
+export async function probeNativeCodexRuntime(
+  options: { force?: boolean } = {},
+): Promise<CodexRuntimeProbe | null> {
+  if (
+    !options.force &&
+    codexCache &&
+    Date.now() - codexCache.at < CACHE_TTL_MS
+  ) {
+    return codexCache.value;
+  }
+  if (codexInFlight) return codexInFlight;
+
+  const operation = probeCliRuntime({
+    provider: "codex",
+    binary: "codex",
+    explicitCommand: process.env.OPENLOOMI_AGENT_CODEX_COMMAND,
+    explicitSource: "OPENLOOMI_AGENT_CODEX_COMMAND",
+    authArgs: ["login", "status"],
+    status: {
+      ready: "CODEX_CLI_AUTHENTICATED",
+      authRequired: "CODEX_CLI_AUTH_REQUIRED",
+      authTimeout: "CODEX_CLI_AUTH_STATUS_TIMEOUT",
+      authUnavailable: "CODEX_CLI_AUTH_STATUS_UNAVAILABLE",
+      versionFailed: "CODEX_CLI_VERSION_FAILED",
+      versionTimeout: "CODEX_CLI_VERSION_TIMEOUT",
+      unavailable: "CODEX_CLI_UNAVAILABLE",
+    },
+  }).then((result) => {
+    codexCache = { at: Date.now(), value: result };
+    return result;
+  });
+  codexInFlight = operation;
+  try {
+    return await operation;
+  } finally {
+    if (codexInFlight === operation) codexInFlight = null;
+  }
 }
 
 export function clearNativeClaudeRuntimeCache(): void {
-  cache = null;
+  claudeCache = null;
+}
+
+export function clearNativeCodexRuntimeCache(): void {
+  codexCache = null;
+}
+
+export function clearNativeRuntimeCaches(): void {
+  clearNativeClaudeRuntimeCache();
+  clearNativeCodexRuntimeCache();
+}
+
+export function getRuntimePlatform(): "windows" | "macos" | "linux" {
+  if (platform() === "win32") return "windows";
+  if (platform() === "darwin") return "macos";
+  return "linux";
 }

--- a/apps/web/lib/ai/native-agent/runtime-settings.ts
+++ b/apps/web/lib/ai/native-agent/runtime-settings.ts
@@ -90,21 +90,10 @@ export function toPublicProbe(
     };
   }
 
-  if (probe.ready && probe.authenticated) {
-    return {
-      provider,
-      installed: true,
-      authenticated: true,
-      ready: true,
-      readyVia: "cli",
-      status: "ready",
-      version: probe.version,
-      reason: "READY",
-    };
-  }
-
-  // Claude still needs an installed CLI, but a complete saved Anthropic-
-  // compatible configuration is a valid alternative to `claude auth login`.
+  // Claude Agent SDK needs its runtime executable, which packaged desktop
+  // builds bundle with OpenLoomi. A complete saved Anthropic-compatible
+  // configuration overrides existing Claude authentication during execution,
+  // so report it first when both credential sources exist.
   if (
     provider === "claude" &&
     options.claudeApiConfigured &&
@@ -116,6 +105,19 @@ export function toPublicProbe(
       authenticated: probe.authenticated,
       ready: true,
       readyVia: "api",
+      status: "ready",
+      version: probe.version,
+      reason: "READY",
+    };
+  }
+
+  if (probe.ready && probe.authenticated) {
+    return {
+      provider,
+      installed: true,
+      authenticated: true,
+      ready: true,
+      readyVia: "cli",
       status: "ready",
       version: probe.version,
       reason: "READY",

--- a/apps/web/lib/ai/native-agent/runtime-settings.ts
+++ b/apps/web/lib/ai/native-agent/runtime-settings.ts
@@ -1,0 +1,146 @@
+import { isTauriMode } from "@/lib/env/constants";
+import { getConfiguredAgentProviderResolution } from "./provider-env";
+import type {
+  AgentRuntimePublicProbe,
+  AgentRuntimeSettingsResponse,
+  SelectableAgentRuntime,
+} from "./runtime-contract";
+import {
+  type CodexRuntimeProbe,
+  getRuntimePlatform,
+  type NativeRuntimeProbe,
+  probeNativeClaudeRuntime,
+  probeNativeCodexRuntime,
+} from "./runtime-probe";
+
+type RuntimeProbe = NativeRuntimeProbe | CodexRuntimeProbe;
+
+export async function getAgentRuntimeSettings(
+  options: {
+    forceRefresh?: boolean;
+  } = {},
+): Promise<AgentRuntimeSettingsResponse> {
+  const resolution = getConfiguredAgentProviderResolution();
+
+  if (!isTauriMode()) {
+    return {
+      editable: false,
+      preference: null,
+      effective: {
+        provider: resolution.provider,
+        source: resolution.source,
+      },
+      platform: getRuntimePlatform(),
+      runtimes: null,
+    };
+  }
+
+  const [claude, codex] = await Promise.all([
+    safelyProbe("claude", options.forceRefresh),
+    safelyProbe("codex", options.forceRefresh),
+  ]);
+
+  return {
+    editable: true,
+    preference: resolution.preference ?? null,
+    effective: {
+      provider: resolution.provider,
+      source: resolution.source,
+    },
+    platform: getRuntimePlatform(),
+    runtimes: { claude, codex },
+  };
+}
+
+async function safelyProbe(
+  provider: SelectableAgentRuntime,
+  forceRefresh = false,
+): Promise<AgentRuntimePublicProbe> {
+  try {
+    const probe =
+      provider === "claude"
+        ? await probeNativeClaudeRuntime({ force: forceRefresh })
+        : await probeNativeCodexRuntime({ force: forceRefresh });
+    return toPublicProbe(provider, probe);
+  } catch (error) {
+    console.warn(`[AgentRuntimeSettings] ${provider} probe failed`, error);
+    return unverifiedProbe(provider);
+  }
+}
+
+export function toPublicProbe(
+  provider: SelectableAgentRuntime,
+  probe: RuntimeProbe | null,
+): AgentRuntimePublicProbe {
+  if (!probe) return unverifiedProbe(provider);
+
+  if (!probe.available) {
+    return {
+      provider,
+      installed: false,
+      authenticated: null,
+      ready: false,
+      status: "not_installed",
+      version: null,
+      reason: "CLI_UNAVAILABLE",
+    };
+  }
+
+  if (probe.ready && probe.authenticated) {
+    return {
+      provider,
+      installed: true,
+      authenticated: true,
+      ready: true,
+      status: "ready",
+      version: probe.version,
+      reason: "READY",
+    };
+  }
+
+  if (probe.reason.endsWith("_AUTH_REQUIRED")) {
+    return {
+      provider,
+      installed: true,
+      authenticated: false,
+      ready: false,
+      status: "login_required",
+      version: probe.version,
+      reason: "AUTH_REQUIRED",
+    };
+  }
+
+  const reason = probe.reason.endsWith("_VERSION_TIMEOUT")
+    ? "VERSION_TIMEOUT"
+    : probe.reason.endsWith("_VERSION_FAILED")
+      ? "VERSION_FAILED"
+      : probe.reason.endsWith("_AUTH_STATUS_TIMEOUT")
+        ? "AUTH_TIMEOUT"
+        : probe.reason.endsWith("_AUTH_STATUS_UNAVAILABLE")
+          ? "AUTH_UNAVAILABLE"
+          : "PROBE_FAILED";
+
+  return {
+    provider,
+    installed: true,
+    authenticated: null,
+    ready: false,
+    status: "unverified",
+    version: probe.version,
+    reason,
+  };
+}
+
+function unverifiedProbe(
+  provider: SelectableAgentRuntime,
+): AgentRuntimePublicProbe {
+  return {
+    provider,
+    installed: false,
+    authenticated: null,
+    ready: false,
+    status: "unverified",
+    version: null,
+    reason: "PROBE_FAILED",
+  };
+}

--- a/apps/web/lib/ai/native-agent/runtime-settings.ts
+++ b/apps/web/lib/ai/native-agent/runtime-settings.ts
@@ -7,8 +7,8 @@ import type {
 } from "./runtime-contract";
 import {
   type CodexRuntimeProbe,
-  getRuntimePlatform,
   type NativeRuntimeProbe,
+  getRuntimePlatform,
   probeNativeClaudeRuntime,
   probeNativeCodexRuntime,
 } from "./runtime-probe";
@@ -18,6 +18,7 @@ type RuntimeProbe = NativeRuntimeProbe | CodexRuntimeProbe;
 export async function getAgentRuntimeSettings(
   options: {
     forceRefresh?: boolean;
+    claudeApiConfigured?: boolean;
   } = {},
 ): Promise<AgentRuntimeSettingsResponse> {
   const resolution = getConfiguredAgentProviderResolution();
@@ -36,7 +37,7 @@ export async function getAgentRuntimeSettings(
   }
 
   const [claude, codex] = await Promise.all([
-    safelyProbe("claude", options.forceRefresh),
+    safelyProbe("claude", options.forceRefresh, options.claudeApiConfigured),
     safelyProbe("codex", options.forceRefresh),
   ]);
 
@@ -55,13 +56,14 @@ export async function getAgentRuntimeSettings(
 async function safelyProbe(
   provider: SelectableAgentRuntime,
   forceRefresh = false,
+  claudeApiConfigured = false,
 ): Promise<AgentRuntimePublicProbe> {
   try {
     const probe =
       provider === "claude"
         ? await probeNativeClaudeRuntime({ force: forceRefresh })
         : await probeNativeCodexRuntime({ force: forceRefresh });
-    return toPublicProbe(provider, probe);
+    return toPublicProbe(provider, probe, { claudeApiConfigured });
   } catch (error) {
     console.warn(`[AgentRuntimeSettings] ${provider} probe failed`, error);
     return unverifiedProbe(provider);
@@ -71,6 +73,7 @@ async function safelyProbe(
 export function toPublicProbe(
   provider: SelectableAgentRuntime,
   probe: RuntimeProbe | null,
+  options: { claudeApiConfigured?: boolean } = {},
 ): AgentRuntimePublicProbe {
   if (!probe) return unverifiedProbe(provider);
 
@@ -80,6 +83,7 @@ export function toPublicProbe(
       installed: false,
       authenticated: null,
       ready: false,
+      readyVia: null,
       status: "not_installed",
       version: null,
       reason: "CLI_UNAVAILABLE",
@@ -92,6 +96,26 @@ export function toPublicProbe(
       installed: true,
       authenticated: true,
       ready: true,
+      readyVia: "cli",
+      status: "ready",
+      version: probe.version,
+      reason: "READY",
+    };
+  }
+
+  // Claude still needs an installed CLI, but a complete saved Anthropic-
+  // compatible configuration is a valid alternative to `claude auth login`.
+  if (
+    provider === "claude" &&
+    options.claudeApiConfigured &&
+    probe.versionPresent
+  ) {
+    return {
+      provider,
+      installed: true,
+      authenticated: probe.authenticated,
+      ready: true,
+      readyVia: "api",
       status: "ready",
       version: probe.version,
       reason: "READY",
@@ -104,6 +128,7 @@ export function toPublicProbe(
       installed: true,
       authenticated: false,
       ready: false,
+      readyVia: null,
       status: "login_required",
       version: probe.version,
       reason: "AUTH_REQUIRED",
@@ -125,6 +150,7 @@ export function toPublicProbe(
     installed: true,
     authenticated: null,
     ready: false,
+    readyVia: null,
     status: "unverified",
     version: probe.version,
     reason,
@@ -139,6 +165,7 @@ function unverifiedProbe(
     installed: false,
     authenticated: null,
     ready: false,
+    readyVia: null,
     status: "unverified",
     version: null,
     reason: "PROBE_FAILED",

--- a/apps/web/lib/ai/notify-ai-settings-changed.ts
+++ b/apps/web/lib/ai/notify-ai-settings-changed.ts
@@ -1,0 +1,14 @@
+import { AI_SETTINGS_CHANGED_EVENT } from "./conversation-api-configuration";
+
+/** Notify listeners in this webview and the other Tauri webviews. */
+export function notifyAiSettingsChanged(): void {
+  if (typeof window === "undefined") return;
+
+  window.dispatchEvent(new Event(AI_SETTINGS_CHANGED_EVENT));
+  const tauriEvent = (
+    window as unknown as {
+      __TAURI__?: { event?: { emit?: (name: string) => unknown } };
+    }
+  ).__TAURI__;
+  tauriEvent?.event?.emit?.(AI_SETTINGS_CHANGED_EVENT);
+}

--- a/apps/web/tests/api/agent-runtime-preferences.route.test.ts
+++ b/apps/web/tests/api/agent-runtime-preferences.route.test.ts
@@ -18,12 +18,15 @@ const runtimeState = vi.hoisted(() => ({
     },
   },
   get: vi.fn(),
+  read: vi.fn(),
   write: vi.fn(),
+  clear: vi.fn(),
 }));
 const llmSettingsState = vi.hoisted(() => ({
   config: undefined as
     | { apiKey: string; baseUrl: string; model: string }
     | undefined,
+  get: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/dual-auth", () => ({
@@ -39,14 +42,16 @@ vi.mock("@/lib/ai/native-agent/runtime-settings", () => ({
 }));
 
 vi.mock("@/lib/ai/native-agent/runtime-preference", () => ({
+  clearAgentRuntimePreference: runtimeState.clear,
+  readAgentRuntimePreference: runtimeState.read,
   writeAgentRuntimePreference: runtimeState.write,
 }));
 
 vi.mock("@/lib/ai/user-llm-api-settings", () => ({
-  getUserLlmProviderConfig: vi.fn(async () => llmSettingsState.config),
+  getUserLlmProviderConfig: llmSettingsState.get,
 }));
 
-const { GET, PUT } =
+const { DELETE, GET, PUT } =
   await import("@/app/(chat)/api/preferences/agent-runtime/route");
 
 function request(method = "GET", body?: unknown, query = "") {
@@ -63,8 +68,13 @@ beforeEach(() => {
   modeState.tauri = true;
   runtimeState.get.mockReset();
   runtimeState.get.mockResolvedValue(runtimeState.response);
+  runtimeState.read.mockReset();
+  runtimeState.read.mockReturnValue(undefined);
   runtimeState.write.mockReset();
+  runtimeState.clear.mockReset();
   llmSettingsState.config = undefined;
+  llmSettingsState.get.mockReset();
+  llmSettingsState.get.mockImplementation(async () => llmSettingsState.config);
 });
 
 describe("agent runtime preferences route", () => {
@@ -109,14 +119,85 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.write).not.toHaveBeenCalled();
   });
 
-  test("persists the choice before returning the resolved state", async () => {
+  test("persists the choice and returns the selected effective state", async () => {
+    const savedResponse = {
+      ...runtimeState.response,
+      preference: "codex",
+      effective: { provider: "codex", source: "preference" },
+    };
     const response = await PUT(request("PUT", { provider: "codex" }));
 
     expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(savedResponse);
     expect(runtimeState.write).toHaveBeenCalledWith("codex");
-    expect(runtimeState.write.mock.invocationCallOrder[0]).toBeLessThan(
-      runtimeState.get.mock.invocationCallOrder[1],
-    );
+    expect(runtimeState.get).toHaveBeenCalledOnce();
+  });
+
+  test("rechecks Claude API readiness when configuration changes during the probe", async () => {
+    const configured = {
+      apiKey: "decrypted-key",
+      baseUrl: "https://api.example.test",
+      model: "claude-test",
+    };
+    llmSettingsState.get
+      .mockResolvedValueOnce(configured)
+      .mockResolvedValueOnce(undefined);
+    runtimeState.get
+      .mockResolvedValueOnce(runtimeState.response)
+      .mockResolvedValueOnce({
+        ...runtimeState.response,
+        runtimes: {
+          claude: { ready: false },
+          codex: { ready: true },
+        },
+      });
+
+    const response = await PUT(request("PUT", { provider: "claude" }));
+
+    expect(response.status).toBe(409);
+    expect(runtimeState.get).toHaveBeenNthCalledWith(2, {
+      claudeApiConfigured: false,
+    });
+    expect(runtimeState.write).not.toHaveBeenCalled();
+  });
+
+  test("clears the desktop preference and returns environment/default state", async () => {
+    const restoredResponse = {
+      ...runtimeState.response,
+      preference: null,
+      effective: { provider: "opencode", source: "environment" },
+    };
+    runtimeState.get.mockResolvedValueOnce(restoredResponse);
+
+    const response = await DELETE(request("DELETE"));
+
+    expect(response.status).toBe(200);
+    expect(runtimeState.clear).toHaveBeenCalledOnce();
+    expect(runtimeState.get).toHaveBeenCalledWith({
+      forceRefresh: true,
+      claudeApiConfigured: false,
+    });
+    expect(await response.json()).toEqual(restoredResponse);
+  });
+
+  test("rejects clearing the desktop preference outside the desktop app", async () => {
+    modeState.tauri = false;
+
+    const response = await DELETE(request("DELETE"));
+
+    expect(response.status).toBe(403);
+    expect(runtimeState.clear).not.toHaveBeenCalled();
+  });
+
+  test("restores the previous preference when reset state cannot be loaded", async () => {
+    runtimeState.read.mockReturnValue("codex");
+    runtimeState.get.mockRejectedValueOnce(new Error("invalid environment"));
+
+    const response = await DELETE(request("DELETE"));
+
+    expect(response.status).toBe(500);
+    expect(runtimeState.clear).toHaveBeenCalledOnce();
+    expect(runtimeState.write).toHaveBeenCalledWith("codex");
   });
 
   test("passes a complete saved Claude API configuration into readiness", async () => {

--- a/apps/web/tests/api/agent-runtime-preferences.route.test.ts
+++ b/apps/web/tests/api/agent-runtime-preferences.route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  user: { id: "user-1" } as object | null,
+}));
+const modeState = vi.hoisted(() => ({ tauri: true }));
+const runtimeState = vi.hoisted(() => ({
+  response: {
+    editable: true,
+    preference: null,
+    effective: { provider: "claude", source: "default" },
+    platform: "windows",
+    runtimes: null,
+  },
+  get: vi.fn(),
+  write: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/dual-auth", () => ({
+  getAuthUser: vi.fn(async () => authState.user),
+}));
+
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: vi.fn(() => modeState.tauri),
+}));
+
+vi.mock("@/lib/ai/native-agent/runtime-settings", () => ({
+  getAgentRuntimeSettings: runtimeState.get,
+}));
+
+vi.mock("@/lib/ai/native-agent/runtime-preference", () => ({
+  writeAgentRuntimePreference: runtimeState.write,
+}));
+
+const { GET, PUT } =
+  await import("@/app/(chat)/api/preferences/agent-runtime/route");
+
+function request(method = "GET", body?: unknown, query = "") {
+  return new Request(`http://localhost/api/preferences/agent-runtime${query}`, {
+    method,
+    headers:
+      body === undefined ? undefined : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  authState.user = { id: "user-1" };
+  modeState.tauri = true;
+  runtimeState.get.mockReset();
+  runtimeState.get.mockResolvedValue(runtimeState.response);
+  runtimeState.write.mockReset();
+});
+
+describe("agent runtime preferences route", () => {
+  test("requires authentication before reading device runtime state", async () => {
+    authState.user = null;
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+    expect(runtimeState.get).not.toHaveBeenCalled();
+  });
+
+  test("loads a safe no-store state and supports an explicit refresh", async () => {
+    const response = await GET(request("GET", undefined, "?refresh=1"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(runtimeState.get).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(await response.json()).toEqual(runtimeState.response);
+  });
+
+  test("rejects runtime writes outside the desktop app", async () => {
+    modeState.tauri = false;
+
+    const response = await PUT(request("PUT", { provider: "codex" }));
+
+    expect(response.status).toBe(403);
+    expect(runtimeState.write).not.toHaveBeenCalled();
+  });
+
+  test("strictly accepts only Claude or Codex", async () => {
+    const unsupported = await PUT(request("PUT", { provider: "opencode" }));
+    const extraField = await PUT(
+      request("PUT", { provider: "codex", command: "custom" }),
+    );
+
+    expect(unsupported.status).toBe(400);
+    expect(extraField.status).toBe(400);
+    expect(runtimeState.write).not.toHaveBeenCalled();
+  });
+
+  test("persists the choice before returning the resolved state", async () => {
+    const response = await PUT(request("PUT", { provider: "codex" }));
+
+    expect(response.status).toBe(200);
+    expect(runtimeState.write).toHaveBeenCalledWith("codex");
+    expect(runtimeState.write.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeState.get.mock.invocationCallOrder[0],
+    );
+  });
+
+  test("does not claim success when the atomic preference write fails", async () => {
+    runtimeState.write.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const response = await PUT(request("PUT", { provider: "claude" }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "runtime_preference_save_failed",
+    });
+    expect(runtimeState.get).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/api/agent-runtime-preferences.route.test.ts
+++ b/apps/web/tests/api/agent-runtime-preferences.route.test.ts
@@ -12,10 +12,18 @@ const runtimeState = vi.hoisted(() => ({
     preference: null,
     effective: { provider: "claude", source: "default" },
     platform: "windows",
-    runtimes: null,
+    runtimes: {
+      claude: { ready: true },
+      codex: { ready: true },
+    },
   },
   get: vi.fn(),
   write: vi.fn(),
+}));
+const llmSettingsState = vi.hoisted(() => ({
+  config: undefined as
+    | { apiKey: string; baseUrl: string; model: string }
+    | undefined,
 }));
 
 vi.mock("@/lib/auth/dual-auth", () => ({
@@ -32,6 +40,10 @@ vi.mock("@/lib/ai/native-agent/runtime-settings", () => ({
 
 vi.mock("@/lib/ai/native-agent/runtime-preference", () => ({
   writeAgentRuntimePreference: runtimeState.write,
+}));
+
+vi.mock("@/lib/ai/user-llm-api-settings", () => ({
+  getUserLlmProviderConfig: vi.fn(async () => llmSettingsState.config),
 }));
 
 const { GET, PUT } =
@@ -52,6 +64,7 @@ beforeEach(() => {
   runtimeState.get.mockReset();
   runtimeState.get.mockResolvedValue(runtimeState.response);
   runtimeState.write.mockReset();
+  llmSettingsState.config = undefined;
 });
 
 describe("agent runtime preferences route", () => {
@@ -69,7 +82,10 @@ describe("agent runtime preferences route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(runtimeState.get).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(runtimeState.get).toHaveBeenCalledWith({
+      forceRefresh: true,
+      claudeApiConfigured: false,
+    });
     expect(await response.json()).toEqual(runtimeState.response);
   });
 
@@ -99,8 +115,40 @@ describe("agent runtime preferences route", () => {
     expect(response.status).toBe(200);
     expect(runtimeState.write).toHaveBeenCalledWith("codex");
     expect(runtimeState.write.mock.invocationCallOrder[0]).toBeLessThan(
-      runtimeState.get.mock.invocationCallOrder[0],
+      runtimeState.get.mock.invocationCallOrder[1],
     );
+  });
+
+  test("passes a complete saved Claude API configuration into readiness", async () => {
+    llmSettingsState.config = {
+      apiKey: "decrypted-key",
+      baseUrl: "https://api.example.test",
+      model: "claude-test",
+    };
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(runtimeState.get).toHaveBeenCalledWith({
+      forceRefresh: false,
+      claudeApiConfigured: true,
+    });
+  });
+
+  test("does not persist a runtime that fails the server readiness check", async () => {
+    runtimeState.get.mockResolvedValueOnce({
+      ...runtimeState.response,
+      runtimes: {
+        claude: { ready: true },
+        codex: { ready: false },
+      },
+    });
+
+    const response = await PUT(request("PUT", { provider: "codex" }));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "runtime_not_ready" });
+    expect(runtimeState.write).not.toHaveBeenCalled();
   });
 
   test("does not claim success when the atomic preference write fails", async () => {
@@ -114,6 +162,6 @@ describe("agent runtime preferences route", () => {
     expect(await response.json()).toEqual({
       error: "runtime_preference_save_failed",
     });
-    expect(runtimeState.get).not.toHaveBeenCalled();
+    expect(runtimeState.get).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/agent-runtime-settings.test.ts
+++ b/apps/web/tests/unit/agent-runtime-settings.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "vitest";
 
 import {
-  canSaveAgentRuntime,
   type AgentRuntimeSettingsResponse,
+  canSaveAgentRuntime,
 } from "@/lib/ai/native-agent/runtime-contract";
-import { toPublicProbe } from "@/lib/ai/native-agent/runtime-settings";
 import type {
   CodexRuntimeProbe,
   NativeRuntimeProbe,
 } from "@/lib/ai/native-agent/runtime-probe";
+import { toPublicProbe } from "@/lib/ai/native-agent/runtime-settings";
 
 function codexProbe(overrides: Partial<CodexRuntimeProbe>): CodexRuntimeProbe {
   return {
@@ -56,6 +56,7 @@ describe("agent runtime public probe", () => {
       installed: true,
       authenticated: true,
       ready: true,
+      readyVia: "cli",
       status: "ready",
       version: "1.2.0",
       reason: "READY",
@@ -99,6 +100,7 @@ describe("agent runtime public probe", () => {
       installed: false,
       authenticated: null,
       ready: false,
+      readyVia: null,
       status: "unverified",
       version: null,
       reason: "PROBE_FAILED",
@@ -126,6 +128,35 @@ describe("agent runtime public probe", () => {
       status: "unverified",
       reason: "AUTH_UNAVAILABLE",
       version: "2.1.3",
+    });
+  });
+
+  test("accepts a complete saved API configuration instead of CLI login for Claude", () => {
+    const probe: NativeRuntimeProbe = {
+      checked: true,
+      provider: "claude",
+      defaultAgent: "claude",
+      available: true,
+      authenticated: false,
+      active: false,
+      ready: false,
+      reason: "CLAUDE_CLI_AUTH_REQUIRED",
+      cliPathPresent: true,
+      cliPathSource: "PATH",
+      versionPresent: true,
+      version: "2.1.3",
+      probes: {},
+    };
+
+    expect(
+      toPublicProbe("claude", probe, { claudeApiConfigured: true }),
+    ).toMatchObject({
+      installed: true,
+      authenticated: false,
+      ready: true,
+      readyVia: "api",
+      status: "ready",
+      reason: "READY",
     });
   });
 });

--- a/apps/web/tests/unit/agent-runtime-settings.test.ts
+++ b/apps/web/tests/unit/agent-runtime-settings.test.ts
@@ -131,7 +131,7 @@ describe("agent runtime public probe", () => {
     });
   });
 
-  test("accepts a complete saved API configuration instead of CLI login for Claude", () => {
+  test("accepts a complete saved API configuration for the bundled Claude runtime", () => {
     const probe: NativeRuntimeProbe = {
       checked: true,
       provider: "claude",
@@ -142,12 +142,18 @@ describe("agent runtime public probe", () => {
       ready: false,
       reason: "CLAUDE_CLI_AUTH_REQUIRED",
       cliPathPresent: true,
-      cliPathSource: "PATH",
+      cliPathSource: "BUNDLED",
       versionPresent: true,
       version: "2.1.3",
       probes: {},
     };
 
+    expect(toPublicProbe("claude", probe)).toMatchObject({
+      installed: true,
+      ready: false,
+      readyVia: null,
+      status: "login_required",
+    });
     expect(
       toPublicProbe("claude", probe, { claudeApiConfigured: true }),
     ).toMatchObject({
@@ -157,6 +163,33 @@ describe("agent runtime public probe", () => {
       readyVia: "api",
       status: "ready",
       reason: "READY",
+    });
+  });
+
+  test("reports the saved Claude API configuration when CLI auth is also available", () => {
+    const probe: NativeRuntimeProbe = {
+      checked: true,
+      provider: "claude",
+      defaultAgent: "claude",
+      available: true,
+      authenticated: true,
+      active: true,
+      ready: true,
+      reason: "CLAUDE_CLI_AUTHENTICATED",
+      cliPathPresent: true,
+      cliPathSource: "BUNDLED",
+      versionPresent: true,
+      version: "2.1.141",
+      probes: {},
+    };
+
+    expect(
+      toPublicProbe("claude", probe, { claudeApiConfigured: true }),
+    ).toMatchObject({
+      authenticated: true,
+      ready: true,
+      readyVia: "api",
+      status: "ready",
     });
   });
 });

--- a/apps/web/tests/unit/agent-runtime-settings.test.ts
+++ b/apps/web/tests/unit/agent-runtime-settings.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
 
+import {
+  canSaveAgentRuntime,
+  type AgentRuntimeSettingsResponse,
+} from "@/lib/ai/native-agent/runtime-contract";
 import { toPublicProbe } from "@/lib/ai/native-agent/runtime-settings";
 import type {
   CodexRuntimeProbe,
@@ -123,5 +127,34 @@ describe("agent runtime public probe", () => {
       reason: "AUTH_UNAVAILABLE",
       version: "2.1.3",
     });
+  });
+});
+
+describe("agent runtime selection", () => {
+  test("only enables a ready runtime that is not already active", () => {
+    const state: AgentRuntimeSettingsResponse = {
+      editable: true,
+      preference: "claude",
+      effective: { provider: "claude", source: "preference" },
+      platform: "windows",
+      runtimes: {
+        claude: toPublicProbe("claude", null),
+        codex: toPublicProbe(
+          "codex",
+          codexProbe({
+            authenticated: true,
+            active: true,
+            ready: true,
+            reason: "CODEX_CLI_AUTHENTICATED",
+          }),
+        ),
+      },
+    };
+
+    expect(canSaveAgentRuntime(state, "codex")).toBe(true);
+    expect(canSaveAgentRuntime(state, "claude")).toBe(false);
+    if (!state.runtimes) throw new Error("expected runtime probes");
+    state.runtimes.codex.ready = false;
+    expect(canSaveAgentRuntime(state, "codex")).toBe(false);
   });
 });

--- a/apps/web/tests/unit/agent-runtime-settings.test.ts
+++ b/apps/web/tests/unit/agent-runtime-settings.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+
+import { toPublicProbe } from "@/lib/ai/native-agent/runtime-settings";
+import type {
+  CodexRuntimeProbe,
+  NativeRuntimeProbe,
+} from "@/lib/ai/native-agent/runtime-probe";
+
+function codexProbe(overrides: Partial<CodexRuntimeProbe>): CodexRuntimeProbe {
+  return {
+    checked: true,
+    provider: "codex",
+    available: true,
+    authenticated: false,
+    active: false,
+    ready: false,
+    reason: "CODEX_CLI_AUTH_REQUIRED",
+    cliPathPresent: true,
+    cliPathSource: "PATH",
+    versionPresent: true,
+    version: "1.2.0",
+    probes: {},
+    ...overrides,
+  };
+}
+
+describe("agent runtime public probe", () => {
+  test("exposes a stable ready summary without command details", () => {
+    const result = toPublicProbe(
+      "codex",
+      codexProbe({
+        authenticated: true,
+        active: true,
+        ready: true,
+        reason: "CODEX_CLI_AUTHENTICATED",
+        probes: {
+          auth: {
+            ok: true,
+            stdout: "account@example.test",
+            stderr: "",
+            exitCode: 0,
+            error: null,
+            elapsedMs: 5,
+            timedOut: false,
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      provider: "codex",
+      installed: true,
+      authenticated: true,
+      ready: true,
+      status: "ready",
+      version: "1.2.0",
+      reason: "READY",
+    });
+    expect(JSON.stringify(result)).not.toContain("account@example.test");
+  });
+
+  test("separates missing, login-required, and failed probes", () => {
+    const unavailable = toPublicProbe(
+      "codex",
+      codexProbe({
+        available: false,
+        cliPathPresent: false,
+        cliPathSource: null,
+        versionPresent: false,
+        version: null,
+        reason: "CODEX_CLI_UNAVAILABLE",
+      }),
+    );
+    const loginRequired = toPublicProbe("codex", codexProbe({}));
+    const failed = toPublicProbe(
+      "codex",
+      codexProbe({
+        reason: "CODEX_CLI_VERSION_TIMEOUT",
+        versionPresent: false,
+        version: null,
+      }),
+    );
+
+    expect(unavailable.status).toBe("not_installed");
+    expect(unavailable.authenticated).toBeNull();
+    expect(loginRequired.status).toBe("login_required");
+    expect(loginRequired.authenticated).toBe(false);
+    expect(failed.status).toBe("unverified");
+    expect(failed.reason).toBe("VERSION_TIMEOUT");
+  });
+
+  test("treats a missing probe as unverified instead of not installed", () => {
+    expect(toPublicProbe("claude", null)).toEqual({
+      provider: "claude",
+      installed: false,
+      authenticated: null,
+      ready: false,
+      status: "unverified",
+      version: null,
+      reason: "PROBE_FAILED",
+    });
+  });
+
+  test("accepts the existing Claude compatibility probe shape", () => {
+    const probe: NativeRuntimeProbe = {
+      checked: true,
+      provider: "claude",
+      defaultAgent: "claude",
+      available: true,
+      authenticated: false,
+      active: false,
+      ready: false,
+      reason: "CLAUDE_CLI_AUTH_STATUS_UNAVAILABLE",
+      cliPathPresent: true,
+      cliPathSource: "BUNDLED",
+      versionPresent: true,
+      version: "2.1.3",
+      probes: {},
+    };
+
+    expect(toPublicProbe("claude", probe)).toMatchObject({
+      status: "unverified",
+      reason: "AUTH_UNAVAILABLE",
+      version: "2.1.3",
+    });
+  });
+});

--- a/apps/web/tests/unit/claude-process-spawner.test.ts
+++ b/apps/web/tests/unit/claude-process-spawner.test.ts
@@ -102,7 +102,7 @@ describe("createClaudeCodeProcessSpawner", () => {
       platform: "win32",
       command: "C:/app/cli-bundle/claude.cmd",
       expectedCommand: "node",
-      expectedArgumentPrefix: "C:/app/cli-bundle/cli.js",
+      expectedArgumentPrefix: "--max-old-space-size=8192",
       clearsChildMarker: true,
       killsWindowsTree: true,
     },
@@ -278,8 +278,32 @@ describe("createClaudeCodeProcessSpawner", () => {
     const [spawnedCommand, spawnedArguments] =
       childProcessMocks.spawn.mock.calls[0];
     expect(spawnedCommand).toBe("node");
-    expect(normalizePath(spawnedArguments[0])).toBe(
+    expect(normalizePath(spawnedArguments[1])).toBe(
       "D:/real-claude-bundle/cli.js",
     );
+  });
+
+  it("prefers the bundled Node executable for a Windows legacy bundle", () => {
+    operatingSystemMocks.platform.mockReturnValue("win32");
+    fileSystemMocks.existsSync.mockImplementation(
+      (path) => normalizePath(path) === "C:/app/cli-bundle/node.exe",
+    );
+    childProcessMocks.spawn.mockReturnValue(createFakeChildProcess());
+
+    createClaudeCodeProcessSpawner(vi.fn())({
+      command: "C:/app/cli-bundle/claude.cmd",
+      args: ["--version"],
+      env: {},
+      signal: new AbortController().signal,
+    });
+
+    const [spawnedCommand, spawnedArguments] =
+      childProcessMocks.spawn.mock.calls[0];
+    expect(normalizePath(spawnedCommand)).toBe("C:/app/cli-bundle/node.exe");
+    expect(spawnedArguments).toEqual([
+      "--max-old-space-size=8192",
+      join("C:/app/cli-bundle", "cli.js"),
+      "--version",
+    ]);
   });
 });

--- a/apps/web/tests/unit/cli-process.test.ts
+++ b/apps/web/tests/unit/cli-process.test.ts
@@ -1,16 +1,22 @@
-import { homedir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
   buildAgentCliSearchPath,
   buildCliEnvironment,
+  findCliExecutableOnSearchPath,
 } from "@/lib/ai/extensions/agent/cli-process";
 
 const originalEnv = process.env;
+const temporaryDirectories: string[] = [];
 
 afterEach(() => {
   process.env = originalEnv;
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 describe("CLI process environment", () => {
@@ -45,10 +51,38 @@ describe("CLI process environment", () => {
   });
 
   it("adds native installer locations to the shared desktop CLI path", () => {
-    const searchPath = buildAgentCliSearchPath("custom-bin").split(delimiter);
+    const windowsHome = "windows-home";
+    const localAppData = "windows-local-app-data";
+    const searchPath = buildAgentCliSearchPath("custom-bin", {
+      platform: "win32",
+      homeDirectory: windowsHome,
+      localAppData,
+    }).split(delimiter);
 
     expect(searchPath).toContain("custom-bin");
-    expect(searchPath).toContain(join(homedir(), ".local", "bin"));
+    expect(searchPath).toContain(join(windowsHome, ".local", "bin"));
+    expect(searchPath).toContain(
+      join(localAppData, "Programs", "OpenAI", "Codex", "bin"),
+    );
+  });
+
+  it("resolves PATH directories before executable extensions", () => {
+    const root = mkdtempSync(join(tmpdir(), "openloomi-cli-path-"));
+    temporaryDirectories.push(root);
+    const earlierDirectory = join(root, "earlier");
+    const laterDirectory = join(root, "later");
+    mkdirSync(earlierDirectory);
+    mkdirSync(laterDirectory);
+    const earlierCommand = join(earlierDirectory, "codex.cmd");
+    writeFileSync(earlierCommand, "");
+    writeFileSync(join(laterDirectory, "codex.exe"), "");
+
+    expect(
+      findCliExecutableOnSearchPath(
+        [earlierDirectory, laterDirectory].join(delimiter),
+        ["codex.exe", "codex.cmd", "codex"],
+      ),
+    ).toBe(earlierCommand);
   });
 
   it("supports an explicit server-controlled allowlist and trusted overrides", () => {

--- a/apps/web/tests/unit/cli-process.test.ts
+++ b/apps/web/tests/unit/cli-process.test.ts
@@ -1,6 +1,11 @@
+import { homedir } from "node:os";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildCliEnvironment } from "@/lib/ai/extensions/agent/cli-process";
+import {
+  buildAgentCliSearchPath,
+  buildCliEnvironment,
+} from "@/lib/ai/extensions/agent/cli-process";
 
 const originalEnv = process.env;
 
@@ -16,6 +21,9 @@ describe("CLI process environment", () => {
       DATABASE_URL: "postgres://secret",
       AUTH_SECRET: "auth-secret",
       OPENAI_API_KEY: "model-secret",
+      ANTHROPIC_AUTH_TOKEN: "claude-token",
+      CLAUDE_CONFIG_DIR: "/tmp/claude-config",
+      CLAUDE_UNRELATED_SECRET: "hidden-claude-secret",
       OPENCLAW_GATEWAY_TOKEN: "gateway-secret",
       CODEX_API_KEY: "codex-secret",
       CODEX_HOME: "/tmp/codex-home",
@@ -31,6 +39,16 @@ describe("CLI process environment", () => {
     });
     expect(buildCliEnvironment()).not.toHaveProperty("DATABASE_URL");
     expect(buildCliEnvironment()).not.toHaveProperty("AUTH_SECRET");
+    expect(buildCliEnvironment()).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+    expect(buildCliEnvironment()).not.toHaveProperty("CLAUDE_CONFIG_DIR");
+    expect(buildCliEnvironment()).not.toHaveProperty("CLAUDE_UNRELATED_SECRET");
+  });
+
+  it("adds native installer locations to the shared desktop CLI path", () => {
+    const searchPath = buildAgentCliSearchPath("custom-bin").split(delimiter);
+
+    expect(searchPath).toContain("custom-bin");
+    expect(searchPath).toContain(join(homedir(), ".local", "bin"));
   });
 
   it("supports an explicit server-controlled allowlist and trusted overrides", () => {

--- a/apps/web/tests/unit/native-agent-cli-bundle.test.ts
+++ b/apps/web/tests/unit/native-agent-cli-bundle.test.ts
@@ -84,6 +84,7 @@ describe("packaged native-agent CLI bundle", () => {
 
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,
+      HOME: workDir,
       NODE_OPTIONS: "--conditions=react-server",
       OPENLOOMI_AGENT_PROVIDER: "codex",
       OPENLOOMI_AGENT_CODEX_COMMAND: process.execPath,
@@ -93,6 +94,7 @@ describe("packaged native-agent CLI bundle", () => {
       TAURI_MODE: "1",
       TAURI_DATA_DIR: join(workDir, "data"),
       TAURI_DB_PATH: join(workDir, "data", "data.db"),
+      USERPROFILE: workDir,
     };
     childEnv.ANTHROPIC_API_KEY = undefined;
     childEnv.ANTHROPIC_AUTH_TOKEN = undefined;

--- a/apps/web/tests/unit/native-agent-memory-context-route.test.ts
+++ b/apps/web/tests/unit/native-agent-memory-context-route.test.ts
@@ -450,6 +450,7 @@ describe("native agent memory-context route", () => {
       await response.text();
 
       expect(response.status).toBe(200);
+      expect(mocks.resolveProviderRequest).toHaveBeenCalledTimes(1);
       expect(mocks.capturedPrompts).toHaveLength(1);
       expect(mocks.capturedPrompts[0]).toContain(
         "Use my stored preference for concise answers",

--- a/apps/web/tests/unit/native-agent-provider-env.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-env.test.ts
@@ -10,6 +10,7 @@ import type { NativeAgentRequest } from "@openloomi/ai/agent/native-runner";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const AGENT_ENV_KEYS = [
+  "IS_TAURI",
   "OPENLOOMI_AGENT_PROVIDER",
   "OPENLOOMI_AGENT_OPENCODE_COMMAND",
   "OPENLOOMI_AGENT_OPENCODE_MODEL",
@@ -39,6 +40,7 @@ const AGENT_ENV_KEYS = [
   "OPENLOOMI_AGENT_CODEX_SKIP_GIT_REPO_CHECK",
   "OPENLOOMI_AGENT_CODEX_FULL_AUTO",
   "OPENLOOMI_AGENT_CODEX_TIMEOUT_MS",
+  "TAURI_MODE",
 ];
 
 let originalEnv: NodeJS.ProcessEnv;

--- a/apps/web/tests/unit/native-agent-provider-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-preference.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  getConfiguredAgentProviderResolution,
   getConfiguredDefaultAgentProvider,
   resolveNativeAgentProviderRequest,
 } from "@/lib/ai/native-agent/provider-env";
@@ -46,6 +47,19 @@ describe("desktop agent runtime selection", () => {
       modelConfig: { model: "gpt-5.4" },
       providerConfig: { codexPath: "codex-custom" },
     });
+    expect(
+      getConfiguredAgentProviderResolution(
+        {
+          TAURI_MODE: "1",
+          OPENLOOMI_AGENT_PROVIDER: "claude",
+        },
+        { preferencePath },
+      ),
+    ).toEqual({
+      provider: "codex",
+      preference: "codex",
+      source: "preference",
+    });
   });
 
   it("uses the saved Claude selection and clears request provider config", () => {
@@ -79,5 +93,11 @@ describe("desktop agent runtime selection", () => {
         { preferencePath },
       ),
     ).toBe("claude");
+    expect(
+      getConfiguredAgentProviderResolution(
+        { OPENLOOMI_AGENT_PROVIDER: "claude" },
+        { preferencePath },
+      ),
+    ).toEqual({ provider: "claude", source: "environment" });
   });
 });

--- a/apps/web/tests/unit/native-agent-provider-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-preference.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getConfiguredDefaultAgentProvider,
+  resolveNativeAgentProviderRequest,
+} from "@/lib/ai/native-agent/provider-env";
+import { writeAgentRuntimePreference } from "@/lib/ai/native-agent/runtime-preference";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("desktop agent runtime selection", () => {
+  let directory: string;
+  let preferencePath: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "openloomi-provider-selection-"));
+    preferencePath = join(directory, "agent-runtime.json");
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("uses the saved Codex selection instead of the desktop environment", () => {
+    writeAgentRuntimePreference("codex", preferencePath);
+
+    const request = resolveNativeAgentProviderRequest(
+      {
+        prompt: "hello",
+        provider: "claude",
+        modelConfig: { model: "request-model" },
+        providerConfig: { codexPath: "request-command" },
+      },
+      {
+        TAURI_MODE: "1",
+        OPENLOOMI_AGENT_PROVIDER: "unsupported-runtime",
+        OPENLOOMI_AGENT_CODEX_COMMAND: "codex-custom",
+        OPENLOOMI_AGENT_CODEX_MODEL: "gpt-5.4",
+      },
+      { preferencePath },
+    );
+
+    expect(request).toMatchObject({
+      provider: "codex",
+      modelConfig: { model: "gpt-5.4" },
+      providerConfig: { codexPath: "codex-custom" },
+    });
+  });
+
+  it("uses the saved Claude selection and clears request provider config", () => {
+    writeAgentRuntimePreference("claude", preferencePath);
+
+    const request = resolveNativeAgentProviderRequest(
+      {
+        prompt: "hello",
+        provider: "codex",
+        modelConfig: { model: "claude-model" },
+        providerConfig: { codexPath: "request-command" },
+      },
+      {
+        IS_TAURI: "true",
+        OPENLOOMI_AGENT_PROVIDER: "codex",
+      },
+      { preferencePath },
+    );
+
+    expect(request.provider).toBe("claude");
+    expect(request.modelConfig).toEqual({ model: "claude-model" });
+    expect(request.providerConfig).toBeUndefined();
+  });
+
+  it("keeps server deployments environment-controlled", () => {
+    writeAgentRuntimePreference("codex", preferencePath);
+
+    expect(
+      getConfiguredDefaultAgentProvider(
+        { OPENLOOMI_AGENT_PROVIDER: "claude" },
+        { preferencePath },
+      ),
+    ).toBe("claude");
+  });
+});

--- a/apps/web/tests/unit/native-agent-runtime-installation.test.ts
+++ b/apps/web/tests/unit/native-agent-runtime-installation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CODEX_LOGIN_COMMAND,
+  getCodexInstallCommand,
+} from "@/lib/ai/native-agent/runtime-installation";
+
+describe("native agent runtime installation", () => {
+  test("provides the official standalone installer for each platform", () => {
+    expect(getCodexInstallCommand("windows")).toBe(
+      'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+    );
+    expect(getCodexInstallCommand("macos")).toBe(
+      "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+    );
+    expect(getCodexInstallCommand("linux")).toBe(
+      "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+    );
+  });
+
+  test("uses the browser-login command after installation", () => {
+    expect(CODEX_LOGIN_COMMAND).toBe("codex login");
+  });
+});

--- a/apps/web/tests/unit/native-agent-runtime-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-runtime-preference.test.ts
@@ -1,0 +1,57 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readAgentRuntimePreference,
+  writeAgentRuntimePreference,
+} from "@/lib/ai/native-agent/runtime-preference";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("agent runtime preference", () => {
+  let directory: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "openloomi-agent-runtime-"));
+    filePath = join(directory, "agent-runtime.json");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("returns no preference when the file does not exist", () => {
+    expect(readAgentRuntimePreference(filePath)).toBeUndefined();
+  });
+
+  it("writes and replaces a Claude or Codex preference", () => {
+    writeAgentRuntimePreference("claude", filePath);
+    expect(readAgentRuntimePreference(filePath)).toBe("claude");
+
+    writeAgentRuntimePreference("codex", filePath);
+    expect(readAgentRuntimePreference(filePath)).toBe("codex");
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual({
+      provider: "codex",
+    });
+    expect(readdirSync(directory)).toEqual(["agent-runtime.json"]);
+  });
+
+  it("ignores malformed or unsupported preferences", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    writeFileSync(filePath, "not-json", "utf8");
+    expect(readAgentRuntimePreference(filePath)).toBeUndefined();
+
+    writeFileSync(filePath, JSON.stringify({ provider: "opencode" }), "utf8");
+    expect(readAgentRuntimePreference(filePath)).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/unit/native-agent-runtime-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-runtime-preference.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  clearAgentRuntimePreference,
   readAgentRuntimePreference,
   writeAgentRuntimePreference,
 } from "@/lib/ai/native-agent/runtime-preference";
@@ -42,6 +43,15 @@ describe("agent runtime preference", () => {
       provider: "codex",
     });
     expect(readdirSync(directory)).toEqual(["agent-runtime.json"]);
+  });
+
+  it("clears a desktop preference without failing when it is already absent", () => {
+    writeAgentRuntimePreference("codex", filePath);
+
+    clearAgentRuntimePreference(filePath);
+    expect(readAgentRuntimePreference(filePath)).toBeUndefined();
+
+    expect(() => clearAgentRuntimePreference(filePath)).not.toThrow();
   });
 
   it("ignores malformed or unsupported preferences", () => {

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -1,20 +1,18 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const existingPaths = vi.hoisted(() => new Set<string>());
 
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return {
-    ...actual,
-    spawn: spawnMock,
-  };
-});
+vi.mock("cross-spawn", () => ({ default: spawnMock }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
-    existsSync: vi.fn((path: string) => path === "C:\\fake\\claude.exe"),
+    existsSync: vi.fn((path: string) => existingPaths.has(path)),
     readdirSync: vi.fn(() => []),
   };
 });
@@ -28,34 +26,164 @@ vi.mock("@/lib/utils/logger", () => ({
   }),
 }));
 
-const { clearNativeClaudeRuntimeCache, probeNativeClaudeRuntime } =
-  await import("@/lib/ai/native-agent/runtime-probe");
+vi.mock("@/lib/ai/extensions/agent/cli-process", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/ai/extensions/agent/cli-process")
+    >();
+  return {
+    ...actual,
+    shouldDetachCliProcess: vi.fn(() => false),
+    terminateCliProcessTree: vi.fn(),
+  };
+});
 
-describe("probeNativeClaudeRuntime", () => {
+const {
+  clearNativeRuntimeCaches,
+  probeNativeClaudeRuntime,
+  probeNativeCodexRuntime,
+} = await import("@/lib/ai/native-agent/runtime-probe");
+
+function completedProcess({
+  code = 0,
+  stdout = "",
+  stderr = "",
+}: {
+  code?: number;
+  stdout?: string;
+  stderr?: string;
+} = {}): ChildProcess {
+  type MutableChildProcess = {
+    -readonly [Key in keyof ChildProcess]: ChildProcess[Key];
+  };
+  const child = new EventEmitter() as MutableChildProcess;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = null;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.pid = 1234;
+  child.kill = vi.fn(() => true);
+
+  queueMicrotask(() => {
+    if (stdout) child.stdout?.emit("data", Buffer.from(stdout));
+    if (stderr) child.stderr?.emit("data", Buffer.from(stderr));
+    child.exitCode = code;
+    child.emit("close", code);
+  });
+  return child as ChildProcess;
+}
+
+describe("native agent runtime probes", () => {
   beforeEach(() => {
-    clearNativeClaudeRuntimeCache();
+    clearNativeRuntimeCaches();
     spawnMock.mockReset();
-    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+    existingPaths.clear();
+    Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_CODEX_COMMAND");
   });
 
   afterEach(() => {
-    clearNativeClaudeRuntimeCache();
-    process.env.CLAUDE_CODE_PATH = undefined;
+    clearNativeRuntimeCaches();
+    Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_CODEX_COMMAND");
   });
 
-  test("returns a structured failure when spawning claude fails synchronously", async () => {
+  test("returns a structured failure when spawning Claude fails synchronously", async () => {
+    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+    existingPaths.add(process.env.CLAUDE_CODE_PATH);
     spawnMock.mockImplementation(() => {
       throw new Error("spawn boom");
     });
 
     const probe = await probeNativeClaudeRuntime();
 
-    expect(probe).not.toBeNull();
     expect(probe?.ready).toBe(false);
     expect(probe?.reason).toBe("CLAUDE_CLI_VERSION_FAILED");
     expect(probe?.probes.version?.error).toEqual({
       code: "SPAWN_FAILED",
       message: "spawn boom",
     });
+  });
+
+  test("reports an authenticated Claude CLI and reuses the short-lived cache", async () => {
+    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+    existingPaths.add(process.env.CLAUDE_CODE_PATH);
+    spawnMock
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "2.1.3 (Claude Code)" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "Authenticated" }),
+      );
+
+    const [first, second] = await Promise.all([
+      probeNativeClaudeRuntime(),
+      probeNativeClaudeRuntime(),
+    ]);
+
+    expect(first).toMatchObject({
+      provider: "claude",
+      available: true,
+      authenticated: true,
+      ready: true,
+      version: "2.1.3",
+      reason: "CLAUDE_CLI_AUTHENTICATED",
+    });
+    expect(second).toBe(first);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(["auth", "status"]);
+  });
+
+  test("distinguishes a Claude sign-in requirement from an unavailable CLI", async () => {
+    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+    existingPaths.add(process.env.CLAUDE_CODE_PATH);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "2.1.3" }))
+      .mockImplementationOnce(() =>
+        completedProcess({ code: 1, stderr: "Not authenticated" }),
+      );
+
+    const needsLogin = await probeNativeClaudeRuntime();
+    clearNativeRuntimeCaches();
+    existingPaths.clear();
+    Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
+    const unavailable = await probeNativeClaudeRuntime();
+
+    expect(needsLogin?.reason).toBe("CLAUDE_CLI_AUTH_REQUIRED");
+    expect(needsLogin?.available).toBe(true);
+    expect(unavailable?.reason).toBe("CLAUDE_CLI_UNAVAILABLE");
+    expect(unavailable?.available).toBe(false);
+  });
+
+  test("checks Codex with login status and supports a forced refresh", async () => {
+    process.env.OPENLOOMI_AGENT_CODEX_COMMAND = "C:\\fake\\codex.cmd";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_CODEX_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "codex-cli 1.2.0" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "Logged in using ChatGPT" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "codex-cli 1.2.1" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "Logged in using ChatGPT" }),
+      );
+
+    const initial = await probeNativeCodexRuntime();
+    const refreshed = await probeNativeCodexRuntime({ force: true });
+
+    expect(initial).toMatchObject({
+      provider: "codex",
+      ready: true,
+      version: "1.2.0",
+      reason: "CODEX_CLI_AUTHENTICATED",
+    });
+    expect(refreshed?.version).toBe("1.2.1");
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(["login", "status"]);
+    expect(spawnMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -87,6 +88,7 @@ describe("native agent runtime probes", () => {
     clearNativeRuntimeCaches();
     Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
     Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_CODEX_COMMAND");
+    vi.unstubAllEnvs();
   });
 
   test("returns a structured failure when spawning Claude fails synchronously", async () => {
@@ -135,6 +137,31 @@ describe("native agent runtime probes", () => {
     expect(spawnMock.mock.calls[1]?.[1]).toEqual(["auth", "status"]);
   });
 
+  test("uses a least-privilege environment for readiness commands", async () => {
+    process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
+    existingPaths.add(process.env.CLAUDE_CODE_PATH);
+    vi.stubEnv("DATABASE_URL", "postgres://must-not-leak");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "C:\\fake\\claude-config");
+    vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "claude-auth-token");
+    vi.stubEnv("OPENAI_API_KEY", "must-not-reach-claude");
+    vi.stubEnv("CODEX_API_KEY", "must-not-reach-claude");
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "2.1.3" }))
+      .mockImplementationOnce(() => completedProcess({ stdout: "ok" }));
+
+    await probeNativeClaudeRuntime();
+
+    const spawnedEnvironment = spawnMock.mock.calls[0]?.[2]?.env;
+    expect(spawnedEnvironment).not.toHaveProperty("DATABASE_URL");
+    expect(spawnedEnvironment).not.toHaveProperty("OPENAI_API_KEY");
+    expect(spawnedEnvironment).not.toHaveProperty("CODEX_API_KEY");
+    expect(spawnedEnvironment).toMatchObject({
+      ANTHROPIC_AUTH_TOKEN: "claude-auth-token",
+      CLAUDE_CONFIG_DIR: "C:\\fake\\claude-config",
+      CLAUDECODE: "",
+    });
+  });
+
   test("distinguishes a Claude sign-in requirement from an unavailable CLI", async () => {
     process.env.CLAUDE_CODE_PATH = "C:\\fake\\claude.exe";
     existingPaths.add(process.env.CLAUDE_CODE_PATH);
@@ -156,9 +183,43 @@ describe("native agent runtime probes", () => {
     expect(unavailable?.available).toBe(false);
   });
 
+  test("probes a bundled legacy cli.js with its bundled Node runtime", async () => {
+    const bundleDirectory = join(process.cwd(), "apps", "web", "cli-bundle");
+    const cliPath = join(bundleDirectory, "cli.js");
+    const nodePath = join(
+      bundleDirectory,
+      process.platform === "win32" ? "node.exe" : "node",
+    );
+    existingPaths.add(cliPath);
+    existingPaths.add(join(bundleDirectory, "vendor"));
+    existingPaths.add(nodePath);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "2.1.3" }))
+      .mockImplementationOnce(() => completedProcess({ stdout: "ok" }));
+
+    const probe = await probeNativeClaudeRuntime();
+
+    expect(probe).toMatchObject({
+      ready: true,
+      cliPathSource: "BUNDLED",
+    });
+    expect(spawnMock.mock.calls[0]?.slice(0, 2)).toEqual([
+      nodePath,
+      ["--max-old-space-size=8192", cliPath, "--version"],
+    ]);
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      "--max-old-space-size=8192",
+      cliPath,
+      "auth",
+      "status",
+    ]);
+  });
+
   test("checks Codex with login status and supports a forced refresh", async () => {
     process.env.OPENLOOMI_AGENT_CODEX_COMMAND = "C:\\fake\\codex.cmd";
     existingPaths.add(process.env.OPENLOOMI_AGENT_CODEX_COMMAND);
+    vi.stubEnv("OPENAI_API_KEY", "codex-model-key");
+    vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "must-not-reach-codex");
     spawnMock
       .mockImplementationOnce(() =>
         completedProcess({ stdout: "codex-cli 1.2.0" }),
@@ -184,6 +245,12 @@ describe("native agent runtime probes", () => {
     });
     expect(refreshed?.version).toBe("1.2.1");
     expect(spawnMock.mock.calls[1]?.[1]).toEqual(["login", "status"]);
+    expect(spawnMock.mock.calls[0]?.[2]?.env).toMatchObject({
+      OPENAI_API_KEY: "codex-model-key",
+    });
+    expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty(
+      "ANTHROPIC_AUTH_TOKEN",
+    );
     expect(spawnMock).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Summary

Add a desktop settings flow for selecting the Agent runtime used by new OpenLoomi tasks.

This PR completes the initial runtime-selection loop for:

- **Claude** — powered by the Claude Agent SDK bundled with OpenLoomi; no separate Claude CLI installation is required
- **Codex** — powered by the locally installed and authenticated Codex CLI

The selected runtime is persisted locally and applied to new tasks. Tasks that are already running are not interrupted.

## Motivation

Runtime selection previously depended on environment variables or application defaults, making it difficult for desktop users to switch providers or understand why a runtime was unavailable.

The implementation includes backend preference storage and readiness checks because the settings UI cannot directly inspect local CLI installations, execute authentication checks, or configure the server-side Agent runner.

## What changed

### Runtime configuration

- Persist the desktop runtime preference in `~/.openloomi/agent-runtime.json`
- Add authenticated APIs for reading, updating, and resetting the preference
- Validate the selected runtime before saving it
- Apply the saved preference when resolving the provider for new tasks
- Preserve environment-variable and application-default fallbacks

### Runtime readiness

- Detect the bundled Claude runtime
- Detect Codex CLI from `PATH` and common installation locations
- Check runtime version and authentication state
- Report whether a runtime is ready, requires login, is not installed, or cannot be verified
- Keep raw CLI output and authentication details on the server
- Add timeouts, process cleanup, caching, and concurrent-check deduplication

### Settings experience

- Add an **Agent Runtime** section to desktop settings
- Explain that Claude is bundled with OpenLoomi
- Show Codex installation and login status
- Provide platform-specific Codex installation commands
- Guide users through Codex first-run prompts, hook review, login, terminal cleanup, and readiness rechecking
- Allow users to restore the environment/default runtime selection

## User flow

For Codex:

1. Select **Codex CLI** in settings
2. Follow the installation instructions if the CLI is missing
3. Complete the Codex first-run prompts and run `codex login` if required
4. Close the setup terminal and select **Check again**
5. Once ready, Codex can be saved as the runtime for new tasks

Readiness checks do not send an actual model request.

## Runtime precedence

For the desktop application:

1. Saved desktop runtime preference
2. `OPENLOOMI_AGENT_PROVIDER`
3. Application default

Non-desktop behavior remains unchanged.

### End-to-end verification

The complete Codex desktop flow was manually tested with a real local environment:

1. Start without Codex CLI installed
2. Confirm OpenLoomi reports Codex as not installed
3. Follow the in-app installation instructions
4. Complete the Codex first-run prompts and hook review
5. Authenticate through `codex login`
6. Return to OpenLoomi and run **Check again**
7. Confirm Codex is detected as installed and authenticated
8. Select Codex as the active runtime
9. Create a new task and verify it runs successfully through the real Codex runtime

The full installation, authentication, runtime selection, and task execution chain works as expected.

The repository-wide test run still contains unrelated Windows failures in `loop/cli-path.test.ts`. All tests directly related to this PR pass.