### PR TITLE
fix: Optimize Kokoro TTS playback latency

### DIFF
--- a/apps/web/app/api/ai/v1/audio/speech/route.ts
+++ b/apps/web/app/api/ai/v1/audio/speech/route.ts
@@ -131,7 +131,10 @@ async function readSpeechPayload(request: Request): Promise<SpeechPayload> {
       readPayloadResponseFormat(body.response_format ?? body.responseFormat) ??
       readResponseFormat(process.env.KOKORO_TTS_RESPONSE_FORMAT) ??
       DEFAULT_KOKORO_TTS_RESPONSE_FORMAT,
-    speed: readPositiveNumber(body.speed) ?? DEFAULT_KOKORO_TTS_SPEED,
+    speed:
+      readPositiveNumber(body.speed) ??
+      readPositiveNumber(process.env.KOKORO_TTS_SPEED) ??
+      DEFAULT_KOKORO_TTS_SPEED,
   };
 }
 

--- a/apps/web/components/audio/voice-provider.tsx
+++ b/apps/web/components/audio/voice-provider.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { createContext, useContext, useState, useMemo } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useMemo,
+} from "react";
 import { KokoroPlugin } from "@openloomi/voice-kokoro";
 import { WhisperPlugin } from "@openloomi/voice-whisper";
 
@@ -36,8 +42,16 @@ export function VoiceProvider({ children }: { children: React.ReactNode }) {
     () => new WhisperPlugin({ enabled: isWhisperEnabledByEnv }),
   );
 
