### PR TITLE
feat(agent): add durable SQLite Goal Runtime persistence

### DIFF
--- a/apps/web/lib/ai/runtime-instructions/goal-state-error.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-state-error.ts
@@ -1,0 +1,29 @@
+export type AgentGoalStateErrorCode =
+  | "active_primary_goal_conflict"
+  | "goal_conflict"
+  | "goal_not_found"
+  | "idempotency_conflict"
+  | "invalid_commit"
+  | "lifecycle_transition_in_progress"
+  | "lifecycle_transition_not_found"
+  | "replacement_in_progress"
+  | "replacement_not_found"
+  | "run_epoch_conflict"
+  | "revision_conflict";
+
+/**
+ * Storage-neutral failure raised by authoritative Goal state adapters.
+ *
+ * The codes intentionally match the in-memory adapter contract so callers do
+ * not need dialect-specific error handling when durable persistence is wired.
+ */
+export class AgentGoalStateError extends Error {
+  constructor(
+    public readonly code: AgentGoalStateErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentGoalStateError";
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
@@ -1,0 +1,643 @@
+import {
+  type AgentGoal,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalReplacement,
+  AgentGoalSchema,
+  type GoalCommandIdentity,
+  type GoalLifecycleTransitionAction,
+  type GoalStatus,
+  type RuntimeInstruction,
+  type RuntimeInstructionDraft,
+  RuntimeInstructionSchema,
+  assertGoalStatusTransition,
+  canonicalJson,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { AgentGoalStateError as DurableAgentGoalStateError } from "./goal-state-error";
+
+export interface ValidatedGoalStateScope {
+  ownerId: string;
+  runtimeSessionId: string;
+}
+
+export function validateGoalStateScope(
+  ownerId: string,
+  runtimeSessionId: string,
+): ValidatedGoalStateScope {
+  return {
+    ownerId: requireGoalStateIdentifier(ownerId, "ownerId"),
+    runtimeSessionId: requireGoalStateIdentifier(
+      runtimeSessionId,
+      "runtimeSessionId",
+    ),
+  };
+}
+
+export function requireGoalStateIdentifier(
+  value: unknown,
+  field: string,
+): string {
+  if (typeof value !== "string") {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `${field} must be a string`,
+    );
+  }
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    normalized.length > 256 ||
+    normalized !== value
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `${field} must contain 1 to 256 characters without surrounding whitespace`,
+    );
+  }
+  return value;
+}
+
+export function requirePositiveGoalStateInteger(
+  value: unknown,
+  field: string,
+): number {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `${field} must be a positive integer`,
+    );
+  }
+  return value as number;
+}
+
+export function requireNonNegativeGoalStateInteger(
+  value: unknown,
+  field: string,
+): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `${field} must be a non-negative integer`,
+    );
+  }
+  return value as number;
+}
+
+export function parseGoalState(candidate: AgentGoal): AgentGoal {
+  try {
+    return AgentGoalSchema.parse(candidate);
+  } catch (cause) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Goal state is invalid",
+      cause,
+    );
+  }
+}
+
+export function validateGoalCommandIdentity(
+  command: GoalCommandIdentity,
+): GoalCommandIdentity {
+  const idempotencyKey = requireGoalStateIdentifier(
+    command.idempotencyKey,
+    "idempotencyKey",
+  );
+  if (!/^[a-f0-9]{64}$/i.test(command.requestFingerprint)) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Goal command request fingerprint must be a SHA-256 digest",
+    );
+  }
+  return { idempotencyKey, requestFingerprint: command.requestFingerprint };
+}
+
+export function materializeGoalInstruction(
+  draft: RuntimeInstructionDraft,
+  command: GoalCommandIdentity,
+  sequence: number,
+): RuntimeInstruction {
+  if (draft.idempotencyKey !== command.idempotencyKey) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Instruction and Goal command idempotency keys must match",
+    );
+  }
+  try {
+    return RuntimeInstructionSchema.parse({ ...draft, sequence });
+  } catch (cause) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Runtime Instruction draft is invalid",
+      cause,
+    );
+  }
+}
+
+export function assertGoalActivationCommit(
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+): void {
+  if (
+    goal.revision !== 1 ||
+    goal.status !== "active" ||
+    instruction.kind !== "goal.activate" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision ||
+    canonicalJson(instruction.payload.goal) !== canonicalJson(goal)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Activation must atomically commit an active revision-one Goal and its matching instruction",
+    );
+  }
+}
+
+export function assertGoalRevisionCommit(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+): void {
+  if (
+    goal.revision !== expectedRevision + 1 ||
+    goal.createdAt !== previousGoal.createdAt ||
+    goal.status !== "active" ||
+    canonicalJson(goal.source) !== canonicalJson(previousGoal.source) ||
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal revision commit must advance the active Goal exactly once without changing immutable state or moving time backwards",
+    );
+  }
+
+  const supportedKind =
+    instruction.kind === "goal.update" ||
+    instruction.kind === "context.upsert" ||
+    instruction.kind === "context.remove";
+  if (
+    !supportedKind ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Goal revision commits must use a supported update instruction with matching identity",
+    );
+  }
+
+  switch (instruction.kind) {
+    case "goal.update":
+      if (
+        instruction.payload.previousRevision !== expectedRevision ||
+        canonicalJson(instruction.payload.goal) !== canonicalJson(goal) ||
+        canonicalJson(previousGoal.contextRefs) !==
+          canonicalJson(goal.contextRefs)
+      ) {
+        throw new DurableAgentGoalStateError(
+          "invalid_commit",
+          "A Goal update instruction must contain the authoritative Goal revision, preserve context, and identify its exact previous revision",
+        );
+      }
+      return;
+    case "context.upsert":
+      assertContextUpsertTransition(
+        previousGoal,
+        goal,
+        instruction.payload.contextRef,
+      );
+      return;
+    case "context.remove":
+      assertContextRemoveTransition(
+        previousGoal,
+        goal,
+        instruction.payload.contextRefId,
+      );
+      return;
+  }
+}
+
+export function assertGoalResumeCommit(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+): void {
+  if (
+    previousGoal.status !== "paused" ||
+    goal.status !== "active" ||
+    goal.revision !== expectedRevision + 1 ||
+    instruction.kind !== "goal.resume" ||
+    instruction.deliveryMode !== "steer" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "An ordinary Goal transition may only resume a paused Goal with its matching steer instruction",
+    );
+  }
+
+  assertStatusTransition(previousGoal.status, goal.status, "lifecycle");
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: goal.status,
+    updatedAt: goal.updatedAt,
+  };
+  if (
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expected) !== canonicalJson(goal)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal lifecycle commit may change only status, revision, and updatedAt",
+    );
+  }
+}
+
+export function assertGoalContinuationCommit(
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+): void {
+  if (
+    goal.status !== "active" ||
+    goal.revision !== expectedRevision ||
+    instruction.kind !== "goal.continue" ||
+    instruction.deliveryMode !== "steer" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== expectedRevision
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal continuation must append a matching steer instruction without revising the active Goal",
+    );
+  }
+
+  assertGoalContinuationCriteria(goal, instruction);
+}
+
+export function assertGoalContinuationCriteria(
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+): void {
+  if (instruction.kind !== "goal.continue") {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal continuation must use a goal.continue instruction",
+    );
+  }
+
+  const requiredCriteria = new Map(
+    goal.successCriteria
+      .filter((criterion) => criterion.required)
+      .map((criterion) => [criterion.id, criterion.description] as const),
+  );
+  const seenCriteria = new Set<string>();
+  const hasInvalidCriterion = instruction.payload.missingCriteria.some(
+    (criterion) => {
+      if (seenCriteria.has(criterion.id)) return true;
+      seenCriteria.add(criterion.id);
+      return requiredCriteria.get(criterion.id) !== criterion.description;
+    },
+  );
+  if (instruction.payload.missingCriteria.length === 0 || hasInvalidCriterion) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal continuation may reference only unique, current required success criteria with their exact descriptions",
+    );
+  }
+}
+
+export function assertGoalEvaluationTransition(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  expectedRevision: number,
+): void {
+  const allowedStatus =
+    goal.status === "blocked" ||
+    goal.status === "completed" ||
+    goal.status === "expired" ||
+    goal.status === "budget_limited" ||
+    goal.status === "failed";
+  if (
+    previousGoal.status !== "active" ||
+    !allowedStatus ||
+    goal.revision !== expectedRevision + 1
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "An evaluator transition must advance an active Goal exactly once to an evaluator-owned outcome",
+    );
+  }
+  assertStatusTransition(previousGoal.status, goal.status, "evaluation");
+
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: goal.status,
+    updatedAt: goal.updatedAt,
+  };
+  if (
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expected) !== canonicalJson(goal)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "A Goal evaluation transition may change only status, revision, and updatedAt",
+    );
+  }
+}
+
+export function assertGoalLifecyclePreparation(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  instruction: RuntimeInstruction,
+  action: GoalLifecycleTransitionAction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+  expectedRunEpoch: number,
+): void {
+  const expectedStatus = action === "pause" ? "paused" : "cancelled";
+  const instructionExpectedRunEpoch =
+    instruction.kind === "goal.pause" || instruction.kind === "goal.cancel"
+      ? instruction.payload.expectedRunEpoch
+      : undefined;
+  const validSourceStatus =
+    action === "pause"
+      ? previousGoal.status === "active"
+      : previousGoal.status === "active" || previousGoal.status === "paused";
+  if (
+    !validSourceStatus ||
+    goal.status !== expectedStatus ||
+    goal.revision !== expectedRevision + 1 ||
+    instruction.kind !== `goal.${action}` ||
+    instruction.deliveryMode !== "interrupt_replace" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.id ||
+    instruction.goalRevision !== goal.revision ||
+    instructionExpectedRunEpoch !== expectedRunEpoch
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `A Goal ${action} barrier must advance the authoritative Goal exactly once with its matching interrupting steer instruction`,
+    );
+  }
+
+  assertStatusTransition(previousGoal.status, goal.status, "lifecycle");
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: expectedStatus,
+    updatedAt: goal.updatedAt,
+  };
+  if (
+    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expected) !== canonicalJson(goal)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `A Goal ${action} barrier may change only status, revision, and updatedAt`,
+    );
+  }
+}
+
+export function assertGoalReplacementPreparation(
+  previousGoal: AgentGoal,
+  supersededGoal: AgentGoal,
+  replacementGoal: AgentGoal,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+  expectedRevision: number,
+  expectedRunEpoch: number,
+): void {
+  try {
+    assertGoalStatusTransition(previousGoal.status, "cancelled");
+  } catch (cause) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Goal replacement cannot supersede a ${previousGoal.status} Goal`,
+      cause,
+    );
+  }
+
+  const expectedSupersededGoal: AgentGoal = {
+    ...previousGoal,
+    revision: expectedRevision + 1,
+    status: "cancelled",
+    updatedAt: supersededGoal.updatedAt,
+  };
+  if (
+    supersededGoal.id === replacementGoal.id ||
+    supersededGoal.revision !== expectedRevision + 1 ||
+    Date.parse(supersededGoal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
+    canonicalJson(expectedSupersededGoal) !== canonicalJson(supersededGoal) ||
+    replacementGoal.revision !== 1 ||
+    replacementGoal.status !== "active"
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Replacement preparation must only cancel the current Goal and reserve a distinct active revision-one Goal",
+    );
+  }
+  if (
+    instruction.kind !== "control.interrupt" ||
+    instruction.deliveryMode !== "interrupt_replace" ||
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== supersededGoal.id ||
+    instruction.goalRevision !== supersededGoal.revision ||
+    instruction.payload.replacementGoalId !== replacementGoal.id ||
+    instruction.payload.expectedRunEpoch !== expectedRunEpoch
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Replacement preparation requires a matching control.interrupt instruction and run epoch",
+    );
+  }
+}
+
+export function assertGoalReplacementActivation(
+  replacement: AgentGoalReplacement,
+  instruction: RuntimeInstruction,
+  runtimeSessionId: string,
+): void {
+  assertGoalActivationCommit(
+    replacement.replacementGoal.goal,
+    instruction,
+    runtimeSessionId,
+  );
+  if (
+    canonicalJson(instruction.source) !==
+      canonicalJson(replacement.controlInstruction.source) ||
+    Date.parse(instruction.issuedAt) <
+      Date.parse(replacement.controlInstruction.issuedAt)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Replacement activation must preserve command authority and monotonic instruction time",
+    );
+  }
+}
+
+export function assertReplacementEpochAdvance(
+  replacement: AgentGoalReplacement,
+  expectedRunEpoch: number,
+  nextRunEpoch: number,
+): void {
+  if (
+    expectedRunEpoch !== replacement.expectedRunEpoch ||
+    nextRunEpoch !== expectedRunEpoch + 1
+  ) {
+    throw new DurableAgentGoalStateError(
+      "run_epoch_conflict",
+      `Replacement must advance Runtime Session epoch ${replacement.expectedRunEpoch} exactly once`,
+    );
+  }
+  if (
+    replacement.phase !== "prepared" &&
+    replacement.runEpoch !== nextRunEpoch
+  ) {
+    throw new DurableAgentGoalStateError(
+      "run_epoch_conflict",
+      `Replacement already observed Runtime Session epoch ${replacement.runEpoch}`,
+    );
+  }
+}
+
+export function assertLifecycleEpochAdvance(
+  transition: AgentGoalLifecycleTransition,
+  expectedRunEpoch: number,
+  nextRunEpoch: number,
+): void {
+  const requiredNextRunEpoch =
+    transition.action === "pause"
+      ? transition.expectedRunEpoch
+      : transition.expectedRunEpoch + 1;
+  if (
+    expectedRunEpoch !== transition.expectedRunEpoch ||
+    nextRunEpoch !== requiredNextRunEpoch
+  ) {
+    throw new DurableAgentGoalStateError(
+      "run_epoch_conflict",
+      `Goal ${transition.action} must finalize Runtime Session epoch ${transition.expectedRunEpoch} as epoch ${requiredNextRunEpoch}`,
+    );
+  }
+  if (
+    transition.phase === "finalized" &&
+    transition.runEpoch !== nextRunEpoch
+  ) {
+    throw new DurableAgentGoalStateError(
+      "run_epoch_conflict",
+      `Goal ${transition.action} already finalized Runtime Session epoch ${transition.runEpoch}`,
+    );
+  }
+}
+
+export function validateLifecycleTransitionAction(
+  value: unknown,
+): GoalLifecycleTransitionAction {
+  if (value !== "pause" && value !== "cancel") {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      "Lifecycle transition action must be pause or cancel",
+    );
+  }
+  return value;
+}
+
+export function goalOccupiesPrimarySlot(status: GoalStatus): boolean {
+  return status === "active" || status === "paused" || status === "blocked";
+}
+
+function assertContextUpsertTransition(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  contextRef: AgentGoal["contextRefs"][number],
+): void {
+  const contextRefs = structuredClone(previousGoal.contextRefs);
+  const existingIndex = contextRefs.findIndex(
+    (candidate) => candidate.id === contextRef.id,
+  );
+  if (
+    existingIndex >= 0 &&
+    canonicalJson(contextRefs[existingIndex]) === canonicalJson(contextRef)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Context upsert ${contextRef.id} does not change authoritative Goal context`,
+    );
+  }
+  if (existingIndex >= 0)
+    contextRefs[existingIndex] = structuredClone(contextRef);
+  else contextRefs.push(structuredClone(contextRef));
+
+  assertExactContextTransition(previousGoal, goal, contextRefs, "upsert");
+}
+
+function assertContextRemoveTransition(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  contextRefId: string,
+): void {
+  if (
+    !previousGoal.contextRefs.some((candidate) => candidate.id === contextRefId)
+  ) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Context remove ${contextRefId} does not reference existing authoritative Goal context`,
+    );
+  }
+  assertExactContextTransition(
+    previousGoal,
+    goal,
+    previousGoal.contextRefs.filter(
+      (candidate) => candidate.id !== contextRefId,
+    ),
+    "remove",
+  );
+}
+
+function assertExactContextTransition(
+  previousGoal: AgentGoal,
+  goal: AgentGoal,
+  contextRefs: AgentGoal["contextRefs"],
+  operation: "upsert" | "remove",
+): void {
+  const expected: AgentGoal = {
+    ...previousGoal,
+    revision: goal.revision,
+    updatedAt: goal.updatedAt,
+    contextRefs,
+  };
+  if (canonicalJson(expected) !== canonicalJson(goal)) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Context ${operation} must change only the referenced authoritative Goal context`,
+    );
+  }
+}
+
+function assertStatusTransition(
+  previous: GoalStatus,
+  next: GoalStatus,
+  source: "lifecycle" | "evaluation",
+): void {
+  try {
+    assertGoalStatusTransition(previous, next);
+  } catch (cause) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Goal ${source} transition ${previous} -> ${next} is invalid`,
+      cause,
+    );
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
@@ -1,25 +1,44 @@
-import {
-  type AgentGoal,
-  type AgentGoalEvaluationStatePort,
-  type AgentGoalLifecycleTransition,
-  type AgentGoalReplacement,
-  AgentGoalSchema,
-  type AgentGoalStatePort,
-  type GoalCommandIdentity,
-  type GoalEvaluationTransitionCommit,
-  type GoalInstructionCommit,
-  type GoalLifecycleTransitionAction,
-  type GoalLifecycleTransitionCommit,
-  type GoalReplacementCommit,
-  type GoalStatus,
-  type PersistedAgentGoal,
-  type RuntimeInstruction,
-  type RuntimeInstructionDraft,
-  RuntimeInstructionSchema,
-  assertGoalStatusTransition,
-  canonicalJson,
+import type {
+  AgentGoal,
+  AgentGoalEvaluationStatePort,
+  AgentGoalLifecycleTransition,
+  AgentGoalReplacement,
+  AgentGoalStatePort,
+  GoalCommandIdentity,
+  GoalEvaluationTransitionCommit,
+  GoalInstructionCommit,
+  GoalLifecycleTransitionAction,
+  GoalLifecycleTransitionCommit,
+  GoalReplacementCommit,
+  PersistedAgentGoal,
+  RuntimeInstruction,
+  RuntimeInstructionDraft,
 } from "@openloomi/ai/agent/runtime-instructions";
 
+import {
+  AgentGoalStateError as InMemoryGoalStateError,
+  type AgentGoalStateErrorCode as InMemoryGoalStateErrorCode,
+} from "./goal-state-error";
+import {
+  assertGoalActivationCommit as assertActivationCommit,
+  assertGoalContinuationCommit as assertContinuationCommit,
+  assertGoalEvaluationTransition as assertEvaluationTransition,
+  assertGoalLifecyclePreparation as assertLifecycleTransitionPreparation,
+  assertGoalReplacementActivation as assertReplacementActivation,
+  assertGoalReplacementPreparation as assertReplacementPreparation,
+  assertGoalRevisionCommit as assertRevisionCommit,
+  assertGoalResumeCommit as assertTransitionCommit,
+  assertLifecycleEpochAdvance,
+  assertReplacementEpochAdvance,
+  goalOccupiesPrimarySlot as occupiesPrimarySlot,
+  materializeGoalInstruction as materializeInstruction,
+  parseGoalState as parseGoal,
+  requireGoalStateIdentifier as requiredIdentifier,
+  requireNonNegativeGoalStateInteger as nonNegativeInteger,
+  requirePositiveGoalStateInteger as positiveInteger,
+  validateGoalCommandIdentity as validateCommand,
+  validateLifecycleTransitionAction as lifecycleTransitionAction,
+} from "./goal-state-validation";
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
 
 interface StoredGoalInstructionCommit {
@@ -60,29 +79,8 @@ interface GoalSessionSnapshot {
   runEpoch: number;
 }
 
-export type InMemoryGoalStateErrorCode =
-  | "active_primary_goal_conflict"
-  | "goal_conflict"
-  | "goal_not_found"
-  | "idempotency_conflict"
-  | "invalid_commit"
-  | "lifecycle_transition_in_progress"
-  | "lifecycle_transition_not_found"
-  | "replacement_in_progress"
-  | "replacement_not_found"
-  | "run_epoch_conflict"
-  | "revision_conflict";
-
-export class InMemoryGoalStateError extends Error {
-  constructor(
-    public readonly code: InMemoryGoalStateErrorCode,
-    message: string,
-    public readonly cause?: unknown,
-  ) {
-    super(message);
-    this.name = "InMemoryGoalStateError";
-  }
-}
+export { InMemoryGoalStateError };
+export type { InMemoryGoalStateErrorCode };
 
 /**
  * In-memory authoritative Goal state and immutable instruction outbox.
@@ -332,19 +330,6 @@ export class InMemoryAgentGoalState
           `Expected Goal revision ${expectedRevision}, received ${persisted.goal.revision}`,
         );
       }
-      if (
-        goal.revision !== expectedRevision + 1 ||
-        goal.createdAt !== persisted.goal.createdAt ||
-        goal.status !== "active" ||
-        canonicalJson(goal.source) !== canonicalJson(persisted.goal.source) ||
-        Date.parse(goal.updatedAt) < Date.parse(persisted.goal.updatedAt)
-      ) {
-        throw new InMemoryGoalStateError(
-          "invalid_commit",
-          "A Goal revision commit must advance the active Goal exactly once without changing immutable state or moving time backwards",
-        );
-      }
-
       const instruction = materializeInstruction(
         input.instruction,
         command,
@@ -529,7 +514,6 @@ export class InMemoryAgentGoalState
         command,
         current.lastInstructionSequence + 1,
       );
-      assertContinuationCriteria(persisted.goal, instruction);
       assertContinuationCommit(
         persisted.goal,
         instruction,
@@ -1286,479 +1270,6 @@ function throwIdempotencyNamespaceConflict(
   );
 }
 
-function materializeInstruction(
-  draft: RuntimeInstructionDraft,
-  command: GoalCommandIdentity,
-  sequence: number,
-): RuntimeInstruction {
-  if (draft.idempotencyKey !== command.idempotencyKey) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Instruction and Goal command idempotency keys must match",
-    );
-  }
-  try {
-    return RuntimeInstructionSchema.parse({ ...draft, sequence });
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Runtime Instruction draft is invalid",
-      cause,
-    );
-  }
-}
-
-function assertActivationCommit(
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-): void {
-  if (
-    goal.revision !== 1 ||
-    goal.status !== "active" ||
-    instruction.kind !== "goal.activate" ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== goal.id ||
-    instruction.goalRevision !== goal.revision ||
-    canonicalJson(instruction.payload.goal) !== canonicalJson(goal)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Activation must atomically commit an active revision-one Goal and its matching instruction",
-    );
-  }
-}
-
-function assertReplacementPreparation(
-  previousGoal: AgentGoal,
-  supersededGoal: AgentGoal,
-  replacementGoal: AgentGoal,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-  expectedRevision: number,
-  expectedRunEpoch: number,
-): void {
-  try {
-    assertGoalStatusTransition(previousGoal.status, "cancelled");
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Goal replacement cannot supersede a ${previousGoal.status} Goal`,
-      cause,
-    );
-  }
-
-  const expectedSupersededGoal: AgentGoal = {
-    ...previousGoal,
-    revision: expectedRevision + 1,
-    status: "cancelled",
-    updatedAt: supersededGoal.updatedAt,
-  };
-  if (
-    supersededGoal.id === replacementGoal.id ||
-    supersededGoal.revision !== expectedRevision + 1 ||
-    Date.parse(supersededGoal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
-    canonicalJson(expectedSupersededGoal) !== canonicalJson(supersededGoal) ||
-    replacementGoal.revision !== 1 ||
-    replacementGoal.status !== "active"
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Replacement preparation must only cancel the current Goal and reserve a distinct active revision-one Goal",
-    );
-  }
-  if (
-    instruction.kind !== "control.interrupt" ||
-    instruction.deliveryMode !== "interrupt_replace" ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== supersededGoal.id ||
-    instruction.goalRevision !== supersededGoal.revision ||
-    instruction.payload.replacementGoalId !== replacementGoal.id ||
-    instruction.payload.expectedRunEpoch !== expectedRunEpoch
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Replacement preparation requires a matching control.interrupt instruction and run epoch",
-    );
-  }
-}
-
-function assertReplacementActivation(
-  replacement: AgentGoalReplacement,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-): void {
-  assertActivationCommit(
-    replacement.replacementGoal.goal,
-    instruction,
-    runtimeSessionId,
-  );
-  if (
-    canonicalJson(instruction.source) !==
-      canonicalJson(replacement.controlInstruction.source) ||
-    Date.parse(instruction.issuedAt) <
-      Date.parse(replacement.controlInstruction.issuedAt)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Replacement activation must preserve command authority and monotonic instruction time",
-    );
-  }
-}
-
-function assertRevisionCommit(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-  expectedRevision: number,
-): void {
-  const supportedKind =
-    instruction.kind === "goal.update" ||
-    instruction.kind === "context.upsert" ||
-    instruction.kind === "context.remove";
-  if (
-    !supportedKind ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== goal.id ||
-    instruction.goalRevision !== goal.revision
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Goal revision commits must use a supported update instruction with matching identity",
-    );
-  }
-
-  switch (instruction.kind) {
-    case "goal.update":
-      if (
-        instruction.payload.previousRevision !== expectedRevision ||
-        canonicalJson(instruction.payload.goal) !== canonicalJson(goal) ||
-        canonicalJson(previousGoal.contextRefs) !==
-          canonicalJson(goal.contextRefs)
-      ) {
-        throw new InMemoryGoalStateError(
-          "invalid_commit",
-          "A Goal update instruction must contain the authoritative Goal revision, preserve context, and identify its exact previous revision",
-        );
-      }
-      return;
-    case "context.upsert":
-      assertContextUpsertTransition(
-        previousGoal,
-        goal,
-        instruction.payload.contextRef,
-      );
-      return;
-    case "context.remove":
-      assertContextRemoveTransition(
-        previousGoal,
-        goal,
-        instruction.payload.contextRefId,
-      );
-      return;
-  }
-}
-
-function assertTransitionCommit(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-  expectedRevision: number,
-): void {
-  if (
-    previousGoal.status !== "paused" ||
-    goal.status !== "active" ||
-    goal.revision !== expectedRevision + 1 ||
-    instruction.kind !== "goal.resume" ||
-    instruction.deliveryMode !== "steer" ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== goal.id ||
-    instruction.goalRevision !== goal.revision
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "An ordinary Goal transition may only resume a paused Goal with its matching steer instruction",
-    );
-  }
-
-  try {
-    assertGoalStatusTransition(previousGoal.status, goal.status);
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Goal lifecycle transition ${previousGoal.status} -> ${goal.status} is invalid`,
-      cause,
-    );
-  }
-
-  const expected: AgentGoal = {
-    ...previousGoal,
-    revision: expectedRevision + 1,
-    status: goal.status,
-    updatedAt: goal.updatedAt,
-  };
-  if (
-    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
-    canonicalJson(expected) !== canonicalJson(goal)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal lifecycle commit may change only status, revision, and updatedAt",
-    );
-  }
-}
-
-function assertContinuationCriteria(
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-): void {
-  if (instruction.kind !== "goal.continue") {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal continuation must use a goal.continue instruction",
-    );
-  }
-
-  const requiredCriteria = new Map(
-    goal.successCriteria
-      .filter((criterion) => criterion.required)
-      .map((criterion) => [criterion.id, criterion.description] as const),
-  );
-  const seenCriteria = new Set<string>();
-  const hasInvalidCriterion = instruction.payload.missingCriteria.some(
-    (criterion) => {
-      if (seenCriteria.has(criterion.id)) return true;
-      seenCriteria.add(criterion.id);
-      return requiredCriteria.get(criterion.id) !== criterion.description;
-    },
-  );
-
-  if (instruction.payload.missingCriteria.length === 0 || hasInvalidCriterion) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal continuation may reference only unique, current required success criteria with their exact descriptions",
-    );
-  }
-}
-
-function assertContinuationCommit(
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-  runtimeSessionId: string,
-  expectedRevision: number,
-): void {
-  if (
-    goal.status !== "active" ||
-    goal.revision !== expectedRevision ||
-    instruction.kind !== "goal.continue" ||
-    instruction.deliveryMode !== "steer" ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== goal.id ||
-    instruction.goalRevision !== expectedRevision
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal continuation must append a matching steer instruction without revising the active Goal",
-    );
-  }
-
-  const requiredCriteria = new Map(
-    goal.successCriteria
-      .filter((criterion) => criterion.required)
-      .map((criterion) => [criterion.id, criterion.description]),
-  );
-  if (
-    instruction.payload.missingCriteria.some(
-      (criterion) =>
-        requiredCriteria.get(criterion.id) !== criterion.description,
-    )
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal continuation may reference only missing required criteria from the active Goal revision",
-    );
-  }
-}
-
-function assertEvaluationTransition(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  expectedRevision: number,
-): void {
-  const allowedStatus =
-    goal.status === "blocked" ||
-    goal.status === "completed" ||
-    goal.status === "expired" ||
-    goal.status === "budget_limited" ||
-    goal.status === "failed";
-  if (
-    previousGoal.status !== "active" ||
-    !allowedStatus ||
-    goal.revision !== expectedRevision + 1
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "An evaluator transition must advance an active Goal exactly once to an evaluator-owned outcome",
-    );
-  }
-  try {
-    assertGoalStatusTransition(previousGoal.status, goal.status);
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Goal evaluation transition ${previousGoal.status} -> ${goal.status} is invalid`,
-      cause,
-    );
-  }
-
-  const expected: AgentGoal = {
-    ...previousGoal,
-    revision: expectedRevision + 1,
-    status: goal.status,
-    updatedAt: goal.updatedAt,
-  };
-  if (
-    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
-    canonicalJson(expected) !== canonicalJson(goal)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "A Goal evaluation transition may change only status, revision, and updatedAt",
-    );
-  }
-}
-
-function assertLifecycleTransitionPreparation(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  instruction: RuntimeInstruction,
-  action: GoalLifecycleTransitionAction,
-  runtimeSessionId: string,
-  expectedRevision: number,
-  expectedRunEpoch: number,
-): void {
-  const expectedStatus = action === "pause" ? "paused" : "cancelled";
-  const instructionExpectedRunEpoch =
-    instruction.kind === "goal.pause" || instruction.kind === "goal.cancel"
-      ? instruction.payload.expectedRunEpoch
-      : undefined;
-  const validSourceStatus =
-    action === "pause"
-      ? previousGoal.status === "active"
-      : previousGoal.status === "active" || previousGoal.status === "paused";
-  if (
-    !validSourceStatus ||
-    goal.status !== expectedStatus ||
-    goal.revision !== expectedRevision + 1 ||
-    instruction.kind !== `goal.${action}` ||
-    instruction.deliveryMode !== "interrupt_replace" ||
-    instruction.targetSessionId !== runtimeSessionId ||
-    instruction.goalId !== goal.id ||
-    instruction.goalRevision !== goal.revision ||
-    instructionExpectedRunEpoch !== expectedRunEpoch
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `A Goal ${action} barrier must advance the authoritative Goal exactly once with its matching interrupting steer instruction`,
-    );
-  }
-
-  try {
-    assertGoalStatusTransition(previousGoal.status, goal.status);
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Goal lifecycle transition ${previousGoal.status} -> ${goal.status} is invalid`,
-      cause,
-    );
-  }
-
-  const expected: AgentGoal = {
-    ...previousGoal,
-    revision: expectedRevision + 1,
-    status: expectedStatus,
-    updatedAt: goal.updatedAt,
-  };
-  if (
-    Date.parse(goal.updatedAt) < Date.parse(previousGoal.updatedAt) ||
-    canonicalJson(expected) !== canonicalJson(goal)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `A Goal ${action} barrier may change only status, revision, and updatedAt`,
-    );
-  }
-}
-
-function assertContextUpsertTransition(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  contextRef: AgentGoal["contextRefs"][number],
-): void {
-  const contextRefs = clone(previousGoal.contextRefs);
-  const existingIndex = contextRefs.findIndex(
-    (candidate) => candidate.id === contextRef.id,
-  );
-  if (
-    existingIndex >= 0 &&
-    canonicalJson(contextRefs[existingIndex]) === canonicalJson(contextRef)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Context upsert ${contextRef.id} does not change authoritative Goal context`,
-    );
-  }
-  if (existingIndex >= 0) contextRefs[existingIndex] = clone(contextRef);
-  else contextRefs.push(clone(contextRef));
-
-  assertExactContextTransition(previousGoal, goal, contextRefs, "upsert");
-}
-
-function assertContextRemoveTransition(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  contextRefId: string,
-): void {
-  if (
-    !previousGoal.contextRefs.some((candidate) => candidate.id === contextRefId)
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Context remove ${contextRefId} does not reference existing authoritative Goal context`,
-    );
-  }
-  assertExactContextTransition(
-    previousGoal,
-    goal,
-    previousGoal.contextRefs.filter(
-      (candidate) => candidate.id !== contextRefId,
-    ),
-    "remove",
-  );
-}
-
-function assertExactContextTransition(
-  previousGoal: AgentGoal,
-  goal: AgentGoal,
-  contextRefs: AgentGoal["contextRefs"],
-  operation: "upsert" | "remove",
-): void {
-  const expected: AgentGoal = {
-    ...previousGoal,
-    revision: goal.revision,
-    updatedAt: goal.updatedAt,
-    contextRefs,
-  };
-  if (canonicalJson(expected) !== canonicalJson(goal)) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `Context ${operation} must change only the referenced authoritative Goal context`,
-    );
-  }
-}
-
 function createStoredCommit(
   goal: PersistedAgentGoal,
   instruction: RuntimeInstruction,
@@ -1863,32 +1374,6 @@ function toLifecycleTransitionCommit(
     transition: clone(stored.transition),
     deduplicated,
   };
-}
-
-function parseGoal(candidate: AgentGoal): AgentGoal {
-  try {
-    return AgentGoalSchema.parse(candidate);
-  } catch (cause) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Goal state is invalid",
-      cause,
-    );
-  }
-}
-
-function validateCommand(command: GoalCommandIdentity): GoalCommandIdentity {
-  const idempotencyKey = requiredIdentifier(
-    command.idempotencyKey,
-    "idempotencyKey",
-  );
-  if (!/^[a-f0-9]{64}$/i.test(command.requestFingerprint)) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Goal command request fingerprint must be a SHA-256 digest",
-    );
-  }
-  return { idempotencyKey, requestFingerprint: command.requestFingerprint };
 }
 
 function requireReplacement(
@@ -2011,24 +1496,11 @@ function assertReplacementEpochRequest(
   expectedRunEpoch: number,
   nextRunEpoch: number,
 ): void {
-  if (
-    expectedRunEpoch !== stored.replacement.expectedRunEpoch ||
-    nextRunEpoch !== expectedRunEpoch + 1
-  ) {
-    throw new InMemoryGoalStateError(
-      "run_epoch_conflict",
-      `Replacement must advance Runtime Session epoch ${stored.replacement.expectedRunEpoch} exactly once`,
-    );
-  }
-  if (
-    stored.replacement.phase !== "prepared" &&
-    stored.replacement.runEpoch !== nextRunEpoch
-  ) {
-    throw new InMemoryGoalStateError(
-      "run_epoch_conflict",
-      `Replacement already observed Runtime Session epoch ${stored.replacement.runEpoch}`,
-    );
-  }
+  assertReplacementEpochAdvance(
+    stored.replacement,
+    expectedRunEpoch,
+    nextRunEpoch,
+  );
 }
 
 function assertLifecycleEpochRequest(
@@ -2036,32 +1508,11 @@ function assertLifecycleEpochRequest(
   expectedRunEpoch: number,
   nextRunEpoch: number,
 ): void {
-  const requiredNextRunEpoch =
-    stored.transition.action === "pause"
-      ? stored.transition.expectedRunEpoch
-      : stored.transition.expectedRunEpoch + 1;
-  if (
-    expectedRunEpoch !== stored.transition.expectedRunEpoch ||
-    nextRunEpoch !== requiredNextRunEpoch
-  ) {
-    throw new InMemoryGoalStateError(
-      "run_epoch_conflict",
-      `Goal ${stored.transition.action} must finalize Runtime Session epoch ${stored.transition.expectedRunEpoch} as epoch ${requiredNextRunEpoch}`,
-    );
-  }
-  if (
-    stored.transition.phase === "finalized" &&
-    stored.transition.runEpoch !== nextRunEpoch
-  ) {
-    throw new InMemoryGoalStateError(
-      "run_epoch_conflict",
-      `Goal ${stored.transition.action} already finalized Runtime Session epoch ${stored.transition.runEpoch}`,
-    );
-  }
-}
-
-function occupiesPrimarySlot(status: GoalStatus): boolean {
-  return status === "active" || status === "paused" || status === "blocked";
+  assertLifecycleEpochAdvance(
+    stored.transition,
+    expectedRunEpoch,
+    nextRunEpoch,
+  );
 }
 
 function validatedScope(ownerId: string, runtimeSessionId: string) {
@@ -2075,59 +1526,6 @@ function validatedScope(ownerId: string, runtimeSessionId: string) {
     runtimeSessionId: normalizedSessionId,
     key: sessionScope(normalizedOwnerId, normalizedSessionId),
   };
-}
-
-function requiredIdentifier(value: unknown, field: string): string {
-  if (typeof value !== "string") {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `${field} must be a string`,
-    );
-  }
-  const normalized = value.trim();
-  if (
-    normalized.length === 0 ||
-    normalized.length > 256 ||
-    normalized !== value
-  ) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `${field} must contain 1 to 256 characters without surrounding whitespace`,
-    );
-  }
-  return value;
-}
-
-function positiveInteger(value: unknown, field: string): number {
-  if (!Number.isInteger(value) || (value as number) <= 0) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `${field} must be a positive integer`,
-    );
-  }
-  return value as number;
-}
-
-function nonNegativeInteger(value: unknown, field: string): number {
-  if (!Number.isInteger(value) || (value as number) < 0) {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      `${field} must be a non-negative integer`,
-    );
-  }
-  return value as number;
-}
-
-function lifecycleTransitionAction(
-  value: unknown,
-): GoalLifecycleTransitionAction {
-  if (value !== "pause" && value !== "cancel") {
-    throw new InMemoryGoalStateError(
-      "invalid_commit",
-      "Lifecycle transition action must be pause or cancel",
-    );
-  }
-  return value;
 }
 
 function sessionScope(ownerId: string, runtimeSessionId: string): string {

--- a/apps/web/lib/ai/runtime-instructions/persistence/checkpoints.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/checkpoints.ts
@@ -1,0 +1,357 @@
+import {
+  AgentGoalSchema,
+  RuntimeInstructionSchema,
+  canonicalJson,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalReplacement,
+  type GoalInstructionCommit,
+  type PersistedAgentGoal,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type { AgentGoalCommandCheckpoint } from "@/lib/db/agent-goal-runtime-schema-types";
+import { invalidPersistenceRecord } from "./errors";
+import type { StoredRuntimeInstruction } from "./goal-instruction-mappers";
+
+export function goalInstructionCommitFromRoot(
+  root: StoredRuntimeInstruction,
+  scope: { ownerId: string; runtimeSessionId: string },
+  deduplicated: boolean,
+): GoalInstructionCommit {
+  assertRootScope(root, scope, "Goal command");
+  const checkpoint = requireCheckpoint(root, "goal_instruction");
+  const goal = parsePersistedGoal(checkpoint.goal, scope, "Goal command");
+  const instruction = parseCheckpointInstruction(
+    checkpoint.instruction,
+    "Goal command",
+  );
+  assertInstructionGoalIdentity(
+    instruction,
+    goal,
+    scope.runtimeSessionId,
+    "Goal command",
+  );
+  assertSameInstruction(root, instruction, "Goal command");
+  return {
+    goal,
+    instruction,
+    deduplicated,
+  };
+}
+
+export function lifecycleTransitionFromRoot(
+  root: StoredRuntimeInstruction,
+  scope: { ownerId: string; runtimeSessionId: string },
+): AgentGoalLifecycleTransition {
+  assertRootScope(root, scope, "Goal lifecycle checkpoint");
+  const checkpoint = requireCheckpoint(root, "lifecycle");
+  const transition = checkpoint.transition;
+  if (
+    transition.ownerId !== scope.ownerId ||
+    transition.runtimeSessionId !== scope.runtimeSessionId ||
+    (transition.action !== "pause" && transition.action !== "cancel") ||
+    !["prepared", "boundary_observed", "finalized"].includes(
+      transition.phase,
+    ) ||
+    transition.phase !== root.commandPhase ||
+    !Number.isSafeInteger(transition.expectedRunEpoch) ||
+    transition.expectedRunEpoch < 0 ||
+    !Number.isSafeInteger(transition.runEpoch) ||
+    transition.runEpoch < 0
+  ) {
+    invalidPersistenceRecord(
+      "Goal lifecycle checkpoint",
+      "scope, phase, action, or run epoch is invalid",
+    );
+  }
+  const parsed: AgentGoalLifecycleTransition = {
+    ...structuredClone(transition),
+    transitionedGoal: parsePersistedGoal(
+      transition.transitionedGoal,
+      scope,
+      "Goal lifecycle checkpoint",
+    ),
+    instruction: parseCheckpointInstruction(
+      transition.instruction,
+      "Goal lifecycle checkpoint",
+    ),
+  };
+  const expectedEpoch =
+    parsed.action === "pause" || parsed.phase === "prepared"
+      ? parsed.expectedRunEpoch
+      : parsed.expectedRunEpoch + 1;
+  if (
+    parsed.runEpoch !== expectedEpoch ||
+    (parsed.action === "pause" && parsed.phase === "boundary_observed")
+  ) {
+    invalidPersistenceRecord(
+      "Goal lifecycle checkpoint",
+      "phase and run epoch do not describe a reachable lifecycle barrier",
+    );
+  }
+  assertLifecycleIdentity(root, parsed, scope.runtimeSessionId);
+  assertSameInstruction(root, parsed.instruction, "Goal lifecycle checkpoint");
+  return parsed;
+}
+
+export function replacementFromRoot(
+  root: StoredRuntimeInstruction,
+  scope: { ownerId: string; runtimeSessionId: string },
+): AgentGoalReplacement {
+  assertRootScope(root, scope, "Goal replacement checkpoint");
+  const checkpoint = requireCheckpoint(root, "replacement");
+  const replacement = checkpoint.replacement;
+  if (
+    replacement.ownerId !== scope.ownerId ||
+    replacement.runtimeSessionId !== scope.runtimeSessionId ||
+    !["prepared", "boundary_observed", "activated"].includes(
+      replacement.phase,
+    ) ||
+    replacement.phase !== root.commandPhase ||
+    !Number.isSafeInteger(replacement.expectedRunEpoch) ||
+    replacement.expectedRunEpoch < 0 ||
+    !Number.isSafeInteger(replacement.runEpoch) ||
+    replacement.runEpoch < 0
+  ) {
+    invalidPersistenceRecord(
+      "Goal replacement checkpoint",
+      "scope, phase, or run epoch is invalid",
+    );
+  }
+  const parsed: AgentGoalReplacement = {
+    ...structuredClone(replacement),
+    supersededGoal: parsePersistedGoal(
+      replacement.supersededGoal,
+      scope,
+      "Goal replacement checkpoint",
+    ),
+    replacementGoal: parsePersistedGoal(
+      replacement.replacementGoal,
+      scope,
+      "Goal replacement checkpoint",
+    ),
+    controlInstruction: parseCheckpointInstruction(
+      replacement.controlInstruction,
+      "Goal replacement checkpoint",
+    ),
+    ...(replacement.activationInstruction === undefined
+      ? {}
+      : {
+          activationInstruction: parseCheckpointInstruction(
+            replacement.activationInstruction,
+            "Goal replacement checkpoint",
+          ),
+        }),
+  };
+  const expectedEpoch =
+    parsed.phase === "prepared"
+      ? parsed.expectedRunEpoch
+      : parsed.expectedRunEpoch + 1;
+  if (
+    parsed.runEpoch !== expectedEpoch ||
+    (parsed.phase === "activated") !==
+      (parsed.activationInstruction !== undefined)
+  ) {
+    invalidPersistenceRecord(
+      "Goal replacement checkpoint",
+      "phase, run epoch, and activation snapshot are inconsistent",
+    );
+  }
+  assertReplacementIdentity(root, parsed, scope.runtimeSessionId);
+  assertSameInstruction(
+    root,
+    parsed.controlInstruction,
+    "Goal replacement checkpoint",
+  );
+  return parsed;
+}
+
+function assertRootScope(
+  root: StoredRuntimeInstruction,
+  scope: { ownerId: string; runtimeSessionId: string },
+  entity: string,
+): void {
+  if (
+    root.ownerId !== scope.ownerId ||
+    root.runtimeSessionId !== scope.runtimeSessionId
+  ) {
+    invalidPersistenceRecord(
+      entity,
+      "root instruction crosses its command scope",
+    );
+  }
+}
+
+function assertLifecycleIdentity(
+  root: StoredRuntimeInstruction,
+  transition: AgentGoalLifecycleTransition,
+  runtimeSessionId: string,
+): void {
+  const instruction = transition.instruction;
+  assertInstructionGoalIdentity(
+    instruction,
+    transition.transitionedGoal,
+    runtimeSessionId,
+    "Goal lifecycle checkpoint",
+  );
+  const instructionExpectedRunEpoch =
+    instruction.kind === "goal.pause" || instruction.kind === "goal.cancel"
+      ? instruction.payload.expectedRunEpoch
+      : undefined;
+  if (
+    instruction.kind !== `goal.${transition.action}` ||
+    instructionExpectedRunEpoch !== transition.expectedRunEpoch ||
+    root.runEpoch !== transition.expectedRunEpoch
+  ) {
+    invalidPersistenceRecord(
+      "Goal lifecycle checkpoint",
+      "action or run epoch does not match its root instruction",
+    );
+  }
+}
+
+function assertReplacementIdentity(
+  root: StoredRuntimeInstruction,
+  replacement: AgentGoalReplacement,
+  runtimeSessionId: string,
+): void {
+  const controlInstruction = replacement.controlInstruction;
+  assertInstructionGoalIdentity(
+    controlInstruction,
+    replacement.supersededGoal,
+    runtimeSessionId,
+    "Goal replacement checkpoint",
+  );
+  if (
+    controlInstruction.kind !== "control.interrupt" ||
+    controlInstruction.payload.replacementGoalId !==
+      replacement.replacementGoal.goal.id ||
+    controlInstruction.payload.expectedRunEpoch !==
+      replacement.expectedRunEpoch ||
+    root.runEpoch !== replacement.expectedRunEpoch
+  ) {
+    invalidPersistenceRecord(
+      "Goal replacement checkpoint",
+      "control instruction does not identify its Goals or root run epoch",
+    );
+  }
+
+  const activationInstruction = replacement.activationInstruction;
+  if (activationInstruction === undefined) return;
+  assertInstructionGoalIdentity(
+    activationInstruction,
+    replacement.replacementGoal,
+    runtimeSessionId,
+    "Goal replacement checkpoint",
+  );
+  if (
+    activationInstruction.kind !== "goal.activate" ||
+    activationInstruction.idempotencyKey !==
+      controlInstruction.idempotencyKey ||
+    activationInstruction.payload.goal.id !==
+      replacement.replacementGoal.goal.id ||
+    activationInstruction.payload.goal.revision !==
+      replacement.replacementGoal.goal.revision
+  ) {
+    invalidPersistenceRecord(
+      "Goal replacement checkpoint",
+      "activation instruction does not identify the reserved replacement Goal or command",
+    );
+  }
+}
+
+function assertInstructionGoalIdentity(
+  instruction: ReturnType<typeof parseCheckpointInstruction>,
+  goal: PersistedAgentGoal,
+  runtimeSessionId: string,
+  entity: string,
+): void {
+  if (
+    instruction.targetSessionId !== runtimeSessionId ||
+    instruction.goalId !== goal.goal.id ||
+    instruction.goalRevision !== goal.goal.revision
+  ) {
+    invalidPersistenceRecord(
+      entity,
+      "instruction Goal identity does not match its authoritative Goal snapshot and Runtime Session",
+    );
+  }
+}
+
+function requireCheckpoint<T extends AgentGoalCommandCheckpoint["type"]>(
+  root: StoredRuntimeInstruction,
+  type: T,
+): Extract<AgentGoalCommandCheckpoint, { type: T }> {
+  if (
+    root.commandOrder !== 0 ||
+    root.commandType !== type ||
+    root.commandCheckpoint?.type !== type
+  ) {
+    invalidPersistenceRecord(
+      "Runtime Instruction command checkpoint",
+      `expected a ${type} root command`,
+    );
+  }
+  return root.commandCheckpoint as Extract<
+    AgentGoalCommandCheckpoint,
+    { type: T }
+  >;
+}
+
+function parsePersistedGoal(
+  value: unknown,
+  scope: { ownerId: string; runtimeSessionId: string },
+  entity: string,
+): PersistedAgentGoal {
+  if (typeof value !== "object" || value === null) {
+    invalidPersistenceRecord(entity, "Goal snapshot is not an object");
+  }
+  const candidate = value as PersistedAgentGoal;
+  if (
+    candidate.ownerId !== scope.ownerId ||
+    candidate.runtimeSessionId !== scope.runtimeSessionId ||
+    candidate.slot !== "primary"
+  ) {
+    invalidPersistenceRecord(entity, "Goal snapshot crosses its command scope");
+  }
+  const parsedGoal = AgentGoalSchema.safeParse(candidate.goal);
+  if (!parsedGoal.success) {
+    invalidPersistenceRecord(
+      entity,
+      "Goal snapshot failed protocol validation",
+      parsedGoal.error,
+    );
+  }
+  return {
+    ownerId: scope.ownerId,
+    runtimeSessionId: scope.runtimeSessionId,
+    slot: "primary",
+    goal: parsedGoal.data,
+  };
+}
+
+function parseCheckpointInstruction(value: unknown, entity: string) {
+  const parsed = RuntimeInstructionSchema.safeParse(value);
+  if (!parsed.success) {
+    invalidPersistenceRecord(
+      entity,
+      "instruction snapshot failed protocol validation",
+      parsed.error,
+    );
+  }
+  return parsed.data;
+}
+
+function assertSameInstruction(
+  root: StoredRuntimeInstruction,
+  checkpointInstruction: unknown,
+  entity: string,
+): void {
+  if (
+    canonicalJson(root.instruction) !== canonicalJson(checkpointInstruction)
+  ) {
+    invalidPersistenceRecord(
+      entity,
+      "checkpoint instruction does not match the immutable outbox snapshot",
+    );
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/errors.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/errors.ts
@@ -1,0 +1,39 @@
+export type AgentGoalPersistenceErrorCode =
+  | "invalid_record"
+  | "conflict"
+  | "idempotency_conflict"
+  | "run_epoch_conflict";
+
+export class AgentGoalPersistenceError extends Error {
+  constructor(
+    public readonly code: AgentGoalPersistenceErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentGoalPersistenceError";
+  }
+}
+
+export function invalidPersistenceRecord(
+  entity: string,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AgentGoalPersistenceError(
+    "invalid_record",
+    `Invalid persisted ${entity}: ${message}`,
+    cause,
+  );
+}
+
+export function persistenceConflict(
+  message: string,
+  code: Extract<
+    AgentGoalPersistenceErrorCode,
+    "conflict" | "idempotency_conflict" | "run_epoch_conflict"
+  > = "conflict",
+  cause?: unknown,
+): AgentGoalPersistenceError {
+  return new AgentGoalPersistenceError(code, message, cause);
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/goal-instruction-mappers.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/goal-instruction-mappers.ts
@@ -1,0 +1,466 @@
+import {
+  AgentGoalSchema,
+  RuntimeInstructionSchema,
+  type AgentGoal,
+  type PersistedAgentGoal,
+  type RuntimeInstruction,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type {
+  AgentGoalCommandCheckpoint,
+  AgentGoalCommandPhase,
+  AgentGoalCommandType,
+  AgentGoalSlotState,
+} from "@/lib/db/agent-goal-runtime-schema-types";
+
+import { invalidPersistenceRecord } from "./errors";
+import type { PersistedInstantPrecision } from "./instant-precision";
+import {
+  asPersistenceRecord,
+  assertChronological,
+  assertPersistedEqual,
+  assertPersistedInstantMatchesSnapshot,
+  normalizeOptionalPersistedDate,
+  normalizePersistedDate,
+  parsePersistedJson,
+  parsePersistedSchema,
+  readOptionalString,
+  readRequiredInteger,
+  readRequiredString,
+  type PersistenceRecord,
+} from "./mapping";
+
+const GOAL_ENTITY = "Agent Goal";
+const INSTRUCTION_ENTITY = "Runtime Instruction";
+
+const SLOT_STATES = new Set<AgentGoalSlotState>([
+  "assigned",
+  "reserved",
+  "released",
+]);
+
+export interface StoredRuntimeInstruction {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly instruction: RuntimeInstruction;
+  readonly requestFingerprint: string;
+  readonly commandOrder: number;
+  readonly commandType?: AgentGoalCommandType;
+  readonly commandPhase?: AgentGoalCommandPhase;
+  readonly commandCheckpoint?: AgentGoalCommandCheckpoint;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export function mapAgentGoalRecord(
+  value: unknown,
+  persistedInstantPrecision: PersistedInstantPrecision,
+): PersistedAgentGoal {
+  const row = asPersistenceRecord(value, GOAL_ENTITY);
+  const ownerId = readRequiredString(row, "ownerId", GOAL_ENTITY);
+  const runtimeSessionId = readRequiredString(
+    row,
+    "runtimeSessionId",
+    GOAL_ENTITY,
+  );
+  const id = readRequiredString(row, "id", GOAL_ENTITY);
+  const slot = readRequiredString(row, "slot", GOAL_ENTITY);
+  const slotState = readRequiredString(row, "slotState", GOAL_ENTITY);
+  if (slot !== "primary") {
+    invalidPersistenceRecord(GOAL_ENTITY, `unsupported slot ${slot}`);
+  }
+  if (!SLOT_STATES.has(slotState as AgentGoalSlotState)) {
+    invalidPersistenceRecord(GOAL_ENTITY, `unsupported slotState ${slotState}`);
+  }
+
+  const goal = normalizeGoalSnapshot(row.goalSnapshot);
+  const deadline = normalizeOptionalPersistedDate(
+    row.deadline,
+    "deadline",
+    GOAL_ENTITY,
+  );
+  const createdAt = normalizePersistedDate(
+    row.createdAt,
+    "createdAt",
+    GOAL_ENTITY,
+  );
+  const updatedAt = normalizePersistedDate(
+    row.updatedAt,
+    "updatedAt",
+    GOAL_ENTITY,
+  );
+
+  assertPersistedEqual(GOAL_ENTITY, "id", id, goal.id);
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "revision",
+    readRequiredInteger(row, "revision", GOAL_ENTITY, 1),
+    goal.revision,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "objective",
+    readRequiredString(row, "objective", GOAL_ENTITY, 8_000),
+    goal.objective,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "priority",
+    readRequiredInteger(row, "priority", GOAL_ENTITY, 0),
+    goal.priority,
+  );
+  assertPersistedEqual(GOAL_ENTITY, "status", row.status, goal.status);
+  assertPersistedInstantMatchesSnapshot(
+    GOAL_ENTITY,
+    "deadline",
+    deadline,
+    goal.deadline,
+    persistedInstantPrecision,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "maxTurns",
+    row.maxTurns ?? undefined,
+    goal.maxTurns,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "maxTokens",
+    row.maxTokens ?? undefined,
+    goal.maxTokens,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "maxDurationSeconds",
+    row.maxDurationSeconds ?? undefined,
+    goal.maxDurationSeconds,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "completionPolicy",
+    row.completionPolicy,
+    goal.completionPolicy,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "sourceType",
+    row.sourceType,
+    goal.source.type,
+  );
+  assertPersistedEqual(
+    GOAL_ENTITY,
+    "sourceId",
+    readOptionalString(row, "sourceId", GOAL_ENTITY),
+    goal.source.id,
+  );
+  assertPersistedInstantMatchesSnapshot(
+    GOAL_ENTITY,
+    "createdAt",
+    createdAt,
+    goal.createdAt,
+    persistedInstantPrecision,
+  );
+  assertPersistedInstantMatchesSnapshot(
+    GOAL_ENTITY,
+    "updatedAt",
+    updatedAt,
+    goal.updatedAt,
+    persistedInstantPrecision,
+  );
+
+  return {
+    ownerId,
+    runtimeSessionId,
+    slot: "primary",
+    goal,
+  };
+}
+
+export function mapRuntimeInstructionRecord(
+  value: unknown,
+  persistedInstantPrecision: PersistedInstantPrecision,
+): RuntimeInstruction {
+  return mapStoredRuntimeInstructionRecord(value, persistedInstantPrecision)
+    .instruction;
+}
+
+export function mapStoredRuntimeInstructionRecord(
+  value: unknown,
+  persistedInstantPrecision: PersistedInstantPrecision,
+): StoredRuntimeInstruction {
+  const row = asPersistenceRecord(value, INSTRUCTION_ENTITY);
+  const ownerId = readRequiredString(row, "ownerId", INSTRUCTION_ENTITY);
+  const runtimeSessionId = readRequiredString(
+    row,
+    "runtimeSessionId",
+    INSTRUCTION_ENTITY,
+  );
+  const instruction = normalizeInstructionSnapshot(row.instructionSnapshot);
+  const issuedAt = normalizePersistedDate(
+    row.issuedAt,
+    "issuedAt",
+    INSTRUCTION_ENTITY,
+  );
+  const expiresAt = normalizeOptionalPersistedDate(
+    row.expiresAt,
+    "expiresAt",
+    INSTRUCTION_ENTITY,
+  );
+  const createdAt = normalizePersistedDate(
+    row.createdAt,
+    "createdAt",
+    INSTRUCTION_ENTITY,
+  );
+  const updatedAt = normalizePersistedDate(
+    row.updatedAt,
+    "updatedAt",
+    INSTRUCTION_ENTITY,
+  );
+  const sequence = readRequiredInteger(row, "sequence", INSTRUCTION_ENTITY, 1);
+  const runEpoch = readRequiredInteger(row, "runEpoch", INSTRUCTION_ENTITY, 0);
+  const commandOrder = readRequiredInteger(
+    row,
+    "commandOrder",
+    INSTRUCTION_ENTITY,
+    0,
+  );
+  const requestFingerprint = readRequiredString(
+    row,
+    "requestFingerprint",
+    INSTRUCTION_ENTITY,
+    64,
+  );
+  if (!/^[a-f0-9]{64}$/i.test(requestFingerprint)) {
+    invalidPersistenceRecord(
+      INSTRUCTION_ENTITY,
+      "requestFingerprint must be a SHA-256 digest",
+    );
+  }
+
+  assertPersistedEqual(INSTRUCTION_ENTITY, "id", row.id, instruction.id);
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "schemaVersion",
+    row.schemaVersion,
+    instruction.schemaVersion,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "sequence",
+    sequence,
+    instruction.sequence,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "goalId",
+    row.goalId ?? undefined,
+    instruction.goalId,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "goalRevision",
+    row.goalRevision ?? undefined,
+    instruction.goalRevision,
+  );
+  assertPersistedEqual(INSTRUCTION_ENTITY, "kind", row.kind, instruction.kind);
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "deliveryMode",
+    row.deliveryMode,
+    instruction.deliveryMode,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "targetSessionId",
+    runtimeSessionId,
+    instruction.targetSessionId,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "payload",
+    row.payload,
+    instruction.payload,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "sourceType",
+    row.sourceType,
+    instruction.source.type,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "sourceAuthority",
+    row.sourceAuthority,
+    instruction.source.authority,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "sourceRef",
+    readOptionalString(row, "sourceRef", INSTRUCTION_ENTITY, 2_048),
+    instruction.source.sourceRef,
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "idempotencyKey",
+    row.idempotencyKey,
+    instruction.idempotencyKey,
+  );
+  assertPersistedInstantMatchesSnapshot(
+    INSTRUCTION_ENTITY,
+    "issuedAt",
+    issuedAt,
+    instruction.issuedAt,
+    persistedInstantPrecision,
+  );
+  assertPersistedInstantMatchesSnapshot(
+    INSTRUCTION_ENTITY,
+    "expiresAt",
+    expiresAt,
+    instruction.expiresAt,
+    persistedInstantPrecision,
+  );
+  assertChronological(
+    INSTRUCTION_ENTITY,
+    "createdAt",
+    createdAt,
+    "updatedAt",
+    updatedAt,
+  );
+
+  const command = mapCommandMetadata(row, commandOrder);
+  return {
+    ownerId,
+    runtimeSessionId,
+    runEpoch,
+    instruction,
+    requestFingerprint,
+    commandOrder,
+    ...command,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function normalizeGoalSnapshot(value: unknown): AgentGoal {
+  const snapshot = parsePersistedSchema(
+    AgentGoalSchema,
+    value,
+    "goalSnapshot",
+    GOAL_ENTITY,
+  );
+  return AgentGoalSchema.parse({
+    ...snapshot,
+    createdAt: normalizePersistedDate(
+      snapshot.createdAt,
+      "goalSnapshot.createdAt",
+      GOAL_ENTITY,
+    ),
+    updatedAt: normalizePersistedDate(
+      snapshot.updatedAt,
+      "goalSnapshot.updatedAt",
+      GOAL_ENTITY,
+    ),
+    ...(snapshot.deadline === undefined || snapshot.deadline === null
+      ? {}
+      : {
+          deadline: normalizePersistedDate(
+            snapshot.deadline,
+            "goalSnapshot.deadline",
+            GOAL_ENTITY,
+          ),
+        }),
+  });
+}
+
+function normalizeInstructionSnapshot(value: unknown): RuntimeInstruction {
+  const snapshot = parsePersistedSchema(
+    RuntimeInstructionSchema,
+    value,
+    "instructionSnapshot",
+    INSTRUCTION_ENTITY,
+  );
+  return RuntimeInstructionSchema.parse({
+    ...snapshot,
+    issuedAt: normalizePersistedDate(
+      snapshot.issuedAt,
+      "instructionSnapshot.issuedAt",
+      INSTRUCTION_ENTITY,
+    ),
+    ...(snapshot.expiresAt === undefined || snapshot.expiresAt === null
+      ? {}
+      : {
+          expiresAt: normalizePersistedDate(
+            snapshot.expiresAt,
+            "instructionSnapshot.expiresAt",
+            INSTRUCTION_ENTITY,
+          ),
+        }),
+  });
+}
+
+function mapCommandMetadata(
+  row: PersistenceRecord,
+  commandOrder: number,
+): Pick<
+  StoredRuntimeInstruction,
+  "commandType" | "commandPhase" | "commandCheckpoint"
+> {
+  if (commandOrder > 0) {
+    if (
+      row.commandType !== null ||
+      row.commandPhase !== null ||
+      row.commandCheckpoint !== null
+    ) {
+      invalidPersistenceRecord(
+        INSTRUCTION_ENTITY,
+        "non-root command rows cannot contain command metadata",
+      );
+    }
+    return {};
+  }
+
+  const commandType = readRequiredString(
+    row,
+    "commandType",
+    INSTRUCTION_ENTITY,
+    32,
+  ) as AgentGoalCommandType;
+  const commandPhase = readRequiredString(
+    row,
+    "commandPhase",
+    INSTRUCTION_ENTITY,
+    32,
+  ) as AgentGoalCommandPhase;
+  const validPhase =
+    (commandType === "goal_instruction" && commandPhase === "committed") ||
+    (commandType === "lifecycle" &&
+      ["prepared", "boundary_observed", "finalized"].includes(commandPhase)) ||
+    (commandType === "replacement" &&
+      ["prepared", "boundary_observed", "activated"].includes(commandPhase));
+  if (!validPhase) {
+    invalidPersistenceRecord(
+      INSTRUCTION_ENTITY,
+      `invalid command phase ${commandType}/${commandPhase}`,
+    );
+  }
+  const checkpoint = asPersistenceRecord(
+    parsePersistedJson(
+      row.commandCheckpoint,
+      "commandCheckpoint",
+      INSTRUCTION_ENTITY,
+    ),
+    "Runtime Instruction command checkpoint",
+  );
+  assertPersistedEqual(
+    INSTRUCTION_ENTITY,
+    "commandCheckpoint.type",
+    checkpoint.type,
+    commandType,
+  );
+  return {
+    commandType,
+    commandPhase,
+    commandCheckpoint: checkpoint as AgentGoalCommandCheckpoint,
+  };
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/goal-run-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/goal-run-state.ts
@@ -1,0 +1,67 @@
+import {
+  assertGoalRunStatusTransition,
+  type AgentGoal,
+  type AgentGoalRun,
+  type GoalRunStatus,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { AgentGoalStateError } from "../goal-state-error";
+
+export function assertGoalRunMutationTransition(
+  current: GoalRunStatus,
+  next: GoalRunStatus,
+): void {
+  if (current === next) return;
+  try {
+    assertGoalRunStatusTransition(current, next);
+  } catch (cause) {
+    throw new AgentGoalStateError(
+      "invalid_commit",
+      `Goal Run transition ${current} -> ${next} is invalid for this Goal mutation`,
+      cause,
+    );
+  }
+}
+
+export function goalRunStatusForEvaluation(
+  status: AgentGoal["status"],
+): GoalRunStatus {
+  switch (status) {
+    case "blocked":
+      return "blocked";
+    case "completed":
+      return "completed";
+    case "expired":
+    case "budget_limited":
+      return "budget_limited";
+    case "failed":
+      return "failed";
+    default:
+      throw new AgentGoalStateError(
+        "invalid_commit",
+        `Goal status ${status} is not an evaluator-owned Run outcome`,
+      );
+  }
+}
+
+export function isTerminalGoalRunStatus(status: GoalRunStatus): boolean {
+  return (
+    status === "completed" ||
+    status === "cancelled" ||
+    status === "budget_limited" ||
+    status === "failed"
+  );
+}
+
+export function monotonicGoalRunActivity(
+  run: Pick<AgentGoalRun, "startedAt" | "lastActivityAt">,
+  observedAt: Date | string,
+): Date {
+  const observedAtMillis =
+    observedAt instanceof Date ? observedAt.getTime() : Date.parse(observedAt);
+  const lowerBound = Math.max(
+    Date.parse(run.startedAt),
+    Date.parse(run.lastActivityAt),
+  );
+  return new Date(Math.max(observedAtMillis, lowerBound));
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/index.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/index.ts
@@ -1,0 +1,5 @@
+export * from "./errors";
+export * from "./goal-instruction-mappers";
+export * from "./instant-precision";
+export * from "./runtime-observation-mappers";
+export * from "./sqlite";

--- a/apps/web/lib/ai/runtime-instructions/persistence/instant-precision.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/instant-precision.ts
@@ -1,0 +1,7 @@
+export type PersistedInstantPrecision = "exact" | "whole-second";
+
+export const EXACT_PERSISTED_INSTANT_PRECISION =
+  "exact" as const satisfies PersistedInstantPrecision;
+
+export const WHOLE_SECOND_PERSISTED_INSTANT_PRECISION =
+  "whole-second" as const satisfies PersistedInstantPrecision;

--- a/apps/web/lib/ai/runtime-instructions/persistence/internal/record-builders.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/internal/record-builders.ts
@@ -1,0 +1,246 @@
+import type {
+  AgentGoalRun,
+  GoalEvidence,
+  PersistedAgentGoal,
+  RuntimeInstruction,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type {
+  AgentGoalCommandCheckpoint,
+  AgentGoalCommandPhase,
+  AgentGoalCommandType,
+  AgentGoalSlotState,
+} from "@/lib/db/agent-goal-runtime-schema-types";
+
+import {
+  mapAgentGoalRecord,
+  mapStoredRuntimeInstructionRecord,
+} from "../goal-instruction-mappers";
+import { EXACT_PERSISTED_INSTANT_PRECISION } from "../instant-precision";
+import { readRequiredInteger, toDatabaseDate } from "../mapping";
+import {
+  mapAgentGoalRunRecord,
+  mapGoalEvidenceRecord,
+  mapRuntimeInstructionDeliveryRecord,
+} from "../runtime-observation-mappers";
+
+export interface AgentGoalRecordInput {
+  readonly persistedGoal: PersistedAgentGoal;
+  readonly slotState: AgentGoalSlotState;
+}
+
+export function buildAgentGoalRecord(input: AgentGoalRecordInput) {
+  const { persistedGoal, slotState } = input;
+  const { goal } = persistedGoal;
+  const row = {
+    id: goal.id,
+    ownerId: persistedGoal.ownerId,
+    runtimeSessionId: persistedGoal.runtimeSessionId,
+    slot: persistedGoal.slot,
+    slotState,
+    revision: goal.revision,
+    objective: goal.objective,
+    priority: goal.priority,
+    status: goal.status,
+    deadline: goal.deadline
+      ? toDatabaseDate(goal.deadline, "deadline", "Agent Goal")
+      : null,
+    maxTurns: goal.maxTurns ?? null,
+    maxTokens: goal.maxTokens ?? null,
+    maxDurationSeconds: goal.maxDurationSeconds ?? null,
+    completionPolicy: goal.completionPolicy,
+    sourceType: goal.source.type,
+    sourceId: goal.source.id ?? null,
+    goalSnapshot: goal,
+    createdAt: toDatabaseDate(goal.createdAt, "createdAt", "Agent Goal"),
+    updatedAt: toDatabaseDate(goal.updatedAt, "updatedAt", "Agent Goal"),
+  };
+  mapAgentGoalRecord(row, EXACT_PERSISTED_INSTANT_PRECISION);
+  return row;
+}
+
+export interface AgentGoalRunRecordInput {
+  readonly run: AgentGoalRun;
+  readonly recordedAt: string;
+}
+
+export function buildAgentGoalRunRecord(input: AgentGoalRunRecordInput) {
+  const createdAt = toDatabaseDate(input.recordedAt, "recordedAt", "Goal Run");
+  const row = {
+    id: input.run.id,
+    ownerId: input.run.ownerId,
+    runtimeSessionId: input.run.runtimeSessionId,
+    goalId: input.run.goalId,
+    goalRevision: input.run.goalRevision,
+    runEpoch: input.run.runEpoch,
+    providerSessionId: input.run.providerSessionId ?? null,
+    status: input.run.status,
+    turnsUsed: input.run.turnsUsed,
+    tokensUsed: input.run.tokensUsed,
+    startedAt: toDatabaseDate(input.run.startedAt, "startedAt", "Goal Run"),
+    lastActivityAt: toDatabaseDate(
+      input.run.lastActivityAt,
+      "lastActivityAt",
+      "Goal Run",
+    ),
+    completedAt: input.run.completedAt
+      ? toDatabaseDate(input.run.completedAt, "completedAt", "Goal Run")
+      : null,
+    lastEvaluation: input.run.lastEvaluation ?? null,
+    createdAt,
+    updatedAt: createdAt,
+  };
+  mapAgentGoalRunRecord(row);
+  return row;
+}
+
+export interface RuntimeInstructionRecordInput {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly instruction: RuntimeInstruction;
+  readonly requestFingerprint: string;
+  readonly commandOrder: number;
+  readonly commandType?: AgentGoalCommandType;
+  readonly commandPhase?: AgentGoalCommandPhase;
+  readonly commandCheckpoint?: AgentGoalCommandCheckpoint;
+  readonly recordedAt: string;
+}
+
+export function buildRuntimeInstructionRecord(
+  input: RuntimeInstructionRecordInput,
+) {
+  const recordedAt = toDatabaseDate(
+    input.recordedAt,
+    "recordedAt",
+    "Runtime Instruction",
+  );
+  const row = {
+    id: input.instruction.id,
+    ownerId: input.ownerId,
+    runtimeSessionId: input.runtimeSessionId,
+    schemaVersion: input.instruction.schemaVersion,
+    sequence: input.instruction.sequence,
+    runEpoch: input.runEpoch,
+    goalId: input.instruction.goalId ?? null,
+    goalRevision: input.instruction.goalRevision ?? null,
+    kind: input.instruction.kind,
+    deliveryMode: input.instruction.deliveryMode,
+    payload: input.instruction.payload,
+    sourceType: input.instruction.source.type,
+    sourceAuthority: input.instruction.source.authority,
+    sourceRef: input.instruction.source.sourceRef ?? null,
+    idempotencyKey: input.instruction.idempotencyKey,
+    requestFingerprint: input.requestFingerprint,
+    commandOrder: input.commandOrder,
+    commandType: input.commandType ?? null,
+    commandPhase: input.commandPhase ?? null,
+    commandCheckpoint: input.commandCheckpoint ?? null,
+    instructionSnapshot: input.instruction,
+    issuedAt: toDatabaseDate(
+      input.instruction.issuedAt,
+      "issuedAt",
+      "Runtime Instruction",
+    ),
+    expiresAt: input.instruction.expiresAt
+      ? toDatabaseDate(
+          input.instruction.expiresAt,
+          "expiresAt",
+          "Runtime Instruction",
+        )
+      : null,
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+  };
+  mapStoredRuntimeInstructionRecord(row, EXACT_PERSISTED_INSTANT_PRECISION);
+  return row;
+}
+
+export interface PendingRuntimeDeliveryRecordInput {
+  readonly id: string;
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly instructionId: string;
+  readonly goalRunId?: string;
+  readonly runEpoch: number;
+  readonly attempt?: number;
+  readonly availableAt: string;
+  readonly recordedAt: string;
+}
+
+export function buildPendingRuntimeDeliveryRecord(
+  input: PendingRuntimeDeliveryRecordInput,
+) {
+  const recordedAt = toDatabaseDate(
+    input.recordedAt,
+    "recordedAt",
+    "Runtime Instruction Delivery",
+  );
+  const row = {
+    id: input.id,
+    ownerId: input.ownerId,
+    runtimeSessionId: input.runtimeSessionId,
+    instructionId: input.instructionId,
+    goalRunId: input.goalRunId ?? null,
+    runEpoch: readRequiredInteger(
+      { runEpoch: input.runEpoch },
+      "runEpoch",
+      "Runtime Instruction Delivery",
+      0,
+    ),
+    state: "pending" as const,
+    attempt: input.attempt ?? 1,
+    availableAt: toDatabaseDate(
+      input.availableAt,
+      "availableAt",
+      "Runtime Instruction Delivery",
+    ),
+    leaseToken: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    providerEventId: null,
+    errorCode: null,
+    errorMessage: null,
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+  };
+  mapRuntimeInstructionDeliveryRecord(row);
+  return row;
+}
+
+export interface AgentGoalEvidenceRecordInput {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly evidence: GoalEvidence;
+  readonly recordedAt: string;
+}
+
+export function buildAgentGoalEvidenceRecord(
+  input: AgentGoalEvidenceRecordInput,
+) {
+  const row = {
+    id: input.evidence.id,
+    ownerId: input.ownerId,
+    runtimeSessionId: input.runtimeSessionId,
+    goalId: input.evidence.goalId,
+    goalRunId: input.evidence.goalRunId,
+    instructionId: input.evidence.instructionId ?? null,
+    goalRevision: input.evidence.goalRevision,
+    runEpoch: input.runEpoch,
+    criterionId: input.evidence.criterionId ?? null,
+    type: input.evidence.type,
+    sourceEventId: input.evidence.sourceEventId,
+    summary: input.evidence.summary,
+    success: input.evidence.success ?? null,
+    payload: input.evidence.payload,
+    observedAt: toDatabaseDate(
+      input.evidence.observedAt,
+      "observedAt",
+      "Goal Evidence",
+    ),
+    createdAt: toDatabaseDate(input.recordedAt, "recordedAt", "Goal Evidence"),
+  };
+  mapGoalEvidenceRecord(row);
+  return row;
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/mapping.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/mapping.ts
@@ -1,0 +1,263 @@
+import { canonicalJson } from "@openloomi/ai/agent/runtime-instructions";
+import type { z } from "zod";
+
+import { invalidPersistenceRecord } from "./errors";
+import type { PersistedInstantPrecision } from "./instant-precision";
+
+export type PersistenceRecord = Readonly<Record<string, unknown>>;
+
+export function asPersistenceRecord(
+  value: unknown,
+  entity: string,
+): PersistenceRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    invalidPersistenceRecord(entity, "expected an object row");
+  }
+  return value as PersistenceRecord;
+}
+
+export function readRequiredString(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+  maxCharacters = 256,
+): string {
+  const value = row[field];
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxCharacters ||
+    value.trim() !== value
+  ) {
+    invalidPersistenceRecord(entity, `${field} is not a valid identifier`);
+  }
+  return value;
+}
+
+export function readOptionalString(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+  maxCharacters = 256,
+): string | undefined {
+  const value = row[field];
+  if (value === undefined || value === null) return undefined;
+  return readRequiredString({ [field]: value }, field, entity, maxCharacters);
+}
+
+export function readOptionalText(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+): string | undefined {
+  const value = row[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    invalidPersistenceRecord(entity, `${field} must be a string or null`);
+  }
+  return value;
+}
+
+export function readRequiredUuid(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+): string {
+  const value = readRequiredString(row, field, entity);
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  ) {
+    invalidPersistenceRecord(entity, `${field} must be a UUID`);
+  }
+  return value;
+}
+
+export function readOptionalUuid(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+): string | undefined {
+  const value = row[field];
+  if (value === undefined || value === null) return undefined;
+  return readRequiredUuid({ [field]: value }, field, entity);
+}
+
+export function readRequiredInteger(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+  minimum: number,
+): number {
+  const value = row[field];
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    invalidPersistenceRecord(
+      entity,
+      `${field} must be a safe integer greater than or equal to ${minimum}`,
+    );
+  }
+  return value as number;
+}
+
+export function readOptionalBoolean(
+  row: PersistenceRecord,
+  field: string,
+  entity: string,
+): boolean | undefined {
+  const value = row[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "boolean") {
+    invalidPersistenceRecord(entity, `${field} must be a boolean or null`);
+  }
+  return value;
+}
+
+export function normalizePersistedDate(
+  value: unknown,
+  field: string,
+  entity: string,
+): string {
+  if (!(value instanceof Date) && typeof value !== "string") {
+    invalidPersistenceRecord(entity, `${field} must be a Date or ISO string`);
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    invalidPersistenceRecord(entity, `${field} is not a valid date`);
+  }
+  return date.toISOString();
+}
+
+export function normalizeOptionalPersistedDate(
+  value: unknown,
+  field: string,
+  entity: string,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return normalizePersistedDate(value, field, entity);
+}
+
+export function parsePersistedJson(
+  value: unknown,
+  field: string,
+  entity: string,
+): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch (cause) {
+    invalidPersistenceRecord(entity, `${field} is not valid JSON`, cause);
+  }
+}
+
+export function parsePersistedSchema<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  field: string,
+  entity: string,
+): T {
+  let parsed = schema.safeParse(value);
+  if (!parsed.success && typeof value === "string") {
+    try {
+      parsed = schema.safeParse(JSON.parse(value));
+    } catch {
+      // Scalar text columns are valid inputs for enum/string schemas. Keep the
+      // direct validation error when the value is not serialized JSON.
+    }
+  }
+  if (!parsed.success) {
+    invalidPersistenceRecord(
+      entity,
+      `${field} failed validation`,
+      parsed.error,
+    );
+  }
+  return parsed.data;
+}
+
+export function assertPersistedEqual(
+  entity: string,
+  field: string,
+  actual: unknown,
+  expected: unknown,
+): void {
+  // `canonicalJson` intentionally accepts JSON values, while optional
+  // snapshot fields are represented as `undefined` in the domain model.
+  if (actual === undefined || expected === undefined) {
+    if (actual === expected) return;
+    invalidPersistenceRecord(
+      entity,
+      `${field} does not match its authoritative snapshot`,
+    );
+  }
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    invalidPersistenceRecord(
+      entity,
+      `${field} does not match its authoritative snapshot`,
+    );
+  }
+}
+
+export function assertPersistedInstantMatchesSnapshot(
+  entity: string,
+  field: string,
+  persisted: string | undefined,
+  snapshot: string | undefined,
+  precision: PersistedInstantPrecision,
+): void {
+  if (persisted === undefined || snapshot === undefined) {
+    assertPersistedEqual(entity, field, persisted, snapshot);
+    return;
+  }
+  const persistedMillis = Date.parse(persisted);
+  const snapshotMillis = Date.parse(snapshot);
+  const matches =
+    precision === "exact"
+      ? persistedMillis === snapshotMillis
+      : Math.floor(persistedMillis / 1_000) ===
+        Math.floor(snapshotMillis / 1_000);
+  if (
+    !Number.isFinite(persistedMillis) ||
+    !Number.isFinite(snapshotMillis) ||
+    !matches
+  ) {
+    invalidPersistenceRecord(
+      entity,
+      `${field} does not match its authoritative snapshot`,
+    );
+  }
+}
+
+export function persistedInstantIsStrictlyAfter(
+  later: Date,
+  earlier: Date,
+  precision: PersistedInstantPrecision,
+): boolean {
+  return precision === "exact"
+    ? later.getTime() > earlier.getTime()
+    : Math.floor(later.getTime() / 1_000) >
+        Math.floor(earlier.getTime() / 1_000);
+}
+
+export function assertChronological(
+  entity: string,
+  earlierField: string,
+  earlier: string,
+  laterField: string,
+  later: string,
+): void {
+  if (Date.parse(later) < Date.parse(earlier)) {
+    invalidPersistenceRecord(
+      entity,
+      `${laterField} cannot be earlier than ${earlierField}`,
+    );
+  }
+}
+
+export function toDatabaseDate(
+  value: string,
+  field: string,
+  entity: string,
+): Date {
+  return new Date(normalizePersistedDate(value, field, entity));
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/runtime-observation-mappers.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/runtime-observation-mappers.ts
@@ -1,0 +1,302 @@
+import {
+  DeliveryStateSchema,
+  GoalEvaluationResultSchema,
+  GoalEvidenceSchema,
+  GoalRunStatusSchema,
+  RuntimeProviderSchema,
+  RuntimeSessionStateSchema,
+  type AgentGoalRun,
+  type AgentRuntimeSession,
+  type GoalEvidence,
+  type RuntimeInstructionDelivery,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { invalidPersistenceRecord } from "./errors";
+import {
+  asPersistenceRecord,
+  assertChronological,
+  normalizeOptionalPersistedDate,
+  normalizePersistedDate,
+  parsePersistedSchema,
+  readOptionalBoolean,
+  readOptionalString,
+  readOptionalText,
+  readOptionalUuid,
+  readRequiredInteger,
+  readRequiredString,
+  readRequiredUuid,
+} from "./mapping";
+import { isTerminalGoalRunStatus } from "./goal-run-state";
+
+const SESSION_ENTITY = "Runtime Session";
+const RUN_ENTITY = "Goal Run";
+const DELIVERY_ENTITY = "Runtime Instruction Delivery";
+const EVIDENCE_ENTITY = "Goal Evidence";
+
+/** Delivery fields required to lease and fence a row returned by a worker query. */
+export interface PersistedRuntimeInstructionDelivery extends RuntimeInstructionDelivery {
+  readonly runEpoch: number;
+  readonly availableAt: string;
+}
+
+export function mapRuntimeSessionRecord(value: unknown): AgentRuntimeSession {
+  const row = asPersistenceRecord(value, SESSION_ENTITY);
+  const createdAt = normalizePersistedDate(
+    row.createdAt,
+    "createdAt",
+    SESSION_ENTITY,
+  );
+  const updatedAt = normalizePersistedDate(
+    row.updatedAt,
+    "updatedAt",
+    SESSION_ENTITY,
+  );
+  assertChronological(
+    SESSION_ENTITY,
+    "createdAt",
+    createdAt,
+    "updatedAt",
+    updatedAt,
+  );
+  readRequiredInteger(row, "lastInstructionSequence", SESSION_ENTITY, 0);
+  if (row.pendingOperation !== null && row.pendingOperation !== undefined) {
+    asPersistenceRecord(
+      row.pendingOperation,
+      "Runtime Session pending operation",
+    );
+  }
+
+  return {
+    id: readRequiredString(row, "id", SESSION_ENTITY),
+    ownerId: readRequiredString(row, "ownerId", SESSION_ENTITY),
+    provider: parsePersistedSchema(
+      RuntimeProviderSchema,
+      row.provider,
+      "provider",
+      SESSION_ENTITY,
+    ),
+    providerSessionId: readOptionalString(
+      row,
+      "providerSessionId",
+      SESSION_ENTITY,
+    ),
+    workingDirectory: readOptionalText(row, "workingDirectory", SESSION_ENTITY),
+    state: parsePersistedSchema(
+      RuntimeSessionStateSchema,
+      row.state,
+      "state",
+      SESSION_ENTITY,
+    ),
+    runEpoch: readRequiredInteger(row, "runEpoch", SESSION_ENTITY, 0),
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function mapAgentGoalRunRecord(value: unknown): AgentGoalRun {
+  const row = asPersistenceRecord(value, RUN_ENTITY);
+  const status = parsePersistedSchema(
+    GoalRunStatusSchema,
+    row.status,
+    "status",
+    RUN_ENTITY,
+  );
+  const startedAt = normalizePersistedDate(
+    row.startedAt,
+    "startedAt",
+    RUN_ENTITY,
+  );
+  const lastActivityAt = normalizePersistedDate(
+    row.lastActivityAt,
+    "lastActivityAt",
+    RUN_ENTITY,
+  );
+  const completedAt = normalizeOptionalPersistedDate(
+    row.completedAt,
+    "completedAt",
+    RUN_ENTITY,
+  );
+  const createdAt = normalizePersistedDate(
+    row.createdAt,
+    "createdAt",
+    RUN_ENTITY,
+  );
+  const updatedAt = normalizePersistedDate(
+    row.updatedAt,
+    "updatedAt",
+    RUN_ENTITY,
+  );
+  assertChronological(
+    RUN_ENTITY,
+    "startedAt",
+    startedAt,
+    "lastActivityAt",
+    lastActivityAt,
+  );
+  if (completedAt) {
+    assertChronological(
+      RUN_ENTITY,
+      "lastActivityAt",
+      lastActivityAt,
+      "completedAt",
+      completedAt,
+    );
+  }
+  if (isTerminalGoalRunStatus(status) !== (completedAt !== undefined)) {
+    invalidPersistenceRecord(
+      RUN_ENTITY,
+      "completedAt must be present exactly when the Run is terminal",
+    );
+  }
+  assertChronological(
+    RUN_ENTITY,
+    "createdAt",
+    createdAt,
+    "updatedAt",
+    updatedAt,
+  );
+
+  return {
+    id: readRequiredUuid(row, "id", RUN_ENTITY),
+    ownerId: readRequiredString(row, "ownerId", RUN_ENTITY),
+    goalId: readRequiredUuid(row, "goalId", RUN_ENTITY),
+    goalRevision: readRequiredInteger(row, "goalRevision", RUN_ENTITY, 1),
+    runtimeSessionId: readRequiredString(row, "runtimeSessionId", RUN_ENTITY),
+    providerSessionId: readOptionalString(row, "providerSessionId", RUN_ENTITY),
+    runEpoch: readRequiredInteger(row, "runEpoch", RUN_ENTITY, 0),
+    status,
+    turnsUsed: readRequiredInteger(row, "turnsUsed", RUN_ENTITY, 0),
+    tokensUsed: readRequiredInteger(row, "tokensUsed", RUN_ENTITY, 0),
+    startedAt,
+    lastActivityAt,
+    completedAt,
+    lastEvaluation:
+      row.lastEvaluation === null || row.lastEvaluation === undefined
+        ? undefined
+        : parsePersistedSchema(
+            GoalEvaluationResultSchema,
+            row.lastEvaluation,
+            "lastEvaluation",
+            RUN_ENTITY,
+          ),
+  };
+}
+
+export function mapRuntimeInstructionDeliveryRecord(
+  value: unknown,
+): PersistedRuntimeInstructionDelivery {
+  const row = asPersistenceRecord(value, DELIVERY_ENTITY);
+  const state = parsePersistedSchema(
+    DeliveryStateSchema,
+    row.state,
+    "state",
+    DELIVERY_ENTITY,
+  );
+  const leaseToken = readOptionalString(row, "leaseToken", DELIVERY_ENTITY);
+  const leaseOwner = readOptionalString(row, "leaseOwner", DELIVERY_ENTITY);
+  const leaseExpiresAt = normalizeOptionalPersistedDate(
+    row.leaseExpiresAt,
+    "leaseExpiresAt",
+    DELIVERY_ENTITY,
+  );
+  const leaseFields = [leaseToken, leaseOwner, leaseExpiresAt];
+  const hasCompleteLease = leaseFields.every((value) => value !== undefined);
+  const hasNoLease = leaseFields.every((value) => value === undefined);
+  if (
+    (state === "leased" && !hasCompleteLease) ||
+    (state !== "leased" && !hasNoLease)
+  ) {
+    invalidPersistenceRecord(
+      DELIVERY_ENTITY,
+      "lease fields must all be present only while state is leased",
+    );
+  }
+  const createdAt = normalizePersistedDate(
+    row.createdAt,
+    "createdAt",
+    DELIVERY_ENTITY,
+  );
+  const updatedAt = normalizePersistedDate(
+    row.updatedAt,
+    "updatedAt",
+    DELIVERY_ENTITY,
+  );
+  assertChronological(
+    DELIVERY_ENTITY,
+    "createdAt",
+    createdAt,
+    "updatedAt",
+    updatedAt,
+  );
+  const availableAt = normalizePersistedDate(
+    row.availableAt,
+    "availableAt",
+    DELIVERY_ENTITY,
+  );
+  const runEpoch = readRequiredInteger(row, "runEpoch", DELIVERY_ENTITY, 0);
+
+  return {
+    id: readRequiredUuid(row, "id", DELIVERY_ENTITY),
+    ownerId: readRequiredString(row, "ownerId", DELIVERY_ENTITY),
+    instructionId: readRequiredUuid(row, "instructionId", DELIVERY_ENTITY),
+    runtimeSessionId: readRequiredString(
+      row,
+      "runtimeSessionId",
+      DELIVERY_ENTITY,
+    ),
+    goalRunId: readOptionalUuid(row, "goalRunId", DELIVERY_ENTITY),
+    runEpoch,
+    state,
+    attempt: readRequiredInteger(row, "attempt", DELIVERY_ENTITY, 1),
+    availableAt,
+    leaseToken,
+    leaseOwner,
+    leaseExpiresAt,
+    providerEventId: readOptionalString(
+      row,
+      "providerEventId",
+      DELIVERY_ENTITY,
+    ),
+    errorCode: readOptionalString(row, "errorCode", DELIVERY_ENTITY, 128),
+    errorMessage: readOptionalText(row, "errorMessage", DELIVERY_ENTITY),
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function mapGoalEvidenceRecord(value: unknown): GoalEvidence {
+  const row = asPersistenceRecord(value, EVIDENCE_ENTITY);
+  const evidence = parsePersistedSchema(
+    GoalEvidenceSchema,
+    {
+      id: readRequiredUuid(row, "id", EVIDENCE_ENTITY),
+      goalId: readRequiredUuid(row, "goalId", EVIDENCE_ENTITY),
+      goalRunId: readRequiredUuid(row, "goalRunId", EVIDENCE_ENTITY),
+      goalRevision: readRequiredInteger(
+        row,
+        "goalRevision",
+        EVIDENCE_ENTITY,
+        1,
+      ),
+      instructionId: readOptionalUuid(row, "instructionId", EVIDENCE_ENTITY),
+      criterionId: readOptionalString(row, "criterionId", EVIDENCE_ENTITY),
+      type: row.type,
+      sourceEventId: readRequiredString(row, "sourceEventId", EVIDENCE_ENTITY),
+      summary: readRequiredString(row, "summary", EVIDENCE_ENTITY, 8_000),
+      success: readOptionalBoolean(row, "success", EVIDENCE_ENTITY),
+      payload: row.payload,
+      observedAt: normalizePersistedDate(
+        row.observedAt,
+        "observedAt",
+        EVIDENCE_ENTITY,
+      ),
+    },
+    "row",
+    EVIDENCE_ENTITY,
+  );
+  readRequiredString(row, "ownerId", EVIDENCE_ENTITY);
+  readRequiredString(row, "runtimeSessionId", EVIDENCE_ENTITY);
+  readRequiredInteger(row, "runEpoch", EVIDENCE_ENTITY, 0);
+  normalizePersistedDate(row.createdAt, "createdAt", EVIDENCE_ENTITY);
+  return evidence;
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/agent-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/agent-goal-state.ts
@@ -1,0 +1,1707 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type AgentGoal,
+  type AgentGoalEvaluationStatePort,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalReplacement,
+  type AgentGoalRun,
+  type AgentGoalStatePort,
+  type GoalRunStatus,
+  type GoalCommandIdentity,
+  type GoalEvaluationTransitionCommit,
+  type GoalInstructionCommit,
+  type GoalLifecycleTransitionAction,
+  type GoalLifecycleTransitionCommit,
+  type GoalReplacementCommit,
+  type PersistedAgentGoal,
+  type RuntimeInstruction,
+  type RuntimeInstructionDraft,
+  canonicalJson,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type { AgentGoalCommandCheckpoint } from "@/lib/db/agent-goal-runtime-schema-types";
+
+import { AgentGoalStateError as DurableAgentGoalStateError } from "../../goal-state-error";
+import {
+  assertGoalActivationCommit,
+  assertGoalContinuationCommit,
+  assertGoalEvaluationTransition,
+  assertGoalLifecyclePreparation,
+  assertGoalReplacementActivation,
+  assertGoalReplacementPreparation,
+  assertGoalResumeCommit,
+  assertGoalRevisionCommit,
+  assertLifecycleEpochAdvance,
+  assertReplacementEpochAdvance,
+  goalOccupiesPrimarySlot,
+  materializeGoalInstruction,
+  parseGoalState,
+  requireGoalStateIdentifier,
+  requireNonNegativeGoalStateInteger,
+  requirePositiveGoalStateInteger,
+  validateGoalCommandIdentity,
+  validateGoalStateScope,
+  validateLifecycleTransitionAction,
+} from "../../goal-state-validation";
+import {
+  goalInstructionCommitFromRoot,
+  lifecycleTransitionFromRoot,
+  replacementFromRoot,
+} from "../checkpoints";
+import { AgentGoalPersistenceError } from "../errors";
+import {
+  assertGoalRunMutationTransition as assertRunStatusTransition,
+  goalRunStatusForEvaluation as evaluationRunStatus,
+  isTerminalGoalRunStatus as isTerminalRunStatus,
+  monotonicGoalRunActivity,
+} from "../goal-run-state";
+import type { StoredRuntimeInstruction } from "../goal-instruction-mappers";
+import type { SqliteGoalRuntimeStore, SqliteGoalSessionRecord } from "./store";
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+
+export interface SqliteAgentGoalStateOptions {
+  readonly now?: () => Date;
+  readonly generateId?: () => string;
+}
+
+/**
+ * SQLite authoritative Goal state and transactional instruction outbox.
+ *
+ * Every mutation executes synchronously inside a native better-sqlite3
+ * `BEGIN IMMEDIATE` transaction. Goal/session/run state, the exact historical
+ * command checkpoint, the immutable instruction, and its initial pending
+ * delivery therefore commit or roll back as one unit.
+ */
+export class SqliteAgentGoalState
+  implements AgentGoalStatePort, AgentGoalEvaluationStatePort
+{
+  private readonly database: SqliteGoalRuntimeDatabase;
+  private readonly storage: SqliteGoalRuntimeStore;
+  private readonly now: () => Date;
+  private readonly generateId: () => string;
+
+  constructor(
+    source: SqliteGoalRuntimeDatabaseSource,
+    options: SqliteAgentGoalStateOptions = {},
+  ) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+    this.storage = this.database.store;
+    this.now = options.now ?? (() => new Date());
+    this.generateId = options.generateId ?? randomUUID;
+  }
+
+  async getRuntimeSessionRunEpoch(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<number> {
+    const scope = validateGoalStateScope(ownerId, runtimeSessionId);
+    return (
+      this.storage.getSession(scope.ownerId, scope.runtimeSessionId)
+        ?.runEpoch ?? 0
+    );
+  }
+
+  async getGoal(
+    ownerId: string,
+    goalId: string,
+  ): Promise<PersistedAgentGoal | null> {
+    const normalizedOwnerId = requireGoalStateIdentifier(ownerId, "ownerId");
+    const normalizedGoalId = requireGoalStateIdentifier(goalId, "goalId");
+    const stored = this.storage.getGoalForOwner(
+      normalizedOwnerId,
+      normalizedGoalId,
+    );
+    return stored && stored.slotState !== "reserved"
+      ? clone(stored.persistedGoal)
+      : null;
+  }
+
+  async getActivePrimaryGoal(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<PersistedAgentGoal | null> {
+    const scope = validateGoalStateScope(ownerId, runtimeSessionId);
+    const stored = this.storage.getAssignedPrimaryGoal(
+      scope.ownerId,
+      scope.runtimeSessionId,
+    );
+    return stored?.persistedGoal.goal.status === "active"
+      ? clone(stored.persistedGoal)
+      : null;
+  }
+
+  async listInstructions(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeInstruction[]> {
+    const scope = validateGoalStateScope(ownerId, runtimeSessionId);
+    return clone(
+      this.storage.listInstructions(scope.ownerId, scope.runtimeSessionId),
+    );
+  }
+
+  async findCommitByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit | null> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const stored = this.storage.findCommand(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      command.idempotencyKey,
+    );
+    if (!stored) return null;
+    assertCommandFingerprint(stored, command);
+    if (stored.commandType !== "goal_instruction") {
+      throwIdempotencyNamespaceConflict(command);
+    }
+    return goalInstructionCommitFromRoot(stored, scope, true);
+  }
+
+  async findReplacementByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit | null> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const stored = this.storage.findCommand(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      command.idempotencyKey,
+    );
+    if (!stored) return null;
+    assertCommandFingerprint(stored, command);
+    if (stored.commandType !== "replacement") {
+      throwIdempotencyNamespaceConflict(command);
+    }
+    return {
+      replacement: replacementFromRoot(stored, scope),
+      deduplicated: true,
+    };
+  }
+
+  async findLifecycleTransitionByIdempotency(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit | null> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const stored = this.storage.findCommand(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      command.idempotencyKey,
+    );
+    if (!stored) return null;
+    assertCommandFingerprint(stored, command);
+    if (stored.commandType !== "lifecycle") {
+      throwIdempotencyNamespaceConflict(command);
+    }
+    return {
+      transition: lifecycleTransitionFromRoot(stored, scope),
+      deduplicated: true,
+    };
+  }
+
+  async commitActivation(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const goal = parseGoalState(input.goal);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "goal_instruction") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return goalInstructionCommitFromRoot(duplicate, scope, true);
+      }
+      assertNoPendingOperation(session);
+      const existing = this.storage.getGoalForOwner(scope.ownerId, goal.id);
+      if (existing) {
+        throw new DurableAgentGoalStateError(
+          "goal_conflict",
+          `Goal ${goal.id} already exists in Runtime Session ${existing.persistedGoal.runtimeSessionId} for this owner`,
+        );
+      }
+      const primary = this.storage.getAssignedPrimaryGoal(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      if (
+        primary &&
+        goalOccupiesPrimarySlot(primary.persistedGoal.goal.status)
+      ) {
+        throw new DurableAgentGoalStateError(
+          "active_primary_goal_conflict",
+          `Runtime Session ${scope.runtimeSessionId} already has primary Goal ${primary.persistedGoal.goal.id}`,
+        );
+      }
+
+      const instruction = materializeGoalInstruction(
+        input.instruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalActivationCommit(goal, instruction, scope.runtimeSessionId);
+      const persisted = persistedGoal(scope, goal);
+      const checkpoint = goalInstructionCheckpoint(persisted, instruction);
+      const recordedAt = this.recordedAt();
+
+      this.storage.insertGoal(persisted, "assigned");
+      const runId = this.createQueuedRun(
+        session,
+        persisted,
+        instruction.issuedAt,
+        recordedAt,
+      );
+      this.commitInstruction({
+        session,
+        instruction,
+        command,
+        checkpoint,
+        commandOrder: 0,
+        commandType: "goal_instruction",
+        commandPhase: "committed",
+        goalRunId: runId,
+        expectedPendingOperation: null,
+        pendingOperation: null,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return {
+        goal: clone(persisted),
+        instruction: clone(instruction),
+        deduplicated: false,
+      };
+    });
+  }
+
+  async commitRevision(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const goal = parseGoalState(input.goal);
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "goal_instruction") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return goalInstructionCommitFromRoot(duplicate, scope, true);
+      }
+      assertNoPendingOperation(session);
+      const current = this.requireGoal(scope, goal.id);
+      assertAssignedActiveGoal(
+        current,
+        expectedRevision,
+        scope.runtimeSessionId,
+      );
+
+      const instruction = materializeGoalInstruction(
+        input.instruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalRevisionCommit(
+        current.goal,
+        goal,
+        instruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+      );
+      const revised = persistedGoal(scope, goal);
+      const recordedAt = this.recordedAt();
+      if (
+        !this.storage.updateGoal(
+          revised,
+          expectedRevision,
+          "assigned",
+          "assigned",
+        )
+      ) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const run = this.requireRun(session, goal.id);
+      this.updateRun(run, { goalRevision: goal.revision }, recordedAt);
+      this.commitInstruction({
+        session,
+        instruction,
+        command,
+        checkpoint: goalInstructionCheckpoint(revised, instruction),
+        commandOrder: 0,
+        commandType: "goal_instruction",
+        commandPhase: "committed",
+        goalRunId: run.id,
+        expectedPendingOperation: null,
+        pendingOperation: null,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return {
+        goal: clone(revised),
+        instruction: clone(instruction),
+        deduplicated: false,
+      };
+    });
+  }
+
+  async commitTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const command = validateGoalCommandIdentity(input.command);
+    const goal = parseGoalState(input.goal);
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "goal_instruction") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return goalInstructionCommitFromRoot(duplicate, scope, true);
+      }
+      assertNoPendingOperation(session);
+      const current = this.requireGoal(scope, goal.id);
+      if (current.slotState !== "assigned") {
+        throw invalidPrimaryGoal(goal.id, scope.runtimeSessionId);
+      }
+      if (current.goal.revision !== expectedRevision) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const instruction = materializeGoalInstruction(
+        input.instruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalResumeCommit(
+        current.goal,
+        goal,
+        instruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+      );
+      const transitioned = persistedGoal(scope, goal);
+      const recordedAt = this.recordedAt();
+      if (
+        !this.storage.updateGoal(
+          transitioned,
+          expectedRevision,
+          "assigned",
+          "assigned",
+        )
+      ) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const run = this.requireRun(session, goal.id);
+      this.updateRun(
+        run,
+        { goalRevision: goal.revision, status: "running" },
+        recordedAt,
+      );
+      this.commitInstruction({
+        session,
+        instruction,
+        command,
+        checkpoint: goalInstructionCheckpoint(transitioned, instruction),
+        commandOrder: 0,
+        commandType: "goal_instruction",
+        commandPhase: "committed",
+        goalRunId: run.id,
+        expectedPendingOperation: null,
+        pendingOperation: null,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return {
+        goal: clone(transitioned),
+        instruction: clone(instruction),
+        deduplicated: false,
+      };
+    });
+  }
+
+  async commitContinuation(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalInstructionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const goalId = requireGoalStateIdentifier(input.goalId, "goalId");
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "goal_instruction") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return goalInstructionCommitFromRoot(duplicate, scope, true);
+      }
+      assertNoPendingOperation(session);
+      assertRunEpoch(session, expectedRunEpoch);
+      const current = this.requireGoal(scope, goalId);
+      assertAssignedActiveGoal(
+        current,
+        expectedRevision,
+        scope.runtimeSessionId,
+      );
+      const instruction = materializeGoalInstruction(
+        input.instruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalContinuationCommit(
+        current.goal,
+        instruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+      );
+      const checkpoint = goalInstructionCheckpoint(current, instruction);
+      const recordedAt = this.recordedAt();
+      const run = this.requireRun(session, goalId);
+      this.commitInstruction({
+        session,
+        instruction,
+        command,
+        checkpoint,
+        commandOrder: 0,
+        commandType: "goal_instruction",
+        commandPhase: "committed",
+        goalRunId: run.id,
+        expectedPendingOperation: null,
+        pendingOperation: null,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return {
+        goal: clone(current),
+        instruction: clone(instruction),
+        deduplicated: false,
+      };
+    });
+  }
+
+  async commitEvaluationTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    goal: AgentGoal;
+  }): Promise<GoalEvaluationTransitionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const goal = parseGoalState(input.goal);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      assertNoPendingOperation(session);
+      assertRunEpoch(session, expectedRunEpoch);
+      const current = this.requireGoal(scope, goal.id);
+      assertAssignedActiveGoal(
+        current,
+        expectedRevision,
+        scope.runtimeSessionId,
+      );
+      assertGoalEvaluationTransition(current.goal, goal, expectedRevision);
+      const transitioned = persistedGoal(scope, goal);
+      const nextSlotState = goalOccupiesPrimarySlot(goal.status)
+        ? "assigned"
+        : "released";
+      if (
+        !this.storage.updateGoal(
+          transitioned,
+          expectedRevision,
+          "assigned",
+          nextSlotState,
+        )
+      ) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const run = this.requireRun(session, goal.id, expectedRunEpoch);
+      const nextRunStatus = evaluationRunStatus(goal.status);
+      this.updateRun(
+        run,
+        {
+          goalRevision: goal.revision,
+          status: nextRunStatus,
+          terminal: isTerminalRunStatus(nextRunStatus),
+        },
+        this.recordedAt(),
+      );
+      return { goal: clone(transitioned) };
+    });
+  }
+
+  async prepareLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    action: GoalLifecycleTransitionAction;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    goal: AgentGoal;
+    instruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const action = validateLifecycleTransitionAction(input.action);
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const goal = parseGoalState(input.goal);
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "lifecycle") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return {
+          transition: lifecycleTransitionFromRoot(duplicate, scope),
+          deduplicated: true,
+        };
+      }
+      assertNoPendingOperation(session);
+      assertRunEpoch(session, expectedRunEpoch);
+      const current = this.requireGoal(scope, goal.id);
+      if (current.slotState !== "assigned") {
+        throw invalidPrimaryGoal(goal.id, scope.runtimeSessionId);
+      }
+      if (current.goal.revision !== expectedRevision) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const instruction = materializeGoalInstruction(
+        input.instruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalLifecyclePreparation(
+        current.goal,
+        goal,
+        instruction,
+        action,
+        scope.runtimeSessionId,
+        expectedRevision,
+        expectedRunEpoch,
+      );
+      const transitionedGoal = persistedGoal(scope, goal);
+      const transition: AgentGoalLifecycleTransition = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        action,
+        transitionedGoal,
+        instruction,
+        expectedRunEpoch,
+        runEpoch: expectedRunEpoch,
+        phase: "prepared",
+      };
+      const recordedAt = this.recordedAt();
+      if (
+        !this.storage.updateGoal(
+          transitionedGoal,
+          expectedRevision,
+          "assigned",
+          "assigned",
+        )
+      ) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const run = this.requireRun(session, goal.id, expectedRunEpoch);
+      this.updateRun(
+        run,
+        {
+          goalRevision: goal.revision,
+          ...(action === "pause" ? { status: "paused" as const } : {}),
+        },
+        recordedAt,
+      );
+      this.commitInstruction({
+        session,
+        instruction,
+        command,
+        checkpoint: lifecycleCheckpoint(transition),
+        commandOrder: 0,
+        commandType: "lifecycle",
+        commandPhase: "prepared",
+        goalRunId: run.id,
+        expectedPendingOperation: null,
+        pendingOperation: transition,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return { transition: clone(transition), deduplicated: false };
+    });
+  }
+
+  async markLifecycleTransitionBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const goalId = requireGoalStateIdentifier(input.goalId, "goalId");
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = requireNonNegativeGoalStateInteger(
+      input.nextRunEpoch,
+      "nextRunEpoch",
+    );
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const stored = this.requireCommand(scope, command, "lifecycle");
+      const transition = lifecycleTransitionFromRoot(stored, scope);
+      assertLifecycleIdentity(transition, goalId);
+      assertLifecycleEpochAdvance(transition, expectedRunEpoch, nextRunEpoch);
+      if (
+        transition.phase === "boundary_observed" ||
+        transition.phase === "finalized"
+      ) {
+        return { transition: clone(transition), deduplicated: true };
+      }
+      if (transition.action !== "cancel" || transition.phase !== "prepared") {
+        throw new DurableAgentGoalStateError(
+          "invalid_commit",
+          "Only a prepared Goal cancel can record a Runtime Session terminal boundary",
+        );
+      }
+      assertPendingOperation(session, transition, "lifecycle");
+      assertRunEpoch(session, expectedRunEpoch);
+      const updated: AgentGoalLifecycleTransition = {
+        ...clone(transition),
+        phase: "boundary_observed",
+        runEpoch: nextRunEpoch,
+      };
+      const recordedAt = this.recordedAt();
+      const run = this.requireRun(session, goalId, expectedRunEpoch);
+      this.updateRun(run, { status: "cancelled", terminal: true }, recordedAt);
+      this.updateBarrier({
+        session,
+        command,
+        expectedPhase: "prepared",
+        phase: "boundary_observed",
+        checkpoint: lifecycleCheckpoint(updated),
+        pendingOperation: updated,
+        runEpoch: nextRunEpoch,
+        recordedAt,
+        commandType: "lifecycle",
+      });
+      return { transition: clone(updated), deduplicated: false };
+    });
+  }
+
+  async finalizeLifecycleTransition(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalLifecycleTransitionCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const goalId = requireGoalStateIdentifier(input.goalId, "goalId");
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = requireNonNegativeGoalStateInteger(
+      input.nextRunEpoch,
+      "nextRunEpoch",
+    );
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const stored = this.requireCommand(scope, command, "lifecycle");
+      const transition = lifecycleTransitionFromRoot(stored, scope);
+      assertLifecycleIdentity(transition, goalId);
+      assertLifecycleEpochAdvance(transition, expectedRunEpoch, nextRunEpoch);
+      if (transition.phase === "finalized") {
+        return { transition: clone(transition), deduplicated: true };
+      }
+      assertPendingOperation(session, transition, "lifecycle");
+      if (
+        (transition.action === "pause" && transition.phase !== "prepared") ||
+        (transition.action === "cancel" &&
+          transition.phase !== "boundary_observed")
+      ) {
+        throw new DurableAgentGoalStateError(
+          "invalid_commit",
+          transition.action === "cancel"
+            ? "A Goal cancel must record its provider terminal boundary before finalization"
+            : "A Goal pause can only finalize directly from its prepared state",
+        );
+      }
+      const requiredEpoch =
+        transition.action === "pause" ? expectedRunEpoch : nextRunEpoch;
+      assertRunEpoch(session, requiredEpoch);
+      const updated: AgentGoalLifecycleTransition = {
+        ...clone(transition),
+        phase: "finalized",
+        runEpoch: nextRunEpoch,
+      };
+      const recordedAt = this.recordedAt();
+      if (
+        transition.action === "cancel" &&
+        !this.storage.updateGoalSlotState({
+          ownerId: scope.ownerId,
+          runtimeSessionId: scope.runtimeSessionId,
+          goalId,
+          expectedSlotState: "assigned",
+          slotState: "released",
+        })
+      ) {
+        throw invalidPrimaryGoal(goalId, scope.runtimeSessionId);
+      }
+      this.updateBarrier({
+        session,
+        command,
+        expectedPhase: transition.phase,
+        phase: "finalized",
+        checkpoint: lifecycleCheckpoint(updated),
+        pendingOperation: null,
+        runEpoch: nextRunEpoch,
+        recordedAt,
+        commandType: "lifecycle",
+      });
+      return { transition: clone(updated), deduplicated: false };
+    });
+  }
+
+  async prepareReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedRevision: number;
+    expectedRunEpoch: number;
+    supersededGoal: AgentGoal;
+    replacementGoal: AgentGoal;
+    controlInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const expectedRevision = requirePositiveGoalStateInteger(
+      input.expectedRevision,
+      "expectedRevision",
+    );
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const supersededGoal = parseGoalState(input.supersededGoal);
+    const replacementGoal = parseGoalState(input.replacementGoal);
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const duplicate = this.findCommand(scope, command);
+      if (duplicate) {
+        if (duplicate.commandType !== "replacement") {
+          throwIdempotencyNamespaceConflict(command);
+        }
+        return {
+          replacement: replacementFromRoot(duplicate, scope),
+          deduplicated: true,
+        };
+      }
+      assertNoPendingOperation(session);
+      assertRunEpoch(session, expectedRunEpoch);
+      const current = this.requireGoal(scope, supersededGoal.id);
+      if (current.slotState !== "assigned") {
+        throw invalidPrimaryGoal(supersededGoal.id, scope.runtimeSessionId);
+      }
+      if (current.goal.revision !== expectedRevision) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      const existingReplacement = this.storage.getGoalForOwner(
+        scope.ownerId,
+        replacementGoal.id,
+      );
+      if (existingReplacement) {
+        throw new DurableAgentGoalStateError(
+          "goal_conflict",
+          `Goal ${replacementGoal.id} already exists in Runtime Session ${existingReplacement.persistedGoal.runtimeSessionId} for this owner`,
+        );
+      }
+      const controlInstruction = materializeGoalInstruction(
+        input.controlInstruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalReplacementPreparation(
+        current.goal,
+        supersededGoal,
+        replacementGoal,
+        controlInstruction,
+        scope.runtimeSessionId,
+        expectedRevision,
+        expectedRunEpoch,
+      );
+      const superseded = persistedGoal(scope, supersededGoal);
+      const replacementGoalState = persistedGoal(scope, replacementGoal);
+      const replacement: AgentGoalReplacement = {
+        ownerId: scope.ownerId,
+        runtimeSessionId: scope.runtimeSessionId,
+        supersededGoal: superseded,
+        replacementGoal: replacementGoalState,
+        controlInstruction,
+        expectedRunEpoch,
+        runEpoch: expectedRunEpoch,
+        phase: "prepared",
+      };
+      const recordedAt = this.recordedAt();
+      if (
+        !this.storage.updateGoal(
+          superseded,
+          expectedRevision,
+          "assigned",
+          "assigned",
+        )
+      ) {
+        throw revisionConflict(expectedRevision, current.goal.revision);
+      }
+      this.storage.insertGoal(replacementGoalState, "reserved");
+      const run = this.requireRun(session, supersededGoal.id, expectedRunEpoch);
+      this.updateRun(
+        run,
+        { goalRevision: supersededGoal.revision },
+        recordedAt,
+      );
+      this.commitInstruction({
+        session,
+        instruction: controlInstruction,
+        command,
+        checkpoint: replacementCheckpoint(replacement),
+        commandOrder: 0,
+        commandType: "replacement",
+        commandPhase: "prepared",
+        goalRunId: run.id,
+        expectedPendingOperation: null,
+        pendingOperation: replacement,
+        runEpoch: session.runEpoch,
+        recordedAt,
+      });
+      return { replacement: clone(replacement), deduplicated: false };
+    });
+  }
+
+  async markReplacementBoundary(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    expectedRunEpoch: number;
+    nextRunEpoch: number;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const replacementGoalId = requireGoalStateIdentifier(
+      input.replacementGoalId,
+      "replacementGoalId",
+    );
+    const expectedRunEpoch = requireNonNegativeGoalStateInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const nextRunEpoch = requireNonNegativeGoalStateInteger(
+      input.nextRunEpoch,
+      "nextRunEpoch",
+    );
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const stored = this.requireCommand(scope, command, "replacement");
+      const replacement = replacementFromRoot(stored, scope);
+      assertReplacementIdentity(replacement, replacementGoalId);
+      assertReplacementEpochAdvance(
+        replacement,
+        expectedRunEpoch,
+        nextRunEpoch,
+      );
+      if (replacement.phase !== "prepared") {
+        return { replacement: clone(replacement), deduplicated: true };
+      }
+      assertPendingOperation(session, replacement, "replacement");
+      assertRunEpoch(session, expectedRunEpoch);
+      const updated: AgentGoalReplacement = {
+        ...clone(replacement),
+        phase: "boundary_observed",
+        runEpoch: nextRunEpoch,
+      };
+      const recordedAt = this.recordedAt();
+      const run = this.requireRun(
+        session,
+        replacement.supersededGoal.goal.id,
+        expectedRunEpoch,
+      );
+      this.updateRun(run, { status: "cancelled", terminal: true }, recordedAt);
+      this.updateBarrier({
+        session,
+        command,
+        expectedPhase: "prepared",
+        phase: "boundary_observed",
+        checkpoint: replacementCheckpoint(updated),
+        pendingOperation: updated,
+        runEpoch: nextRunEpoch,
+        recordedAt,
+        commandType: "replacement",
+      });
+      return { replacement: clone(updated), deduplicated: false };
+    });
+  }
+
+  async finalizeReplacement(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    replacementGoalId: string;
+    activationInstruction: RuntimeInstructionDraft;
+    command: GoalCommandIdentity;
+  }): Promise<GoalReplacementCommit> {
+    const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
+    const replacementGoalId = requireGoalStateIdentifier(
+      input.replacementGoalId,
+      "replacementGoalId",
+    );
+    const command = validateGoalCommandIdentity(input.command);
+
+    return this.mutate(() => {
+      const session = this.requireSession(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      );
+      const stored = this.requireCommand(scope, command, "replacement");
+      const replacement = replacementFromRoot(stored, scope);
+      assertReplacementIdentity(replacement, replacementGoalId);
+      if (replacement.phase === "activated") {
+        return { replacement: clone(replacement), deduplicated: true };
+      }
+      if (replacement.phase !== "boundary_observed") {
+        throw new DurableAgentGoalStateError(
+          "invalid_commit",
+          "A replacement cannot activate before its Runtime Session boundary is observed",
+        );
+      }
+      assertPendingOperation(session, replacement, "replacement");
+      assertRunEpoch(session, replacement.runEpoch);
+      const activationInstruction = materializeGoalInstruction(
+        input.activationInstruction,
+        command,
+        session.lastInstructionSequence + 1,
+      );
+      assertGoalReplacementActivation(
+        replacement,
+        activationInstruction,
+        scope.runtimeSessionId,
+      );
+      const updated: AgentGoalReplacement = {
+        ...clone(replacement),
+        phase: "activated",
+        activationInstruction,
+      };
+      const recordedAt = this.recordedAt();
+
+      if (
+        !this.storage.updateGoalSlotState({
+          ownerId: scope.ownerId,
+          runtimeSessionId: scope.runtimeSessionId,
+          goalId: replacement.supersededGoal.goal.id,
+          expectedSlotState: "assigned",
+          slotState: "released",
+        })
+      ) {
+        throw invalidPrimaryGoal(
+          replacement.supersededGoal.goal.id,
+          scope.runtimeSessionId,
+        );
+      }
+      if (
+        !this.storage.updateGoalSlotState({
+          ownerId: scope.ownerId,
+          runtimeSessionId: scope.runtimeSessionId,
+          goalId: replacementGoalId,
+          expectedSlotState: "reserved",
+          slotState: "assigned",
+        })
+      ) {
+        throw new DurableAgentGoalStateError(
+          "replacement_not_found",
+          `Replacement Goal ${replacementGoalId} is not the pending primary reservation`,
+        );
+      }
+      const runId = this.createQueuedRun(
+        session,
+        replacement.replacementGoal,
+        activationInstruction.issuedAt,
+        recordedAt,
+      );
+      this.updateBarrier({
+        session,
+        command,
+        expectedPhase: "boundary_observed",
+        phase: "activated",
+        checkpoint: replacementCheckpoint(updated),
+        pendingOperation: null,
+        runEpoch: session.runEpoch,
+        recordedAt,
+        commandType: "replacement",
+        nextInstruction: {
+          instruction: activationInstruction,
+          commandOrder: 1,
+          goalRunId: runId,
+        },
+      });
+      return { replacement: clone(updated), deduplicated: false };
+    });
+  }
+
+  private mutate<T>(work: () => T): T {
+    try {
+      return this.database.immediate(() => work());
+    } catch (cause) {
+      if (
+        cause instanceof DurableAgentGoalStateError ||
+        cause instanceof AgentGoalPersistenceError
+      ) {
+        throw cause;
+      }
+      throw mapSqliteMutationError(cause);
+    }
+  }
+
+  private requireSession(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): SqliteGoalSessionRecord {
+    const session = this.storage.getSession(ownerId, runtimeSessionId);
+    if (!session) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        `Runtime Session ${runtimeSessionId} does not exist for this owner`,
+      );
+    }
+    return session;
+  }
+
+  private requireGoal(
+    scope: { ownerId: string; runtimeSessionId: string },
+    goalId: string,
+  ): PersistedAgentGoal & { slotState: "assigned" | "reserved" | "released" } {
+    const stored = this.storage.getGoal(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      goalId,
+    );
+    if (!stored) {
+      throw new DurableAgentGoalStateError(
+        "goal_not_found",
+        `Goal ${goalId} does not exist in Runtime Session ${scope.runtimeSessionId}`,
+      );
+    }
+    return { ...stored.persistedGoal, slotState: stored.slotState };
+  }
+
+  private findCommand(
+    scope: { ownerId: string; runtimeSessionId: string },
+    command: GoalCommandIdentity,
+  ): StoredRuntimeInstruction | null {
+    const stored = this.storage.findCommand(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      command.idempotencyKey,
+    );
+    if (stored) assertCommandFingerprint(stored, command);
+    return stored;
+  }
+
+  private requireCommand(
+    scope: { ownerId: string; runtimeSessionId: string },
+    command: GoalCommandIdentity,
+    type: "lifecycle" | "replacement",
+  ): StoredRuntimeInstruction {
+    const stored = this.findCommand(scope, command);
+    if (!stored) {
+      throw new DurableAgentGoalStateError(
+        type === "lifecycle"
+          ? "lifecycle_transition_not_found"
+          : "replacement_not_found",
+        type === "lifecycle"
+          ? `No Goal lifecycle transition exists for idempotency key ${command.idempotencyKey}`
+          : `No Goal replacement exists for idempotency key ${command.idempotencyKey}`,
+      );
+    }
+    if (stored.commandType !== type) throwIdempotencyNamespaceConflict(command);
+    return stored;
+  }
+
+  private requireRun(
+    session: SqliteGoalSessionRecord,
+    goalId: string,
+    runEpoch = session.runEpoch,
+  ): AgentGoalRun {
+    const run = this.storage.findRun(
+      session.ownerId,
+      session.runtimeSessionId,
+      goalId,
+      runEpoch,
+    );
+    if (!run) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        `Goal ${goalId} has no durable Run for Runtime Session epoch ${runEpoch}`,
+      );
+    }
+    return run;
+  }
+
+  private updateRun(
+    run: AgentGoalRun,
+    input: {
+      goalRevision?: number;
+      status?: GoalRunStatus;
+      terminal?: boolean;
+    },
+    recordedAt: string,
+  ): AgentGoalRun {
+    const status = input.status ?? run.status;
+    if (status !== run.status) assertRunStatusTransition(run.status, status);
+    const lastActivityAt = monotonicGoalRunActivity(
+      run,
+      recordedAt,
+    ).toISOString();
+    const next: AgentGoalRun = {
+      ...run,
+      goalRevision: input.goalRevision ?? run.goalRevision,
+      status,
+      lastActivityAt,
+      ...(input.terminal ? { completedAt: lastActivityAt } : {}),
+    };
+    if (!this.storage.updateRun(run, next, recordedAt)) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        `Goal Run ${run.id} changed during its authoritative Goal mutation`,
+      );
+    }
+    return next;
+  }
+
+  private createQueuedRun(
+    session: SqliteGoalSessionRecord,
+    goal: PersistedAgentGoal,
+    startedAt: string,
+    recordedAt: string,
+  ): string {
+    const existing = this.storage.findRun(
+      session.ownerId,
+      session.runtimeSessionId,
+      goal.goal.id,
+      session.runEpoch,
+    );
+    if (existing) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        `Goal ${goal.goal.id} already has a durable Run for Runtime Session epoch ${session.runEpoch}`,
+      );
+    }
+    const id = this.generateId();
+    this.storage.insertRun(
+      {
+        id,
+        ownerId: session.ownerId,
+        goalId: goal.goal.id,
+        goalRevision: goal.goal.revision,
+        runtimeSessionId: session.runtimeSessionId,
+        ...(session.providerSessionId === undefined
+          ? {}
+          : { providerSessionId: session.providerSessionId }),
+        runEpoch: session.runEpoch,
+        status: "queued",
+        turnsUsed: 0,
+        tokensUsed: 0,
+        startedAt,
+        lastActivityAt: startedAt,
+      },
+      recordedAt,
+    );
+    return id;
+  }
+
+  private commitInstruction(input: {
+    session: SqliteGoalSessionRecord;
+    instruction: RuntimeInstruction;
+    command: GoalCommandIdentity;
+    checkpoint: AgentGoalCommandCheckpoint;
+    commandOrder: number;
+    commandType: "goal_instruction" | "lifecycle" | "replacement";
+    commandPhase: "committed" | "prepared";
+    goalRunId?: string;
+    expectedPendingOperation:
+      | AgentGoalLifecycleTransition
+      | AgentGoalReplacement
+      | null;
+    pendingOperation:
+      | AgentGoalLifecycleTransition
+      | AgentGoalReplacement
+      | null;
+    runEpoch: number;
+    recordedAt: string;
+  }): void {
+    if (this.storage.findInstructionId(input.instruction.id)) {
+      throw new DurableAgentGoalStateError(
+        "idempotency_conflict",
+        `Instruction ID ${input.instruction.id} is already present in the outbox`,
+      );
+    }
+    const nextSequence = input.instruction.sequence;
+    if (
+      nextSequence !== input.session.lastInstructionSequence + 1 ||
+      !this.storage.updateSession({
+        ownerId: input.session.ownerId,
+        runtimeSessionId: input.session.runtimeSessionId,
+        expectedRunEpoch: input.session.runEpoch,
+        expectedInstructionSequence: input.session.lastInstructionSequence,
+        expectedPendingOperation: input.expectedPendingOperation,
+        runEpoch: input.runEpoch,
+        instructionSequence: nextSequence,
+        pendingOperation: input.pendingOperation,
+        updatedAtSeconds: sessionTimestamp(input.session, input.recordedAt),
+      })
+    ) {
+      throw new DurableAgentGoalStateError(
+        "run_epoch_conflict",
+        `Runtime Session ${input.session.runtimeSessionId} changed while committing its instruction outbox`,
+      );
+    }
+    this.storage.insertInstructionAndPendingDelivery({
+      ownerId: input.session.ownerId,
+      runtimeSessionId: input.session.runtimeSessionId,
+      runEpoch: input.runEpoch,
+      instruction: input.instruction,
+      requestFingerprint: input.command.requestFingerprint,
+      commandOrder: input.commandOrder,
+      commandType: input.commandType,
+      commandPhase: input.commandPhase,
+      commandCheckpoint: input.checkpoint,
+      ...(input.goalRunId === undefined ? {} : { goalRunId: input.goalRunId }),
+      deliveryId: this.generateId(),
+      recordedAt: input.recordedAt,
+    });
+  }
+
+  private updateBarrier(input: {
+    session: SqliteGoalSessionRecord;
+    command: GoalCommandIdentity;
+    expectedPhase: "prepared" | "boundary_observed";
+    phase: "boundary_observed" | "finalized" | "activated";
+    checkpoint: AgentGoalCommandCheckpoint;
+    pendingOperation:
+      | AgentGoalLifecycleTransition
+      | AgentGoalReplacement
+      | null;
+    runEpoch: number;
+    recordedAt: string;
+    commandType: "lifecycle" | "replacement";
+    nextInstruction?: {
+      instruction: RuntimeInstruction;
+      commandOrder: number;
+      goalRunId?: string;
+    };
+  }): void {
+    const nextSequence = input.nextInstruction
+      ? input.nextInstruction.instruction.sequence
+      : input.session.lastInstructionSequence;
+    if (
+      input.nextInstruction &&
+      this.storage.findInstructionId(input.nextInstruction.instruction.id)
+    ) {
+      throw new DurableAgentGoalStateError(
+        "idempotency_conflict",
+        `Instruction ID ${input.nextInstruction.instruction.id} is already present in the outbox`,
+      );
+    }
+    if (
+      !this.storage.updateSession({
+        ownerId: input.session.ownerId,
+        runtimeSessionId: input.session.runtimeSessionId,
+        expectedRunEpoch: input.session.runEpoch,
+        expectedInstructionSequence: input.session.lastInstructionSequence,
+        expectedPendingOperation: requirePendingOperation(input.session),
+        runEpoch: input.runEpoch,
+        instructionSequence: nextSequence,
+        pendingOperation: input.pendingOperation,
+        updatedAtSeconds: sessionTimestamp(input.session, input.recordedAt),
+      })
+    ) {
+      throw new DurableAgentGoalStateError(
+        "run_epoch_conflict",
+        `Runtime Session ${input.session.runtimeSessionId} changed during its Goal control barrier`,
+      );
+    }
+    if (
+      !this.storage.updateCommandCheckpoint({
+        ownerId: input.session.ownerId,
+        runtimeSessionId: input.session.runtimeSessionId,
+        idempotencyKey: input.command.idempotencyKey,
+        requestFingerprint: input.command.requestFingerprint,
+        commandType: input.commandType,
+        expectedPhase: input.expectedPhase,
+        phase: input.phase,
+        checkpoint: input.checkpoint,
+        updatedAt: input.recordedAt,
+      })
+    ) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        `Goal ${input.commandType} checkpoint changed during its control barrier`,
+      );
+    }
+    if (input.nextInstruction) {
+      this.storage.insertInstructionAndPendingDelivery({
+        ownerId: input.session.ownerId,
+        runtimeSessionId: input.session.runtimeSessionId,
+        runEpoch: input.runEpoch,
+        instruction: input.nextInstruction.instruction,
+        requestFingerprint: input.command.requestFingerprint,
+        commandOrder: input.nextInstruction.commandOrder,
+        ...(input.nextInstruction.goalRunId === undefined
+          ? {}
+          : { goalRunId: input.nextInstruction.goalRunId }),
+        deliveryId: this.generateId(),
+        recordedAt: input.recordedAt,
+      });
+    }
+  }
+
+  private recordedAt(): string {
+    const value = this.now();
+    if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+      throw new DurableAgentGoalStateError(
+        "invalid_commit",
+        "Goal persistence clock returned an invalid Date",
+      );
+    }
+    return value.toISOString();
+  }
+}
+
+function persistedGoal(
+  scope: { ownerId: string; runtimeSessionId: string },
+  goal: AgentGoal,
+): PersistedAgentGoal {
+  return {
+    ownerId: scope.ownerId,
+    runtimeSessionId: scope.runtimeSessionId,
+    slot: "primary",
+    goal,
+  };
+}
+
+function goalInstructionCheckpoint(
+  goal: PersistedAgentGoal,
+  instruction: RuntimeInstruction,
+): AgentGoalCommandCheckpoint {
+  return { type: "goal_instruction", goal, instruction };
+}
+
+function lifecycleCheckpoint(
+  transition: AgentGoalLifecycleTransition,
+): AgentGoalCommandCheckpoint {
+  return { type: "lifecycle", transition };
+}
+
+function replacementCheckpoint(
+  replacement: AgentGoalReplacement,
+): AgentGoalCommandCheckpoint {
+  return { type: "replacement", replacement };
+}
+
+function assertCommandFingerprint(
+  stored: StoredRuntimeInstruction,
+  command: GoalCommandIdentity,
+): void {
+  if (stored.requestFingerprint !== command.requestFingerprint) {
+    throw new DurableAgentGoalStateError(
+      "idempotency_conflict",
+      `Idempotency key ${command.idempotencyKey} was already used for a different Goal command`,
+    );
+  }
+}
+
+function throwIdempotencyNamespaceConflict(
+  command: GoalCommandIdentity,
+): never {
+  throw new DurableAgentGoalStateError(
+    "idempotency_conflict",
+    `Idempotency key ${command.idempotencyKey} was already used by another Runtime Goal command`,
+  );
+}
+
+function assertNoPendingOperation(session: SqliteGoalSessionRecord): void {
+  if (!session.pendingOperation) return;
+  if (isLifecycleTransition(session.pendingOperation)) {
+    throw new DurableAgentGoalStateError(
+      "lifecycle_transition_in_progress",
+      `Runtime Session ${session.runtimeSessionId} is finalizing ${session.pendingOperation.action} for Goal ${session.pendingOperation.transitionedGoal.goal.id}`,
+    );
+  }
+  throw new DurableAgentGoalStateError(
+    "replacement_in_progress",
+    `Runtime Session ${session.runtimeSessionId} is reserving replacement Goal ${session.pendingOperation.replacementGoal.goal.id}`,
+  );
+}
+
+function assertPendingOperation(
+  session: SqliteGoalSessionRecord,
+  expected: AgentGoalLifecycleTransition | AgentGoalReplacement,
+  type: "lifecycle" | "replacement",
+): void {
+  if (
+    !session.pendingOperation ||
+    canonicalJson(session.pendingOperation) !== canonicalJson(expected)
+  ) {
+    throw new DurableAgentGoalStateError(
+      type === "lifecycle"
+        ? "lifecycle_transition_not_found"
+        : "replacement_not_found",
+      type === "lifecycle"
+        ? `Lifecycle transition for Goal ${(expected as AgentGoalLifecycleTransition).transitionedGoal.goal.id} is not the pending primary reservation`
+        : `Replacement Goal ${(expected as AgentGoalReplacement).replacementGoal.goal.id} is not the pending primary reservation`,
+    );
+  }
+}
+
+function requirePendingOperation(
+  session: SqliteGoalSessionRecord,
+): AgentGoalLifecycleTransition | AgentGoalReplacement {
+  if (!session.pendingOperation) {
+    throw new DurableAgentGoalStateError(
+      "invalid_commit",
+      `Runtime Session ${session.runtimeSessionId} has no pending Goal control barrier`,
+    );
+  }
+  return session.pendingOperation;
+}
+
+function isLifecycleTransition(
+  operation: AgentGoalLifecycleTransition | AgentGoalReplacement,
+): operation is AgentGoalLifecycleTransition {
+  return "action" in operation;
+}
+
+function assertAssignedActiveGoal(
+  goal: PersistedAgentGoal & { slotState: string },
+  expectedRevision: number,
+  runtimeSessionId: string,
+): void {
+  if (goal.slotState !== "assigned" || goal.goal.status !== "active") {
+    throw invalidPrimaryGoal(goal.goal.id, runtimeSessionId);
+  }
+  if (goal.goal.revision !== expectedRevision) {
+    throw revisionConflict(expectedRevision, goal.goal.revision);
+  }
+}
+
+function invalidPrimaryGoal(
+  goalId: string,
+  runtimeSessionId: string,
+): DurableAgentGoalStateError {
+  return new DurableAgentGoalStateError(
+    "invalid_commit",
+    `Goal ${goalId} is not the active primary Goal for Runtime Session ${runtimeSessionId}`,
+  );
+}
+
+function revisionConflict(
+  expected: number,
+  actual: number,
+): DurableAgentGoalStateError {
+  return new DurableAgentGoalStateError(
+    "revision_conflict",
+    `Expected Goal revision ${expected}, received ${actual}`,
+  );
+}
+
+function assertRunEpoch(
+  session: SqliteGoalSessionRecord,
+  expectedRunEpoch: number,
+): void {
+  if (session.runEpoch !== expectedRunEpoch) {
+    throw new DurableAgentGoalStateError(
+      "run_epoch_conflict",
+      `Expected Runtime Session epoch ${expectedRunEpoch}, received ${session.runEpoch}`,
+    );
+  }
+}
+
+function assertLifecycleIdentity(
+  transition: AgentGoalLifecycleTransition,
+  goalId: string,
+): void {
+  if (transition.transitionedGoal.goal.id !== goalId) {
+    throw new DurableAgentGoalStateError(
+      "lifecycle_transition_not_found",
+      `Goal ${goalId} does not match the stored lifecycle transition`,
+    );
+  }
+}
+
+function assertReplacementIdentity(
+  replacement: AgentGoalReplacement,
+  replacementGoalId: string,
+): void {
+  if (replacement.replacementGoal.goal.id !== replacementGoalId) {
+    throw new DurableAgentGoalStateError(
+      "replacement_not_found",
+      `Replacement Goal ${replacementGoalId} does not match the stored replacement`,
+    );
+  }
+}
+
+function sessionTimestamp(
+  session: SqliteGoalSessionRecord,
+  recordedAt: string,
+): number {
+  return Math.max(
+    session.createdAtSeconds,
+    session.updatedAtSeconds,
+    Math.floor(Date.parse(recordedAt) / 1000),
+  );
+}
+
+function mapSqliteMutationError(cause: unknown): DurableAgentGoalStateError {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  if (
+    message.includes("agent_goals_assigned_primary_idx") ||
+    message.includes("agent_goals.owner_id, agent_goals.runtime_session_id")
+  ) {
+    return new DurableAgentGoalStateError(
+      "active_primary_goal_conflict",
+      "Runtime Session already has an assigned primary Goal",
+      cause,
+    );
+  }
+  if (
+    message.includes("agent_runtime_instructions_idempotency_key") ||
+    message.includes("agent_runtime_instructions.id")
+  ) {
+    return new DurableAgentGoalStateError(
+      "idempotency_conflict",
+      "Runtime Goal command or instruction identity already exists",
+      cause,
+    );
+  }
+  if (message.includes("agent_goals.id")) {
+    return new DurableAgentGoalStateError(
+      "goal_conflict",
+      "Goal identity already exists",
+      cause,
+    );
+  }
+  return new DurableAgentGoalStateError(
+    "invalid_commit",
+    "SQLite could not atomically commit the Runtime Goal mutation",
+    cause,
+  );
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/database.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/database.ts
@@ -1,0 +1,36 @@
+import { SqliteGoalRuntimeStore } from "./store";
+import {
+  SqliteImmediateTransactionDriver,
+  type BetterSqlite3ClientSource,
+} from "./transaction";
+
+/**
+ * Owns the native SQLite transaction boundary and the single row-store
+ * instance used inside it. Keeping this boundary synchronous is essential:
+ * better-sqlite3 closes a transaction as soon as its callback returns.
+ */
+export class SqliteGoalRuntimeDatabase {
+  readonly store: SqliteGoalRuntimeStore;
+  private readonly transactions: SqliteImmediateTransactionDriver;
+
+  constructor(source: BetterSqlite3ClientSource) {
+    this.transactions = new SqliteImmediateTransactionDriver(source);
+    this.store = new SqliteGoalRuntimeStore(this.transactions.client);
+  }
+
+  immediate<T>(work: (store: SqliteGoalRuntimeStore) => T): T {
+    return this.transactions.immediate(() => work(this.store));
+  }
+}
+
+export type SqliteGoalRuntimeDatabaseSource =
+  | BetterSqlite3ClientSource
+  | SqliteGoalRuntimeDatabase;
+
+export function resolveSqliteGoalRuntimeDatabase(
+  source: SqliteGoalRuntimeDatabaseSource,
+): SqliteGoalRuntimeDatabase {
+  return source instanceof SqliteGoalRuntimeDatabase
+    ? source
+    : new SqliteGoalRuntimeDatabase(source);
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/delivery-repository.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/delivery-repository.ts
@@ -1,0 +1,348 @@
+import {
+  DeliveryStateSchema,
+  assertDeliveryStateTransition,
+  type DeliveryState,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { persistenceConflict } from "../errors";
+import {
+  buildPendingRuntimeDeliveryRecord,
+  type PendingRuntimeDeliveryRecordInput,
+} from "../internal/record-builders";
+import type { PersistedRuntimeInstructionDelivery } from "../runtime-observation-mappers";
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+import {
+  isoDate,
+  isCurrentEpoch,
+  nonNegativeInteger,
+  normalizeIdentifier,
+  normalizeScope,
+  positiveInteger,
+  repositoryMutationError,
+  requireCurrentEpoch,
+  seconds,
+  sqliteIso,
+  type SqliteGoalPersistenceScope,
+} from "./repository-helpers";
+
+export interface SqliteDeliveryTransitionInput extends SqliteGoalPersistenceScope {
+  readonly deliveryId: string;
+  readonly expectedRunEpoch: number;
+  readonly expectedState: DeliveryState;
+  readonly nextState: DeliveryState;
+  readonly updatedAt: string;
+  readonly expectedLeaseToken?: string;
+  readonly lease?: {
+    readonly token: string;
+    readonly owner: string;
+    readonly expiresAt: string;
+  };
+  readonly availableAt?: string;
+  readonly providerEventId?: string | null;
+  readonly errorCode?: string | null;
+  readonly errorMessage?: string | null;
+}
+
+export class SqliteDeliveryRepository {
+  private readonly database: SqliteGoalRuntimeDatabase;
+
+  constructor(source: SqliteGoalRuntimeDatabaseSource) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+  }
+
+  async getById(
+    input: SqliteGoalPersistenceScope & { deliveryId: string },
+  ): Promise<PersistedRuntimeInstructionDelivery | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.getDelivery(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.deliveryId, "deliveryId"),
+    );
+  }
+
+  async getActiveByInstruction(
+    input: SqliteGoalPersistenceScope & { instructionId: string },
+  ): Promise<PersistedRuntimeInstructionDelivery | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.getActiveDeliveryForInstruction(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.instructionId, "instructionId"),
+    );
+  }
+
+  async listAttempts(
+    input: SqliteGoalPersistenceScope & { instructionId: string },
+  ): Promise<PersistedRuntimeInstructionDelivery[]> {
+    const scope = normalizeScope(input);
+    return this.database.store.listDeliveryAttempts(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.instructionId, "instructionId"),
+    );
+  }
+
+  async listDispatchable(
+    input: SqliteGoalPersistenceScope & { availableAt: string; limit?: number },
+  ): Promise<PersistedRuntimeInstructionDelivery[]> {
+    const scope = normalizeScope(input);
+    const limit = positiveInteger(input.limit ?? 100, "limit");
+    if (limit > 1_000) {
+      throw new TypeError("limit must be an integer between 1 and 1000");
+    }
+    return this.database.store.listDispatchableDeliveries(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      seconds(isoDate(input.availableAt, "availableAt")),
+      limit,
+    );
+  }
+
+  async createPending(
+    input: PendingRuntimeDeliveryRecordInput,
+  ): Promise<PersistedRuntimeInstructionDelivery> {
+    const scope = normalizeScope(input);
+    buildPendingRuntimeDeliveryRecord(input);
+    const attempt = positiveInteger(input.attempt ?? 1, "attempt");
+    const instructionId = normalizeIdentifier(
+      input.instructionId,
+      "instructionId",
+    );
+    const goalRunId =
+      input.goalRunId === undefined
+        ? undefined
+        : normalizeIdentifier(input.goalRunId, "goalRunId");
+    isoDate(input.availableAt, "availableAt");
+    isoDate(input.recordedAt, "recordedAt");
+
+    try {
+      return this.database.immediate((store) => {
+        requireCurrentEpoch(
+          store.getSession(scope.ownerId, scope.runtimeSessionId),
+          input.runEpoch,
+        );
+        const instruction = store.getInstruction(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          instructionId,
+        );
+        if (!instruction || instruction.runEpoch !== input.runEpoch) {
+          throw persistenceConflict(
+            "The Delivery does not match its Runtime Instruction",
+            "conflict",
+          );
+        }
+        if (goalRunId === undefined) {
+          if (
+            instruction.instruction.goalId !== undefined ||
+            instruction.instruction.goalRevision !== undefined
+          ) {
+            throw persistenceConflict(
+              "A Goal-bound Runtime Instruction Delivery requires its Goal Run",
+              "conflict",
+            );
+          }
+        } else {
+          const run = store.getRun(
+            scope.ownerId,
+            scope.runtimeSessionId,
+            goalRunId,
+          );
+          if (
+            !run ||
+            run.runEpoch !== input.runEpoch ||
+            run.goalId !== instruction.instruction.goalId ||
+            run.goalRevision !== instruction.instruction.goalRevision
+          ) {
+            throw persistenceConflict(
+              "The Delivery Instruction and Goal Run do not match",
+              "conflict",
+            );
+          }
+        }
+
+        const attempts = store.listDeliveryAttempts(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          instructionId,
+        );
+        const hasExpectedPredecessor =
+          attempt === 1
+            ? attempts.length === 0
+            : attempts.some((candidate) => candidate.attempt === attempt - 1);
+        if (!hasExpectedPredecessor) {
+          throw persistenceConflict(
+            "The Delivery attempt does not immediately follow persisted history",
+            "conflict",
+          );
+        }
+
+        store.insertPendingDelivery({ ...input, attempt, goalRunId });
+        const inserted = store.getDelivery(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          input.id,
+        );
+        if (!inserted) {
+          throw persistenceConflict("Could not read the created Delivery");
+        }
+        return inserted;
+      });
+    } catch (cause) {
+      repositoryMutationError(
+        "Could not create the pending Runtime Instruction Delivery",
+        cause,
+      );
+    }
+  }
+
+  async transition(
+    input: SqliteDeliveryTransitionInput,
+  ): Promise<PersistedRuntimeInstructionDelivery | null> {
+    const scope = normalizeScope(input);
+    const deliveryId = normalizeIdentifier(input.deliveryId, "deliveryId");
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const expectedState = parseState(input.expectedState, "expectedState");
+    const nextState = parseState(input.nextState, "nextState");
+    assertDeliveryStateTransition(expectedState, nextState);
+    validateExpectedLease(expectedState, input.expectedLeaseToken);
+    const updatedAt = isoDate(input.updatedAt, "updatedAt");
+    const lease = materializeLease(nextState, input.lease, updatedAt);
+    const availableAt = input.availableAt
+      ? sqliteIso(isoDate(input.availableAt, "availableAt"))
+      : undefined;
+    const providerEventId = optionalIdentifier(
+      input.providerEventId,
+      "providerEventId",
+    );
+    const errorCode = optionalIdentifier(input.errorCode, "errorCode", 128);
+    if (
+      input.errorMessage !== undefined &&
+      input.errorMessage !== null &&
+      typeof input.errorMessage !== "string"
+    ) {
+      throw new TypeError("errorMessage must be a string or null");
+    }
+
+    try {
+      return this.database.immediate((store) => {
+        const session = store.getSession(scope.ownerId, scope.runtimeSessionId);
+        const current = store.getDelivery(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          deliveryId,
+        );
+        if (
+          !isCurrentEpoch(session, expectedRunEpoch) ||
+          !current ||
+          current.runEpoch !== expectedRunEpoch ||
+          current.state !== expectedState ||
+          Date.parse(current.updatedAt) > updatedAt.getTime() ||
+          (input.expectedLeaseToken !== undefined &&
+            current.leaseToken !== input.expectedLeaseToken)
+        ) {
+          return null;
+        }
+        const next: PersistedRuntimeInstructionDelivery = {
+          ...current,
+          state: nextState,
+          updatedAt: sqliteIso(updatedAt),
+          availableAt: availableAt ?? current.availableAt,
+          ...(lease ?? {
+            leaseToken: undefined,
+            leaseOwner: undefined,
+            leaseExpiresAt: undefined,
+          }),
+          ...(input.providerEventId === undefined
+            ? {}
+            : { providerEventId: providerEventId ?? undefined }),
+          ...(input.errorCode === undefined
+            ? {}
+            : { errorCode: errorCode ?? undefined }),
+          ...(input.errorMessage === undefined
+            ? {}
+            : { errorMessage: input.errorMessage ?? undefined }),
+        };
+        if (!store.updateDelivery(current, next)) return null;
+        return store.getDelivery(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          deliveryId,
+        );
+      });
+    } catch (cause) {
+      repositoryMutationError(
+        "Could not transition the Runtime Instruction Delivery",
+        cause,
+      );
+    }
+  }
+}
+
+function parseState(value: unknown, field: string): DeliveryState {
+  const parsed = DeliveryStateSchema.safeParse(value);
+  if (!parsed.success) throw new TypeError(`${field} is not a Delivery state`);
+  return parsed.data;
+}
+
+function validateExpectedLease(
+  expectedState: DeliveryState,
+  token: string | undefined,
+): void {
+  if (expectedState === "leased" && token === undefined) {
+    throw new TypeError(
+      "expectedLeaseToken is required when transitioning a leased delivery",
+    );
+  }
+  if (expectedState !== "leased" && token !== undefined) {
+    throw new TypeError(
+      "expectedLeaseToken is only valid for a leased delivery",
+    );
+  }
+  if (token !== undefined) normalizeIdentifier(token, "expectedLeaseToken");
+}
+
+function materializeLease(
+  nextState: DeliveryState,
+  input: SqliteDeliveryTransitionInput["lease"],
+  updatedAt: Date,
+):
+  | Pick<
+      PersistedRuntimeInstructionDelivery,
+      "leaseToken" | "leaseOwner" | "leaseExpiresAt"
+    >
+  | undefined {
+  if (nextState !== "leased") {
+    if (input) throw new TypeError("lease is only valid for the leased state");
+    return undefined;
+  }
+  if (!input) throw new TypeError("lease is required for the leased state");
+  const expiresAt = isoDate(input.expiresAt, "lease.expiresAt");
+  if (seconds(expiresAt) <= seconds(updatedAt)) {
+    throw new TypeError(
+      "lease.expiresAt must remain later than updatedAt at SQLite precision",
+    );
+  }
+  return {
+    leaseToken: normalizeIdentifier(input.token, "lease.token"),
+    leaseOwner: normalizeIdentifier(input.owner, "lease.owner"),
+    leaseExpiresAt: sqliteIso(expiresAt),
+  };
+}
+
+function optionalIdentifier(
+  value: string | null | undefined,
+  field: string,
+  maxCharacters = 256,
+): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  return normalizeIdentifier(value, field, maxCharacters);
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/evidence-repository.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/evidence-repository.ts
@@ -1,0 +1,162 @@
+import {
+  canonicalJson,
+  type GoalEvidence,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { persistenceConflict } from "../errors";
+import {
+  buildAgentGoalEvidenceRecord,
+  type AgentGoalEvidenceRecordInput,
+} from "../internal/record-builders";
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+import {
+  normalizeIdentifier,
+  normalizeScope,
+  repositoryMutationError,
+  requireCurrentEpoch,
+  sqliteIso,
+  isoDate,
+  type SqliteGoalPersistenceScope,
+} from "./repository-helpers";
+
+export interface SqliteAppendEvidenceResult {
+  readonly evidence: GoalEvidence;
+  readonly deduplicated: boolean;
+}
+
+export class SqliteEvidenceRepository {
+  private readonly database: SqliteGoalRuntimeDatabase;
+
+  constructor(source: SqliteGoalRuntimeDatabaseSource) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+  }
+
+  async getById(
+    input: SqliteGoalPersistenceScope & { evidenceId: string },
+  ): Promise<GoalEvidence | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.getEvidence(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.evidenceId, "evidenceId"),
+    );
+  }
+
+  async listByRun(
+    input: SqliteGoalPersistenceScope & { goalRunId: string },
+  ): Promise<GoalEvidence[]> {
+    const scope = normalizeScope(input);
+    return this.database.store.listEvidenceByRun(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.goalRunId, "goalRunId"),
+    );
+  }
+
+  async appendOnce(
+    input: AgentGoalEvidenceRecordInput,
+  ): Promise<SqliteAppendEvidenceResult> {
+    const scope = normalizeScope(input);
+    buildAgentGoalEvidenceRecord(input);
+    const runEpoch = input.runEpoch;
+    const evidence = input.evidence;
+    normalizeIdentifier(evidence.id, "evidence.id");
+    normalizeIdentifier(evidence.goalId, "evidence.goalId");
+    normalizeIdentifier(evidence.goalRunId, "evidence.goalRunId");
+    normalizeIdentifier(evidence.sourceEventId, "evidence.sourceEventId");
+    if (evidence.instructionId !== undefined) {
+      normalizeIdentifier(evidence.instructionId, "evidence.instructionId");
+    }
+    isoDate(evidence.observedAt, "evidence.observedAt");
+    isoDate(input.recordedAt, "recordedAt");
+
+    try {
+      return this.database.immediate((store) => {
+        requireCurrentEpoch(
+          store.getSession(scope.ownerId, scope.runtimeSessionId),
+          runEpoch,
+        );
+        const run = store.getRun(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          evidence.goalRunId,
+        );
+        if (
+          !run ||
+          run.runEpoch !== runEpoch ||
+          run.goalId !== evidence.goalId ||
+          run.goalRevision !== evidence.goalRevision
+        ) {
+          throw persistenceConflict(
+            "Goal Evidence does not match its authoritative Goal Run revision",
+            "conflict",
+          );
+        }
+        if (evidence.instructionId !== undefined) {
+          const instruction = store.getInstruction(
+            scope.ownerId,
+            scope.runtimeSessionId,
+            evidence.instructionId,
+          );
+          if (
+            !instruction ||
+            instruction.runEpoch !== runEpoch ||
+            instruction.instruction.goalId !== evidence.goalId ||
+            instruction.instruction.goalRevision !== evidence.goalRevision
+          ) {
+            throw persistenceConflict(
+              "Goal Evidence does not match its Runtime Instruction revision",
+              "conflict",
+            );
+          }
+        }
+
+        const existing = store.findEvidenceBySourceEvent(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          evidence.goalRunId,
+          evidence.sourceEventId,
+        );
+        if (existing) {
+          if (
+            canonicalJson(evidenceDedupeContent(existing)) !==
+            canonicalJson(evidenceDedupeContent(evidence))
+          ) {
+            throw persistenceConflict(
+              "The Goal evidence source event was already recorded with different content",
+              "idempotency_conflict",
+            );
+          }
+          return { evidence: existing, deduplicated: true };
+        }
+
+        store.insertEvidence(input);
+        const inserted = store.getEvidence(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          evidence.id,
+        );
+        if (!inserted) {
+          throw persistenceConflict(
+            "Could not read the appended Goal Evidence",
+          );
+        }
+        return { evidence: inserted, deduplicated: false };
+      });
+    } catch (cause) {
+      repositoryMutationError("Could not append Goal evidence", cause);
+    }
+  }
+}
+
+function evidenceDedupeContent(evidence: GoalEvidence) {
+  const { id: _id, observedAt, ...content } = evidence;
+  return {
+    ...content,
+    observedAt: sqliteIso(isoDate(observedAt, "evidence.observedAt")),
+  };
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/goal-repository.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/goal-repository.ts
@@ -1,0 +1,64 @@
+import type { PersistedAgentGoal } from "@openloomi/ai/agent/runtime-instructions";
+
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+import {
+  normalizeIdentifier,
+  normalizeScope,
+  type SqliteGoalPersistenceScope,
+} from "./repository-helpers";
+
+/** Read repository for visible authoritative Goals in the desktop database. */
+export class SqliteGoalRepository {
+  private readonly database: SqliteGoalRuntimeDatabase;
+
+  constructor(source: SqliteGoalRuntimeDatabaseSource) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+  }
+
+  async listBySession(
+    input: SqliteGoalPersistenceScope,
+  ): Promise<PersistedAgentGoal[]> {
+    const scope = normalizeScope(input);
+    return this.database.store
+      .listGoals(scope.ownerId, scope.runtimeSessionId)
+      .map((record) => record.persistedGoal);
+  }
+
+  async getById(
+    input: SqliteGoalPersistenceScope & { goalId: string },
+  ): Promise<PersistedAgentGoal | null> {
+    const scope = normalizeScope(input);
+    const goalId = normalizeIdentifier(input.goalId, "goalId");
+    const record = this.database.store.getGoal(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      goalId,
+    );
+    return record?.slotState === "reserved"
+      ? null
+      : (record?.persistedGoal ?? null);
+  }
+
+  async getAssignedPrimary(
+    input: SqliteGoalPersistenceScope,
+  ): Promise<PersistedAgentGoal | null> {
+    const scope = normalizeScope(input);
+    return (
+      this.database.store.getAssignedPrimaryGoal(
+        scope.ownerId,
+        scope.runtimeSessionId,
+      )?.persistedGoal ?? null
+    );
+  }
+
+  async getActivePrimary(
+    input: SqliteGoalPersistenceScope,
+  ): Promise<PersistedAgentGoal | null> {
+    const goal = await this.getAssignedPrimary(input);
+    return goal?.goal.status === "active" ? goal : null;
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/index.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/index.ts
@@ -1,0 +1,19 @@
+export {
+  SqliteAgentGoalState,
+  type SqliteAgentGoalStateOptions,
+} from "./agent-goal-state";
+export {
+  SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+export { SqliteDeliveryRepository } from "./delivery-repository";
+export type { SqliteDeliveryTransitionInput } from "./delivery-repository";
+export { SqliteEvidenceRepository } from "./evidence-repository";
+export type { SqliteAppendEvidenceResult } from "./evidence-repository";
+export { SqliteGoalRepository } from "./goal-repository";
+export { SqliteInstructionRepository } from "./instruction-repository";
+export { SqliteRunRepository } from "./run-repository";
+export type {
+  SqliteGoalRunProgressUpdateInput,
+  SqliteGoalRunTransitionInput,
+} from "./run-repository";

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/instruction-repository.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/instruction-repository.ts
@@ -1,0 +1,66 @@
+import type { RuntimeInstruction } from "@openloomi/ai/agent/runtime-instructions";
+
+import type { StoredRuntimeInstruction } from "../goal-instruction-mappers";
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+import {
+  nonNegativeInteger,
+  normalizeIdentifier,
+  normalizeScope,
+  type SqliteGoalPersistenceScope,
+} from "./repository-helpers";
+
+/** Immutable Runtime Instruction/outbox reads for the desktop database. */
+export class SqliteInstructionRepository {
+  private readonly database: SqliteGoalRuntimeDatabase;
+
+  constructor(source: SqliteGoalRuntimeDatabaseSource) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+  }
+
+  async getById(
+    input: SqliteGoalPersistenceScope & { instructionId: string },
+  ): Promise<RuntimeInstruction | null> {
+    return (await this.getStoredById(input))?.instruction ?? null;
+  }
+
+  async getStoredById(
+    input: SqliteGoalPersistenceScope & { instructionId: string },
+  ): Promise<StoredRuntimeInstruction | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.getInstruction(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.instructionId, "instructionId"),
+    );
+  }
+
+  async findCommandByIdempotency(
+    input: SqliteGoalPersistenceScope & { idempotencyKey: string },
+  ): Promise<StoredRuntimeInstruction | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.findCommand(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.idempotencyKey, "idempotencyKey"),
+    );
+  }
+
+  async list(
+    input: SqliteGoalPersistenceScope & { afterSequence?: number },
+  ): Promise<RuntimeInstruction[]> {
+    const scope = normalizeScope(input);
+    const afterSequence = nonNegativeInteger(
+      input.afterSequence ?? 0,
+      "afterSequence",
+    );
+    return this.database.store.listInstructions(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      afterSequence,
+    );
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/repository-helpers.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/repository-helpers.ts
@@ -1,0 +1,130 @@
+import { AgentGoalPersistenceError, persistenceConflict } from "../errors";
+import type { SqliteGoalSessionRecord } from "./store";
+
+export interface SqliteGoalPersistenceScope {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+}
+
+export function normalizeScope(
+  input: SqliteGoalPersistenceScope,
+): SqliteGoalPersistenceScope {
+  return {
+    ownerId: normalizeIdentifier(input.ownerId, "ownerId"),
+    runtimeSessionId: normalizeIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    ),
+  };
+}
+
+export function normalizeIdentifier(
+  value: unknown,
+  field: string,
+  maxCharacters = 256,
+): string {
+  if (typeof value !== "string") {
+    throw new TypeError(`${field} must be a string`);
+  }
+  if (
+    value.length === 0 ||
+    value.length > maxCharacters ||
+    value.trim() !== value
+  ) {
+    throw new TypeError(
+      `${field} must be a non-empty identifier without surrounding whitespace`,
+    );
+  }
+  return value;
+}
+
+export function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${field} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+export function positiveInteger(value: unknown, field: string): number {
+  const parsed = nonNegativeInteger(value, field);
+  if (parsed === 0) throw new TypeError(`${field} must be positive`);
+  return parsed;
+}
+
+export function isoDate(value: string, field: string): Date {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) {
+    throw new TypeError(`${field} must be an ISO timestamp`);
+  }
+  return new Date(milliseconds);
+}
+
+export function seconds(value: Date): number {
+  return Math.floor(value.getTime() / 1_000);
+}
+
+export function sqliteIso(value: Date): string {
+  return new Date(seconds(value) * 1_000).toISOString();
+}
+
+export function requireCurrentEpoch(
+  session: SqliteGoalSessionRecord | null,
+  expectedRunEpoch: number,
+): SqliteGoalSessionRecord {
+  if (!isCurrentEpoch(session, expectedRunEpoch)) {
+    throw persistenceConflict(
+      "The Runtime Session epoch changed",
+      "run_epoch_conflict",
+    );
+  }
+  return session;
+}
+
+export function isCurrentEpoch(
+  session: SqliteGoalSessionRecord | null,
+  expectedRunEpoch: number,
+): session is SqliteGoalSessionRecord {
+  return session !== null && session.runEpoch === expectedRunEpoch;
+}
+
+export function requireProviderSession(
+  session: SqliteGoalSessionRecord,
+  providerSessionId: string | undefined,
+  currentProviderSessionId?: string,
+): void {
+  if (
+    !providerSessionMatches(
+      session,
+      providerSessionId,
+      currentProviderSessionId,
+    )
+  ) {
+    throw persistenceConflict(
+      "The provider session does not match the authoritative Runtime Session",
+      "conflict",
+    );
+  }
+}
+
+export function providerSessionMatches(
+  session: SqliteGoalSessionRecord,
+  providerSessionId: string | undefined,
+  currentProviderSessionId?: string,
+): boolean {
+  if (providerSessionId === undefined) {
+    return session.providerSessionId === currentProviderSessionId;
+  }
+  return (
+    session.providerSessionId === providerSessionId &&
+    (currentProviderSessionId === undefined ||
+      currentProviderSessionId === providerSessionId)
+  );
+}
+
+export function repositoryMutationError(
+  message: string,
+  cause: unknown,
+): never {
+  if (cause instanceof AgentGoalPersistenceError) throw cause;
+  throw persistenceConflict(message, "conflict", cause);
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/run-repository.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/run-repository.ts
@@ -1,0 +1,450 @@
+import {
+  GoalEvaluationResultSchema,
+  GoalRunStatusSchema,
+  assertGoalRunStatusTransition,
+  type AgentGoalRun,
+  type GoalEvaluationResult,
+  type GoalRunStatus,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import { persistenceConflict } from "../errors";
+import { isTerminalGoalRunStatus } from "../goal-run-state";
+import { buildAgentGoalRunRecord } from "../internal/record-builders";
+import {
+  resolveSqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabase,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "./database";
+import {
+  isoDate,
+  isCurrentEpoch,
+  nonNegativeInteger,
+  normalizeIdentifier,
+  normalizeScope,
+  providerSessionMatches,
+  repositoryMutationError,
+  requireCurrentEpoch,
+  seconds,
+  sqliteIso,
+  type SqliteGoalPersistenceScope,
+} from "./repository-helpers";
+
+export interface SqliteGoalRunTransitionInput extends SqliteGoalPersistenceScope {
+  readonly runId: string;
+  readonly expectedRunEpoch: number;
+  readonly expectedStatus: GoalRunStatus;
+  readonly nextStatus: GoalRunStatus;
+  readonly updatedAt: string;
+  readonly providerSessionId?: string;
+  readonly turnsUsed?: number;
+  readonly tokensUsed?: number;
+  readonly lastActivityAt?: string;
+  readonly completedAt?: string | null;
+  readonly lastEvaluation?: GoalEvaluationResult | null;
+}
+
+export interface SqliteGoalRunProgressUpdateInput extends SqliteGoalPersistenceScope {
+  readonly runId: string;
+  readonly expectedRunEpoch: number;
+  readonly expectedStatus: GoalRunStatus;
+  readonly updatedAt: string;
+  readonly providerSessionId?: string;
+  readonly expectedTurnsUsed?: number;
+  readonly turnsUsed?: number;
+  readonly expectedTokensUsed?: number;
+  readonly tokensUsed?: number;
+  readonly lastActivityAt?: string;
+  readonly lastEvaluation?: GoalEvaluationResult | null;
+}
+
+export class SqliteRunRepository {
+  private readonly database: SqliteGoalRuntimeDatabase;
+
+  constructor(source: SqliteGoalRuntimeDatabaseSource) {
+    this.database = resolveSqliteGoalRuntimeDatabase(source);
+  }
+
+  async getById(
+    input: SqliteGoalPersistenceScope & { runId: string },
+  ): Promise<AgentGoalRun | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.getRun(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.runId, "runId"),
+    );
+  }
+
+  async findByGoalEpoch(
+    input: SqliteGoalPersistenceScope & {
+      goalId: string;
+      runEpoch: number;
+    },
+  ): Promise<AgentGoalRun | null> {
+    const scope = normalizeScope(input);
+    return this.database.store.findRun(
+      scope.ownerId,
+      scope.runtimeSessionId,
+      normalizeIdentifier(input.goalId, "goalId"),
+      nonNegativeInteger(input.runEpoch, "runEpoch"),
+    );
+  }
+
+  async listBySession(
+    input: SqliteGoalPersistenceScope,
+  ): Promise<AgentGoalRun[]> {
+    const scope = normalizeScope(input);
+    return this.database.store.listRuns(scope.ownerId, scope.runtimeSessionId);
+  }
+
+  async create(input: {
+    run: AgentGoalRun;
+    recordedAt: string;
+  }): Promise<AgentGoalRun> {
+    const scope = normalizeScope(input.run);
+    buildAgentGoalRunRecord(input);
+    validateInitialRun(input.run);
+    isoDate(input.recordedAt, "recordedAt");
+
+    try {
+      return this.database.immediate((store) => {
+        const session = requireCurrentEpoch(
+          store.getSession(scope.ownerId, scope.runtimeSessionId),
+          input.run.runEpoch,
+        );
+        if (session.providerSessionId !== input.run.providerSessionId) {
+          throw persistenceConflict(
+            "The Goal Run provider session does not match the authoritative Runtime Session",
+            "conflict",
+          );
+        }
+        const goal = store.getGoal(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          input.run.goalId,
+        );
+        if (
+          goal?.slotState !== "assigned" ||
+          goal.persistedGoal.goal.status !== "active" ||
+          goal.persistedGoal.goal.revision !== input.run.goalRevision
+        ) {
+          throw persistenceConflict(
+            "The Goal Run does not match the active assigned Goal revision",
+            "conflict",
+          );
+        }
+        store.insertRun(input.run, input.recordedAt);
+        const inserted = store.getRun(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          input.run.id,
+        );
+        if (!inserted) {
+          throw persistenceConflict("Could not read the created Goal Run");
+        }
+        return inserted;
+      });
+    } catch (cause) {
+      repositoryMutationError("Could not create the Goal Run", cause);
+    }
+  }
+
+  async transition(
+    input: SqliteGoalRunTransitionInput,
+  ): Promise<AgentGoalRun | null> {
+    const scope = normalizeScope(input);
+    const runId = normalizeIdentifier(input.runId, "runId");
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const expectedStatus = parseRunStatus(
+      input.expectedStatus,
+      "expectedStatus",
+    );
+    const nextStatus = parseRunStatus(input.nextStatus, "nextStatus");
+    assertGoalRunStatusTransition(expectedStatus, nextStatus);
+    validateCompletion(nextStatus, input.completedAt);
+    const updatedAt = isoDate(input.updatedAt, "updatedAt");
+    const providerSessionId = optionalIdentifier(
+      input.providerSessionId,
+      "providerSessionId",
+    );
+    const turnsUsed = optionalCounter(input.turnsUsed, "turnsUsed");
+    const tokensUsed = optionalCounter(input.tokensUsed, "tokensUsed");
+    const lastActivityAt = optionalSqliteInstant(
+      input.lastActivityAt,
+      "lastActivityAt",
+    );
+    const completedAt = materializeCompletedAt(nextStatus, input.completedAt);
+    if (
+      completedAt !== undefined &&
+      lastActivityAt !== undefined &&
+      Date.parse(completedAt) < Date.parse(lastActivityAt)
+    ) {
+      throw new TypeError("completedAt cannot be earlier than lastActivityAt");
+    }
+
+    try {
+      return this.database.immediate((store) => {
+        const session = store.getSession(scope.ownerId, scope.runtimeSessionId);
+        const record = store.getRunRecord(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          runId,
+        );
+        if (
+          !isCurrentEpoch(session, expectedRunEpoch) ||
+          !record ||
+          record.run.runEpoch !== expectedRunEpoch ||
+          record.run.status !== expectedStatus
+        ) {
+          return null;
+        }
+        if (
+          !providerSessionMatches(
+            session,
+            providerSessionId,
+            record.run.providerSessionId,
+          )
+        ) {
+          return null;
+        }
+        if (
+          seconds(updatedAt) < record.updatedAtSeconds ||
+          (turnsUsed !== undefined && turnsUsed < record.run.turnsUsed) ||
+          (tokensUsed !== undefined && tokensUsed < record.run.tokensUsed) ||
+          (lastActivityAt !== undefined &&
+            Date.parse(lastActivityAt) < Date.parse(record.run.lastActivityAt))
+        ) {
+          return null;
+        }
+        const nextLastActivityAt = lastActivityAt ?? record.run.lastActivityAt;
+        if (
+          completedAt !== undefined &&
+          Date.parse(completedAt) < Date.parse(nextLastActivityAt)
+        ) {
+          return null;
+        }
+        const next: AgentGoalRun = {
+          ...record.run,
+          status: nextStatus,
+          turnsUsed: turnsUsed ?? record.run.turnsUsed,
+          tokensUsed: tokensUsed ?? record.run.tokensUsed,
+          lastActivityAt: nextLastActivityAt,
+          ...(providerSessionId === undefined ? {} : { providerSessionId }),
+          ...(completedAt === undefined ? {} : { completedAt }),
+          ...(input.lastEvaluation === undefined
+            ? {}
+            : {
+                lastEvaluation:
+                  input.lastEvaluation === null
+                    ? undefined
+                    : parseEvaluation(input.lastEvaluation),
+              }),
+        };
+        if (!store.updateRun(record.run, next, sqliteIso(updatedAt)))
+          return null;
+        return store.getRun(scope.ownerId, scope.runtimeSessionId, runId);
+      });
+    } catch (cause) {
+      repositoryMutationError("Could not transition the Goal Run", cause);
+    }
+  }
+
+  async updateProgress(
+    input: SqliteGoalRunProgressUpdateInput,
+  ): Promise<AgentGoalRun | null> {
+    const scope = normalizeScope(input);
+    const runId = normalizeIdentifier(input.runId, "runId");
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const expectedStatus = parseRunStatus(
+      input.expectedStatus,
+      "expectedStatus",
+    );
+    const updatedAt = isoDate(input.updatedAt, "updatedAt");
+    const providerSessionId = optionalIdentifier(
+      input.providerSessionId,
+      "providerSessionId",
+    );
+    const turns = pairedCounter(
+      input.expectedTurnsUsed,
+      input.turnsUsed,
+      "turnsUsed",
+    );
+    const tokens = pairedCounter(
+      input.expectedTokensUsed,
+      input.tokensUsed,
+      "tokensUsed",
+    );
+    const lastActivityAt = optionalSqliteInstant(
+      input.lastActivityAt,
+      "lastActivityAt",
+    );
+    if (
+      providerSessionId === undefined &&
+      turns === undefined &&
+      tokens === undefined &&
+      input.lastActivityAt === undefined &&
+      input.lastEvaluation === undefined
+    ) {
+      throw new TypeError(
+        "A Goal Run progress update must change progress state",
+      );
+    }
+
+    try {
+      return this.database.immediate((store) => {
+        const session = store.getSession(scope.ownerId, scope.runtimeSessionId);
+        const record = store.getRunRecord(
+          scope.ownerId,
+          scope.runtimeSessionId,
+          runId,
+        );
+        if (
+          !isCurrentEpoch(session, expectedRunEpoch) ||
+          !record ||
+          record.run.runEpoch !== expectedRunEpoch ||
+          record.run.status !== expectedStatus ||
+          seconds(updatedAt) < record.updatedAtSeconds ||
+          (turns !== undefined && record.run.turnsUsed !== turns.expected) ||
+          (tokens !== undefined && record.run.tokensUsed !== tokens.expected) ||
+          (lastActivityAt !== undefined &&
+            Date.parse(lastActivityAt) < Date.parse(record.run.lastActivityAt))
+        ) {
+          return null;
+        }
+        if (
+          !providerSessionMatches(
+            session,
+            providerSessionId,
+            record.run.providerSessionId,
+          )
+        ) {
+          return null;
+        }
+        const next: AgentGoalRun = {
+          ...record.run,
+          turnsUsed: turns?.next ?? record.run.turnsUsed,
+          tokensUsed: tokens?.next ?? record.run.tokensUsed,
+          lastActivityAt: lastActivityAt ?? record.run.lastActivityAt,
+          ...(providerSessionId === undefined ? {} : { providerSessionId }),
+          ...(input.lastEvaluation === undefined
+            ? {}
+            : {
+                lastEvaluation:
+                  input.lastEvaluation === null
+                    ? undefined
+                    : parseEvaluation(input.lastEvaluation),
+              }),
+        };
+        if (!store.updateRun(record.run, next, sqliteIso(updatedAt)))
+          return null;
+        return store.getRun(scope.ownerId, scope.runtimeSessionId, runId);
+      });
+    } catch (cause) {
+      repositoryMutationError("Could not update Goal Run progress", cause);
+    }
+  }
+}
+
+function validateInitialRun(run: AgentGoalRun): void {
+  if (
+    run.status !== "queued" ||
+    run.turnsUsed !== 0 ||
+    run.tokensUsed !== 0 ||
+    run.completedAt !== undefined ||
+    run.lastEvaluation !== undefined ||
+    Date.parse(run.startedAt) !== Date.parse(run.lastActivityAt)
+  ) {
+    throw new TypeError(
+      "A new Goal Run must be queued with zero usage, no evaluation or completion, and no activity after its start",
+    );
+  }
+}
+
+function parseRunStatus(value: unknown, field: string): GoalRunStatus {
+  const parsed = GoalRunStatusSchema.safeParse(value);
+  if (!parsed.success) throw new TypeError(`${field} is not a Goal Run status`);
+  return parsed.data;
+}
+
+function parseEvaluation(value: GoalEvaluationResult): GoalEvaluationResult {
+  const parsed = GoalEvaluationResultSchema.safeParse(value);
+  if (!parsed.success) throw new TypeError("lastEvaluation is invalid");
+  return parsed.data;
+}
+
+function optionalIdentifier(
+  value: string | undefined,
+  field: string,
+): string | undefined {
+  return value === undefined ? undefined : normalizeIdentifier(value, field);
+}
+
+function validateCompletion(
+  status: GoalRunStatus,
+  completedAt: string | null | undefined,
+): void {
+  if (isTerminalGoalRunStatus(status) && !completedAt) {
+    throw new TypeError(
+      `completedAt is required for Goal Run status ${status}`,
+    );
+  }
+  if (
+    !isTerminalGoalRunStatus(status) &&
+    completedAt !== undefined &&
+    completedAt !== null
+  ) {
+    throw new TypeError(
+      `completedAt is not valid for Goal Run status ${status}`,
+    );
+  }
+}
+
+function materializeCompletedAt(
+  status: GoalRunStatus,
+  value: string | null | undefined,
+): string | undefined {
+  if (!isTerminalGoalRunStatus(status)) return undefined;
+  const completed = isoDate(value as string, "completedAt");
+  return sqliteIso(completed);
+}
+
+function optionalCounter(
+  value: number | undefined,
+  field: string,
+): number | undefined {
+  return value === undefined ? undefined : nonNegativeInteger(value, field);
+}
+
+function optionalSqliteInstant(
+  value: string | undefined,
+  field: string,
+): string | undefined {
+  return value === undefined ? undefined : sqliteIso(isoDate(value, field));
+}
+
+function pairedCounter(
+  expected: number | undefined,
+  next: number | undefined,
+  field: string,
+): { expected: number; next: number } | undefined {
+  if ((expected === undefined) !== (next === undefined)) {
+    throw new TypeError(
+      `expected${field[0].toUpperCase()}${field.slice(1)} and ${field} must be supplied together`,
+    );
+  }
+  if (expected === undefined || next === undefined) return undefined;
+  const parsedExpected = nonNegativeInteger(
+    expected,
+    `expected${field[0].toUpperCase()}${field.slice(1)}`,
+  );
+  const parsedNext = nonNegativeInteger(next, field);
+  if (parsedNext < parsedExpected)
+    throw new TypeError(`${field} cannot decrease`);
+  return { expected: parsedExpected, next: parsedNext };
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
@@ -1,0 +1,1064 @@
+import type {
+  AgentGoalRun,
+  GoalEvidence,
+  PersistedAgentGoal,
+  RuntimeInstruction,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type {
+  AgentGoalCommandCheckpoint,
+  AgentGoalCommandPhase,
+  AgentGoalCommandType,
+  AgentGoalSlotState,
+  AgentRuntimePendingOperation,
+} from "@/lib/db/agent-goal-runtime-schema-types";
+
+import {
+  mapAgentGoalRecord,
+  mapStoredRuntimeInstructionRecord,
+  type StoredRuntimeInstruction,
+} from "../goal-instruction-mappers";
+import {
+  buildAgentGoalRecord,
+  buildAgentGoalEvidenceRecord,
+  buildAgentGoalRunRecord,
+  buildPendingRuntimeDeliveryRecord,
+  buildRuntimeInstructionRecord,
+  type AgentGoalEvidenceRecordInput,
+  type PendingRuntimeDeliveryRecordInput,
+} from "../internal/record-builders";
+import { WHOLE_SECOND_PERSISTED_INSTANT_PRECISION } from "../instant-precision";
+import {
+  mapAgentGoalRunRecord,
+  mapGoalEvidenceRecord,
+  mapRuntimeInstructionDeliveryRecord,
+  type PersistedRuntimeInstructionDelivery,
+} from "../runtime-observation-mappers";
+import type { BetterSqlite3Client } from "./transaction";
+
+export interface SqliteGoalSessionRecord {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly lastInstructionSequence: number;
+  readonly providerSessionId?: string;
+  readonly pendingOperation?: AgentRuntimePendingOperation;
+  readonly createdAtSeconds: number;
+  readonly updatedAtSeconds: number;
+}
+
+export interface SqliteGoalRecord {
+  readonly persistedGoal: PersistedAgentGoal;
+  readonly slotState: AgentGoalSlotState;
+}
+
+export interface SqliteGoalRunRecord {
+  readonly run: AgentGoalRun;
+  readonly updatedAtSeconds: number;
+}
+
+export interface UpdateSqliteSessionInput {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly expectedRunEpoch: number;
+  readonly expectedInstructionSequence: number;
+  readonly expectedPendingOperation: AgentRuntimePendingOperation | null;
+  readonly runEpoch: number;
+  readonly instructionSequence: number;
+  readonly pendingOperation: AgentRuntimePendingOperation | null;
+  readonly updatedAtSeconds: number;
+}
+
+export interface InsertSqliteInstructionInput {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly instruction: RuntimeInstruction;
+  readonly requestFingerprint: string;
+  readonly commandOrder: number;
+  readonly commandType?: AgentGoalCommandType;
+  readonly commandPhase?: AgentGoalCommandPhase;
+  readonly commandCheckpoint?: AgentGoalCommandCheckpoint;
+  readonly goalRunId?: string;
+  readonly deliveryId: string;
+  readonly recordedAt: string;
+}
+
+export interface UpdateSqliteDeliveryInput {
+  readonly current: PersistedRuntimeInstructionDelivery;
+  readonly next: PersistedRuntimeInstructionDelivery;
+}
+
+/**
+ * Synchronous SQLite row store shared by the Goal state unit of work and the
+ * standalone repositories. Callers that perform writes must hold the native
+ * `BEGIN IMMEDIATE` boundary supplied by SqliteGoalRuntimeDatabase.
+ */
+export class SqliteGoalRuntimeStore {
+  constructor(private readonly client: BetterSqlite3Client) {}
+
+  getSession(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): SqliteGoalSessionRecord | null {
+    const row = this.client
+      .prepare(
+        `SELECT owner_id, id, run_epoch, last_instruction_sequence,
+                provider_session_id, pending_operation, created_at, updated_at
+           FROM agent_runtime_sessions
+          WHERE owner_id = ? AND id = ?`,
+      )
+      .get(ownerId, runtimeSessionId) as RawRow | undefined;
+    if (!row) return null;
+    return {
+      ownerId: requiredString(row.owner_id, "runtime session owner_id"),
+      runtimeSessionId: requiredString(row.id, "runtime session id"),
+      runEpoch: requiredInteger(row.run_epoch, "runtime session run_epoch", 0),
+      lastInstructionSequence: requiredInteger(
+        row.last_instruction_sequence,
+        "runtime session last_instruction_sequence",
+        0,
+      ),
+      ...(optionalString(row.provider_session_id) === undefined
+        ? {}
+        : { providerSessionId: optionalString(row.provider_session_id) }),
+      ...(row.pending_operation === null || row.pending_operation === undefined
+        ? {}
+        : {
+            pendingOperation: parseJsonObject(
+              row.pending_operation,
+              "runtime session pending_operation",
+            ) as unknown as AgentRuntimePendingOperation,
+          }),
+      createdAtSeconds: requiredInteger(
+        row.created_at,
+        "runtime session created_at",
+        0,
+      ),
+      updatedAtSeconds: requiredInteger(
+        row.updated_at,
+        "runtime session updated_at",
+        0,
+      ),
+    };
+  }
+
+  updateSession(input: UpdateSqliteSessionInput): boolean {
+    const expectedPending = serializeJson(input.expectedPendingOperation);
+    const pendingPredicate =
+      input.expectedPendingOperation === null
+        ? "pending_operation IS NULL"
+        : "pending_operation = ?";
+    const parameters: unknown[] = [
+      input.runEpoch,
+      input.instructionSequence,
+      serializeJson(input.pendingOperation),
+      input.updatedAtSeconds,
+      input.ownerId,
+      input.runtimeSessionId,
+      input.expectedRunEpoch,
+      input.expectedInstructionSequence,
+    ];
+    if (input.expectedPendingOperation !== null) {
+      parameters.push(expectedPending);
+    }
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET run_epoch = ?, last_instruction_sequence = ?,
+                  pending_operation = ?, updated_at = ?
+            WHERE owner_id = ? AND id = ? AND run_epoch = ?
+              AND last_instruction_sequence = ? AND ${pendingPredicate}`,
+        )
+        .run(...parameters).changes === 1
+    );
+  }
+
+  getGoalForOwner(ownerId: string, goalId: string): SqliteGoalRecord | null {
+    const row = this.client
+      .prepare("SELECT * FROM agent_goals WHERE owner_id = ? AND id = ?")
+      .get(ownerId, goalId) as RawRow | undefined;
+    return row ? mapGoalRow(row) : null;
+  }
+
+  getGoal(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalId: string,
+  ): SqliteGoalRecord | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goals
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?`,
+      )
+      .get(ownerId, runtimeSessionId, goalId) as RawRow | undefined;
+    return row ? mapGoalRow(row) : null;
+  }
+
+  getAssignedPrimaryGoal(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): SqliteGoalRecord | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goals
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND slot = 'primary' AND slot_state = 'assigned'
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId) as RawRow | undefined;
+    return row ? mapGoalRow(row) : null;
+  }
+
+  listGoals(ownerId: string, runtimeSessionId: string): SqliteGoalRecord[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_goals
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND slot_state IN ('assigned', 'released')
+          ORDER BY updated_at DESC, id DESC`,
+      )
+      .all(ownerId, runtimeSessionId)
+      .map((row) => mapGoalRow(row as RawRow));
+  }
+
+  insertGoal(
+    persistedGoal: PersistedAgentGoal,
+    slotState: AgentGoalSlotState,
+  ): void {
+    const row = buildAgentGoalRecord({ persistedGoal, slotState });
+    this.client
+      .prepare(
+        `INSERT INTO agent_goals (
+           id, owner_id, runtime_session_id, slot, slot_state, revision,
+           objective, priority, status, deadline, max_turns, max_tokens,
+           max_duration_seconds, completion_policy, source_type, source_id,
+           goal_snapshot, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        row.id,
+        row.ownerId,
+        row.runtimeSessionId,
+        row.slot,
+        row.slotState,
+        row.revision,
+        row.objective,
+        row.priority,
+        row.status,
+        optionalDateSeconds(row.deadline),
+        row.maxTurns,
+        row.maxTokens,
+        row.maxDurationSeconds,
+        row.completionPolicy,
+        row.sourceType,
+        row.sourceId,
+        JSON.stringify(row.goalSnapshot),
+        dateSeconds(row.createdAt),
+        dateSeconds(row.updatedAt),
+      );
+  }
+
+  updateGoal(
+    persistedGoal: PersistedAgentGoal,
+    expectedRevision: number,
+    expectedSlotState: AgentGoalSlotState,
+    slotState: AgentGoalSlotState,
+  ): boolean {
+    const row = buildAgentGoalRecord({ persistedGoal, slotState });
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_goals
+              SET slot_state = ?, revision = ?, objective = ?, priority = ?,
+                  status = ?, deadline = ?, max_turns = ?, max_tokens = ?,
+                  max_duration_seconds = ?, completion_policy = ?,
+                  source_type = ?, source_id = ?, goal_snapshot = ?,
+                  updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+              AND revision = ? AND slot_state = ?`,
+        )
+        .run(
+          row.slotState,
+          row.revision,
+          row.objective,
+          row.priority,
+          row.status,
+          optionalDateSeconds(row.deadline),
+          row.maxTurns,
+          row.maxTokens,
+          row.maxDurationSeconds,
+          row.completionPolicy,
+          row.sourceType,
+          row.sourceId,
+          JSON.stringify(row.goalSnapshot),
+          dateSeconds(row.updatedAt),
+          row.ownerId,
+          row.runtimeSessionId,
+          row.id,
+          expectedRevision,
+          expectedSlotState,
+        ).changes === 1
+    );
+  }
+
+  updateGoalSlotState(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+    expectedSlotState: AgentGoalSlotState;
+    slotState: AgentGoalSlotState;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_goals SET slot_state = ?
+            WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+              AND slot_state = ?`,
+        )
+        .run(
+          input.slotState,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.goalId,
+          input.expectedSlotState,
+        ).changes === 1
+    );
+  }
+
+  findCommand(
+    ownerId: string,
+    runtimeSessionId: string,
+    idempotencyKey: string,
+  ): StoredRuntimeInstruction | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_instructions
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND idempotency_key = ? AND command_order = 0
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, idempotencyKey) as RawRow | undefined;
+    return row ? mapInstructionRow(row) : null;
+  }
+
+  getInstruction(
+    ownerId: string,
+    runtimeSessionId: string,
+    instructionId: string,
+  ): StoredRuntimeInstruction | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_instructions
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, instructionId) as RawRow | undefined;
+    return row ? mapInstructionRow(row) : null;
+  }
+
+  findInstructionId(instructionId: string): boolean {
+    return Boolean(
+      this.client
+        .prepare("SELECT 1 FROM agent_runtime_instructions WHERE id = ?")
+        .get(instructionId),
+    );
+  }
+
+  listInstructions(
+    ownerId: string,
+    runtimeSessionId: string,
+    afterSequence = 0,
+  ): RuntimeInstruction[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_instructions
+          WHERE owner_id = ? AND runtime_session_id = ? AND sequence > ?
+          ORDER BY sequence ASC`,
+      )
+      .all(ownerId, runtimeSessionId, afterSequence)
+      .map((row) => mapInstructionRow(row as RawRow).instruction);
+  }
+
+  insertInstruction(input: InsertSqliteInstructionInput): void {
+    const instructionRow = buildRuntimeInstructionRecord(input);
+    this.client
+      .prepare(
+        `INSERT INTO agent_runtime_instructions (
+           id, owner_id, runtime_session_id, schema_version, sequence,
+           run_epoch, goal_id, goal_revision, kind, delivery_mode, payload,
+           source_type, source_authority, source_ref, idempotency_key,
+           request_fingerprint, command_order, command_type, command_phase,
+           command_checkpoint, instruction_snapshot, issued_at, expires_at,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        instructionRow.id,
+        instructionRow.ownerId,
+        instructionRow.runtimeSessionId,
+        instructionRow.schemaVersion,
+        instructionRow.sequence,
+        instructionRow.runEpoch,
+        instructionRow.goalId,
+        instructionRow.goalRevision,
+        instructionRow.kind,
+        instructionRow.deliveryMode,
+        JSON.stringify(instructionRow.payload),
+        instructionRow.sourceType,
+        instructionRow.sourceAuthority,
+        instructionRow.sourceRef,
+        instructionRow.idempotencyKey,
+        instructionRow.requestFingerprint,
+        instructionRow.commandOrder,
+        instructionRow.commandType,
+        instructionRow.commandPhase,
+        serializeJson(instructionRow.commandCheckpoint),
+        JSON.stringify(instructionRow.instructionSnapshot),
+        dateSeconds(instructionRow.issuedAt),
+        optionalDateSeconds(instructionRow.expiresAt),
+        dateSeconds(instructionRow.createdAt),
+        dateSeconds(instructionRow.updatedAt),
+      );
+  }
+
+  insertPendingDelivery(input: PendingRuntimeDeliveryRecordInput): void {
+    const deliveryRow = buildPendingRuntimeDeliveryRecord({
+      ...input,
+    });
+    this.client
+      .prepare(
+        `INSERT INTO agent_runtime_deliveries (
+           id, owner_id, runtime_session_id, instruction_id, goal_run_id,
+           run_epoch, state, attempt, available_at, lease_token, lease_owner,
+           lease_expires_at, provider_event_id, error_code, error_message,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        deliveryRow.id,
+        deliveryRow.ownerId,
+        deliveryRow.runtimeSessionId,
+        deliveryRow.instructionId,
+        deliveryRow.goalRunId,
+        deliveryRow.runEpoch,
+        deliveryRow.state,
+        deliveryRow.attempt,
+        dateSeconds(deliveryRow.availableAt),
+        deliveryRow.leaseToken,
+        deliveryRow.leaseOwner,
+        optionalDateSeconds(deliveryRow.leaseExpiresAt),
+        deliveryRow.providerEventId,
+        deliveryRow.errorCode,
+        deliveryRow.errorMessage,
+        dateSeconds(deliveryRow.createdAt),
+        dateSeconds(deliveryRow.updatedAt),
+      );
+  }
+
+  insertInstructionAndPendingDelivery(
+    input: InsertSqliteInstructionInput,
+  ): void {
+    this.insertInstruction(input);
+    this.insertPendingDelivery({
+      id: input.deliveryId,
+      ownerId: input.ownerId,
+      runtimeSessionId: input.runtimeSessionId,
+      instructionId: input.instruction.id,
+      ...(input.goalRunId === undefined ? {} : { goalRunId: input.goalRunId }),
+      runEpoch: input.runEpoch,
+      availableAt: input.recordedAt,
+      recordedAt: input.recordedAt,
+    });
+  }
+
+  updateCommandCheckpoint(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    idempotencyKey: string;
+    requestFingerprint: string;
+    commandType: Exclude<AgentGoalCommandType, "goal_instruction">;
+    expectedPhase: AgentGoalCommandPhase;
+    phase: AgentGoalCommandPhase;
+    checkpoint: AgentGoalCommandCheckpoint;
+    updatedAt: string;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_instructions
+              SET command_phase = ?, command_checkpoint = ?, updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ?
+              AND idempotency_key = ? AND command_order = 0
+              AND request_fingerprint = ? AND command_type = ?
+              AND command_phase = ?`,
+        )
+        .run(
+          input.phase,
+          JSON.stringify(input.checkpoint),
+          isoSeconds(input.updatedAt),
+          input.ownerId,
+          input.runtimeSessionId,
+          input.idempotencyKey,
+          input.requestFingerprint,
+          input.commandType,
+          input.expectedPhase,
+        ).changes === 1
+    );
+  }
+
+  findRun(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalId: string,
+    runEpoch: number,
+  ): AgentGoalRun | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goal_runs
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND goal_id = ? AND run_epoch = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, goalId, runEpoch) as RawRow | undefined;
+    return row ? mapRunRow(row) : null;
+  }
+
+  getRun(
+    ownerId: string,
+    runtimeSessionId: string,
+    runId: string,
+  ): AgentGoalRun | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goal_runs
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, runId) as RawRow | undefined;
+    return row ? mapRunRow(row) : null;
+  }
+
+  getRunRecord(
+    ownerId: string,
+    runtimeSessionId: string,
+    runId: string,
+  ): SqliteGoalRunRecord | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goal_runs
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, runId) as RawRow | undefined;
+    return row
+      ? {
+          run: mapRunRow(row),
+          updatedAtSeconds: requiredInteger(
+            row.updated_at,
+            "Goal Run updated_at",
+            0,
+          ),
+        }
+      : null;
+  }
+
+  listRuns(ownerId: string, runtimeSessionId: string): AgentGoalRun[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_goal_runs
+          WHERE owner_id = ? AND runtime_session_id = ?
+          ORDER BY started_at ASC, id ASC`,
+      )
+      .all(ownerId, runtimeSessionId)
+      .map((row) => mapRunRow(row as RawRow));
+  }
+
+  insertRun(run: AgentGoalRun, recordedAt: string): void {
+    const row = buildAgentGoalRunRecord({ run, recordedAt });
+    this.client
+      .prepare(
+        `INSERT INTO agent_goal_runs (
+           id, owner_id, runtime_session_id, goal_id, goal_revision,
+           run_epoch, provider_session_id, status, turns_used, tokens_used,
+           started_at, last_activity_at, completed_at, last_evaluation,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        row.id,
+        row.ownerId,
+        row.runtimeSessionId,
+        row.goalId,
+        row.goalRevision,
+        row.runEpoch,
+        row.providerSessionId,
+        row.status,
+        row.turnsUsed,
+        row.tokensUsed,
+        dateSeconds(row.startedAt),
+        dateSeconds(row.lastActivityAt),
+        optionalDateSeconds(row.completedAt),
+        serializeJson(row.lastEvaluation),
+        dateSeconds(row.createdAt),
+        dateSeconds(row.updatedAt),
+      );
+  }
+
+  updateRun(
+    current: AgentGoalRun,
+    next: AgentGoalRun,
+    recordedAt: string,
+  ): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_goal_runs
+              SET goal_revision = ?, provider_session_id = ?, status = ?,
+                  turns_used = ?, tokens_used = ?, last_activity_at = ?,
+                  completed_at = ?, last_evaluation = ?, updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+              AND goal_id = ? AND run_epoch = ? AND goal_revision = ?
+              AND status = ?`,
+        )
+        .run(
+          next.goalRevision,
+          next.providerSessionId ?? null,
+          next.status,
+          next.turnsUsed,
+          next.tokensUsed,
+          isoSeconds(next.lastActivityAt),
+          next.completedAt ? isoSeconds(next.completedAt) : null,
+          serializeJson(next.lastEvaluation),
+          isoSeconds(recordedAt),
+          current.ownerId,
+          current.runtimeSessionId,
+          current.id,
+          current.goalId,
+          current.runEpoch,
+          current.goalRevision,
+          current.status,
+        ).changes === 1
+    );
+  }
+
+  getDelivery(
+    ownerId: string,
+    runtimeSessionId: string,
+    deliveryId: string,
+  ): PersistedRuntimeInstructionDelivery | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_deliveries
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, deliveryId) as RawRow | undefined;
+    return row ? mapDeliveryRow(row) : null;
+  }
+
+  getActiveDeliveryForInstruction(
+    ownerId: string,
+    runtimeSessionId: string,
+    instructionId: string,
+  ): PersistedRuntimeInstructionDelivery | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_deliveries
+          WHERE owner_id = ? AND runtime_session_id = ? AND instruction_id = ?
+            AND state IN ('pending', 'leased', 'queued', 'written_to_sdk', 'observed', 'applied')
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, instructionId) as RawRow | undefined;
+    return row ? mapDeliveryRow(row) : null;
+  }
+
+  listDeliveryAttempts(
+    ownerId: string,
+    runtimeSessionId: string,
+    instructionId: string,
+  ): PersistedRuntimeInstructionDelivery[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_deliveries
+          WHERE owner_id = ? AND runtime_session_id = ? AND instruction_id = ?
+          ORDER BY attempt ASC`,
+      )
+      .all(ownerId, runtimeSessionId, instructionId)
+      .map((row) => mapDeliveryRow(row as RawRow));
+  }
+
+  listDispatchableDeliveries(
+    ownerId: string,
+    runtimeSessionId: string,
+    availableAtSeconds: number,
+    limit: number,
+  ): PersistedRuntimeInstructionDelivery[] {
+    return this.client
+      .prepare(
+        `SELECT delivery.*
+           FROM agent_runtime_deliveries AS delivery
+           JOIN agent_runtime_instructions AS instruction
+             ON instruction.owner_id = delivery.owner_id
+            AND instruction.runtime_session_id = delivery.runtime_session_id
+            AND instruction.id = delivery.instruction_id
+            AND instruction.run_epoch = delivery.run_epoch
+           JOIN agent_runtime_sessions AS session
+             ON session.owner_id = delivery.owner_id
+            AND session.id = delivery.runtime_session_id
+            AND session.run_epoch = delivery.run_epoch
+          WHERE delivery.owner_id = ? AND delivery.runtime_session_id = ?
+            AND delivery.state = 'pending' AND delivery.available_at <= ?
+          ORDER BY delivery.available_at ASC, instruction.sequence ASC,
+                   delivery.attempt ASC, delivery.id ASC
+          LIMIT ?`,
+      )
+      .all(ownerId, runtimeSessionId, availableAtSeconds, limit)
+      .map((row) => mapDeliveryRow(row as RawRow));
+  }
+
+  updateDelivery(
+    current: PersistedRuntimeInstructionDelivery,
+    next: PersistedRuntimeInstructionDelivery,
+  ): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_deliveries
+              SET state = ?, available_at = ?, lease_token = ?, lease_owner = ?,
+                  lease_expires_at = ?, provider_event_id = ?, error_code = ?,
+                  error_message = ?, updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+              AND run_epoch = ? AND state = ? AND updated_at = ?
+              AND lease_token IS ?`,
+        )
+        .run(
+          next.state,
+          isoSeconds(next.availableAt),
+          next.leaseToken ?? null,
+          next.leaseOwner ?? null,
+          next.leaseExpiresAt ? isoSeconds(next.leaseExpiresAt) : null,
+          next.providerEventId ?? null,
+          next.errorCode ?? null,
+          next.errorMessage ?? null,
+          isoSeconds(next.updatedAt),
+          current.ownerId,
+          current.runtimeSessionId,
+          current.id,
+          current.runEpoch,
+          current.state,
+          isoSeconds(current.updatedAt),
+          current.leaseToken ?? null,
+        ).changes === 1
+    );
+  }
+
+  getEvidence(
+    ownerId: string,
+    runtimeSessionId: string,
+    evidenceId: string,
+  ): GoalEvidence | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goal_evidence
+          WHERE owner_id = ? AND runtime_session_id = ? AND id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, evidenceId) as RawRow | undefined;
+    return row ? mapEvidenceRow(row) : null;
+  }
+
+  findEvidenceBySourceEvent(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalRunId: string,
+    sourceEventId: string,
+  ): GoalEvidence | null {
+    const row = this.client
+      .prepare(
+        `SELECT * FROM agent_goal_evidence
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND goal_run_id = ? AND source_event_id = ?
+          LIMIT 1`,
+      )
+      .get(ownerId, runtimeSessionId, goalRunId, sourceEventId) as
+      | RawRow
+      | undefined;
+    return row ? mapEvidenceRow(row) : null;
+  }
+
+  listEvidenceByRun(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalRunId: string,
+  ): GoalEvidence[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_goal_evidence
+          WHERE owner_id = ? AND runtime_session_id = ? AND goal_run_id = ?
+          ORDER BY observed_at ASC, id ASC`,
+      )
+      .all(ownerId, runtimeSessionId, goalRunId)
+      .map((row) => mapEvidenceRow(row as RawRow));
+  }
+
+  insertEvidence(input: AgentGoalEvidenceRecordInput): void {
+    const row = buildAgentGoalEvidenceRecord(input);
+    this.client
+      .prepare(
+        `INSERT INTO agent_goal_evidence (
+           id, owner_id, runtime_session_id, goal_id, goal_run_id,
+           instruction_id, goal_revision, run_epoch, criterion_id, type,
+           source_event_id, summary, success, payload, observed_at, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        row.id,
+        row.ownerId,
+        row.runtimeSessionId,
+        row.goalId,
+        row.goalRunId,
+        row.instructionId,
+        row.goalRevision,
+        row.runEpoch,
+        row.criterionId,
+        row.type,
+        row.sourceEventId,
+        row.summary,
+        row.success === null ? null : row.success ? 1 : 0,
+        JSON.stringify(row.payload),
+        dateSeconds(row.observedAt),
+        dateSeconds(row.createdAt),
+      );
+  }
+}
+
+type RawRow = Readonly<Record<string, unknown>>;
+
+function mapGoalRow(row: RawRow): SqliteGoalRecord {
+  const mapped = mapAgentGoalRecord(
+    {
+      id: row.id,
+      ownerId: row.owner_id,
+      runtimeSessionId: row.runtime_session_id,
+      slot: row.slot,
+      slotState: row.slot_state,
+      revision: row.revision,
+      objective: row.objective,
+      priority: row.priority,
+      status: row.status,
+      deadline: optionalUnixDate(row.deadline),
+      maxTurns: row.max_turns,
+      maxTokens: row.max_tokens,
+      maxDurationSeconds: row.max_duration_seconds,
+      completionPolicy: row.completion_policy,
+      sourceType: row.source_type,
+      sourceId: row.source_id,
+      goalSnapshot: parseJsonObject(row.goal_snapshot, "Goal goal_snapshot"),
+      createdAt: unixDate(row.created_at, "Goal created_at"),
+      updatedAt: unixDate(row.updated_at, "Goal updated_at"),
+    },
+    WHOLE_SECOND_PERSISTED_INSTANT_PRECISION,
+  );
+  const slotState = requiredString(row.slot_state, "Goal slot_state");
+  if (!isGoalSlotState(slotState)) {
+    throw new Error(`Invalid persisted Goal slot_state ${slotState}`);
+  }
+  return { persistedGoal: mapped, slotState };
+}
+
+function mapInstructionRow(row: RawRow): StoredRuntimeInstruction {
+  return mapStoredRuntimeInstructionRecord(
+    {
+      id: row.id,
+      ownerId: row.owner_id,
+      runtimeSessionId: row.runtime_session_id,
+      schemaVersion: row.schema_version,
+      sequence: row.sequence,
+      runEpoch: row.run_epoch,
+      goalId: row.goal_id,
+      goalRevision: row.goal_revision,
+      kind: row.kind,
+      deliveryMode: row.delivery_mode,
+      payload: parseJsonObject(row.payload, "Instruction payload"),
+      sourceType: row.source_type,
+      sourceAuthority: row.source_authority,
+      sourceRef: row.source_ref,
+      idempotencyKey: row.idempotency_key,
+      requestFingerprint: row.request_fingerprint,
+      commandOrder: row.command_order,
+      commandType: row.command_type,
+      commandPhase: row.command_phase,
+      commandCheckpoint:
+        row.command_checkpoint === null
+          ? null
+          : parseJsonObject(
+              row.command_checkpoint,
+              "Instruction command_checkpoint",
+            ),
+      instructionSnapshot: parseJsonObject(
+        row.instruction_snapshot,
+        "Instruction instruction_snapshot",
+      ),
+      issuedAt: unixDate(row.issued_at, "Instruction issued_at"),
+      expiresAt: optionalUnixDate(row.expires_at),
+      createdAt: unixDate(row.created_at, "Instruction created_at"),
+      updatedAt: unixDate(row.updated_at, "Instruction updated_at"),
+    },
+    WHOLE_SECOND_PERSISTED_INSTANT_PRECISION,
+  );
+}
+
+function mapRunRow(row: RawRow): AgentGoalRun {
+  return mapAgentGoalRunRecord({
+    id: row.id,
+    ownerId: row.owner_id,
+    runtimeSessionId: row.runtime_session_id,
+    goalId: row.goal_id,
+    goalRevision: row.goal_revision,
+    runEpoch: row.run_epoch,
+    providerSessionId: row.provider_session_id,
+    status: row.status,
+    turnsUsed: row.turns_used,
+    tokensUsed: row.tokens_used,
+    startedAt: unixDate(row.started_at, "Goal Run started_at"),
+    lastActivityAt: unixDate(row.last_activity_at, "Goal Run last_activity_at"),
+    completedAt: optionalUnixDate(row.completed_at),
+    lastEvaluation:
+      row.last_evaluation === null
+        ? null
+        : parseJsonObject(row.last_evaluation, "Goal Run last_evaluation"),
+    createdAt: unixDate(row.created_at, "Goal Run created_at"),
+    updatedAt: unixDate(row.updated_at, "Goal Run updated_at"),
+  });
+}
+
+function mapDeliveryRow(row: RawRow): PersistedRuntimeInstructionDelivery {
+  return mapRuntimeInstructionDeliveryRecord({
+    id: row.id,
+    ownerId: row.owner_id,
+    runtimeSessionId: row.runtime_session_id,
+    instructionId: row.instruction_id,
+    goalRunId: row.goal_run_id,
+    runEpoch: row.run_epoch,
+    state: row.state,
+    attempt: row.attempt,
+    availableAt: unixDate(row.available_at, "Delivery available_at"),
+    leaseToken: row.lease_token,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt: optionalUnixDate(row.lease_expires_at),
+    providerEventId: row.provider_event_id,
+    errorCode: row.error_code,
+    errorMessage: row.error_message,
+    createdAt: unixDate(row.created_at, "Delivery created_at"),
+    updatedAt: unixDate(row.updated_at, "Delivery updated_at"),
+  });
+}
+
+function mapEvidenceRow(row: RawRow): GoalEvidence {
+  return mapGoalEvidenceRecord({
+    id: row.id,
+    ownerId: row.owner_id,
+    runtimeSessionId: row.runtime_session_id,
+    goalId: row.goal_id,
+    goalRunId: row.goal_run_id,
+    instructionId: row.instruction_id,
+    goalRevision: row.goal_revision,
+    runEpoch: row.run_epoch,
+    criterionId: row.criterion_id,
+    type: row.type,
+    sourceEventId: row.source_event_id,
+    summary: row.summary,
+    success:
+      row.success === null || row.success === undefined
+        ? null
+        : requiredInteger(row.success, "Evidence success", 0) === 1,
+    payload: parseJsonValue(row.payload, "Evidence payload"),
+    observedAt: unixDate(row.observed_at, "Evidence observed_at"),
+    createdAt: unixDate(row.created_at, "Evidence created_at"),
+  });
+}
+
+function isGoalSlotState(value: string): value is AgentGoalSlotState {
+  return value === "assigned" || value === "reserved" || value === "released";
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Invalid persisted ${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  return requiredString(value, "optional string");
+}
+
+function requiredInteger(
+  value: unknown,
+  field: string,
+  minimum: number,
+): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new Error(`Invalid persisted ${field}`);
+  }
+  return value as number;
+}
+
+function parseJsonObject(
+  value: unknown,
+  field: string,
+): Record<string, unknown> {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch (cause) {
+      throw new Error(`Invalid persisted ${field}`, { cause });
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Invalid persisted ${field}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseJsonValue(value: unknown, field: string): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch (cause) {
+    throw new Error(`Invalid persisted ${field}`, { cause });
+  }
+}
+
+function serializeJson(value: unknown): string | null {
+  return value === null || value === undefined ? null : JSON.stringify(value);
+}
+
+function dateSeconds(value: Date): number {
+  return Math.floor(value.getTime() / 1000);
+}
+
+function optionalDateSeconds(value: Date | null): number | null {
+  return value === null ? null : dateSeconds(value);
+}
+
+function isoSeconds(value: string): number {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds))
+    throw new TypeError("Invalid ISO timestamp");
+  return Math.floor(milliseconds / 1000);
+}
+
+function unixDate(value: unknown, field: string): Date {
+  return new Date(requiredInteger(value, field, 0) * 1000);
+}
+
+function optionalUnixDate(value: unknown): Date | null {
+  return value === null || value === undefined
+    ? null
+    : unixDate(value, "optional timestamp");
+}

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/transaction.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/transaction.ts
@@ -1,0 +1,52 @@
+import type Database from "better-sqlite3";
+
+export interface SqliteRunResult {
+  readonly changes: number;
+  readonly lastInsertRowid: number | bigint;
+}
+
+export interface SqliteStatement {
+  get(...parameters: readonly unknown[]): unknown;
+  all(...parameters: readonly unknown[]): unknown[];
+  run(...parameters: readonly unknown[]): SqliteRunResult;
+}
+
+export interface BetterSqlite3Client {
+  prepare(sql: string): SqliteStatement;
+  transaction<T>(callback: () => T): {
+    (): T;
+    immediate(): T;
+  };
+}
+
+export type BetterSqlite3ClientSource =
+  | Database.Database
+  | BetterSqlite3Client
+  | { readonly $client: Database.Database | BetterSqlite3Client };
+
+/**
+ * Native synchronous transaction boundary required by better-sqlite3.
+ *
+ * Drizzle's async transaction callback cannot keep a better-sqlite3
+ * transaction open across awaited work, so durable Goal mutations execute a
+ * fully synchronous unit of work under BEGIN IMMEDIATE and only wrap the
+ * result in the async application port at the outer edge.
+ */
+export class SqliteImmediateTransactionDriver {
+  readonly client: BetterSqlite3Client;
+
+  constructor(source: BetterSqlite3ClientSource) {
+    const client = "$client" in source ? source.$client : source;
+    if (
+      typeof client.prepare !== "function" ||
+      typeof client.transaction !== "function"
+    ) {
+      throw new TypeError("A better-sqlite3 client is required");
+    }
+    this.client = client as unknown as BetterSqlite3Client;
+  }
+
+  immediate<T>(work: () => T): T {
+    return this.client.transaction(work).immediate();
+  }
+}

--- a/apps/web/lib/db/agent-goal-runtime-schema-types.ts
+++ b/apps/web/lib/db/agent-goal-runtime-schema-types.ts
@@ -1,0 +1,75 @@
+import type {
+  AgentGoal,
+  AgentGoalLifecycleTransition,
+  AgentGoalReplacement,
+  DeliveryState,
+  GoalCompletionPolicy,
+  GoalEvaluationResult,
+  GoalEvidence,
+  GoalEvidenceType,
+  GoalRunStatus,
+  GoalStatus,
+  PersistedAgentGoal,
+  RuntimeInstruction,
+  RuntimeInstructionDeliveryMode,
+  RuntimeInstructionKind,
+  RuntimeInstructionSource,
+  RuntimeProvider,
+  RuntimeSessionState,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+export type AgentGoalSourceType = AgentGoal["source"]["type"];
+export type AgentGoalSnapshot = AgentGoal;
+export type AgentGoalEvaluationSnapshot = GoalEvaluationResult;
+export type AgentRuntimeInstructionSnapshot = RuntimeInstruction;
+export type AgentRuntimeInstructionPayload = RuntimeInstruction["payload"];
+export type AgentGoalEvidencePayload = GoalEvidence["payload"];
+
+export type AgentRuntimePendingOperation =
+  | AgentGoalLifecycleTransition
+  | AgentGoalReplacement;
+
+/**
+ * Historical command results are kept independently from the mutable Goal row
+ * so an idempotent retry can return the exact revision originally committed.
+ */
+export type AgentGoalCommandCheckpoint =
+  | {
+      type: "goal_instruction";
+      goal: PersistedAgentGoal;
+      instruction: RuntimeInstruction;
+    }
+  | {
+      type: "lifecycle";
+      transition: AgentGoalLifecycleTransition;
+    }
+  | {
+      type: "replacement";
+      replacement: AgentGoalReplacement;
+    };
+
+export type AgentGoalSlot = "primary";
+export type AgentGoalSlotState = "assigned" | "reserved" | "released";
+export type AgentGoalCommandType =
+  | "goal_instruction"
+  | "lifecycle"
+  | "replacement";
+export type AgentGoalCommandPhase =
+  | "committed"
+  | "prepared"
+  | "boundary_observed"
+  | "finalized"
+  | "activated";
+
+export type {
+  DeliveryState,
+  GoalCompletionPolicy,
+  GoalEvidenceType,
+  GoalRunStatus,
+  GoalStatus,
+  RuntimeInstructionDeliveryMode,
+  RuntimeInstructionKind,
+  RuntimeInstructionSource,
+  RuntimeProvider,
+  RuntimeSessionState,
+};

--- a/apps/web/lib/db/migrations-sqlite/0107_agent_goal_runtime.sql
+++ b/apps/web/lib/db/migrations-sqlite/0107_agent_goal_runtime.sql
@@ -1,0 +1,376 @@
+CREATE TABLE IF NOT EXISTS `agent_runtime_sessions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `provider` text DEFAULT 'claude' NOT NULL,
+  `provider_session_id` text,
+  `working_directory` text,
+  `state` text DEFAULT 'starting' NOT NULL,
+  `run_epoch` integer DEFAULT 0 NOT NULL,
+  `last_instruction_sequence` integer DEFAULT 0 NOT NULL,
+  `pending_operation` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  FOREIGN KEY (`owner_id`) REFERENCES `User`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_sessions_provider_check`
+    CHECK (`provider` IN ('claude')),
+  CONSTRAINT `agent_runtime_sessions_state_check`
+    CHECK (`state` IN ('starting', 'idle', 'running', 'evaluating', 'interrupted', 'closed', 'failed')),
+  CONSTRAINT `agent_runtime_sessions_run_epoch_check`
+    CHECK (`run_epoch` >= 0),
+  CONSTRAINT `agent_runtime_sessions_instruction_sequence_check`
+    CHECK (`last_instruction_sequence` >= 0),
+  CONSTRAINT `agent_runtime_sessions_pending_operation_check`
+    CHECK (`pending_operation` IS NULL OR (json_valid(`pending_operation`) AND json_type(`pending_operation`) = 'object')),
+  CONSTRAINT `agent_runtime_sessions_timestamps_check`
+    CHECK (`updated_at` >= `created_at`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_sessions_owner_id_id_key`
+  ON `agent_runtime_sessions` (`owner_id`, `id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_sessions_provider_session_idx`
+  ON `agent_runtime_sessions` (`provider`, `provider_session_id`)
+  WHERE `provider_session_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_sessions_recovery_idx`
+  ON `agent_runtime_sessions` (`owner_id`, `state`, `updated_at`)
+  WHERE `state` NOT IN ('closed', 'failed');
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_goals` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `slot` text DEFAULT 'primary' NOT NULL,
+  `slot_state` text DEFAULT 'assigned' NOT NULL,
+  `revision` integer NOT NULL,
+  `objective` text NOT NULL,
+  `priority` integer NOT NULL,
+  `status` text NOT NULL,
+  `deadline` integer,
+  `max_turns` integer,
+  `max_tokens` integer,
+  `max_duration_seconds` integer,
+  `completion_policy` text NOT NULL,
+  `source_type` text NOT NULL,
+  `source_id` text,
+  `goal_snapshot` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  CONSTRAINT `agent_goals_owner_session_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`)
+    REFERENCES `agent_runtime_sessions`(`owner_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goals_slot_check`
+    CHECK (`slot` = 'primary'),
+  CONSTRAINT `agent_goals_slot_state_check`
+    CHECK (`slot_state` IN ('assigned', 'reserved', 'released')),
+  CONSTRAINT `agent_goals_revision_check`
+    CHECK (`revision` > 0),
+  CONSTRAINT `agent_goals_priority_check`
+    CHECK (`priority` BETWEEN 0 AND 100),
+  CONSTRAINT `agent_goals_objective_check`
+    CHECK (length(trim(`objective`)) BETWEEN 1 AND 8000),
+  CONSTRAINT `agent_goals_status_check`
+    CHECK (`status` IN ('active', 'paused', 'blocked', 'completed', 'cancelled', 'expired', 'budget_limited', 'failed')),
+  CONSTRAINT `agent_goals_budgets_check`
+    CHECK (
+      (`deadline` IS NOT NULL OR `max_turns` IS NOT NULL OR `max_tokens` IS NOT NULL OR `max_duration_seconds` IS NOT NULL)
+      AND (`max_turns` IS NULL OR `max_turns` > 0)
+      AND (`max_tokens` IS NULL OR `max_tokens` > 0)
+      AND (`max_duration_seconds` IS NULL OR `max_duration_seconds` > 0)
+    ),
+  CONSTRAINT `agent_goals_completion_policy_check`
+    CHECK (`completion_policy` IN ('model_evaluator', 'tool_evidence', 'manual')),
+  CONSTRAINT `agent_goals_source_check`
+    CHECK (`source_type` IN ('user', 'loop', 'scheduled_job', 'insight', 'connector') AND (`source_type` = 'user' OR `source_id` IS NOT NULL)),
+  CONSTRAINT `agent_goals_snapshot_check`
+    CHECK (json_valid(`goal_snapshot`) AND json_type(`goal_snapshot`) = 'object'),
+  CONSTRAINT `agent_goals_timestamps_check`
+    CHECK (`updated_at` >= `created_at`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goals_owner_session_id_key`
+  ON `agent_goals` (`owner_id`, `runtime_session_id`, `id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goals_assigned_primary_idx`
+  ON `agent_goals` (`owner_id`, `runtime_session_id`)
+  WHERE `slot` = 'primary' AND `slot_state` = 'assigned';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goals_reserved_primary_idx`
+  ON `agent_goals` (`owner_id`, `runtime_session_id`)
+  WHERE `slot` = 'primary' AND `slot_state` = 'reserved';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goals_session_status_idx`
+  ON `agent_goals` (`owner_id`, `runtime_session_id`, `status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goals_active_deadline_idx`
+  ON `agent_goals` (`owner_id`, `deadline`)
+  WHERE `slot_state` = 'assigned' AND `status` = 'active' AND `deadline` IS NOT NULL;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_goal_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `goal_id` text NOT NULL,
+  `goal_revision` integer NOT NULL,
+  `run_epoch` integer NOT NULL,
+  `provider_session_id` text,
+  `status` text NOT NULL,
+  `turns_used` integer DEFAULT 0 NOT NULL,
+  `tokens_used` integer DEFAULT 0 NOT NULL,
+  `started_at` integer NOT NULL,
+  `last_activity_at` integer NOT NULL,
+  `completed_at` integer,
+  `last_evaluation` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  CONSTRAINT `agent_goal_runs_owner_session_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`)
+    REFERENCES `agent_runtime_sessions`(`owner_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goal_runs_owner_session_goal_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `goal_id`)
+    REFERENCES `agent_goals`(`owner_id`, `runtime_session_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goal_runs_goal_revision_check`
+    CHECK (`goal_revision` > 0),
+  CONSTRAINT `agent_goal_runs_run_epoch_check`
+    CHECK (`run_epoch` >= 0),
+  CONSTRAINT `agent_goal_runs_status_check`
+    CHECK (`status` IN ('queued', 'running', 'evaluating', 'continuing', 'paused', 'blocked', 'completed', 'cancelled', 'budget_limited', 'failed')),
+  CONSTRAINT `agent_goal_runs_completion_check`
+    CHECK ((`status` IN ('completed', 'cancelled', 'budget_limited', 'failed') AND `completed_at` IS NOT NULL) OR (`status` NOT IN ('completed', 'cancelled', 'budget_limited', 'failed') AND `completed_at` IS NULL)),
+  CONSTRAINT `agent_goal_runs_usage_check`
+    CHECK (`turns_used` >= 0 AND `tokens_used` >= 0),
+  CONSTRAINT `agent_goal_runs_evaluation_check`
+    CHECK (`last_evaluation` IS NULL OR (json_valid(`last_evaluation`) AND json_type(`last_evaluation`) = 'object')),
+  CONSTRAINT `agent_goal_runs_activity_check`
+    CHECK (`last_activity_at` >= `started_at` AND (`completed_at` IS NULL OR `completed_at` >= `last_activity_at`)),
+  CONSTRAINT `agent_goal_runs_timestamps_check`
+    CHECK (`updated_at` >= `created_at`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goal_runs_owner_session_id_key`
+  ON `agent_goal_runs` (`owner_id`, `runtime_session_id`, `id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goal_runs_owner_session_id_epoch_key`
+  ON `agent_goal_runs` (`owner_id`, `runtime_session_id`, `id`, `run_epoch`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goal_runs_goal_epoch_key`
+  ON `agent_goal_runs` (`owner_id`, `goal_id`, `run_epoch`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goal_runs_session_status_idx`
+  ON `agent_goal_runs` (`owner_id`, `runtime_session_id`, `status`, `last_activity_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goal_runs_recovery_idx`
+  ON `agent_goal_runs` (`owner_id`, `status`, `last_activity_at`)
+  WHERE `status` NOT IN ('completed', 'cancelled', 'budget_limited', 'failed');
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_runtime_instructions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `schema_version` text DEFAULT '2' NOT NULL,
+  `sequence` integer NOT NULL,
+  `run_epoch` integer NOT NULL,
+  `goal_id` text,
+  `goal_revision` integer,
+  `kind` text NOT NULL,
+  `delivery_mode` text NOT NULL,
+  `payload` text NOT NULL,
+  `source_type` text NOT NULL,
+  `source_authority` text NOT NULL,
+  `source_ref` text,
+  `idempotency_key` text NOT NULL,
+  `request_fingerprint` text NOT NULL,
+  `command_order` integer DEFAULT 0 NOT NULL,
+  `command_type` text,
+  `command_phase` text,
+  `command_checkpoint` text,
+  `instruction_snapshot` text NOT NULL,
+  `issued_at` integer NOT NULL,
+  `expires_at` integer,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  CONSTRAINT `agent_runtime_instructions_owner_session_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`)
+    REFERENCES `agent_runtime_sessions`(`owner_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_instructions_owner_session_goal_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `goal_id`)
+    REFERENCES `agent_goals`(`owner_id`, `runtime_session_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_instructions_schema_version_check`
+    CHECK (`schema_version` = '2'),
+  CONSTRAINT `agent_runtime_instructions_sequence_check`
+    CHECK (`sequence` > 0 AND `run_epoch` >= 0),
+  CONSTRAINT `agent_runtime_instructions_goal_revision_check`
+    CHECK ((`goal_id` IS NULL AND `goal_revision` IS NULL) OR (`goal_id` IS NOT NULL AND `goal_revision` IS NOT NULL AND `goal_revision` > 0)),
+  CONSTRAINT `agent_runtime_instructions_kind_check`
+    CHECK (`kind` IN ('goal.activate', 'goal.update', 'goal.pause', 'goal.resume', 'goal.cancel', 'goal.continue', 'context.upsert', 'context.remove', 'constraint.upsert', 'constraint.remove', 'control.interrupt')),
+  CONSTRAINT `agent_runtime_instructions_delivery_mode_check`
+    CHECK (`delivery_mode` IN ('steer', 'next_boundary', 'interrupt_replace') AND (`kind` NOT IN ('goal.pause', 'goal.cancel', 'control.interrupt') OR `delivery_mode` = 'interrupt_replace')),
+  CONSTRAINT `agent_runtime_instructions_payload_check`
+    CHECK (json_valid(`payload`) AND json_type(`payload`) = 'object'),
+  CONSTRAINT `agent_runtime_instructions_source_check`
+    CHECK (
+      ((`source_type` = 'user' AND `source_authority` = 'user')
+        OR (`source_type` = 'automation' AND `source_authority` = 'automation')
+        OR (`source_type` = 'connector' AND `source_authority` = 'untrusted_data')
+        OR (`source_type` = 'policy' AND `source_authority` = 'organization_policy'))
+      AND (`source_type` NOT IN ('connector', 'policy') OR `source_ref` IS NOT NULL)
+      AND (`source_authority` <> 'untrusted_data' OR `kind` IN ('context.upsert', 'context.remove'))
+    ),
+  CONSTRAINT `agent_runtime_instructions_fingerprint_check`
+    CHECK (length(`request_fingerprint`) = 64 AND `request_fingerprint` NOT GLOB '*[^0-9A-Fa-f]*'),
+  CONSTRAINT `agent_runtime_instructions_command_root_check`
+    CHECK (
+      (`command_order` = 0 AND `command_type` IS NOT NULL AND `command_phase` IS NOT NULL AND `command_checkpoint` IS NOT NULL)
+      OR (`command_order` > 0 AND `command_type` IS NULL AND `command_phase` IS NULL AND `command_checkpoint` IS NULL)
+    ),
+  CONSTRAINT `agent_runtime_instructions_command_phase_check`
+    CHECK (
+      (`command_type` IS NULL AND `command_phase` IS NULL)
+      OR (`command_type` = 'goal_instruction' AND `command_phase` = 'committed')
+      OR (`command_type` = 'lifecycle' AND `command_phase` IN ('prepared', 'boundary_observed', 'finalized'))
+      OR (`command_type` = 'replacement' AND `command_phase` IN ('prepared', 'boundary_observed', 'activated'))
+    ),
+  CONSTRAINT `agent_runtime_instructions_checkpoint_check`
+    CHECK (`command_checkpoint` IS NULL OR (json_valid(`command_checkpoint`) AND json_type(`command_checkpoint`) = 'object')),
+  CONSTRAINT `agent_runtime_instructions_snapshot_check`
+    CHECK (json_valid(`instruction_snapshot`) AND json_type(`instruction_snapshot`) = 'object'),
+  CONSTRAINT `agent_runtime_instructions_expiry_check`
+    CHECK (`expires_at` IS NULL OR `expires_at` >= `issued_at`),
+  CONSTRAINT `agent_runtime_instructions_timestamps_check`
+    CHECK (`updated_at` >= `created_at`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_instructions_owner_session_id_key`
+  ON `agent_runtime_instructions` (`owner_id`, `runtime_session_id`, `id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_instructions_owner_session_id_epoch_key`
+  ON `agent_runtime_instructions` (`owner_id`, `runtime_session_id`, `id`, `run_epoch`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_instructions_sequence_key`
+  ON `agent_runtime_instructions` (`owner_id`, `runtime_session_id`, `sequence`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_instructions_idempotency_key`
+  ON `agent_runtime_instructions` (`owner_id`, `runtime_session_id`, `idempotency_key`, `command_order`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_instructions_pending_command_idx`
+  ON `agent_runtime_instructions` (`owner_id`, `runtime_session_id`)
+  WHERE `command_phase` IN ('prepared', 'boundary_observed');
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_instructions_goal_revision_idx`
+  ON `agent_runtime_instructions` (`owner_id`, `goal_id`, `goal_revision`, `sequence`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_instructions_expiry_idx`
+  ON `agent_runtime_instructions` (`expires_at`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_runtime_deliveries` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `instruction_id` text NOT NULL,
+  `goal_run_id` text,
+  `run_epoch` integer NOT NULL,
+  `state` text DEFAULT 'pending' NOT NULL,
+  `attempt` integer NOT NULL,
+  `available_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `lease_token` text,
+  `lease_owner` text,
+  `lease_expires_at` integer,
+  `provider_event_id` text,
+  `error_code` text,
+  `error_message` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  CONSTRAINT `agent_runtime_deliveries_owner_session_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`)
+    REFERENCES `agent_runtime_sessions`(`owner_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_deliveries_instruction_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `instruction_id`, `run_epoch`)
+    REFERENCES `agent_runtime_instructions`(`owner_id`, `runtime_session_id`, `id`, `run_epoch`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_deliveries_goal_run_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `goal_run_id`, `run_epoch`)
+    REFERENCES `agent_goal_runs`(`owner_id`, `runtime_session_id`, `id`, `run_epoch`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_deliveries_state_check`
+    CHECK (`state` IN ('pending', 'leased', 'queued', 'written_to_sdk', 'observed', 'applied', 'completed', 'rejected', 'expired', 'superseded', 'cancelled', 'failed')),
+  CONSTRAINT `agent_runtime_deliveries_attempt_check`
+    CHECK (`attempt` > 0 AND `run_epoch` >= 0),
+  CONSTRAINT `agent_runtime_deliveries_lease_check`
+    CHECK (
+      (`state` = 'leased' AND `lease_token` IS NOT NULL AND `lease_owner` IS NOT NULL AND `lease_expires_at` IS NOT NULL)
+      OR (`state` <> 'leased' AND `lease_token` IS NULL AND `lease_owner` IS NULL AND `lease_expires_at` IS NULL)
+    ),
+  CONSTRAINT `agent_runtime_deliveries_timestamps_check`
+    CHECK (`updated_at` >= `created_at`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_deliveries_attempt_key`
+  ON `agent_runtime_deliveries` (`instruction_id`, `attempt`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_runtime_deliveries_active_attempt_idx`
+  ON `agent_runtime_deliveries` (`instruction_id`)
+  WHERE `state` IN ('pending', 'leased', 'queued', 'written_to_sdk', 'observed', 'applied');
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_deliveries_lease_idx`
+  ON `agent_runtime_deliveries` (`state`, `available_at`, `lease_expires_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_deliveries_session_state_idx`
+  ON `agent_runtime_deliveries` (`owner_id`, `runtime_session_id`, `state`, `updated_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_runtime_deliveries_goal_run_idx`
+  ON `agent_runtime_deliveries` (`goal_run_id`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_goal_evidence` (
+  `id` text PRIMARY KEY NOT NULL,
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `goal_id` text NOT NULL,
+  `goal_run_id` text NOT NULL,
+  `instruction_id` text,
+  `goal_revision` integer NOT NULL,
+  `run_epoch` integer NOT NULL,
+  `criterion_id` text,
+  `type` text NOT NULL,
+  `source_event_id` text NOT NULL,
+  `summary` text NOT NULL,
+  `success` integer,
+  `payload` text NOT NULL,
+  `observed_at` integer NOT NULL,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  CONSTRAINT `agent_goal_evidence_owner_session_goal_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `goal_id`)
+    REFERENCES `agent_goals`(`owner_id`, `runtime_session_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goal_evidence_owner_session_run_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `goal_run_id`, `run_epoch`)
+    REFERENCES `agent_goal_runs`(`owner_id`, `runtime_session_id`, `id`, `run_epoch`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goal_evidence_owner_session_instruction_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`, `instruction_id`, `run_epoch`)
+    REFERENCES `agent_runtime_instructions`(`owner_id`, `runtime_session_id`, `id`, `run_epoch`) ON DELETE CASCADE,
+  CONSTRAINT `agent_goal_evidence_revision_check`
+    CHECK (`goal_revision` > 0 AND `run_epoch` >= 0),
+  CONSTRAINT `agent_goal_evidence_type_check`
+    CHECK (`type` IN ('command_result', 'tool_result', 'test_result', 'file_change', 'agent_report', 'hook_result', 'manual_attestation', 'evaluation')),
+  CONSTRAINT `agent_goal_evidence_payload_check`
+    CHECK (json_valid(`payload`)),
+  CONSTRAINT `agent_goal_evidence_success_check`
+    CHECK (`success` IS NULL OR `success` IN (0, 1)),
+  CONSTRAINT `agent_goal_evidence_source_event_check`
+    CHECK (length(trim(`source_event_id`)) BETWEEN 1 AND 256),
+  CONSTRAINT `agent_goal_evidence_summary_check`
+    CHECK (length(trim(`summary`)) BETWEEN 1 AND 8000)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `agent_goal_evidence_run_source_event_key`
+  ON `agent_goal_evidence` (`goal_run_id`, `source_event_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goal_evidence_goal_revision_idx`
+  ON `agent_goal_evidence` (`owner_id`, `goal_id`, `goal_revision`, `observed_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goal_evidence_criterion_idx`
+  ON `agent_goal_evidence` (`goal_run_id`, `criterion_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `agent_goal_evidence_instruction_idx`
+  ON `agent_goal_evidence` (`instruction_id`);

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -246,6 +246,13 @@
                         "when": 1784236800000,
                         "tag": "0106_llm_usage",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx": 35,
+                        "version": "7",
+                        "when": 1785917494363,
+                        "tag": "0107_agent_goal_runtime",
+                        "breakpoints": true
                     }
                 ]
 }

--- a/apps/web/lib/db/schema-sqlite.ts
+++ b/apps/web/lib/db/schema-sqlite.ts
@@ -17,8 +17,34 @@ import {
   primaryKey,
   uniqueIndex,
   index,
+  check,
+  foreignKey,
 } from "drizzle-orm/sqlite-core";
 import type { DetailData, TimelineData } from "../ai/subagents/insights";
+import type {
+  AgentGoalCommandCheckpoint,
+  AgentGoalCommandPhase,
+  AgentGoalCommandType,
+  AgentGoalEvaluationSnapshot,
+  AgentGoalEvidencePayload,
+  AgentGoalSlot,
+  AgentGoalSlotState,
+  AgentGoalSnapshot,
+  AgentGoalSourceType,
+  AgentRuntimeInstructionPayload,
+  AgentRuntimeInstructionSnapshot,
+  AgentRuntimePendingOperation,
+  DeliveryState,
+  GoalCompletionPolicy,
+  GoalEvidenceType,
+  GoalRunStatus,
+  GoalStatus,
+  RuntimeInstructionDeliveryMode,
+  RuntimeInstructionKind,
+  RuntimeInstructionSource,
+  RuntimeProvider,
+  RuntimeSessionState,
+} from "./agent-goal-runtime-schema-types";
 
 // ============================================================================
 // Core Tables
@@ -2852,3 +2878,689 @@ export const insightEntities = sqliteTable(
 
 export type InsightEntity = InferSelectModel<typeof insightEntities>;
 export type InsertInsightEntity = InferInsertModel<typeof insightEntities>;
+
+// ============================================================================
+// Agent Goal Runtime
+// ============================================================================
+
+export const agentRuntimeSessions = sqliteTable(
+  "agent_runtime_sessions",
+  {
+    id: text("id").primaryKey(),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    provider: text("provider")
+      .$type<RuntimeProvider>()
+      .notNull()
+      .default("claude"),
+    providerSessionId: text("provider_session_id"),
+    workingDirectory: text("working_directory"),
+    state: text("state")
+      .$type<RuntimeSessionState>()
+      .notNull()
+      .default("starting"),
+    runEpoch: integer("run_epoch").notNull().default(0),
+    lastInstructionSequence: integer("last_instruction_sequence")
+      .notNull()
+      .default(0),
+    pendingOperation: text("pending_operation", {
+      mode: "json",
+    }).$type<AgentRuntimePendingOperation | null>(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    ownerSessionUnique: uniqueIndex(
+      "agent_runtime_sessions_owner_id_id_key",
+    ).on(table.ownerId, table.id),
+    providerSessionUnique: uniqueIndex(
+      "agent_runtime_sessions_provider_session_idx",
+    )
+      .on(table.provider, table.providerSessionId)
+      .where(sql`${table.providerSessionId} is not null`),
+    recoveryIdx: index("agent_runtime_sessions_recovery_idx")
+      .on(table.ownerId, table.state, table.updatedAt)
+      .where(sql`${table.state} not in ('closed', 'failed')`),
+    providerCheck: check(
+      "agent_runtime_sessions_provider_check",
+      sql`${table.provider} in ('claude')`,
+    ),
+    stateCheck: check(
+      "agent_runtime_sessions_state_check",
+      sql`${table.state} in ('starting', 'idle', 'running', 'evaluating', 'interrupted', 'closed', 'failed')`,
+    ),
+    epochCheck: check(
+      "agent_runtime_sessions_run_epoch_check",
+      sql`${table.runEpoch} >= 0`,
+    ),
+    sequenceCheck: check(
+      "agent_runtime_sessions_instruction_sequence_check",
+      sql`${table.lastInstructionSequence} >= 0`,
+    ),
+    pendingOperationCheck: check(
+      "agent_runtime_sessions_pending_operation_check",
+      sql`${table.pendingOperation} is null or (json_valid(${table.pendingOperation}) and json_type(${table.pendingOperation}) = 'object')`,
+    ),
+    timestampsCheck: check(
+      "agent_runtime_sessions_timestamps_check",
+      sql`${table.updatedAt} >= ${table.createdAt}`,
+    ),
+  }),
+);
+
+export type AgentRuntimeSessionRecord = InferSelectModel<
+  typeof agentRuntimeSessions
+>;
+export type InsertAgentRuntimeSessionRecord = InferInsertModel<
+  typeof agentRuntimeSessions
+>;
+
+export const agentGoals = sqliteTable(
+  "agent_goals",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    slot: text("slot").$type<AgentGoalSlot>().notNull().default("primary"),
+    slotState: text("slot_state")
+      .$type<AgentGoalSlotState>()
+      .notNull()
+      .default("assigned"),
+    revision: integer("revision").notNull(),
+    objective: text("objective").notNull(),
+    priority: integer("priority").notNull(),
+    status: text("status").$type<GoalStatus>().notNull(),
+    deadline: integer("deadline", { mode: "timestamp" }),
+    maxTurns: integer("max_turns"),
+    maxTokens: integer("max_tokens"),
+    maxDurationSeconds: integer("max_duration_seconds"),
+    completionPolicy: text("completion_policy")
+      .$type<GoalCompletionPolicy>()
+      .notNull(),
+    sourceType: text("source_type").$type<AgentGoalSourceType>().notNull(),
+    sourceId: text("source_id"),
+    goalSnapshot: text("goal_snapshot", { mode: "json" })
+      .$type<AgentGoalSnapshot>()
+      .notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => ({
+    ownerSessionGoalUnique: uniqueIndex("agent_goals_owner_session_id_key").on(
+      table.ownerId,
+      table.runtimeSessionId,
+      table.id,
+    ),
+    assignedPrimaryUnique: uniqueIndex("agent_goals_assigned_primary_idx")
+      .on(table.ownerId, table.runtimeSessionId)
+      .where(
+        sql`${table.slot} = 'primary' and ${table.slotState} = 'assigned'`,
+      ),
+    reservedPrimaryUnique: uniqueIndex("agent_goals_reserved_primary_idx")
+      .on(table.ownerId, table.runtimeSessionId)
+      .where(
+        sql`${table.slot} = 'primary' and ${table.slotState} = 'reserved'`,
+      ),
+    sessionStatusIdx: index("agent_goals_session_status_idx").on(
+      table.ownerId,
+      table.runtimeSessionId,
+      table.status,
+    ),
+    deadlineIdx: index("agent_goals_active_deadline_idx")
+      .on(table.ownerId, table.deadline)
+      .where(
+        sql`${table.slotState} = 'assigned' and ${table.status} = 'active' and ${table.deadline} is not null`,
+      ),
+    sessionForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId],
+      foreignColumns: [agentRuntimeSessions.ownerId, agentRuntimeSessions.id],
+      name: "agent_goals_owner_session_fkey",
+    }).onDelete("cascade"),
+    slotCheck: check("agent_goals_slot_check", sql`${table.slot} = 'primary'`),
+    slotStateCheck: check(
+      "agent_goals_slot_state_check",
+      sql`${table.slotState} in ('assigned', 'reserved', 'released')`,
+    ),
+    revisionCheck: check(
+      "agent_goals_revision_check",
+      sql`${table.revision} > 0`,
+    ),
+    priorityCheck: check(
+      "agent_goals_priority_check",
+      sql`${table.priority} between 0 and 100`,
+    ),
+    objectiveCheck: check(
+      "agent_goals_objective_check",
+      sql`length(trim(${table.objective})) between 1 and 8000`,
+    ),
+    statusCheck: check(
+      "agent_goals_status_check",
+      sql`${table.status} in ('active', 'paused', 'blocked', 'completed', 'cancelled', 'expired', 'budget_limited', 'failed')`,
+    ),
+    budgetCheck: check(
+      "agent_goals_budgets_check",
+      sql`(${table.deadline} is not null or ${table.maxTurns} is not null or ${table.maxTokens} is not null or ${table.maxDurationSeconds} is not null) and (${table.maxTurns} is null or ${table.maxTurns} > 0) and (${table.maxTokens} is null or ${table.maxTokens} > 0) and (${table.maxDurationSeconds} is null or ${table.maxDurationSeconds} > 0)`,
+    ),
+    completionPolicyCheck: check(
+      "agent_goals_completion_policy_check",
+      sql`${table.completionPolicy} in ('model_evaluator', 'tool_evidence', 'manual')`,
+    ),
+    sourceCheck: check(
+      "agent_goals_source_check",
+      sql`${table.sourceType} in ('user', 'loop', 'scheduled_job', 'insight', 'connector') and (${table.sourceType} = 'user' or ${table.sourceId} is not null)`,
+    ),
+    snapshotCheck: check(
+      "agent_goals_snapshot_check",
+      sql`json_valid(${table.goalSnapshot}) and json_type(${table.goalSnapshot}) = 'object'`,
+    ),
+    timestampsCheck: check(
+      "agent_goals_timestamps_check",
+      sql`${table.updatedAt} >= ${table.createdAt}`,
+    ),
+  }),
+);
+
+export type AgentGoalRecord = InferSelectModel<typeof agentGoals>;
+export type InsertAgentGoalRecord = InferInsertModel<typeof agentGoals>;
+
+export const agentGoalRuns = sqliteTable(
+  "agent_goal_runs",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    goalId: text("goal_id").notNull(),
+    goalRevision: integer("goal_revision").notNull(),
+    runEpoch: integer("run_epoch").notNull(),
+    providerSessionId: text("provider_session_id"),
+    status: text("status").$type<GoalRunStatus>().notNull(),
+    turnsUsed: integer("turns_used").notNull().default(0),
+    tokensUsed: integer("tokens_used").notNull().default(0),
+    startedAt: integer("started_at", { mode: "timestamp" }).notNull(),
+    lastActivityAt: integer("last_activity_at", {
+      mode: "timestamp",
+    }).notNull(),
+    completedAt: integer("completed_at", { mode: "timestamp" }),
+    lastEvaluation: text("last_evaluation", {
+      mode: "json",
+    }).$type<AgentGoalEvaluationSnapshot | null>(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    sessionForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId],
+      foreignColumns: [agentRuntimeSessions.ownerId, agentRuntimeSessions.id],
+      name: "agent_goal_runs_owner_session_fkey",
+    }).onDelete("cascade"),
+    ownerSessionRunUnique: uniqueIndex(
+      "agent_goal_runs_owner_session_id_key",
+    ).on(table.ownerId, table.runtimeSessionId, table.id),
+    ownerSessionRunEpochUnique: uniqueIndex(
+      "agent_goal_runs_owner_session_id_epoch_key",
+    ).on(table.ownerId, table.runtimeSessionId, table.id, table.runEpoch),
+    goalEpochUnique: uniqueIndex("agent_goal_runs_goal_epoch_key").on(
+      table.ownerId,
+      table.goalId,
+      table.runEpoch,
+    ),
+    sessionStatusIdx: index("agent_goal_runs_session_status_idx").on(
+      table.ownerId,
+      table.runtimeSessionId,
+      table.status,
+      table.lastActivityAt,
+    ),
+    recoveryIdx: index("agent_goal_runs_recovery_idx")
+      .on(table.ownerId, table.status, table.lastActivityAt)
+      .where(
+        sql`${table.status} not in ('completed', 'cancelled', 'budget_limited', 'failed')`,
+      ),
+    goalForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId, table.goalId],
+      foreignColumns: [
+        agentGoals.ownerId,
+        agentGoals.runtimeSessionId,
+        agentGoals.id,
+      ],
+      name: "agent_goal_runs_owner_session_goal_fkey",
+    }).onDelete("cascade"),
+    revisionCheck: check(
+      "agent_goal_runs_goal_revision_check",
+      sql`${table.goalRevision} > 0`,
+    ),
+    epochCheck: check(
+      "agent_goal_runs_run_epoch_check",
+      sql`${table.runEpoch} >= 0`,
+    ),
+    statusCheck: check(
+      "agent_goal_runs_status_check",
+      sql`${table.status} in ('queued', 'running', 'evaluating', 'continuing', 'paused', 'blocked', 'completed', 'cancelled', 'budget_limited', 'failed')`,
+    ),
+    completionCheck: check(
+      "agent_goal_runs_completion_check",
+      sql`(${table.status} in ('completed', 'cancelled', 'budget_limited', 'failed') and ${table.completedAt} is not null) or (${table.status} not in ('completed', 'cancelled', 'budget_limited', 'failed') and ${table.completedAt} is null)`,
+    ),
+    usageCheck: check(
+      "agent_goal_runs_usage_check",
+      sql`${table.turnsUsed} >= 0 and ${table.tokensUsed} >= 0`,
+    ),
+    evaluationCheck: check(
+      "agent_goal_runs_evaluation_check",
+      sql`${table.lastEvaluation} is null or (json_valid(${table.lastEvaluation}) and json_type(${table.lastEvaluation}) = 'object')`,
+    ),
+    activityCheck: check(
+      "agent_goal_runs_activity_check",
+      sql`${table.lastActivityAt} >= ${table.startedAt} and (${table.completedAt} is null or ${table.completedAt} >= ${table.lastActivityAt})`,
+    ),
+    timestampsCheck: check(
+      "agent_goal_runs_timestamps_check",
+      sql`${table.updatedAt} >= ${table.createdAt}`,
+    ),
+  }),
+);
+
+export type AgentGoalRunRecord = InferSelectModel<typeof agentGoalRuns>;
+export type InsertAgentGoalRunRecord = InferInsertModel<typeof agentGoalRuns>;
+
+export const agentRuntimeInstructions = sqliteTable(
+  "agent_runtime_instructions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    schemaVersion: text("schema_version").notNull().default("2"),
+    sequence: integer("sequence").notNull(),
+    runEpoch: integer("run_epoch").notNull(),
+    goalId: text("goal_id"),
+    goalRevision: integer("goal_revision"),
+    kind: text("kind").$type<RuntimeInstructionKind>().notNull(),
+    deliveryMode: text("delivery_mode")
+      .$type<RuntimeInstructionDeliveryMode>()
+      .notNull(),
+    payload: text("payload", { mode: "json" })
+      .$type<AgentRuntimeInstructionPayload>()
+      .notNull(),
+    sourceType: text("source_type")
+      .$type<RuntimeInstructionSource["type"]>()
+      .notNull(),
+    sourceAuthority: text("source_authority")
+      .$type<RuntimeInstructionSource["authority"]>()
+      .notNull(),
+    sourceRef: text("source_ref"),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    commandOrder: integer("command_order").notNull().default(0),
+    commandType: text("command_type").$type<AgentGoalCommandType>(),
+    commandPhase: text("command_phase").$type<AgentGoalCommandPhase>(),
+    commandCheckpoint: text("command_checkpoint", {
+      mode: "json",
+    }).$type<AgentGoalCommandCheckpoint | null>(),
+    instructionSnapshot: text("instruction_snapshot", { mode: "json" })
+      .$type<AgentRuntimeInstructionSnapshot>()
+      .notNull(),
+    issuedAt: integer("issued_at", { mode: "timestamp" }).notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp" }),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    ownerSessionInstructionUnique: uniqueIndex(
+      "agent_runtime_instructions_owner_session_id_key",
+    ).on(table.ownerId, table.runtimeSessionId, table.id),
+    ownerSessionInstructionEpochUnique: uniqueIndex(
+      "agent_runtime_instructions_owner_session_id_epoch_key",
+    ).on(table.ownerId, table.runtimeSessionId, table.id, table.runEpoch),
+    sessionSequenceUnique: uniqueIndex(
+      "agent_runtime_instructions_sequence_key",
+    ).on(table.ownerId, table.runtimeSessionId, table.sequence),
+    commandOrderUnique: uniqueIndex(
+      "agent_runtime_instructions_idempotency_key",
+    ).on(
+      table.ownerId,
+      table.runtimeSessionId,
+      table.idempotencyKey,
+      table.commandOrder,
+    ),
+    pendingCommandUnique: uniqueIndex(
+      "agent_runtime_instructions_pending_command_idx",
+    )
+      .on(table.ownerId, table.runtimeSessionId)
+      .where(sql`${table.commandPhase} in ('prepared', 'boundary_observed')`),
+    goalRevisionIdx: index("agent_runtime_instructions_goal_revision_idx").on(
+      table.ownerId,
+      table.goalId,
+      table.goalRevision,
+      table.sequence,
+    ),
+    expiryIdx: index("agent_runtime_instructions_expiry_idx").on(
+      table.expiresAt,
+    ),
+    sessionForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId],
+      foreignColumns: [agentRuntimeSessions.ownerId, agentRuntimeSessions.id],
+      name: "agent_runtime_instructions_owner_session_fkey",
+    }).onDelete("cascade"),
+    goalForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId, table.goalId],
+      foreignColumns: [
+        agentGoals.ownerId,
+        agentGoals.runtimeSessionId,
+        agentGoals.id,
+      ],
+      name: "agent_runtime_instructions_owner_session_goal_fkey",
+    }).onDelete("cascade"),
+    schemaVersionCheck: check(
+      "agent_runtime_instructions_schema_version_check",
+      sql`${table.schemaVersion} = '2'`,
+    ),
+    sequenceCheck: check(
+      "agent_runtime_instructions_sequence_check",
+      sql`${table.sequence} > 0 and ${table.runEpoch} >= 0`,
+    ),
+    goalPairCheck: check(
+      "agent_runtime_instructions_goal_revision_check",
+      sql`(${table.goalId} is null and ${table.goalRevision} is null) or (${table.goalId} is not null and ${table.goalRevision} is not null and ${table.goalRevision} > 0)`,
+    ),
+    kindCheck: check(
+      "agent_runtime_instructions_kind_check",
+      sql`${table.kind} in ('goal.activate', 'goal.update', 'goal.pause', 'goal.resume', 'goal.cancel', 'goal.continue', 'context.upsert', 'context.remove', 'constraint.upsert', 'constraint.remove', 'control.interrupt')`,
+    ),
+    deliveryModeCheck: check(
+      "agent_runtime_instructions_delivery_mode_check",
+      sql`${table.deliveryMode} in ('steer', 'next_boundary', 'interrupt_replace') and (${table.kind} not in ('goal.pause', 'goal.cancel', 'control.interrupt') or ${table.deliveryMode} = 'interrupt_replace')`,
+    ),
+    payloadCheck: check(
+      "agent_runtime_instructions_payload_check",
+      sql`json_valid(${table.payload}) and json_type(${table.payload}) = 'object'`,
+    ),
+    sourceCheck: check(
+      "agent_runtime_instructions_source_check",
+      sql`((${table.sourceType} = 'user' and ${table.sourceAuthority} = 'user') or (${table.sourceType} = 'automation' and ${table.sourceAuthority} = 'automation') or (${table.sourceType} = 'connector' and ${table.sourceAuthority} = 'untrusted_data') or (${table.sourceType} = 'policy' and ${table.sourceAuthority} = 'organization_policy')) and (${table.sourceType} not in ('connector', 'policy') or ${table.sourceRef} is not null) and (${table.sourceAuthority} <> 'untrusted_data' or ${table.kind} in ('context.upsert', 'context.remove'))`,
+    ),
+    fingerprintCheck: check(
+      "agent_runtime_instructions_fingerprint_check",
+      sql`length(${table.requestFingerprint}) = 64 and ${table.requestFingerprint} not glob '*[^0-9A-Fa-f]*'`,
+    ),
+    commandMetadataCheck: check(
+      "agent_runtime_instructions_command_root_check",
+      sql`(${table.commandOrder} = 0 and ${table.commandType} is not null and ${table.commandPhase} is not null and ${table.commandCheckpoint} is not null) or (${table.commandOrder} > 0 and ${table.commandType} is null and ${table.commandPhase} is null and ${table.commandCheckpoint} is null)`,
+    ),
+    commandPhaseCheck: check(
+      "agent_runtime_instructions_command_phase_check",
+      sql`(${table.commandType} is null and ${table.commandPhase} is null) or (${table.commandType} = 'goal_instruction' and ${table.commandPhase} = 'committed') or (${table.commandType} = 'lifecycle' and ${table.commandPhase} in ('prepared', 'boundary_observed', 'finalized')) or (${table.commandType} = 'replacement' and ${table.commandPhase} in ('prepared', 'boundary_observed', 'activated'))`,
+    ),
+    checkpointCheck: check(
+      "agent_runtime_instructions_checkpoint_check",
+      sql`${table.commandCheckpoint} is null or (json_valid(${table.commandCheckpoint}) and json_type(${table.commandCheckpoint}) = 'object')`,
+    ),
+    instructionSnapshotCheck: check(
+      "agent_runtime_instructions_snapshot_check",
+      sql`json_valid(${table.instructionSnapshot}) and json_type(${table.instructionSnapshot}) = 'object'`,
+    ),
+    expiryCheck: check(
+      "agent_runtime_instructions_expiry_check",
+      sql`${table.expiresAt} is null or ${table.expiresAt} >= ${table.issuedAt}`,
+    ),
+    timestampsCheck: check(
+      "agent_runtime_instructions_timestamps_check",
+      sql`${table.updatedAt} >= ${table.createdAt}`,
+    ),
+  }),
+);
+
+export type AgentRuntimeInstructionRecord = InferSelectModel<
+  typeof agentRuntimeInstructions
+>;
+export type InsertAgentRuntimeInstructionRecord = InferInsertModel<
+  typeof agentRuntimeInstructions
+>;
+
+export const agentRuntimeDeliveries = sqliteTable(
+  "agent_runtime_deliveries",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    instructionId: text("instruction_id").notNull(),
+    goalRunId: text("goal_run_id"),
+    runEpoch: integer("run_epoch").notNull(),
+    state: text("state").$type<DeliveryState>().notNull().default("pending"),
+    attempt: integer("attempt").notNull(),
+    availableAt: integer("available_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    leaseToken: text("lease_token"),
+    leaseOwner: text("lease_owner"),
+    leaseExpiresAt: integer("lease_expires_at", { mode: "timestamp" }),
+    providerEventId: text("provider_event_id"),
+    errorCode: text("error_code"),
+    errorMessage: text("error_message"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    sessionForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId],
+      foreignColumns: [agentRuntimeSessions.ownerId, agentRuntimeSessions.id],
+      name: "agent_runtime_deliveries_owner_session_fkey",
+    }).onDelete("cascade"),
+    instructionAttemptUnique: uniqueIndex(
+      "agent_runtime_deliveries_attempt_key",
+    ).on(table.instructionId, table.attempt),
+    activeAttemptUnique: uniqueIndex(
+      "agent_runtime_deliveries_active_attempt_idx",
+    )
+      .on(table.instructionId)
+      .where(
+        sql`${table.state} in ('pending', 'leased', 'queued', 'written_to_sdk', 'observed', 'applied')`,
+      ),
+    leaseIdx: index("agent_runtime_deliveries_lease_idx").on(
+      table.state,
+      table.availableAt,
+      table.leaseExpiresAt,
+    ),
+    sessionStateIdx: index("agent_runtime_deliveries_session_state_idx").on(
+      table.ownerId,
+      table.runtimeSessionId,
+      table.state,
+      table.updatedAt,
+    ),
+    goalRunIdx: index("agent_runtime_deliveries_goal_run_idx").on(
+      table.goalRunId,
+    ),
+    instructionForeignKey: foreignKey({
+      columns: [
+        table.ownerId,
+        table.runtimeSessionId,
+        table.instructionId,
+        table.runEpoch,
+      ],
+      foreignColumns: [
+        agentRuntimeInstructions.ownerId,
+        agentRuntimeInstructions.runtimeSessionId,
+        agentRuntimeInstructions.id,
+        agentRuntimeInstructions.runEpoch,
+      ],
+      name: "agent_runtime_deliveries_instruction_fkey",
+    }).onDelete("cascade"),
+    goalRunForeignKey: foreignKey({
+      columns: [
+        table.ownerId,
+        table.runtimeSessionId,
+        table.goalRunId,
+        table.runEpoch,
+      ],
+      foreignColumns: [
+        agentGoalRuns.ownerId,
+        agentGoalRuns.runtimeSessionId,
+        agentGoalRuns.id,
+        agentGoalRuns.runEpoch,
+      ],
+      name: "agent_runtime_deliveries_goal_run_fkey",
+    }).onDelete("cascade"),
+    stateCheck: check(
+      "agent_runtime_deliveries_state_check",
+      sql`${table.state} in ('pending', 'leased', 'queued', 'written_to_sdk', 'observed', 'applied', 'completed', 'rejected', 'expired', 'superseded', 'cancelled', 'failed')`,
+    ),
+    attemptCheck: check(
+      "agent_runtime_deliveries_attempt_check",
+      sql`${table.attempt} > 0 and ${table.runEpoch} >= 0`,
+    ),
+    leaseCheck: check(
+      "agent_runtime_deliveries_lease_check",
+      sql`(${table.state} = 'leased' and ${table.leaseToken} is not null and ${table.leaseOwner} is not null and ${table.leaseExpiresAt} is not null) or (${table.state} <> 'leased' and ${table.leaseToken} is null and ${table.leaseOwner} is null and ${table.leaseExpiresAt} is null)`,
+    ),
+    timestampsCheck: check(
+      "agent_runtime_deliveries_timestamps_check",
+      sql`${table.updatedAt} >= ${table.createdAt}`,
+    ),
+  }),
+);
+
+export type AgentRuntimeDeliveryRecord = InferSelectModel<
+  typeof agentRuntimeDeliveries
+>;
+export type InsertAgentRuntimeDeliveryRecord = InferInsertModel<
+  typeof agentRuntimeDeliveries
+>;
+
+export const agentGoalEvidence = sqliteTable(
+  "agent_goal_evidence",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    goalId: text("goal_id").notNull(),
+    goalRunId: text("goal_run_id").notNull(),
+    instructionId: text("instruction_id"),
+    goalRevision: integer("goal_revision").notNull(),
+    runEpoch: integer("run_epoch").notNull(),
+    criterionId: text("criterion_id"),
+    type: text("type").$type<GoalEvidenceType>().notNull(),
+    sourceEventId: text("source_event_id").notNull(),
+    summary: text("summary").notNull(),
+    success: integer("success", { mode: "boolean" }),
+    payload: text("payload", { mode: "json" })
+      .$type<AgentGoalEvidencePayload>()
+      .notNull(),
+    observedAt: integer("observed_at", { mode: "timestamp" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    sourceEventUnique: uniqueIndex(
+      "agent_goal_evidence_run_source_event_key",
+    ).on(table.goalRunId, table.sourceEventId),
+    goalRevisionIdx: index("agent_goal_evidence_goal_revision_idx").on(
+      table.ownerId,
+      table.goalId,
+      table.goalRevision,
+      table.observedAt,
+    ),
+    criterionIdx: index("agent_goal_evidence_criterion_idx").on(
+      table.goalRunId,
+      table.criterionId,
+    ),
+    instructionIdx: index("agent_goal_evidence_instruction_idx").on(
+      table.instructionId,
+    ),
+    goalForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId, table.goalId],
+      foreignColumns: [
+        agentGoals.ownerId,
+        agentGoals.runtimeSessionId,
+        agentGoals.id,
+      ],
+      name: "agent_goal_evidence_owner_session_goal_fkey",
+    }).onDelete("cascade"),
+    goalRunForeignKey: foreignKey({
+      columns: [
+        table.ownerId,
+        table.runtimeSessionId,
+        table.goalRunId,
+        table.runEpoch,
+      ],
+      foreignColumns: [
+        agentGoalRuns.ownerId,
+        agentGoalRuns.runtimeSessionId,
+        agentGoalRuns.id,
+        agentGoalRuns.runEpoch,
+      ],
+      name: "agent_goal_evidence_owner_session_run_fkey",
+    }).onDelete("cascade"),
+    instructionForeignKey: foreignKey({
+      columns: [
+        table.ownerId,
+        table.runtimeSessionId,
+        table.instructionId,
+        table.runEpoch,
+      ],
+      foreignColumns: [
+        agentRuntimeInstructions.ownerId,
+        agentRuntimeInstructions.runtimeSessionId,
+        agentRuntimeInstructions.id,
+        agentRuntimeInstructions.runEpoch,
+      ],
+      name: "agent_goal_evidence_owner_session_instruction_fkey",
+    }).onDelete("cascade"),
+    revisionCheck: check(
+      "agent_goal_evidence_revision_check",
+      sql`${table.goalRevision} > 0 and ${table.runEpoch} >= 0`,
+    ),
+    typeCheck: check(
+      "agent_goal_evidence_type_check",
+      sql`${table.type} in ('command_result', 'tool_result', 'test_result', 'file_change', 'agent_report', 'hook_result', 'manual_attestation', 'evaluation')`,
+    ),
+    payloadCheck: check(
+      "agent_goal_evidence_payload_check",
+      sql`json_valid(${table.payload})`,
+    ),
+    successCheck: check(
+      "agent_goal_evidence_success_check",
+      sql`${table.success} is null or ${table.success} in (0, 1)`,
+    ),
+    sourceEventCheck: check(
+      "agent_goal_evidence_source_event_check",
+      sql`length(trim(${table.sourceEventId})) between 1 and 256`,
+    ),
+    summaryCheck: check(
+      "agent_goal_evidence_summary_check",
+      sql`length(trim(${table.summary})) between 1 and 8000`,
+    ),
+  }),
+);
+
+export type AgentGoalEvidenceRecord = InferSelectModel<
+  typeof agentGoalEvidence
+>;
+export type InsertAgentGoalEvidenceRecord = InferInsertModel<
+  typeof agentGoalEvidence
+>;

--- a/apps/web/tests/unit/agent-goal-persistence-schema.test.ts
+++ b/apps/web/tests/unit/agent-goal-persistence-schema.test.ts
@@ -1,0 +1,311 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import { getTableConfig as getSqliteTableConfig } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+
+import * as sqliteSchema from "@/lib/db/schema-sqlite";
+
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const RUNTIME_TABLES = [
+  ["agentRuntimeSessions", "agent_runtime_sessions"],
+  ["agentGoals", "agent_goals"],
+  ["agentGoalRuns", "agent_goal_runs"],
+  ["agentRuntimeInstructions", "agent_runtime_instructions"],
+  ["agentRuntimeDeliveries", "agent_runtime_deliveries"],
+  ["agentGoalEvidence", "agent_goal_evidence"],
+] as const;
+
+type RuntimeTableExport = (typeof RUNTIME_TABLES)[number][0];
+
+const REQUIRED_COLUMNS: Record<RuntimeTableExport, readonly string[]> = {
+  agentRuntimeSessions: [
+    "run_epoch",
+    "last_instruction_sequence",
+    "pending_operation",
+  ],
+  agentGoals: [
+    "runtime_session_id",
+    "slot",
+    "slot_state",
+    "revision",
+    "goal_snapshot",
+  ],
+  agentGoalRuns: ["goal_id", "goal_revision", "run_epoch", "status"],
+  agentRuntimeInstructions: [
+    "sequence",
+    "idempotency_key",
+    "request_fingerprint",
+    "command_order",
+    "instruction_snapshot",
+  ],
+  agentRuntimeDeliveries: ["instruction_id", "goal_run_id", "state", "attempt"],
+  agentGoalEvidence: ["goal_id", "goal_run_id", "source_event_id", "payload"],
+};
+
+const CRITICAL_UNIQUE_COLUMN_SETS = {
+  agentRuntimeSessions: [["provider", "provider_session_id"]],
+  agentGoals: [
+    ["owner_id", "runtime_session_id"],
+    ["owner_id", "runtime_session_id"],
+  ],
+  agentGoalRuns: [
+    ["owner_id", "goal_id", "run_epoch"],
+    ["owner_id", "runtime_session_id", "id", "run_epoch"],
+  ],
+  agentRuntimeInstructions: [
+    ["owner_id", "runtime_session_id", "id", "run_epoch"],
+    ["owner_id", "runtime_session_id", "sequence"],
+    ["owner_id", "runtime_session_id", "idempotency_key", "command_order"],
+    ["owner_id", "runtime_session_id"],
+  ],
+  agentRuntimeDeliveries: [["instruction_id", "attempt"], ["instruction_id"]],
+  agentGoalEvidence: [["goal_run_id", "source_event_id"]],
+} as const;
+
+const EXPECTED_SQLITE_FOREIGN_KEYS: Record<
+  (typeof RUNTIME_TABLES)[number][1],
+  readonly string[]
+> = {
+  agent_runtime_sessions: ["User"],
+  agent_goals: ["agent_runtime_sessions"],
+  agent_goal_runs: ["agent_runtime_sessions", "agent_goals"],
+  agent_runtime_instructions: ["agent_runtime_sessions", "agent_goals"],
+  agent_runtime_deliveries: [
+    "agent_runtime_sessions",
+    "agent_runtime_instructions",
+    "agent_goal_runs",
+  ],
+  agent_goal_evidence: [
+    "agent_goals",
+    "agent_goal_runs",
+    "agent_runtime_instructions",
+  ],
+};
+
+const CRITICAL_SQLITE_INDEXES = [
+  "agent_goals_assigned_primary_idx",
+  "agent_goals_reserved_primary_idx",
+  "agent_goal_runs_owner_session_id_epoch_key",
+  "agent_runtime_instructions_owner_session_id_epoch_key",
+  "agent_runtime_instructions_sequence_key",
+  "agent_runtime_instructions_idempotency_key",
+  "agent_runtime_instructions_pending_command_idx",
+  "agent_runtime_deliveries_attempt_key",
+  "agent_runtime_deliveries_active_attempt_idx",
+  "agent_goal_evidence_run_source_event_key",
+] as const;
+
+const SQLITE_MIGRATION_TAG = "0107_agent_goal_runtime";
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+
+function readWebFile(path: string): string {
+  return readFileSync(join(WEB_ROOT, path), "utf8");
+}
+
+function readJournal(path: string): MigrationJournal {
+  return JSON.parse(readWebFile(path)) as MigrationJournal;
+}
+
+interface MigrationJournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface MigrationJournal {
+  entries: MigrationJournalEntry[];
+}
+
+interface TableConstraintMetadata {
+  indexes: Array<{
+    config: { name: string; unique: boolean; columns: unknown[] };
+  }>;
+  uniqueConstraints: Array<{ name: string; columns: unknown[] }>;
+}
+
+function columnName(column: unknown): string {
+  if (
+    typeof column === "object" &&
+    column !== null &&
+    "name" in column &&
+    typeof column.name === "string"
+  ) {
+    return column.name;
+  }
+  throw new Error("Expected an index or constraint to use physical columns");
+}
+
+function uniqueColumnSets(config: unknown): string[][] {
+  const { indexes, uniqueConstraints } = config as TableConstraintMetadata;
+  return [
+    ...indexes
+      .filter((index) => index.config.unique)
+      .map((index) => index.config.columns.map(columnName)),
+    ...uniqueConstraints.map((constraint) =>
+      constraint.columns.map(columnName),
+    ),
+  ];
+}
+
+function expectUniqueColumnSets(
+  actual: string[][],
+  expected: readonly (readonly string[])[],
+): void {
+  const remaining = actual.map((columns) => [...columns]);
+  for (const expectedColumns of expected) {
+    const match = remaining.findIndex(
+      (columns) => JSON.stringify(columns) === JSON.stringify(expectedColumns),
+    );
+    expect(
+      match,
+      `Missing unique key on ${expectedColumns.join(", ")}`,
+    ).toBeGreaterThanOrEqual(0);
+    remaining.splice(match, 1);
+  }
+}
+
+describe("Agent Goal persistence schema", () => {
+  it("defines the required SQLite tables and columns", () => {
+    for (const [exportName, physicalName] of RUNTIME_TABLES) {
+      const sqlite = getSqliteTableConfig(sqliteSchema[exportName]);
+      const sqliteColumns = sqlite.columns.map((column) => column.name).sort();
+
+      expect(sqlite.name).toBe(physicalName);
+      expect(sqliteColumns).toContain("id");
+      expect(sqliteColumns).toContain("owner_id");
+      expect(sqliteColumns).toEqual(
+        expect.arrayContaining([...REQUIRED_COLUMNS[exportName]]),
+      );
+      expect(
+        sqliteColumns.every((column) => /^[a-z][a-z0-9_]*$/.test(column)),
+      ).toBe(true);
+    }
+  });
+
+  it("defines the critical SQLite concurrency and deduplication keys", () => {
+    for (const [exportName, expectedKeys] of Object.entries(
+      CRITICAL_UNIQUE_COLUMN_SETS,
+    ) as Array<
+      [keyof typeof CRITICAL_UNIQUE_COLUMN_SETS, readonly (readonly string[])[]]
+    >) {
+      expectUniqueColumnSets(
+        uniqueColumnSets(getSqliteTableConfig(sqliteSchema[exportName])),
+        expectedKeys,
+      );
+    }
+  });
+
+  it("registers the SQLite migration in journal order", () => {
+    const sqliteJournal = readJournal(
+      "lib/db/migrations-sqlite/meta/_journal.json",
+    );
+    const sqliteIndex = sqliteJournal.entries.findIndex(
+      ({ tag }) => tag === SQLITE_MIGRATION_TAG,
+    );
+    const sqliteEntry = sqliteJournal.entries[sqliteIndex];
+
+    expect(sqliteIndex).toBeGreaterThan(0);
+    expect(sqliteEntry).toMatchObject({
+      idx: 35,
+      version: "7",
+      tag: SQLITE_MIGRATION_TAG,
+      breakpoints: true,
+    });
+    expect(sqliteEntry?.when).toBeGreaterThan(
+      sqliteJournal.entries[sqliteIndex - 1]?.when ?? Number.NEGATIVE_INFINITY,
+    );
+
+    const migration = readMigrationFiles({
+      migrationsFolder: join(WEB_ROOT, "lib/db/migrations-sqlite"),
+    })[sqliteIndex];
+    expect(migration?.folderMillis).toBe(sqliteEntry?.when);
+    expect(migration?.bps).toBe(true);
+    expect(migration?.sql.length).toBeGreaterThan(1);
+  });
+
+  it("applies the SQLite migration idempotently with its foreign keys", () => {
+    const database = new Database(":memory:");
+    database.pragma("foreign_keys = ON");
+    database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
+    const migration = readWebFile(
+      `lib/db/migrations-sqlite/${SQLITE_MIGRATION_TAG}.sql`,
+    );
+
+    try {
+      expect(migration).toContain(STATEMENT_BREAKPOINT);
+      database.exec(migration);
+      database.exec(migration);
+
+      const tables = (
+        database
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+          )
+          .all() as Array<{ name: string }>
+      ).map(({ name }) => name);
+
+      expect(tables).toEqual(
+        expect.arrayContaining(RUNTIME_TABLES.map(([, name]) => name)),
+      );
+
+      for (const [, tableName] of RUNTIME_TABLES) {
+        const foreignKeys = database
+          .prepare(`PRAGMA foreign_key_list('${tableName}')`)
+          .all() as Array<{ table: string }>;
+        expect([...new Set(foreignKeys.map(({ table }) => table))]).toEqual(
+          expect.arrayContaining([...EXPECTED_SQLITE_FOREIGN_KEYS[tableName]]),
+        );
+      }
+
+      const indexes = (
+        database
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'index' ORDER BY name",
+          )
+          .all() as Array<{ name: string }>
+      ).map(({ name }) => name);
+      expect(indexes).toEqual(
+        expect.arrayContaining([...CRITICAL_SQLITE_INDEXES]),
+      );
+
+      const insertSession = database.prepare(
+        "INSERT INTO agent_runtime_sessions (id, owner_id) VALUES (?, ?)",
+      );
+      database.prepare('INSERT INTO "User" (id) VALUES (?)').run("owner-1");
+      insertSession.run("session-1", "owner-1");
+      expect(() =>
+        insertSession.run("session-orphan", "missing-owner"),
+      ).toThrow();
+      expect(() =>
+        database
+          .prepare(
+            "INSERT INTO agent_runtime_sessions (id, owner_id, run_epoch) VALUES (?, ?, ?)",
+          )
+          .run("session-invalid", "owner-1", -1),
+      ).toThrow();
+
+      database.pragma("foreign_keys = OFF");
+      expect(() =>
+        database
+          .prepare(
+            `INSERT INTO agent_goal_evidence (
+              id, owner_id, runtime_session_id, goal_id, goal_run_id,
+              goal_revision, run_epoch, type, source_event_id, summary,
+              success, payload, observed_at
+            ) VALUES ('evidence-invalid', 'owner-1', 'session-1', 'goal-1',
+              'run-1', 1, 0, 'tool_result', 'event-1', 'Observed', 2, '{}', 1)`,
+          )
+          .run(),
+      ).toThrow();
+      database.pragma("foreign_keys = ON");
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/persistence-checkpoints.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/persistence-checkpoints.test.ts
@@ -1,0 +1,364 @@
+import {
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  RuntimeInstructionSchema,
+  createAgentGoal,
+  transitionAgentGoal,
+  type AgentGoal,
+  type PersistedAgentGoal,
+  type RuntimeInstruction,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it } from "vitest";
+
+import {
+  goalInstructionCommitFromRoot,
+  lifecycleTransitionFromRoot,
+  replacementFromRoot,
+} from "@/lib/ai/runtime-instructions/persistence/checkpoints";
+import type { StoredRuntimeInstruction } from "@/lib/ai/runtime-instructions/persistence/goal-instruction-mappers";
+import type { AgentGoalCommandCheckpoint } from "@/lib/db/agent-goal-runtime-schema-types";
+
+const OWNER_ID = "10000000-0000-4000-8000-000000000001";
+const OTHER_OWNER_ID = "10000000-0000-4000-8000-000000000002";
+const SESSION_ID = "checkpoint-runtime";
+const OTHER_SESSION_ID = "other-checkpoint-runtime";
+const GOAL_ID = "20000000-0000-4000-8000-000000000001";
+const REPLACEMENT_GOAL_ID = "20000000-0000-4000-8000-000000000002";
+const OTHER_GOAL_ID = "20000000-0000-4000-8000-000000000003";
+const NOW = new Date("2026-08-05T08:00:00.000Z");
+const LATER = new Date("2026-08-05T08:01:00.000Z");
+const IDEMPOTENCY_KEY = "checkpoint-command";
+
+const SCOPE = { ownerId: OWNER_ID, runtimeSessionId: SESSION_ID };
+
+function goal(id = GOAL_ID, objective = "Validate durable Goal identity") {
+  return createAgentGoal({
+    id,
+    now: NOW,
+    input: {
+      objective,
+      successCriteria: [
+        {
+          id: "checkpoint-valid",
+          description: "The checkpoint remains internally consistent",
+          verification: { type: "model_evidence" },
+          required: true,
+        },
+      ],
+      constraints: [],
+      contextRefs: [],
+      priority: 50,
+      completionPolicy: "model_evaluator",
+      source: { type: "user" },
+    },
+  });
+}
+
+function persistedGoal(value: AgentGoal): PersistedAgentGoal {
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    slot: "primary",
+    goal: value,
+  };
+}
+
+function instruction(
+  value: Omit<RuntimeInstruction, "schemaVersion" | "sequence">,
+  sequence = 1,
+): RuntimeInstruction {
+  return RuntimeInstructionSchema.parse({
+    ...value,
+    schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+    sequence,
+  });
+}
+
+function commandRoot(
+  commandType: NonNullable<StoredRuntimeInstruction["commandType"]>,
+  commandPhase: NonNullable<StoredRuntimeInstruction["commandPhase"]>,
+  rootInstruction: RuntimeInstruction,
+  commandCheckpoint: AgentGoalCommandCheckpoint,
+  runEpoch = 0,
+): StoredRuntimeInstruction {
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    runEpoch,
+    instruction: rootInstruction,
+    requestFingerprint: "a".repeat(64),
+    commandOrder: 0,
+    commandType,
+    commandPhase,
+    commandCheckpoint,
+    createdAt: NOW.toISOString(),
+    updatedAt: NOW.toISOString(),
+  };
+}
+
+function activationInstruction(activeGoal: AgentGoal, sequence = 1) {
+  return instruction(
+    {
+      id: `30000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
+      goalId: activeGoal.id,
+      goalRevision: activeGoal.revision,
+      kind: "goal.activate",
+      deliveryMode: "steer",
+      targetSessionId: SESSION_ID,
+      payload: { goal: activeGoal },
+      source: { type: "user", authority: "user" },
+      idempotencyKey: IDEMPOTENCY_KEY,
+      issuedAt: activeGoal.updatedAt,
+    },
+    sequence,
+  );
+}
+
+function activationRoot(): StoredRuntimeInstruction {
+  const activeGoal = goal();
+  const activate = activationInstruction(activeGoal);
+  return commandRoot("goal_instruction", "committed", activate, {
+    type: "goal_instruction",
+    goal: persistedGoal(activeGoal),
+    instruction: activate,
+  });
+}
+
+function lifecycleRoot(): StoredRuntimeInstruction {
+  const cancelledGoal = transitionAgentGoal({
+    current: goal(),
+    expectedRevision: 1,
+    status: "cancelled",
+    now: LATER,
+  });
+  const cancel = instruction({
+    id: "30000000-0000-4000-8000-000000000010",
+    goalId: cancelledGoal.id,
+    goalRevision: cancelledGoal.revision,
+    kind: "goal.cancel",
+    deliveryMode: "interrupt_replace",
+    targetSessionId: SESSION_ID,
+    payload: { reason: "Cancel safely", expectedRunEpoch: 0 },
+    source: { type: "user", authority: "user" },
+    idempotencyKey: IDEMPOTENCY_KEY,
+    issuedAt: cancelledGoal.updatedAt,
+  });
+  return commandRoot("lifecycle", "prepared", cancel, {
+    type: "lifecycle",
+    transition: {
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      action: "cancel",
+      transitionedGoal: persistedGoal(cancelledGoal),
+      instruction: cancel,
+      expectedRunEpoch: 0,
+      runEpoch: 0,
+      phase: "prepared",
+    },
+  });
+}
+
+function replacementRoot(): StoredRuntimeInstruction {
+  const supersededGoal = transitionAgentGoal({
+    current: goal(),
+    expectedRevision: 1,
+    status: "cancelled",
+    now: LATER,
+  });
+  const replacementGoal = goal(
+    REPLACEMENT_GOAL_ID,
+    "Validate replacement identity",
+  );
+  const control = instruction({
+    id: "30000000-0000-4000-8000-000000000020",
+    goalId: supersededGoal.id,
+    goalRevision: supersededGoal.revision,
+    kind: "control.interrupt",
+    deliveryMode: "interrupt_replace",
+    targetSessionId: SESSION_ID,
+    payload: {
+      reason: "Replace safely",
+      expectedRunEpoch: 0,
+      replacementGoalId: replacementGoal.id,
+    },
+    source: { type: "user", authority: "user" },
+    idempotencyKey: IDEMPOTENCY_KEY,
+    issuedAt: supersededGoal.updatedAt,
+  });
+  return commandRoot("replacement", "prepared", control, {
+    type: "replacement",
+    replacement: {
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      supersededGoal: persistedGoal(supersededGoal),
+      replacementGoal: persistedGoal(replacementGoal),
+      controlInstruction: control,
+      expectedRunEpoch: 0,
+      runEpoch: 0,
+      phase: "prepared",
+    },
+  });
+}
+
+function expectInvalidCheckpoint(run: () => unknown, message: RegExp): void {
+  let captured: unknown;
+  try {
+    run();
+  } catch (error) {
+    captured = error;
+  }
+  expect(captured).toMatchObject({ code: "invalid_record" });
+  expect(String(captured)).toMatch(message);
+}
+
+describe("durable Goal command checkpoint identity", () => {
+  it("rejects Goal checkpoints whose Goal, root, or Session identity diverges", () => {
+    const valid = activationRoot();
+    const checkpoint = valid.commandCheckpoint;
+    if (checkpoint?.type !== "goal_instruction") throw new Error("fixture");
+
+    const revisedGoal = { ...checkpoint.goal.goal, revision: 2 };
+    expectInvalidCheckpoint(
+      () =>
+        goalInstructionCommitFromRoot(
+          {
+            ...valid,
+            commandCheckpoint: {
+              ...checkpoint,
+              goal: { ...checkpoint.goal, goal: revisedGoal },
+            },
+          },
+          SCOPE,
+          true,
+        ),
+      /instruction Goal identity/,
+    );
+
+    const sessionMismatch = RuntimeInstructionSchema.parse({
+      ...valid.instruction,
+      targetSessionId: OTHER_SESSION_ID,
+    });
+    expectInvalidCheckpoint(
+      () =>
+        goalInstructionCommitFromRoot(
+          {
+            ...valid,
+            instruction: sessionMismatch,
+            commandCheckpoint: {
+              ...checkpoint,
+              instruction: sessionMismatch,
+            },
+          },
+          SCOPE,
+          true,
+        ),
+      /instruction Goal identity/,
+    );
+
+    expectInvalidCheckpoint(
+      () =>
+        goalInstructionCommitFromRoot(
+          { ...valid, ownerId: OTHER_OWNER_ID },
+          SCOPE,
+          true,
+        ),
+      /root instruction crosses its command scope/,
+    );
+  });
+
+  it("rejects lifecycle checkpoints whose Goal, action, or epoch identity diverges", () => {
+    const valid = lifecycleRoot();
+    const checkpoint = valid.commandCheckpoint;
+    if (checkpoint?.type !== "lifecycle") throw new Error("fixture");
+
+    const otherGoal = {
+      ...checkpoint.transition.transitionedGoal.goal,
+      id: OTHER_GOAL_ID,
+    };
+    expectInvalidCheckpoint(
+      () =>
+        lifecycleTransitionFromRoot(
+          {
+            ...valid,
+            commandCheckpoint: {
+              ...checkpoint,
+              transition: {
+                ...checkpoint.transition,
+                transitionedGoal: {
+                  ...checkpoint.transition.transitionedGoal,
+                  goal: otherGoal,
+                },
+              },
+            },
+          },
+          SCOPE,
+        ),
+      /instruction Goal identity/,
+    );
+
+    expectInvalidCheckpoint(
+      () => lifecycleTransitionFromRoot({ ...valid, runEpoch: 1 }, SCOPE),
+      /action or run epoch/,
+    );
+  });
+
+  it("rejects replacement checkpoints whose Goal linkage or activation command identity diverges", () => {
+    const valid = replacementRoot();
+    const checkpoint = valid.commandCheckpoint;
+    if (checkpoint?.type !== "replacement") throw new Error("fixture");
+
+    const wrongReplacementGoal = {
+      ...checkpoint.replacement.replacementGoal.goal,
+      id: OTHER_GOAL_ID,
+    };
+    expectInvalidCheckpoint(
+      () =>
+        replacementFromRoot(
+          {
+            ...valid,
+            commandCheckpoint: {
+              ...checkpoint,
+              replacement: {
+                ...checkpoint.replacement,
+                replacementGoal: {
+                  ...checkpoint.replacement.replacementGoal,
+                  goal: wrongReplacementGoal,
+                },
+              },
+            },
+          },
+          SCOPE,
+        ),
+      /control instruction does not identify its Goals/,
+    );
+
+    const replacementGoal = checkpoint.replacement.replacementGoal.goal;
+    const activated = {
+      ...checkpoint.replacement,
+      phase: "activated" as const,
+      runEpoch: 1,
+      activationInstruction: activationInstruction(replacementGoal, 2),
+    };
+    const wrongActivation = RuntimeInstructionSchema.parse({
+      ...activated.activationInstruction,
+      idempotencyKey: "different-command",
+    });
+    expectInvalidCheckpoint(
+      () =>
+        replacementFromRoot(
+          {
+            ...valid,
+            commandPhase: "activated",
+            commandCheckpoint: {
+              ...checkpoint,
+              replacement: {
+                ...activated,
+                activationInstruction: wrongActivation,
+              },
+            },
+          },
+          SCOPE,
+        ),
+      /activation instruction does not identify/,
+    );
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
@@ -1,0 +1,1204 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  type AgentGoal,
+  type GoalCommandIdentity,
+  type GoalEvidence,
+  type RuntimeInstructionDraft,
+  createAgentGoal,
+  reviseAgentGoal,
+  transitionAgentGoal,
+} from "@openloomi/ai/agent/runtime-instructions";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  SqliteAgentGoalState,
+  SqliteDeliveryRepository,
+  SqliteEvidenceRepository,
+  SqliteGoalRepository,
+  SqliteGoalRuntimeDatabase,
+  SqliteInstructionRepository,
+  SqliteRunRepository,
+} from "@/lib/ai/runtime-instructions/persistence/sqlite";
+import { persistedInstantIsStrictlyAfter } from "@/lib/ai/runtime-instructions/persistence/mapping";
+
+const OWNER_A = "10000000-0000-4000-8000-000000000001";
+const OWNER_B = "10000000-0000-4000-8000-000000000002";
+const SESSION_A = "sqlite-runtime-a";
+const SESSION_B = "sqlite-runtime-b";
+const NOW = new Date("2026-08-05T08:00:00.000Z");
+const MIGRATION = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../lib/db/migrations-sqlite/0107_agent_goal_runtime.sql",
+  ),
+  "utf8",
+);
+
+const databases: Database.Database[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function uuid(value: number): string {
+  return `20000000-0000-4000-8000-${String(value).padStart(12, "0")}`;
+}
+
+function command(
+  idempotencyKey: string,
+  fingerprintCharacter: string,
+): GoalCommandIdentity {
+  return {
+    idempotencyKey,
+    requestFingerprint: fingerprintCharacter.repeat(64),
+  };
+}
+
+function goal(
+  id = uuid(1),
+  objective = "Persist the Goal atomically",
+  now = NOW,
+) {
+  return createAgentGoal({
+    id,
+    now,
+    input: {
+      objective,
+      successCriteria: [
+        {
+          id: "durable-result",
+          description: "The durable result is recorded",
+          verification: {
+            type: "tool_result",
+            toolName: "test",
+            expectedOutcome: "passed",
+          },
+          required: true,
+        },
+      ],
+      constraints: [],
+      contextRefs: [],
+      priority: 80,
+      maxTurns: 8,
+      completionPolicy: "tool_evidence",
+      source: { type: "user" },
+    },
+  });
+}
+
+function activationDraft(
+  activeGoal: AgentGoal,
+  idempotencyKey: string,
+  id = uuid(101),
+  runtimeSessionId = SESSION_A,
+): RuntimeInstructionDraft {
+  return {
+    schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+    id,
+    goalId: activeGoal.id,
+    goalRevision: activeGoal.revision,
+    kind: "goal.activate",
+    deliveryMode: "steer",
+    targetSessionId: runtimeSessionId,
+    payload: { goal: activeGoal },
+    source: { type: "user", authority: "user" },
+    idempotencyKey,
+    issuedAt: activeGoal.updatedAt,
+  };
+}
+
+function updateDraft(
+  revisedGoal: AgentGoal,
+  idempotencyKey: string,
+  id: string,
+): RuntimeInstructionDraft {
+  return {
+    schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+    id,
+    goalId: revisedGoal.id,
+    goalRevision: revisedGoal.revision,
+    kind: "goal.update",
+    deliveryMode: "steer",
+    targetSessionId: SESSION_A,
+    payload: { goal: revisedGoal, previousRevision: revisedGoal.revision - 1 },
+    source: { type: "user", authority: "user" },
+    idempotencyKey,
+    issuedAt: revisedGoal.updatedAt,
+  };
+}
+
+function createHarness() {
+  const database = new Database(":memory:");
+  databases.push(database);
+  database.pragma("foreign_keys = ON");
+  database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
+  database.exec(MIGRATION);
+  database
+    .prepare('INSERT INTO "User" (id) VALUES (?), (?)')
+    .run(OWNER_A, OWNER_B);
+  database
+    .prepare(
+      "INSERT INTO agent_runtime_sessions (id, owner_id) VALUES (?, ?), (?, ?)",
+    )
+    .run(SESSION_A, OWNER_A, SESSION_B, OWNER_B);
+  let nextId = 500;
+  const runtimeDatabase = new SqliteGoalRuntimeDatabase(database);
+  const state = new SqliteAgentGoalState(runtimeDatabase, {
+    now: () => NOW,
+    generateId: () => uuid(nextId++),
+  });
+  return { database, runtimeDatabase, state };
+}
+
+function activationInput(activeGoal = goal()) {
+  const identity = command("activate-durable-goal", "a");
+  return {
+    ownerId: OWNER_A,
+    runtimeSessionId: SESSION_A,
+    goal: activeGoal,
+    instruction: activationDraft(activeGoal, identity.idempotencyKey),
+    command: identity,
+  };
+}
+
+function count(database: Database.Database, table: string): number {
+  return (
+    database.prepare(`SELECT count(*) AS count FROM ${table}`).get() as {
+      count: number;
+    }
+  ).count;
+}
+
+describe("SqliteAgentGoalState", () => {
+  it("atomically activates once and returns the exact commit on retry", async () => {
+    const { database, state } = createHarness();
+    const activation = activationInput();
+    const input = {
+      ...activation,
+      instruction: {
+        ...activation.instruction,
+        // SQLite stores both instants as the same whole second while the
+        // immutable snapshot retains the protocol-valid millisecond ordering.
+        expiresAt: "2026-08-05T08:00:00.500Z",
+      },
+    };
+    const committed = await state.commitActivation(input);
+
+    expect(committed).toMatchObject({
+      deduplicated: false,
+      instruction: {
+        sequence: 1,
+        expiresAt: "2026-08-05T08:00:00.500Z",
+      },
+    });
+    expect(
+      database.prepare("SELECT status FROM agent_goal_runs").get(),
+    ).toEqual({ status: "queued" });
+    expect(
+      database.prepare("SELECT state FROM agent_runtime_deliveries").get(),
+    ).toEqual({ state: "pending" });
+    expect(() =>
+      database
+        .prepare(
+          "UPDATE agent_runtime_instructions SET goal_revision = NULL WHERE id = ?",
+        )
+        .run(committed.instruction.id),
+    ).toThrow();
+    expect(
+      database
+        .prepare(
+          "SELECT last_instruction_sequence AS sequence FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(SESSION_A),
+    ).toEqual({ sequence: 1 });
+
+    const retried = await state.commitActivation(input);
+    expect(retried).toEqual({ ...committed, deduplicated: true });
+    expect([
+      count(database, "agent_goals"),
+      count(database, "agent_goal_runs"),
+      count(database, "agent_runtime_instructions"),
+      count(database, "agent_runtime_deliveries"),
+    ]).toEqual([1, 1, 1, 1]);
+
+    await expect(
+      state.commitActivation({
+        ...input,
+        command: command(input.command.idempotencyKey, "b"),
+      }),
+    ).rejects.toMatchObject({ code: "idempotency_conflict" });
+    await expect(state.listInstructions(OWNER_A, SESSION_A)).resolves.toEqual([
+      committed.instruction,
+    ]);
+  });
+
+  it("applies whole-second snapshot matching to SQLite persistence", async () => {
+    expect(
+      persistedInstantIsStrictlyAfter(
+        new Date("2026-08-05T08:00:00.500Z"),
+        new Date("2026-08-05T08:00:00.100Z"),
+        "whole-second",
+      ),
+    ).toBe(false);
+
+    const { runtimeDatabase, state } = createHarness();
+    const preciseNow = new Date("2026-08-05T08:00:00.789Z");
+    const preciseGoal = goal(
+      uuid(3),
+      "Preserve precise authoritative timestamps",
+      preciseNow,
+    );
+    const input = activationInput(preciseGoal);
+    const committed = await state.commitActivation(input);
+
+    await expect(state.commitActivation(input)).resolves.toMatchObject({
+      deduplicated: true,
+    });
+    await expect(state.getGoal(OWNER_A, preciseGoal.id)).resolves.toMatchObject(
+      {
+        goal: {
+          createdAt: preciseNow.toISOString(),
+          updatedAt: preciseNow.toISOString(),
+        },
+      },
+    );
+
+    await expect(
+      new SqliteGoalRepository(runtimeDatabase).getById({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        goalId: preciseGoal.id,
+      }),
+    ).resolves.toMatchObject({
+      goal: { createdAt: preciseNow.toISOString() },
+    });
+    await expect(
+      new SqliteInstructionRepository(runtimeDatabase).getById({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        instructionId: committed.instruction.id,
+      }),
+    ).resolves.toMatchObject({ issuedAt: preciseNow.toISOString() });
+  });
+
+  it("enforces revision CAS, owner/session scope, and runEpoch fencing", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const input = activationInput();
+    await state.commitActivation(input);
+    const revised = reviseAgentGoal({
+      current: input.goal,
+      expectedRevision: 1,
+      update: { objective: "Persist the revised Goal" },
+      now: new Date("2026-08-05T08:00:00.500Z"),
+    });
+    const update = {
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      expectedRevision: 1,
+      goal: revised,
+      instruction: updateDraft(revised, "revise-durable-goal", uuid(102)),
+      command: command("revise-durable-goal", "c"),
+    };
+    await expect(state.commitRevision(update)).resolves.toMatchObject({
+      goal: { goal: { revision: 2 } },
+      instruction: { sequence: 2 },
+    });
+    const dispatchable = await new SqliteDeliveryRepository(
+      runtimeDatabase,
+    ).listDispatchable({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      availableAt: "2026-08-05T08:00:01.000Z",
+    });
+    expect(dispatchable.map(({ instructionId }) => instructionId)).toEqual([
+      input.instruction.id,
+      update.instruction.id,
+    ]);
+    await expect(
+      state.commitRevision({
+        ...update,
+        instruction: updateDraft(revised, "stale-revision", uuid(103)),
+        command: command("stale-revision", "d"),
+      }),
+    ).rejects.toMatchObject({ code: "revision_conflict" });
+
+    await expect(
+      state.commitContinuation({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        goalId: revised.id,
+        expectedRevision: 2,
+        expectedRunEpoch: 1,
+        instruction: {
+          schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+          id: uuid(104),
+          goalId: revised.id,
+          goalRevision: 2,
+          kind: "goal.continue",
+          deliveryMode: "steer",
+          targetSessionId: SESSION_A,
+          payload: {
+            missingCriteria: [
+              {
+                id: "durable-result",
+                description: "The durable result is recorded",
+              },
+            ],
+            reason: "Evidence is still missing",
+            remainingBudget: { turns: 7 },
+          },
+          source: { type: "automation", authority: "automation" },
+          idempotencyKey: "stale-epoch",
+          issuedAt: revised.updatedAt,
+        },
+        command: command("stale-epoch", "e"),
+      }),
+    ).rejects.toMatchObject({ code: "run_epoch_conflict" });
+    await expect(state.getGoal(OWNER_B, revised.id)).resolves.toBeNull();
+    const isolatedGoal = goal(uuid(2));
+    const isolatedCommand = command("cross-owner-session", "f");
+    await expect(
+      state.commitActivation({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_B,
+        goal: isolatedGoal,
+        instruction: activationDraft(
+          isolatedGoal,
+          isolatedCommand.idempotencyKey,
+          uuid(105),
+          SESSION_B,
+        ),
+        command: isolatedCommand,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_commit" });
+    expect(count(database, "agent_runtime_instructions")).toBe(2);
+  });
+
+  it("rolls the entire activation unit of work back after a late failure", async () => {
+    const { database, state } = createHarness();
+    database.exec(`
+      CREATE TRIGGER reject_goal_instruction
+      BEFORE INSERT ON agent_runtime_instructions
+      BEGIN
+        SELECT RAISE(ABORT, 'forced instruction failure');
+      END
+    `);
+
+    await expect(
+      state.commitActivation(activationInput()),
+    ).rejects.toMatchObject({
+      code: "invalid_commit",
+    });
+    expect([
+      count(database, "agent_goals"),
+      count(database, "agent_goal_runs"),
+      count(database, "agent_runtime_instructions"),
+      count(database, "agent_runtime_deliveries"),
+    ]).toEqual([0, 0, 0, 0]);
+    expect(
+      database
+        .prepare(
+          "SELECT last_instruction_sequence AS sequence FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(SESSION_A),
+    ).toEqual({ sequence: 0 });
+  });
+
+  it("atomically completes the Goal, releases its slot, and completes its Run", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const input = activationInput();
+    await state.commitActivation(input);
+    const run = database.prepare("SELECT id FROM agent_goal_runs").get() as {
+      id: string;
+    };
+    await new SqliteRunRepository(runtimeDatabase).transition({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      runId: run.id,
+      expectedRunEpoch: 0,
+      expectedStatus: "queued",
+      nextStatus: "running",
+      updatedAt: "2026-08-05T08:00:30.000Z",
+    });
+    const completed = transitionAgentGoal({
+      current: input.goal,
+      expectedRevision: 1,
+      status: "completed",
+      now: new Date("2026-08-05T08:01:00.000Z"),
+    });
+
+    await expect(
+      state.commitEvaluationTransition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        expectedRevision: 1,
+        expectedRunEpoch: 0,
+        goal: completed,
+      }),
+    ).resolves.toMatchObject({ goal: { goal: { status: "completed" } } });
+    expect(
+      database.prepare("SELECT status, slot_state FROM agent_goals").get(),
+    ).toEqual({ status: "completed", slot_state: "released" });
+    expect(
+      database
+        .prepare("SELECT status, goal_revision FROM agent_goal_runs")
+        .get(),
+    ).toEqual({ status: "completed", goal_revision: 2 });
+    await expect(
+      state.getActivePrimaryGoal(OWNER_A, SESSION_A),
+    ).resolves.toBeNull();
+  });
+
+  it("persists a cancel barrier, advances its epoch, and replays every phase exactly", async () => {
+    const { database, state } = createHarness();
+    const active = goal();
+    await state.commitActivation(activationInput(active));
+    const cancelled = transitionAgentGoal({
+      current: active,
+      expectedRevision: 1,
+      status: "cancelled",
+      now: new Date("2026-08-05T08:01:00.000Z"),
+    });
+    const identity = command("cancel-durable-goal", "6");
+    const input = {
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      action: "cancel" as const,
+      expectedRevision: 1,
+      expectedRunEpoch: 0,
+      goal: cancelled,
+      instruction: {
+        schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+        id: uuid(106),
+        goalId: active.id,
+        goalRevision: cancelled.revision,
+        kind: "goal.cancel",
+        deliveryMode: "interrupt_replace",
+        targetSessionId: SESSION_A,
+        payload: { reason: "Cancel safely", expectedRunEpoch: 0 },
+        source: { type: "user", authority: "user" },
+        idempotencyKey: identity.idempotencyKey,
+        issuedAt: cancelled.updatedAt,
+      } satisfies RuntimeInstructionDraft,
+      command: identity,
+    };
+    const prepared = await state.prepareLifecycleTransition(input);
+    await expect(state.prepareLifecycleTransition(input)).resolves.toEqual({
+      ...prepared,
+      deduplicated: true,
+    });
+
+    const boundaryInput = {
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      goalId: active.id,
+      expectedRunEpoch: 0,
+      nextRunEpoch: 1,
+      command: identity,
+    };
+    const boundary = await state.markLifecycleTransitionBoundary(boundaryInput);
+    await expect(
+      state.markLifecycleTransitionBoundary(boundaryInput),
+    ).resolves.toEqual({ ...boundary, deduplicated: true });
+    const finalized = await state.finalizeLifecycleTransition(boundaryInput);
+    await expect(
+      state.finalizeLifecycleTransition(boundaryInput),
+    ).resolves.toEqual({ ...finalized, deduplicated: true });
+
+    expect(
+      database.prepare("SELECT status FROM agent_goal_runs").get(),
+    ).toEqual({ status: "cancelled" });
+    expect(
+      database
+        .prepare(
+          "SELECT run_epoch, pending_operation FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(SESSION_A),
+    ).toEqual({ run_epoch: 1, pending_operation: null });
+    expect(
+      database.prepare("SELECT slot_state FROM agent_goals").get(),
+    ).toEqual({ slot_state: "released" });
+  });
+
+  it("persists a hidden replacement through its boundary and activates it in sequence", async () => {
+    const { database, state } = createHarness();
+    const active = goal();
+    await state.commitActivation(activationInput(active));
+    const superseded = transitionAgentGoal({
+      current: active,
+      expectedRevision: 1,
+      status: "cancelled",
+      now: new Date("2026-08-05T08:01:00.000Z"),
+    });
+    const replacement = goal(uuid(2), "Persist the replacement Goal");
+    const identity = command("replace-durable-goal", "7");
+    const prepared = await state.prepareReplacement({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      expectedRevision: 1,
+      expectedRunEpoch: 0,
+      supersededGoal: superseded,
+      replacementGoal: replacement,
+      controlInstruction: {
+        schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+        id: uuid(107),
+        goalId: active.id,
+        goalRevision: superseded.revision,
+        kind: "control.interrupt",
+        deliveryMode: "interrupt_replace",
+        targetSessionId: SESSION_A,
+        payload: {
+          reason: "Replace safely",
+          expectedRunEpoch: 0,
+          replacementGoalId: replacement.id,
+        },
+        source: { type: "user", authority: "user" },
+        idempotencyKey: identity.idempotencyKey,
+        issuedAt: superseded.updatedAt,
+      },
+      command: identity,
+    });
+    expect(prepared.replacement.phase).toBe("prepared");
+    await expect(state.getGoal(OWNER_A, replacement.id)).resolves.toBeNull();
+
+    await state.markReplacementBoundary({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      replacementGoalId: replacement.id,
+      expectedRunEpoch: 0,
+      nextRunEpoch: 1,
+      command: identity,
+    });
+    await state.finalizeReplacement({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      replacementGoalId: replacement.id,
+      activationInstruction: {
+        ...activationDraft(replacement, identity.idempotencyKey, uuid(108)),
+        issuedAt: "2026-08-05T08:02:00.000Z",
+      },
+      command: identity,
+    });
+
+    await expect(
+      state.getActivePrimaryGoal(OWNER_A, SESSION_A),
+    ).resolves.toMatchObject({ goal: { id: replacement.id } });
+    expect(
+      database
+        .prepare(
+          "SELECT run_epoch, pending_operation, last_instruction_sequence FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(SESSION_A),
+    ).toEqual({
+      run_epoch: 1,
+      pending_operation: null,
+      last_instruction_sequence: 3,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT run_epoch, status FROM agent_goal_runs ORDER BY run_epoch",
+        )
+        .all(),
+    ).toEqual([
+      { run_epoch: 0, status: "cancelled" },
+      { run_epoch: 1, status: "queued" },
+    ]);
+    expect(
+      (await state.listInstructions(OWNER_A, SESSION_A)).map(
+        ({ sequence, kind }) => ({ sequence, kind }),
+      ),
+    ).toEqual([
+      { sequence: 1, kind: "goal.activate" },
+      { sequence: 2, kind: "control.interrupt" },
+      { sequence: 3, kind: "goal.activate" },
+    ]);
+    expect(
+      database
+        .prepare(
+          "SELECT state FROM agent_runtime_deliveries ORDER BY created_at, id",
+        )
+        .all(),
+    ).toEqual([
+      { state: "pending" },
+      { state: "pending" },
+      { state: "pending" },
+    ]);
+  });
+
+  it("fences provider identity and stale writes at the authoritative Runtime Session", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const committed = await state.commitActivation(activationInput());
+    const runs = new SqliteRunRepository(runtimeDatabase);
+    const deliveries = new SqliteDeliveryRepository(runtimeDatabase);
+    const evidence = new SqliteEvidenceRepository(runtimeDatabase);
+    const run = await runs.findByGoalEpoch({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      goalId: committed.goal.goal.id,
+      runEpoch: 0,
+    });
+    const pending = await deliveries.getActiveByInstruction({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      instructionId: committed.instruction.id,
+    });
+    if (!run || !pending) throw new Error("Activation persistence is missing");
+
+    database
+      .prepare(
+        `UPDATE agent_runtime_sessions
+         SET provider_session_id = ?
+         WHERE owner_id = ? AND id = ?`,
+      )
+      .run("claude-session-a", OWNER_A, SESSION_A);
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        expectedTurnsUsed: 0,
+        turnsUsed: 1,
+        providerSessionId: "claude-session-a",
+        updatedAt: "2026-08-05T08:00:10.000Z",
+      }),
+    ).resolves.toMatchObject({
+      providerSessionId: "claude-session-a",
+      turnsUsed: 1,
+    });
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        expectedTurnsUsed: 1,
+        turnsUsed: 2,
+        providerSessionId: "claude-session-b",
+        updatedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        providerSessionId: null as unknown as string,
+        updatedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).rejects.toThrow("providerSessionId must be a string");
+
+    database
+      .prepare(
+        `UPDATE agent_runtime_sessions
+         SET provider_session_id = ?
+         WHERE owner_id = ? AND id = ?`,
+      )
+      .run("claude-session-b", OWNER_A, SESSION_A);
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        expectedTurnsUsed: 1,
+        turnsUsed: 2,
+        providerSessionId: "claude-session-b",
+        updatedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        expectedTurnsUsed: 1,
+        turnsUsed: 2,
+        updatedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).resolves.toBeNull();
+    database
+      .prepare(
+        `UPDATE agent_runtime_sessions
+         SET provider_session_id = ?
+         WHERE owner_id = ? AND id = ?`,
+      )
+      .run("claude-session-a", OWNER_A, SESSION_A);
+    await expect(
+      runs.create({
+        run: { ...run, id: uuid(209) },
+        recordedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+
+    const observed: GoalEvidence = {
+      id: uuid(210),
+      goalId: committed.goal.goal.id,
+      goalRunId: run.id,
+      goalRevision: 1,
+      instructionId: committed.instruction.id,
+      type: "tool_result",
+      sourceEventId: "stale-provider-event",
+      summary: "Recorded before the session boundary",
+      success: true,
+      payload: ["test"],
+      observedAt: "2026-08-05T08:00:30.000Z",
+    };
+    const evidenceInput = {
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      runEpoch: 0,
+      evidence: observed,
+      recordedAt: observed.observedAt,
+    };
+    await expect(evidence.appendOnce(evidenceInput)).resolves.toMatchObject({
+      deduplicated: false,
+    });
+
+    const advanced = database
+      .prepare(
+        `UPDATE agent_runtime_sessions
+         SET run_epoch = 1
+         WHERE owner_id = ? AND id = ? AND run_epoch = 0`,
+      )
+      .run(OWNER_A, SESSION_A);
+    expect(advanced.changes).toBe(1);
+
+    await expect(
+      runs.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        nextStatus: "running",
+        updatedAt: "2026-08-05T08:01:00.000Z",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        expectedTurnsUsed: 1,
+        turnsUsed: 2,
+        updatedAt: "2026-08-05T08:01:00.000Z",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      runs.create({
+        run: { ...run, id: uuid(211) },
+        recordedAt: "2026-08-05T08:01:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "run_epoch_conflict" });
+
+    await expect(
+      deliveries.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        deliveryId: pending.id,
+        expectedRunEpoch: 0,
+        expectedState: "pending",
+        nextState: "leased",
+        updatedAt: "2026-08-05T08:01:00.000Z",
+        lease: {
+          token: "stale-lease",
+          owner: "worker-1",
+          expiresAt: "2026-08-05T08:02:00.000Z",
+        },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      deliveries.createPending({
+        id: uuid(212),
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        instructionId: committed.instruction.id,
+        goalRunId: run.id,
+        runEpoch: 0,
+        attempt: 2,
+        availableAt: "2026-08-05T08:01:00.000Z",
+        recordedAt: "2026-08-05T08:01:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "run_epoch_conflict" });
+    await expect(
+      deliveries.listDispatchable({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        availableAt: "2026-08-05T08:03:00.000Z",
+      }),
+    ).resolves.toEqual([]);
+
+    await expect(
+      evidence.appendOnce({
+        ...evidenceInput,
+        evidence: { ...observed, id: uuid(213) },
+      }),
+    ).rejects.toMatchObject({ code: "run_epoch_conflict" });
+    expect(
+      database
+        .prepare("SELECT status, turns_used FROM agent_goal_runs WHERE id = ?")
+        .get(run.id),
+    ).toEqual({ status: "queued", turns_used: 1 });
+    expect(count(database, "agent_goal_evidence")).toBe(1);
+  });
+
+  it("rejects Run, Delivery, and Evidence records whose Goal relationships disagree", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const first = await state.commitActivation(activationInput());
+    const runs = new SqliteRunRepository(runtimeDatabase);
+    const deliveries = new SqliteDeliveryRepository(runtimeDatabase);
+    const evidence = new SqliteEvidenceRepository(runtimeDatabase);
+    const firstRun = await runs.findByGoalEpoch({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      goalId: first.goal.goal.id,
+      runEpoch: 0,
+    });
+    if (!firstRun) throw new Error("First Goal Run is missing");
+    await runs.transition({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      runId: firstRun.id,
+      expectedRunEpoch: 0,
+      expectedStatus: "queued",
+      nextStatus: "running",
+      updatedAt: "2026-08-05T08:00:30.000Z",
+      lastActivityAt: "2026-08-05T08:00:30.000Z",
+    });
+    await expect(
+      runs.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: firstRun.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "running",
+        nextStatus: "completed",
+        updatedAt: "2026-08-05T08:00:40.000Z",
+        completedAt: "2026-08-05T08:00:20.000Z",
+      }),
+    ).resolves.toBeNull();
+    const completedFirst = transitionAgentGoal({
+      current: first.goal.goal,
+      expectedRevision: 1,
+      status: "completed",
+      now: new Date("2026-08-05T08:01:00.000Z"),
+    });
+    await state.commitEvaluationTransition({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      expectedRevision: 1,
+      expectedRunEpoch: 0,
+      goal: completedFirst,
+    });
+
+    const secondGoal = goal(uuid(220), "Persist a second Goal in this epoch");
+    const secondCommand = command("activate-second-goal", "9");
+    const second = await state.commitActivation({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      goal: secondGoal,
+      instruction: activationDraft(
+        secondGoal,
+        secondCommand.idempotencyKey,
+        uuid(221),
+      ),
+      command: secondCommand,
+    });
+    const secondRun = await runs.findByGoalEpoch({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      goalId: secondGoal.id,
+      runEpoch: 0,
+    });
+    if (!secondRun) throw new Error("Second Goal Run is missing");
+
+    const retry = {
+      id: uuid(228),
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      instructionId: second.instruction.id,
+      runEpoch: 0,
+      attempt: 2,
+      availableAt: "2026-08-05T08:01:30.000Z",
+      recordedAt: "2026-08-05T08:01:30.000Z",
+    };
+    await expect(deliveries.createPending(retry)).rejects.toMatchObject({
+      code: "conflict",
+    });
+    await expect(
+      deliveries.createPending({ ...retry, goalRunId: firstRun.id }),
+    ).rejects.toMatchObject({ code: "conflict" });
+
+    const secondPending = await deliveries.getActiveByInstruction({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      instructionId: second.instruction.id,
+    });
+    if (!secondPending) throw new Error("Second pending Delivery is missing");
+    database
+      .prepare("DELETE FROM agent_runtime_deliveries WHERE id = ?")
+      .run(secondPending.id);
+    await expect(
+      deliveries.createPending({
+        ...retry,
+        goalRunId: secondRun.id,
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    await expect(
+      deliveries.createPending({
+        ...retry,
+        id: uuid(229),
+        goalRunId: secondRun.id,
+        attempt: 3,
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    const recreatedPending = await deliveries.createPending({
+      ...retry,
+      id: secondPending.id,
+      goalRunId: secondRun.id,
+      attempt: 1,
+    });
+    await deliveries.transition({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      deliveryId: recreatedPending.id,
+      expectedRunEpoch: 0,
+      expectedState: "pending",
+      nextState: "failed",
+      updatedAt: "2026-08-05T08:01:30.000Z",
+    });
+    await expect(
+      deliveries.createPending({
+        ...retry,
+        goalRunId: secondRun.id,
+      }),
+    ).resolves.toMatchObject({
+      state: "pending",
+      attempt: 2,
+      instructionId: second.instruction.id,
+      goalRunId: secondRun.id,
+    });
+
+    const valid: GoalEvidence = {
+      id: uuid(222),
+      goalId: secondGoal.id,
+      goalRunId: secondRun.id,
+      goalRevision: 1,
+      instructionId: second.instruction.id,
+      type: "tool_result",
+      sourceEventId: "second-goal-event",
+      summary: "Evidence belongs to the second Goal Run",
+      success: true,
+      payload: { tool: "test" },
+      observedAt: "2026-08-05T08:02:00.000Z",
+    };
+    const append = (candidate: GoalEvidence) =>
+      evidence.appendOnce({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runEpoch: 0,
+        evidence: candidate,
+        recordedAt: candidate.observedAt,
+      });
+
+    await expect(
+      append({
+        ...valid,
+        id: uuid(223),
+        goalId: first.goal.goal.id,
+        instructionId: undefined,
+        sourceEventId: "mismatched-goal",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    await expect(
+      append({
+        ...valid,
+        id: uuid(224),
+        instructionId: first.instruction.id,
+        sourceEventId: "mismatched-instruction",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    await expect(
+      append({
+        ...valid,
+        id: uuid(225),
+        goalRevision: 2,
+        instructionId: undefined,
+        sourceEventId: "mismatched-revision",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    await expect(append(valid)).resolves.toMatchObject({
+      deduplicated: false,
+    });
+    const revisedSecond = reviseAgentGoal({
+      current: second.goal.goal,
+      expectedRevision: 1,
+      update: { objective: "Persist the revised second Goal" },
+      now: new Date("2026-08-05T08:03:00.000Z"),
+    });
+    const revisionCommand = command("revise-second-goal", "8");
+    await state.commitRevision({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      expectedRevision: 1,
+      goal: revisedSecond,
+      instruction: updateDraft(
+        revisedSecond,
+        revisionCommand.idempotencyKey,
+        uuid(226),
+      ),
+      command: revisionCommand,
+    });
+    await expect(append({ ...valid, id: uuid(227) })).rejects.toMatchObject({
+      code: "conflict",
+    });
+    expect(count(database, "agent_goal_evidence")).toBe(1);
+
+    database
+      .prepare("DELETE FROM agent_goal_runs WHERE id = ?")
+      .run(secondRun.id);
+    await expect(
+      runs.create({
+        run: { ...secondRun, id: uuid(230) },
+        recordedAt: "2026-08-05T08:04:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    await expect(
+      runs.create({
+        run: {
+          ...secondRun,
+          id: uuid(231),
+          goalRevision: 2,
+          status: "running",
+        },
+        recordedAt: "2026-08-05T08:04:00.000Z",
+      }),
+    ).rejects.toThrow("A new Goal Run must be queued");
+    await expect(
+      runs.create({
+        run: { ...secondRun, id: uuid(231), goalRevision: 2 },
+        recordedAt: "2026-08-05T08:04:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      goalId: secondGoal.id,
+      goalRevision: 2,
+    });
+    database
+      .prepare("DELETE FROM agent_goal_runs WHERE id = ?")
+      .run(firstRun.id);
+    await expect(
+      runs.create({
+        run: {
+          ...firstRun,
+          id: uuid(232),
+          goalRevision: completedFirst.revision,
+        },
+        recordedAt: "2026-08-05T08:04:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("fences Delivery transitions and deduplicates Evidence by source event", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const committed = await state.commitActivation(activationInput());
+    const deliveries = new SqliteDeliveryRepository(runtimeDatabase);
+    const evidence = new SqliteEvidenceRepository(runtimeDatabase);
+    const pending = await deliveries.getActiveByInstruction({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      instructionId: committed.instruction.id,
+    });
+    expect(pending).toMatchObject({
+      state: "pending",
+      runEpoch: 0,
+      availableAt: NOW.toISOString(),
+    });
+
+    const lease = {
+      token: "lease-1",
+      owner: "worker-1",
+      expiresAt: "2026-08-05T08:02:00.000Z",
+    };
+    await expect(
+      deliveries.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        deliveryId: pending?.id ?? "missing",
+        expectedRunEpoch: (pending?.runEpoch ?? 0) + 1,
+        expectedState: "pending",
+        nextState: "leased",
+        updatedAt: "2026-08-05T08:01:00.000Z",
+        lease,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      deliveries.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        deliveryId: pending?.id ?? "missing",
+        expectedRunEpoch: pending?.runEpoch ?? -1,
+        expectedState: "pending",
+        nextState: "leased",
+        updatedAt: "2026-08-05T08:01:00.000Z",
+        lease,
+      }),
+    ).resolves.toMatchObject({ state: "leased", leaseToken: "lease-1" });
+
+    const run = database.prepare("SELECT id FROM agent_goal_runs").get() as {
+      id: string;
+    };
+    const observed: GoalEvidence = {
+      id: uuid(201),
+      goalId: committed.goal.goal.id,
+      goalRunId: run.id,
+      goalRevision: 1,
+      instructionId: committed.instruction.id,
+      type: "tool_result",
+      sourceEventId: "provider-event-1",
+      summary: "The tool passed",
+      success: true,
+      payload: { tool: "test" },
+      observedAt: "2026-08-05T08:01:00.000Z",
+    };
+    const append = (candidate: GoalEvidence) =>
+      evidence.appendOnce({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runEpoch: 0,
+        evidence: candidate,
+        recordedAt: candidate.observedAt,
+      });
+    await expect(append(observed)).resolves.toMatchObject({
+      deduplicated: false,
+    });
+    await expect(
+      append({
+        ...observed,
+        id: uuid(202),
+        observedAt: "2026-08-05T08:01:00.999Z",
+      }),
+    ).resolves.toMatchObject({
+      deduplicated: true,
+      evidence: { id: observed.id },
+    });
+
+    await expect(
+      append({ ...observed, id: uuid(203), summary: "Conflicting result" }),
+    ).rejects.toMatchObject({ code: "idempotency_conflict" });
+  });
+});


### PR DESCRIPTION
## Summary

Add durable SQLite persistence for the Claude Goal Runtime on desktop.

This PR introduces the schema, repositories, transaction boundary, and durable Goal state adapter required to persist the complete runtime state of a Goal. Goal mutations are committed together with their Runs, runtime instructions, pending deliveries, lifecycle checkpoints, and session sequencing state.

Related to #176.

## What Changed

### SQLite Schema and Migration

Add six runtime persistence tables:

- `agent_runtime_sessions`
  - Stores the runtime provider session, current `runEpoch`, instruction sequence, and pending lifecycle or replacement operation.
- `agent_goals`
  - Stores the authoritative Goal snapshot, revision, status, budget, deadline, and primary slot state.
- `agent_goal_runs`
  - Stores per-epoch execution state, provider session identity, usage counters, activity timestamps, and evaluation results.
- `agent_runtime_instructions`
  - Stores the immutable ordered instruction outbox, idempotency identity, command phase, and recovery checkpoint.
- `agent_runtime_deliveries`
  - Stores delivery attempts, leases, retry state, provider event identity, and delivery errors.
- `agent_goal_evidence`
  - Stores completion evidence associated with an exact Goal Run, revision, instruction, and provider source event.

The schema includes foreign keys, partial unique indexes, JSON validation, legal status constraints, timestamp checks, and owner/session relationship constraints.

### Durable Goal State Adapter

Add `SqliteAgentGoalState` as a durable implementation of the existing Goal state ports.

It supports:

- Goal activation
- Goal revision updates
- Context updates and removals
- Goal continuation
- Evaluation transitions
- Pause, resume, and cancel
- Lifecycle prepare, boundary, and finalize phases
- Goal replacement prepare, boundary, and activation phases
- Exact idempotent command replay

Lifecycle and replacement operations persist their current phase and complete command result, allowing retries to recover the exact previously committed state.

### Atomic State and Instruction Outbox

Add a synchronous SQLite transaction boundary using `BEGIN IMMEDIATE`.

A Goal activation now atomically commits:

- The authoritative Goal
- Its queued Goal Run
- The Runtime Session instruction sequence
- The immutable Runtime Instruction
- The initial pending Delivery
- The command checkpoint used for idempotent replay

If any write fails, the complete unit of work is rolled back.

The same atomic guarantees are applied to Goal revisions, continuations, evaluations, lifecycle transitions, and Goal replacement.

### SQLite Repositories

Add dedicated repositories for:

- Goal lookup and primary slot resolution
- Runtime Instruction and idempotency checkpoint lookup
- Goal Run creation, progress updates, and state transitions
- Delivery attempts, leasing, dispatchability, and acknowledgement transitions
- Evidence insertion, relationship validation, and source-event deduplication

All repositories share the same SQLite store and transaction infrastructure.

### Runtime Consistency Guarantees

The persistence layer enforces:

- Revision compare-and-set updates
- Monotonic instruction sequencing
- `runEpoch` fencing for stale events and delayed writes
- Runtime provider session identity checks
- One assigned primary Goal per Runtime Session
- Reserved primary Goal protection during replacement
- Legal Goal Run and Delivery state transitions
- Monotonic token, turn, and activity updates
- Continuous Delivery attempt numbering
- Goal, Run, Instruction, Delivery, and Evidence relationship validation
- Evidence deduplication by Goal Run and provider source event
- Idempotency conflicts when the same key or source event is reused with different content

### Shared Goal Validation

Extract common Goal transition validation from the in-memory adapter so the in-memory and SQLite implementations use the same rules for:

- Goal activation and revision changes
- Context mutations
- Continuation criteria
- Evaluation outcomes
- Lifecycle transitions
- Replacement transitions
- Status and `runEpoch` progression

## Validation

- 15 related test files passed.
- 77 related tests passed.
- SQLite migration and constraint tests passed.
- Atomic rollback and idempotency tests passed.
- Lifecycle and replacement recovery tests passed.