-  // Dummy state updates to force re-renders if enabled flags change
-  const [, setTick] = useState(0);
+  // Bump this when runtime toggles change so effects can react.
+  const [voiceVersion, setVoiceVersion] = useState(0);
+
+  useEffect(() => {
+    if (!kokoro.enabled) return;
+
+    void kokoro.warmup().catch((error) => {
+      console.warn("[VoiceProvider] Kokoro warmup failed:", error);
+    });
+  }, [kokoro, voiceVersion]);
 
   const contextValue = useMemo(
     () => ({
@@ -45,11 +59,11 @@ export function VoiceProvider({ children }: { children: React.ReactNode }) {
       whisper,
       setKokoroEnabled: (enabled: boolean) => {
         kokoro.enabled = isKokoroEnabledByEnv && enabled;
-        setTick((t) => t + 1);
+        setVoiceVersion((version) => version + 1);
       },
       setWhisperEnabled: (enabled: boolean) => {
         whisper.enabled = isWhisperEnabledByEnv && enabled;
-        setTick((t) => t + 1);
+        setVoiceVersion((version) => version + 1);
       },
     }),
     [kokoro, whisper],

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -325,7 +325,7 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value:
-      "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' tauri: https://d3js.org https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://geddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; img-src 'self' data: https: http: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http: wss: tauri: ipc: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://fonts.googleapis.com; frame-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
+      "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' tauri: https://d3js.org https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://geddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; img-src 'self' data: https: http: blob:; media-src 'self' data: https: http: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http: wss: tauri: ipc: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://fonts.googleapis.com; frame-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
   },
 ];
 

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: tauri: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://geddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; img-src 'self' data: https: http: blob: asset: http://asset.localhost https://asset.localhost; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http: wss: blob: data: tauri: ipc: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://fonts.googleapis.com; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';",
+			"csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: tauri: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://geddle.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; img-src 'self' data: https: http: blob: asset: http://asset.localhost https://asset.localhost; media-src 'self' data: https: http: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http: wss: blob: data: tauri: ipc: https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://fonts.googleapis.com; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';",
 			"assetProtocol": {
 				"enable": true,
 				"scope": [

--- a/apps/web/tests/unit/voice-kokoro.test.ts
+++ b/apps/web/tests/unit/voice-kokoro.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { KokoroPlugin } from "../../../../packages/voice-kokoro/src/index.ts";
+import { KokoroPlugin } from "../../../../packages/voice-kokoro/src/index";
 
 function createLongSpeechText(): string {
   return [

--- a/apps/web/tests/unit/voice-kokoro.test.ts
+++ b/apps/web/tests/unit/voice-kokoro.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { KokoroPlugin } from "../../../../packages/voice-kokoro/src/index.ts";
+
+function createLongSpeechText(): string {
+  return [
+    "第一段先说明核心结论，语音应该尽快开始播放，避免用户等待整段回答全部合成完成。",
+    "第二段继续补充更多背景信息，让文字长度足够触发多个 TTS 请求，同时仍然沿着自然句子边界切分。",
+    "第三段解释实现方式，当前音频播放时后台会提前请求下一段音频，这样段落之间的空隙会更短。",
+    "最后一段保留一点收尾说明，确保尾段不要短到听起来很突兀。",
+  ].join(" ");
+}
+
+function installBrowserAudioMocks(options?: { autoEnd?: boolean }) {
+  const autoEnd = options?.autoEnd ?? true;
+  const fetchBodies: string[] = [];
+  const playedUrls: string[] = [];
+  let objectUrlIndex = 0;
+
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: () => null,
+    },
+    speechSynthesis: {
+      speaking: false,
+      pending: false,
+      cancel: vi.fn(),
+      speak: vi.fn(),
+    },
+  });
+
+  class MockAudio {
+    public preload = "";
+    public autoplay = false;
+    public onended: (() => void) | null = null;
+    public onerror: (() => void) | null = null;
+
+    constructor(public src: string) {}
+
+    async play() {
+      playedUrls.push(this.src);
+      if (autoEnd) {
+        queueMicrotask(() => {
+          this.onended?.();
+        });
+      }
+    }
+
+    pause() {}
+    removeAttribute(_name: string) {}
+    load() {}
+  }
+
+  vi.stubGlobal("Audio", MockAudio);
+  vi.spyOn(URL, "createObjectURL").mockImplementation(() => {
+    objectUrlIndex += 1;
+    return `blob:kokoro-test-${objectUrlIndex.toString()}`;
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input: string };
+      fetchBodies.push(body.input);
+      return new Response(new Blob([body.input], { type: "audio/mpeg" }), {
+        status: 200,
+        headers: { "content-type": "audio/mpeg" },
+      });
+    }),
+  );
+
+  return {
+    fetchBodies,
+    playedUrls,
+  };
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for condition.");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("KokoroPlugin queued speech", () => {
+  it("skips fenced code blocks and sends long replies as smaller chunks", async () => {
+    const { fetchBodies, playedUrls } = installBrowserAudioMocks();
+    const plugin = new KokoroPlugin({ enabled: true });
+
+    await plugin.speak(`${createLongSpeechText()}
+
+\`\`\`ts
+const secret = "do not speak this";
+\`\`\`
+
+${createLongSpeechText()}`);
+
+    expect(fetchBodies.length).toBeGreaterThan(1);
+    expect(playedUrls).toHaveLength(fetchBodies.length);
+    expect(fetchBodies.every((chunk) => !chunk.includes("secret"))).toBe(true);
+    expect(fetchBodies[0].length).toBeLessThanOrEqual(220);
+    expect(fetchBodies.slice(1).every((chunk) => chunk.length <= 420)).toBe(
+      true,
+    );
+  });
+
+  it("prefetches the next chunk while the current chunk is playing", async () => {
+    const { fetchBodies, playedUrls } = installBrowserAudioMocks({
+      autoEnd: false,
+    });
+    const plugin = new KokoroPlugin({ enabled: true });
+
+    const speakPromise = plugin.speak(
+      `${createLongSpeechText()} ${createLongSpeechText()}`,
+    );
+    await waitForCondition(() => fetchBodies.length >= 2);
+
+    expect(playedUrls).toHaveLength(1);
+    expect(fetchBodies.length).toBeGreaterThanOrEqual(2);
+
+    plugin.stop();
+    await expect(speakPromise).resolves.toBeUndefined();
+  });
+});

--- a/packages/voice-kokoro/src/index.ts
+++ b/packages/voice-kokoro/src/index.ts
@@ -2,6 +2,43 @@ const DEFAULT_SPEECH_ENDPOINT = "/api/ai/v1/audio/speech";
 const DEFAULT_FALLBACK_VOICE = "af_bella";
 const DEFAULT_WARMUP_TEXT = "Hi.";
 
+function stripFencedCodeBlocks(text: string): string {
+  const outputLines: string[] = [];
+  let activeFence: { marker: string; length: number } | null = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    const fenceMatch = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+
+    if (activeFence) {
+      const isClosingFence =
+        fenceMatch &&
+        fenceMatch[1][0] === activeFence.marker &&
+        fenceMatch[1].length >= activeFence.length &&
+        fenceMatch[2].trim().length === 0;
+
+      if (isClosingFence) {
+        activeFence = null;
+      }
+      continue;
+    }
+
+    if (fenceMatch) {
+      activeFence = {
+        marker: fenceMatch[1][0],
+        length: fenceMatch[1].length,
+      };
+      continue;
+    }
+
+    outputLines.push(line);
+  }
+
+  return outputLines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function isAbortError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === "AbortError") ||
@@ -88,7 +125,7 @@ export class KokoroPlugin {
       return;
     }
 
-    const input = text.trim();
+    const input = stripFencedCodeBlocks(text);
     if (!input) return;
 
     if (typeof window === "undefined") {

--- a/packages/voice-kokoro/src/index.ts
+++ b/packages/voice-kokoro/src/index.ts
@@ -1,5 +1,6 @@
 const DEFAULT_SPEECH_ENDPOINT = "/api/ai/v1/audio/speech";
 const DEFAULT_FALLBACK_VOICE = "af_bella";
+const DEFAULT_WARMUP_TEXT = "Hi.";
 
 function isAbortError(error: unknown): boolean {
   return (
@@ -20,21 +21,29 @@ export class KokoroPlugin {
 
   private speechEndpoint: string;
   private currentRequestController: AbortController | null;
+  private currentWarmupController: AbortController | null;
   private currentAudio: HTMLAudioElement | null;
   private currentObjectUrl: string | null;
+  private hasWarmedUp: boolean;
+  private warmupPromise: Promise<void> | null;
 
   constructor(options?: { enabled?: boolean; voice?: string }) {
     this.enabled = options?.enabled ?? true;
     this.voice = options?.voice ?? DEFAULT_FALLBACK_VOICE;
     this.speechEndpoint = DEFAULT_SPEECH_ENDPOINT;
     this.currentRequestController = null;
+    this.currentWarmupController = null;
     this.currentAudio = null;
     this.currentObjectUrl = null;
+    this.hasWarmedUp = false;
+    this.warmupPromise = null;
   }
 
   public stop(): void {
     this.currentRequestController?.abort();
     this.currentRequestController = null;
+    this.currentWarmupController?.abort();
+    this.currentWarmupController = null;
 
     if (this.currentAudio) {
       this.currentAudio.pause();
@@ -52,6 +61,25 @@ export class KokoroPlugin {
     if (synthesis) {
       synthesis.cancel();
     }
+  }
+
+  public async warmup(text: string = DEFAULT_WARMUP_TEXT): Promise<void> {
+    if (!this.enabled || this.hasWarmedUp) return;
+
+    const input = text.trim();
+    if (!input) return;
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (this.warmupPromise) {
+      return this.warmupPromise;
+    }
+
+    const warmupPromise = this.runWarmup(input);
+    this.warmupPromise = warmupPromise;
+    return warmupPromise;
   }
 
   public async speak(text: string): Promise<void> {
@@ -96,33 +124,65 @@ export class KokoroPlugin {
     this.currentRequestController = controller;
 
     try {
-      const response = await fetch(this.speechEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          input: text,
-          voice: this.voice === DEFAULT_FALLBACK_VOICE ? undefined : this.voice,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(await this.readProviderError(response));
-      }
-
-      const audioBlob = await response.blob();
-      if (audioBlob.size <= 0) {
-        throw new Error("Kokoro TTS response was empty.");
-      }
-
+      const audioBlob = await this.fetchSpeechBlob(text, controller.signal);
       await this.playAudioBlob(audioBlob);
     } finally {
       if (this.currentRequestController === controller) {
         this.currentRequestController = null;
       }
     }
+  }
+
+  private async runWarmup(text: string): Promise<void> {
+    const controller = new AbortController();
+    this.currentWarmupController = controller;
+
+    try {
+      await this.fetchSpeechBlob(text, controller.signal);
+      this.hasWarmedUp = true;
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
+      throw error;
+    } finally {
+      if (this.currentWarmupController === controller) {
+        this.currentWarmupController = null;
+      }
+      this.warmupPromise = null;
+    }
+  }
+
+  private async fetchSpeechBlob(
+    text: string,
+    signal: AbortSignal,
+  ): Promise<Blob> {
+    if (typeof fetch !== "function") {
+      throw new Error("Fetch is not available for Kokoro TTS.");
+    }
+
+    const response = await fetch(this.speechEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input: text,
+        voice: this.voice === DEFAULT_FALLBACK_VOICE ? undefined : this.voice,
+      }),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await this.readProviderError(response));
+    }
+
+    const audioBlob = await response.blob();
+    if (audioBlob.size <= 0) {
+      throw new Error("Kokoro TTS response was empty.");
+    }
+
+    return audioBlob;
   }
 
   private async playAudioBlob(audioBlob: Blob): Promise<void> {

--- a/packages/voice-kokoro/src/index.ts
+++ b/packages/voice-kokoro/src/index.ts
@@ -1,6 +1,239 @@
 const DEFAULT_SPEECH_ENDPOINT = "/api/ai/v1/audio/speech";
 const DEFAULT_FALLBACK_VOICE = "af_bella";
 const DEFAULT_WARMUP_TEXT = "Hi.";
+const FIRST_SPEECH_CHUNK_TARGET_LENGTH = 160;
+const FIRST_SPEECH_CHUNK_MAX_LENGTH = 220;
+const SPEECH_CHUNK_TARGET_LENGTH = 280;
+const SPEECH_CHUNK_MAX_LENGTH = 420;
+const MIN_SPEECH_CHUNK_BREAK_LENGTH = 80;
+const MIN_FINAL_SPEECH_CHUNK_LENGTH = 40;
+const HARD_SPEECH_BOUNDARIES = new Set(["。", "！", "？", "!", "?", "；", ";"]);
+const SOFT_SPEECH_BOUNDARIES = new Set(["，", ",", "、", "：", ":", ")", "）"]);
+const CLOSING_BOUNDARY_CHARACTERS = new Set([
+  '"',
+  "'",
+  ")",
+  "]",
+  "}",
+  "”",
+  "’",
+  "）",
+  "】",
+  "》",
+]);
+
+type SpeechFetchResult =
+  | { ok: true; audioBlob: Blob }
+  | { ok: false; error: unknown };
+
+function getNowMs(): number {
+  if (typeof performance !== "undefined") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function normalizeSpeechText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function isDigit(value: string | undefined): boolean {
+  return Boolean(value && /\d/.test(value));
+}
+
+function findNextMeaningfulCharacter(text: string, index: number): string {
+  let nextIndex = index + 1;
+  while (CLOSING_BOUNDARY_CHARACTERS.has(text[nextIndex])) {
+    nextIndex += 1;
+  }
+  return text[nextIndex] ?? "";
+}
+
+function isSentencePeriod(text: string, index: number): boolean {
+  const previousCharacter = text[index - 1];
+  const nextCharacter = findNextMeaningfulCharacter(text, index);
+
+  if (isDigit(previousCharacter) && isDigit(text[index + 1])) {
+    return false;
+  }
+
+  return !nextCharacter || /\s/.test(nextCharacter);
+}
+
+function isHardSpeechBoundary(text: string, index: number): boolean {
+  const character = text[index];
+  return (
+    HARD_SPEECH_BOUNDARIES.has(character) ||
+    (character === "." && isSentencePeriod(text, index))
+  );
+}
+
+function isSoftSpeechBoundary(text: string, index: number): boolean {
+  const character = text[index];
+  if (!SOFT_SPEECH_BOUNDARIES.has(character)) return false;
+  if (
+    character === "," &&
+    isDigit(text[index - 1]) &&
+    isDigit(text[index + 1])
+  ) {
+    return false;
+  }
+  if (character === ":" && text[index + 1] === "/") {
+    return false;
+  }
+  return true;
+}
+
+function extendBoundaryEnd(text: string, index: number): number {
+  let endIndex = index + 1;
+  while (CLOSING_BOUNDARY_CHARACTERS.has(text[endIndex])) {
+    endIndex += 1;
+  }
+  return endIndex;
+}
+
+function findLastBoundary(
+  text: string,
+  startIndex: number,
+  endIndex: number,
+  predicate: (value: string, index: number) => boolean,
+): number | null {
+  const boundedEndIndex = Math.min(endIndex, text.length - 1);
+  for (let index = boundedEndIndex; index >= startIndex; index -= 1) {
+    if (predicate(text, index)) {
+      return extendBoundaryEnd(text, index);
+    }
+  }
+  return null;
+}
+
+function findFirstBoundary(
+  text: string,
+  startIndex: number,
+  endIndex: number,
+  predicate: (value: string, index: number) => boolean,
+): number | null {
+  const boundedEndIndex = Math.min(endIndex, text.length - 1);
+  for (let index = startIndex; index <= boundedEndIndex; index += 1) {
+    if (predicate(text, index)) {
+      return extendBoundaryEnd(text, index);
+    }
+  }
+  return null;
+}
+
+function findWhitespaceBoundary(
+  text: string,
+  startIndex: number,
+  endIndex: number,
+  direction: "first" | "last",
+): number | null {
+  const boundedEndIndex = Math.min(endIndex, text.length - 1);
+
+  if (direction === "first") {
+    for (let index = startIndex; index <= boundedEndIndex; index += 1) {
+      if (/\s/.test(text[index])) return index;
+    }
+    return null;
+  }
+
+  for (let index = boundedEndIndex; index >= startIndex; index -= 1) {
+    if (/\s/.test(text[index])) return index;
+  }
+  return null;
+}
+
+function findSpeechBreakIndex(
+  text: string,
+  targetLength: number,
+  maxLength: number,
+): number {
+  const minBreakLength = Math.min(
+    MIN_SPEECH_CHUNK_BREAK_LENGTH,
+    Math.max(1, targetLength - 1),
+  );
+  const beforeTarget = Math.min(targetLength, text.length - 1);
+  const beforeMax = Math.min(maxLength, text.length - 1);
+
+  return (
+    findLastBoundary(
+      text,
+      minBreakLength,
+      beforeTarget,
+      isHardSpeechBoundary,
+    ) ??
+    findFirstBoundary(text, targetLength, beforeMax, isHardSpeechBoundary) ??
+    findLastBoundary(
+      text,
+      minBreakLength,
+      beforeTarget,
+      isSoftSpeechBoundary,
+    ) ??
+    findFirstBoundary(text, targetLength, beforeMax, isSoftSpeechBoundary) ??
+    findWhitespaceBoundary(text, minBreakLength, beforeTarget, "last") ??
+    findWhitespaceBoundary(text, targetLength, beforeMax, "first") ??
+    maxLength
+  );
+}
+
+function mergeShortFinalSpeechChunk(chunks: string[]): string[] {
+  if (chunks.length < 2) return chunks;
+
+  const lastChunk = chunks[chunks.length - 1];
+  if (lastChunk.length >= MIN_FINAL_SPEECH_CHUNK_LENGTH) {
+    return chunks;
+  }
+
+  const previousChunk = chunks[chunks.length - 2];
+  const mergedChunk = `${previousChunk} ${lastChunk}`.trim();
+  if (mergedChunk.length > SPEECH_CHUNK_MAX_LENGTH) {
+    return chunks;
+  }
+
+  return [...chunks.slice(0, -2), mergedChunk];
+}
+
+function splitSpeechText(text: string): string[] {
+  let remainingText = normalizeSpeechText(text);
+  const chunks: string[] = [];
+
+  while (remainingText) {
+    const isFirstChunk = chunks.length === 0;
+    const targetLength = isFirstChunk
+      ? FIRST_SPEECH_CHUNK_TARGET_LENGTH
+      : SPEECH_CHUNK_TARGET_LENGTH;
+    const maxLength = isFirstChunk
+      ? FIRST_SPEECH_CHUNK_MAX_LENGTH
+      : SPEECH_CHUNK_MAX_LENGTH;
+
+    if (remainingText.length <= maxLength) {
+      chunks.push(remainingText);
+      break;
+    }
+
+    const breakIndex = findSpeechBreakIndex(
+      remainingText,
+      targetLength,
+      maxLength,
+    );
+    const chunk = remainingText.slice(0, breakIndex).trim();
+    if (chunk) {
+      chunks.push(chunk);
+    }
+    remainingText = remainingText.slice(breakIndex).trim();
+  }
+
+  return mergeShortFinalSpeechChunk(chunks);
+}
+
+function isKokoroDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage?.getItem("openloomi:kokoro-debug") === "1";
+  } catch {
+    return false;
+  }
+}
 
 function stripFencedCodeBlocks(text: string): string {
   const outputLines: string[] = [];
@@ -61,8 +294,10 @@ export class KokoroPlugin {
   private currentWarmupController: AbortController | null;
   private currentAudio: HTMLAudioElement | null;
   private currentObjectUrl: string | null;
+  private currentPlaybackAbort: (() => void) | null;
   private hasWarmedUp: boolean;
   private warmupPromise: Promise<void> | null;
+  private speechRunId: number;
 
   constructor(options?: { enabled?: boolean; voice?: string }) {
     this.enabled = options?.enabled ?? true;
@@ -72,15 +307,21 @@ export class KokoroPlugin {
     this.currentWarmupController = null;
     this.currentAudio = null;
     this.currentObjectUrl = null;
+    this.currentPlaybackAbort = null;
     this.hasWarmedUp = false;
     this.warmupPromise = null;
+    this.speechRunId = 0;
   }
 
   public stop(): void {
+    this.speechRunId += 1;
     this.currentRequestController?.abort();
     this.currentRequestController = null;
     this.currentWarmupController?.abort();
     this.currentWarmupController = null;
+
+    this.currentPlaybackAbort?.();
+    this.currentPlaybackAbort = null;
 
     if (this.currentAudio) {
       this.currentAudio.pause();
@@ -126,7 +367,8 @@ export class KokoroPlugin {
     }
 
     const input = stripFencedCodeBlocks(text);
-    if (!input) return;
+    const chunks = splitSpeechText(input);
+    if (chunks.length === 0) return;
 
     if (typeof window === "undefined") {
       console.warn("[KokoroPlugin] Browser APIs are unavailable.");
@@ -134,16 +376,25 @@ export class KokoroPlugin {
     }
 
     this.stop();
+    const runId = this.speechRunId;
+    let didStartRemotePlayback = false;
 
     try {
-      await this.speakViaRemoteService(input);
+      await this.speakViaRemoteService(chunks, runId, () => {
+        didStartRemotePlayback = true;
+      });
       return;
     } catch (error) {
       if (isAbortError(error)) {
         return;
       }
 
+      this.stop();
       console.warn("[KokoroPlugin] Remote TTS unavailable:", error);
+      if (didStartRemotePlayback) {
+        return;
+      }
+
       if (this.speakViaBrowser(input)) {
         return;
       }
@@ -152,17 +403,99 @@ export class KokoroPlugin {
     }
   }
 
-  private async speakViaRemoteService(text: string): Promise<void> {
+  private async speakViaRemoteService(
+    chunks: string[],
+    runId: number,
+    onPlaybackStart: () => void,
+  ): Promise<void> {
     if (typeof fetch !== "function") {
       throw new Error("Fetch is not available for Kokoro TTS.");
     }
 
+    const startedAtMs = getNowMs();
+    let firstAudioReadyMs: number | null = null;
+    let firstPlaybackStartedMs: number | null = null;
+    let nextFetchPromise: Promise<SpeechFetchResult> | null = null;
+
+    this.logDebug("Queued TTS started.", {
+      chunks: chunks.length,
+      firstChunkLength: chunks[0]?.length ?? 0,
+      totalLength: chunks.reduce((total, chunk) => total + chunk.length, 0),
+    });
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      if (runId !== this.speechRunId) {
+        throw new DOMException("Kokoro TTS request was aborted.", "AbortError");
+      }
+
+      const currentFetchPromise =
+        nextFetchPromise ?? this.prefetchSpeechBlob(chunks[index], runId);
+      nextFetchPromise = null;
+
+      const result = await currentFetchPromise;
+      if (!result.ok) {
+        throw result.error;
+      }
+
+      if (index === 0) {
+        firstAudioReadyMs = getNowMs() - startedAtMs;
+      }
+
+      if (runId !== this.speechRunId) {
+        throw new DOMException("Kokoro TTS request was aborted.", "AbortError");
+      }
+
+      const nextChunk = chunks[index + 1];
+      if (nextChunk) {
+        nextFetchPromise = this.prefetchSpeechBlob(nextChunk, runId);
+      }
+
+      await this.playAudioBlob(result.audioBlob, () => {
+        if (index === 0) {
+          firstPlaybackStartedMs = getNowMs() - startedAtMs;
+          onPlaybackStart();
+          this.logDebug("Queued TTS first chunk playing.", {
+            firstAudioReadyMs: Math.round(firstAudioReadyMs ?? 0),
+            firstPlaybackStartedMs: Math.round(firstPlaybackStartedMs),
+          });
+        }
+      });
+    }
+
+    this.logDebug("Queued TTS finished.", {
+      chunks: chunks.length,
+      firstAudioReadyMs: Math.round(firstAudioReadyMs ?? 0),
+      firstPlaybackStartedMs: Math.round(firstPlaybackStartedMs ?? 0),
+      totalMs: Math.round(getNowMs() - startedAtMs),
+    });
+  }
+
+  private prefetchSpeechBlob(
+    text: string,
+    runId: number,
+  ): Promise<SpeechFetchResult> {
+    return this.fetchSpeechBlobForPlayback(text, runId)
+      .then((audioBlob) => ({ ok: true as const, audioBlob }))
+      .catch((error) => ({ ok: false as const, error }));
+  }
+
+  private async fetchSpeechBlobForPlayback(
+    text: string,
+    runId: number,
+  ): Promise<Blob> {
     const controller = new AbortController();
     this.currentRequestController = controller;
 
     try {
       const audioBlob = await this.fetchSpeechBlob(text, controller.signal);
-      await this.playAudioBlob(audioBlob);
+      if (runId !== this.speechRunId) {
+        throw new DOMException("Kokoro TTS request was aborted.", "AbortError");
+      }
+      this.logDebug("Queued TTS chunk fetched.", {
+        length: text.length,
+        size: audioBlob.size,
+      });
+      return audioBlob;
     } finally {
       if (this.currentRequestController === controller) {
         this.currentRequestController = null;
@@ -222,7 +555,10 @@ export class KokoroPlugin {
     return audioBlob;
   }
 
-  private async playAudioBlob(audioBlob: Blob): Promise<void> {
+  private async playAudioBlob(
+    audioBlob: Blob,
+    onPlaybackStart?: () => void,
+  ): Promise<void> {
     if (typeof Audio === "undefined") {
       throw new Error("Browser audio playback is not available.");
     }
@@ -231,40 +567,61 @@ export class KokoroPlugin {
     const audio = new Audio(objectUrl);
     audio.preload = "auto";
     audio.autoplay = true;
-    audio.onended = () => {
-      if (this.currentAudio === audio) {
-        this.currentAudio = null;
-      }
-      if (this.currentObjectUrl === objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-        this.currentObjectUrl = null;
-      }
-    };
-    audio.onerror = () => {
-      if (this.currentAudio === audio) {
-        this.currentAudio = null;
-      }
-      if (this.currentObjectUrl === objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-        this.currentObjectUrl = null;
-      }
-    };
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
 
-    this.currentAudio = audio;
-    this.currentObjectUrl = objectUrl;
+      const cleanup = () => {
+        audio.onended = null;
+        audio.onerror = null;
 
-    try {
-      await audio.play();
-    } catch (error) {
-      if (this.currentAudio === audio) {
-        this.currentAudio = null;
-      }
-      if (this.currentObjectUrl === objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-        this.currentObjectUrl = null;
-      }
-      throw error;
-    }
+        if (this.currentAudio === audio) {
+          this.currentAudio = null;
+        }
+        if (this.currentObjectUrl === objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          this.currentObjectUrl = null;
+        }
+        if (this.currentPlaybackAbort === abortPlayback) {
+          this.currentPlaybackAbort = null;
+        }
+      };
+
+      const settle = (error?: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+
+      const abortPlayback = () => {
+        audio.pause();
+        audio.removeAttribute("src");
+        audio.load();
+        settle(
+          new DOMException("Kokoro TTS playback was aborted.", "AbortError"),
+        );
+      };
+
+      audio.onended = () => settle();
+      audio.onerror = () =>
+        settle(new Error("Kokoro TTS audio playback failed."));
+
+      this.currentAudio = audio;
+      this.currentObjectUrl = objectUrl;
+      this.currentPlaybackAbort = abortPlayback;
+
+      void audio
+        .play()
+        .then(() => {
+          if (settled) return;
+          onPlaybackStart?.();
+        })
+        .catch((error) => settle(error));
+    });
   }
 
   private speakViaBrowser(text: string): boolean {
@@ -307,5 +664,10 @@ export class KokoroPlugin {
     } catch {
       return text.trim().slice(0, 400);
     }
+  }
+
+  private logDebug(message: string, data?: Record<string, unknown>): void {
+    if (!isKokoroDebugEnabled()) return;
+    console.info("[KokoroPlugin]", message, data ?? {});
   }
 }


### PR DESCRIPTION
## Why

Kokoro TTS was working, but the playback experience was noticeably delayed. In desktop testing, longer replies could take several seconds before the user heard anything because the app waited for the generated audio blob before playback.

There was also a desktop playback issue where valid Kokoro MP3 responses could fail inside the WebView when played through `Audio(blobUrl)`.

## What Changed

- Added queued playback for Kokoro TTS.
- Split assistant replies into smaller speech chunks.
- Start playing the first generated chunk as soon as it is ready.
- Prefetch the next TTS chunk while the current chunk is playing.
- Strip fenced code blocks before sending text to TTS.
- Updated CSP to allow `blob:` media playback in the desktop WebView.

## Result

Manual desktop testing showed that a longer English reply was split into multiple TTS requests:

- First chunk completed in about `2.5s`
- Second chunk completed in about `7.8s`

Playback can now begin after the first chunk is ready instead of waiting for the full response audio to be generated.

The previous playback failure did not appear after the CSP update:

- `Kokoro TTS audio playback failed`
- `Remote TTS unavailable`

## Limitations

- This is chunk-queued playback, not true audio streaming.
- Chunk size thresholds may still need tuning.
- Only fenced code blocks are skipped for now.
- No stop/pause playback UI is included in this PR.