### PR TITLE
feat(agent): add authenticated Goal Runtime API

### DIFF
--- a/apps/web/app/api/agent-goals/[goalId]/context/route.ts
+++ b/apps/web/app/api/agent-goals/[goalId]/context/route.ts
@@ -1,0 +1,78 @@
+import {
+  GoalIdSchema,
+  RemoveGoalContextRequestSchema,
+  UpsertGoalContextRequestSchema,
+  getAgentGoalApiService,
+  goalCommandResponse,
+  invalidGoalApiRequest,
+  parseGoalApiBody,
+  readIdempotencyKey,
+  withAuthenticatedGoalApi,
+} from "@/lib/ai/runtime-instructions/api/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface GoalContextRouteContext {
+  params: Promise<{ goalId: string }>;
+}
+
+export async function PUT(request: Request, context: GoalContextRouteContext) {
+  return mutateContext(request, context, "upsert");
+}
+
+export async function DELETE(
+  request: Request,
+  context: GoalContextRouteContext,
+) {
+  return mutateContext(request, context, "remove");
+}
+
+function mutateContext(
+  request: Request,
+  context: GoalContextRouteContext,
+  action: "upsert" | "remove",
+) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const goalId = GoalIdSchema.safeParse((await context.params).goalId);
+      if (!goalId.success) {
+        return invalidGoalApiRequest(goalId.error.issues[0]?.message);
+      }
+      const idempotency = readIdempotencyKey(request);
+      if ("response" in idempotency) return idempotency.response;
+
+      if (action === "upsert") {
+        const parsed = await parseGoalApiBody(
+          request,
+          UpsertGoalContextRequestSchema,
+        );
+        if ("response" in parsed) return parsed.response;
+        return goalCommandResponse(
+          await service.upsertContext(
+            ownerId,
+            goalId.data,
+            parsed.data,
+            idempotency.data,
+          ),
+        );
+      }
+
+      const parsed = await parseGoalApiBody(
+        request,
+        RemoveGoalContextRequestSchema,
+      );
+      if ("response" in parsed) return parsed.response;
+      return goalCommandResponse(
+        await service.removeContext(
+          ownerId,
+          goalId.data,
+          parsed.data,
+          idempotency.data,
+        ),
+      );
+    },
+  );
+}

--- a/apps/web/app/api/agent-goals/[goalId]/route.ts
+++ b/apps/web/app/api/agent-goals/[goalId]/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+
+import type { AgentGoalDetailResponse } from "@/lib/ai/runtime-instructions/api";
+
+import {
+  GoalIdSchema,
+  GoalSessionQuerySchema,
+  NO_STORE_HEADERS,
+  UpdateGoalRequestSchema,
+  getAgentGoalApiService,
+  goalCommandResponse,
+  invalidGoalApiRequest,
+  parseGoalApiBody,
+  publicGoalDetail,
+  readIdempotencyKey,
+  withAuthenticatedGoalApi,
+} from "@/lib/ai/runtime-instructions/api/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface GoalRouteContext {
+  params: Promise<{ goalId: string }>;
+}
+
+export async function GET(request: Request, context: GoalRouteContext) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const goalId = GoalIdSchema.safeParse((await context.params).goalId);
+      const query = GoalSessionQuerySchema.safeParse(
+        Object.fromEntries(new URL(request.url).searchParams),
+      );
+      if (!goalId.success) {
+        return invalidGoalApiRequest(goalId.error.issues[0]?.message);
+      }
+      if (!query.success) {
+        return invalidGoalApiRequest(query.error.issues[0]?.message);
+      }
+      const view = await service.getById({
+        ownerId,
+        runtimeSessionId: query.data.runtimeSessionId,
+        goalId: goalId.data,
+      });
+      const response: AgentGoalDetailResponse = {
+        runtimeSessionId: view.runtimeSessionId,
+        live: view.live,
+        ...publicGoalDetail(view),
+      };
+      return NextResponse.json(response, { headers: NO_STORE_HEADERS });
+    },
+  );
+}
+
+export async function PATCH(request: Request, context: GoalRouteContext) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const goalId = GoalIdSchema.safeParse((await context.params).goalId);
+      if (!goalId.success) {
+        return invalidGoalApiRequest(goalId.error.issues[0]?.message);
+      }
+      const idempotency = readIdempotencyKey(request);
+      if ("response" in idempotency) return idempotency.response;
+      const parsed = await parseGoalApiBody(request, UpdateGoalRequestSchema);
+      if ("response" in parsed) return parsed.response;
+      return goalCommandResponse(
+        await service.update(
+          ownerId,
+          goalId.data,
+          parsed.data,
+          idempotency.data,
+        ),
+      );
+    },
+  );
+}

--- a/apps/web/app/api/agent-goals/route.ts
+++ b/apps/web/app/api/agent-goals/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+import type { AgentGoalSessionResponse } from "@/lib/ai/runtime-instructions/api";
+
+import {
+  ActivateGoalRequestSchema,
+  GoalSessionQuerySchema,
+  NO_STORE_HEADERS,
+  getAgentGoalApiService,
+  goalCommandResponse,
+  invalidGoalApiRequest,
+  parseGoalApiBody,
+  publicGoalSummary,
+  readIdempotencyKey,
+  withAuthenticatedGoalApi,
+} from "@/lib/ai/runtime-instructions/api/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const query = GoalSessionQuerySchema.safeParse(
+        Object.fromEntries(new URL(request.url).searchParams),
+      );
+      if (!query.success) {
+        return invalidGoalApiRequest(query.error.issues[0]?.message);
+      }
+      const view = await service.listBySession(
+        ownerId,
+        query.data.runtimeSessionId,
+      );
+      const response: AgentGoalSessionResponse = {
+        runtimeSessionId: view.runtimeSessionId,
+        live: view.live,
+        activeGoalId: view.activeGoalId,
+        goals: view.goals.map(publicGoalSummary),
+      };
+      return NextResponse.json(response, { headers: NO_STORE_HEADERS });
+    },
+  );
+}
+
+export async function POST(request: Request) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const idempotency = readIdempotencyKey(request);
+      if ("response" in idempotency) return idempotency.response;
+      const parsed = await parseGoalApiBody(request, ActivateGoalRequestSchema);
+      if ("response" in parsed) return parsed.response;
+      return goalCommandResponse(
+        await service.activate(ownerId, parsed.data, idempotency.data),
+        { created: true },
+      );
+    },
+  );
+}

--- a/apps/web/lib/ai/runtime-instructions/api/contracts.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/contracts.ts
@@ -1,0 +1,120 @@
+import type {
+  AgentGoal,
+  AgentGoalRun,
+  DeliveryState,
+  GoalEvaluationResult,
+  GoalEvidence,
+  RuntimeInstructionKind,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+export type PublicAgentGoal = AgentGoal & {
+  runtimeSessionId: string;
+  slot: "primary";
+};
+
+export type PublicGoalEvaluationResult = Omit<
+  GoalEvaluationResult,
+  "nextInstruction"
+>;
+
+export type PublicAgentGoalRun = Omit<
+  AgentGoalRun,
+  "ownerId" | "providerSessionId" | "lastEvaluation"
+> & { lastEvaluation?: PublicGoalEvaluationResult };
+
+export type PublicGoalEvidence = Omit<GoalEvidence, "payload">;
+
+export interface PublicGoalDelivery {
+  instructionId: string;
+  sequence: number;
+  kind: RuntimeInstructionKind;
+  goalRevision?: number;
+  state: DeliveryState;
+  attempt: number;
+  issuedAt: string;
+  updatedAt: string;
+  errorCode?: string;
+}
+
+export interface PublicGoalProgress {
+  completedCriteria: number;
+  totalCriteria: number;
+  turnsUsed: number;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+  lastReason?: string;
+  lastEvidenceAt?: string;
+}
+
+export interface PublicGoalSummary {
+  goal: PublicAgentGoal;
+  latestRun: PublicAgentGoalRun | null;
+  latestDelivery: PublicGoalDelivery | null;
+  progress: PublicGoalProgress;
+}
+
+export interface AgentGoalSessionResponse {
+  runtimeSessionId: string;
+  live: boolean;
+  activeGoalId: string | null;
+  goals: PublicGoalSummary[];
+}
+
+export interface AgentGoalDetailResponse extends PublicGoalSummary {
+  runtimeSessionId: string;
+  live: boolean;
+  evidence: PublicGoalEvidence[];
+}
+
+export interface PublicDeliveryReceipt {
+  runtimeSessionId: string;
+  state: "queued" | "written_to_sdk" | "rejected";
+  recordedAt: string;
+}
+
+export type PublicInstructionDispatchFailure =
+  | {
+      status: "rejected";
+      instructionId: string;
+      receipt: PublicDeliveryReceipt;
+      code: "transport_rejected";
+    }
+  | {
+      status: "transport_failed";
+      runtimeSessionId: string;
+      instructionId: string;
+      code: "transport_failed";
+    };
+
+export type PublicInstructionDispatch =
+  | {
+      status: "accepted";
+      instructionId: string;
+      receipt: PublicDeliveryReceipt;
+    }
+  | PublicInstructionDispatchFailure
+  | {
+      status: "unavailable" | "superseded";
+      runtimeSessionId: string;
+      instructionId: string;
+    }
+  | {
+      status: "deferred";
+      runtimeSessionId: string;
+      instructionId: string;
+      blockedByInstructionId: string;
+      failure: PublicInstructionDispatchFailure;
+    };
+
+export interface AgentGoalCommandResponse {
+  goal: PublicAgentGoal;
+  instruction: {
+    id: string;
+    sequence: number;
+    kind: RuntimeInstructionKind;
+    goalRevision?: number;
+    issuedAt: string;
+  };
+  deduplicated: boolean;
+  dispatch: PublicInstructionDispatch;
+}

--- a/apps/web/lib/ai/runtime-instructions/api/http.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/http.ts
@@ -1,0 +1,289 @@
+import {
+  AgentGoalDomainError,
+  type AgentGoalRun,
+  type GoalEvidence,
+  type PersistedAgentGoal,
+  type RuntimeDeliveryReceipt,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+
+import { getAuthUser } from "@/lib/auth/dual-auth";
+import { isTauriMode } from "@/lib/env/constants";
+
+import { AgentGoalStateError } from "../goal-state-error";
+import type { GoalCommandResult } from "../goal-service";
+import { GoalServiceError } from "../goal-service-error";
+import type {
+  AgentGoalDetailView,
+  AgentGoalSummaryView,
+} from "../goal-query-service";
+import type {
+  RuntimeInstructionDispatch,
+  RuntimeInstructionDispatchFailure,
+} from "../instruction-dispatcher";
+import type {
+  AgentGoalCommandResponse,
+  AgentGoalDetailResponse,
+  PublicAgentGoal,
+  PublicAgentGoalRun,
+  PublicDeliveryReceipt,
+  PublicGoalEvidence,
+  PublicGoalSummary,
+  PublicInstructionDispatch,
+  PublicInstructionDispatchFailure,
+} from "./contracts";
+import { AgentGoalApiError, type AgentGoalApiService } from "./service";
+import { IdempotencyKeySchema } from "./schemas";
+
+export const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
+
+export interface AuthenticatedGoalApiContext {
+  ownerId: string;
+  service: AgentGoalApiService;
+}
+
+export async function withAuthenticatedGoalApi(
+  request: Request,
+  getService: () => AgentGoalApiService,
+  handler: (context: AuthenticatedGoalApiContext) => Promise<NextResponse>,
+): Promise<NextResponse> {
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user) {
+    return apiError("unauthorized", 401);
+  }
+  if (!isTauriMode()) {
+    return apiError("goal_runtime_unavailable", 503);
+  }
+
+  try {
+    return await handler({ ownerId: user.id, service: getService() });
+  } catch (error) {
+    return goalApiErrorResponse(error);
+  }
+}
+
+export async function parseGoalApiBody<T extends z.ZodType>(
+  request: Request,
+  schema: T,
+): Promise<{ data: z.output<T> } | { response: NextResponse }> {
+  const payload = await request.json().catch(() => undefined);
+  if (payload === undefined) {
+    return { response: apiError("invalid_json", 400) };
+  }
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    return {
+      response: apiError(
+        "invalid_goal_request",
+        400,
+        parsed.error.issues[0]?.message,
+      ),
+    };
+  }
+  return { data: parsed.data };
+}
+
+export function readIdempotencyKey(
+  request: Request,
+): { data: string } | { response: NextResponse } {
+  const parsed = IdempotencyKeySchema.safeParse(
+    request.headers.get("idempotency-key"),
+  );
+  return parsed.success
+    ? { data: parsed.data }
+    : { response: apiError("idempotency_key_required", 400) };
+}
+
+export function invalidGoalApiRequest(cause?: string): NextResponse {
+  return apiError("invalid_goal_request", 400, cause);
+}
+
+export function goalCommandResponse(
+  result: GoalCommandResult,
+  options: { created?: boolean } = {},
+): NextResponse {
+  const delivered =
+    result.dispatch.status === "accepted" ||
+    result.dispatch.status === "superseded";
+  const status = delivered
+    ? options.created && !result.deduplicated
+      ? 201
+      : 200
+    : 202;
+  const response: AgentGoalCommandResponse = {
+    goal: publicGoal(result.goal),
+    instruction: {
+      id: result.instruction.id,
+      sequence: result.instruction.sequence,
+      kind: result.instruction.kind,
+      ...(result.instruction.goalRevision === undefined
+        ? {}
+        : { goalRevision: result.instruction.goalRevision }),
+      issuedAt: result.instruction.issuedAt,
+    },
+    deduplicated: result.deduplicated,
+    dispatch: publicDispatch(result.dispatch),
+  };
+  return NextResponse.json(response, { status, headers: NO_STORE_HEADERS });
+}
+
+export function publicGoalSummary(
+  view: AgentGoalSummaryView,
+): PublicGoalSummary {
+  return {
+    goal: publicGoal(view.goal),
+    latestRun: view.latestRun ? publicRun(view.latestRun) : null,
+    latestDelivery: view.latestDelivery,
+    progress: view.progress,
+  };
+}
+
+export function publicGoalDetail(
+  view: AgentGoalDetailView,
+): Omit<AgentGoalDetailResponse, "runtimeSessionId" | "live"> {
+  return {
+    ...publicGoalSummary(view),
+    evidence: view.evidence.map(publicEvidence),
+  };
+}
+
+function goalApiErrorResponse(error: unknown): NextResponse {
+  if (error instanceof AgentGoalApiError) {
+    return apiError(error.code, 404);
+  }
+  if (error instanceof GoalServiceError) {
+    const status =
+      error.code === "goal_not_found" ||
+      error.code === "goal_session_mismatch" ||
+      error.code === "context_not_found"
+        ? 404
+        : error.code === "no_change" || error.code === "goal_not_active"
+          ? 409
+          : 400;
+    return apiError(error.code, status);
+  }
+  if (error instanceof AgentGoalDomainError) {
+    return apiError(error.code, error.code === "invalid_goal" ? 400 : 409);
+  }
+  if (error instanceof AgentGoalStateError) {
+    const status =
+      error.code === "goal_not_found"
+        ? 404
+        : error.code === "invalid_commit"
+          ? 500
+          : 409;
+    return apiError(error.code, status);
+  }
+  console.error("[Agent Goal API] Request failed", error);
+  return apiError("goal_runtime_error", 500);
+}
+
+function apiError(code: string, status: number, cause?: string): NextResponse {
+  return NextResponse.json(
+    { error: code, code, ...(cause === undefined ? {} : { cause }) },
+    { status, headers: NO_STORE_HEADERS },
+  );
+}
+
+function publicGoal(goal: PersistedAgentGoal): PublicAgentGoal {
+  return {
+    runtimeSessionId: goal.runtimeSessionId,
+    slot: goal.slot,
+    ...structuredClone(goal.goal),
+  };
+}
+
+function publicRun(run: AgentGoalRun): PublicAgentGoalRun {
+  const {
+    ownerId: _ownerId,
+    providerSessionId: _providerSessionId,
+    lastEvaluation,
+    ...publicFields
+  } = structuredClone(run);
+  if (!lastEvaluation) return publicFields;
+  const { nextInstruction: _nextInstruction, ...publicEvaluation } =
+    lastEvaluation;
+  return { ...publicFields, lastEvaluation: publicEvaluation };
+}
+
+function publicEvidence(evidence: GoalEvidence): PublicGoalEvidence {
+  const { payload: _payload, ...publicFields } = structuredClone(evidence);
+  return publicFields;
+}
+
+function publicDispatch(
+  dispatch: RuntimeInstructionDispatch,
+): PublicInstructionDispatch {
+  if (dispatch.status === "accepted") {
+    return {
+      status: dispatch.status,
+      instructionId: dispatch.instructionId,
+      receipt: publicReceipt(dispatch.receipt),
+    };
+  }
+  if (dispatch.status === "rejected") {
+    return {
+      status: dispatch.status,
+      instructionId: dispatch.instructionId,
+      receipt: publicReceipt(dispatch.receipt),
+      code: "transport_rejected",
+    };
+  }
+  if (dispatch.status === "transport_failed") {
+    return {
+      status: dispatch.status,
+      runtimeSessionId: dispatch.runtimeSessionId,
+      instructionId: dispatch.instructionId,
+      code: "transport_failed",
+    };
+  }
+  if (dispatch.status === "deferred") {
+    return {
+      status: dispatch.status,
+      runtimeSessionId: dispatch.runtimeSessionId,
+      instructionId: dispatch.instructionId,
+      blockedByInstructionId: dispatch.blockedByInstructionId,
+      failure: publicDispatchFailure(dispatch.failure),
+    };
+  }
+  if (dispatch.status === "superseded") {
+    return {
+      status: dispatch.status,
+      runtimeSessionId: dispatch.runtimeSessionId,
+      instructionId: dispatch.instructionId,
+    };
+  }
+  return {
+    status: dispatch.status,
+    runtimeSessionId: dispatch.runtimeSessionId,
+    instructionId: dispatch.instructionId,
+  };
+}
+
+function publicDispatchFailure(
+  failure: RuntimeInstructionDispatchFailure,
+): PublicInstructionDispatchFailure {
+  if (failure.status === "transport_failed") {
+    return {
+      status: failure.status,
+      runtimeSessionId: failure.runtimeSessionId,
+      instructionId: failure.instructionId,
+      code: "transport_failed",
+    };
+  }
+  return {
+    status: failure.status,
+    instructionId: failure.instructionId,
+    receipt: publicReceipt(failure.receipt),
+    code: "transport_rejected",
+  };
+}
+
+function publicReceipt(receipt: RuntimeDeliveryReceipt): PublicDeliveryReceipt {
+  return {
+    runtimeSessionId: receipt.runtimeSessionId,
+    state: receipt.state,
+    recordedAt: receipt.recordedAt,
+  };
+}

--- a/apps/web/lib/ai/runtime-instructions/api/index.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/index.ts
@@ -1,0 +1,3 @@
+/** Client-safe request schemas and response contracts for the Goal API. */
+export * from "./contracts";
+export * from "./schemas";

--- a/apps/web/lib/ai/runtime-instructions/api/schemas.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/schemas.ts
@@ -1,0 +1,147 @@
+import {
+  AgentGoalUpdateSchema,
+  CreateAgentGoalInputSchema,
+  GoalConstraintSchema,
+  GoalContextReferenceSchema,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { z } from "zod";
+
+const identifierSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => value === value.trim(), {
+    message: "Identifier must not contain surrounding whitespace",
+  });
+
+const userConstraintSchema = z
+  .object({
+    id: GoalConstraintSchema.shape.id,
+    description: GoalConstraintSchema.shape.description,
+    enforcement: z.literal("model_guidance").default("model_guidance"),
+  })
+  .strict();
+
+const userContextReferenceSchema = z
+  .object({
+    id: GoalContextReferenceSchema.shape.id,
+    kind: GoalContextReferenceSchema.shape.kind,
+    refId: GoalContextReferenceSchema.shape.refId,
+    label: GoalContextReferenceSchema.shape.label,
+    summary: GoalContextReferenceSchema.shape.summary,
+    attributes: GoalContextReferenceSchema.shape.attributes,
+  })
+  .strict();
+
+const autoCompletableCriteriaSchema =
+  CreateAgentGoalInputSchema.shape.successCriteria.refine(
+    (criteria) =>
+      criteria.every((criterion) => criterion.verification.type !== "manual"),
+    {
+      message:
+        "Manual success criteria require an attestation API that is not available yet",
+    },
+  );
+
+const autoCompletionPolicySchema =
+  CreateAgentGoalInputSchema.shape.completionPolicy.refine(
+    (policy) => policy !== "manual",
+    {
+      message:
+        "The manual completion policy requires an attestation API that is not available yet",
+    },
+  );
+
+export const UserGoalInputSchema = z
+  .object({
+    objective: CreateAgentGoalInputSchema.shape.objective,
+    successCriteria: autoCompletableCriteriaSchema,
+    constraints: z.array(userConstraintSchema).default([]),
+    priority: CreateAgentGoalInputSchema.shape.priority,
+    deadline: CreateAgentGoalInputSchema.shape.deadline,
+    maxTurns: CreateAgentGoalInputSchema.shape.maxTurns,
+    maxTokens: CreateAgentGoalInputSchema.shape.maxTokens,
+    maxDurationSeconds: CreateAgentGoalInputSchema.shape.maxDurationSeconds,
+    completionPolicy: autoCompletionPolicySchema,
+  })
+  .strict();
+
+const userGoalUpdateSchema = z
+  .object({
+    objective: AgentGoalUpdateSchema.shape.objective,
+    successCriteria: AgentGoalUpdateSchema.shape.successCriteria.refine(
+      (criteria) =>
+        criteria === undefined ||
+        criteria.every((criterion) => criterion.verification.type !== "manual"),
+      {
+        message:
+          "Manual success criteria require an attestation API that is not available yet",
+      },
+    ),
+    constraints: z.array(userConstraintSchema).optional(),
+    priority: AgentGoalUpdateSchema.shape.priority,
+    deadline: AgentGoalUpdateSchema.shape.deadline,
+    maxTurns: AgentGoalUpdateSchema.shape.maxTurns,
+    maxTokens: AgentGoalUpdateSchema.shape.maxTokens,
+    maxDurationSeconds: AgentGoalUpdateSchema.shape.maxDurationSeconds,
+    completionPolicy: AgentGoalUpdateSchema.shape.completionPolicy.refine(
+      (policy) => policy === undefined || policy !== "manual",
+      {
+        message:
+          "The manual completion policy requires an attestation API that is not available yet",
+      },
+    ),
+  })
+  .strict()
+  .refine((value) => Object.values(value).some((item) => item !== undefined), {
+    message: "A Goal update must change at least one field",
+  });
+
+export const GoalSessionQuerySchema = z
+  .object({ runtimeSessionId: identifierSchema })
+  .strict();
+
+export const ActivateGoalRequestSchema = z
+  .object({
+    runtimeSessionId: identifierSchema,
+    goal: UserGoalInputSchema,
+  })
+  .strict();
+
+export const UpdateGoalRequestSchema = z
+  .object({
+    runtimeSessionId: identifierSchema,
+    expectedRevision: z.int().positive(),
+    update: userGoalUpdateSchema,
+  })
+  .strict();
+
+export const UpsertGoalContextRequestSchema = z
+  .object({
+    runtimeSessionId: identifierSchema,
+    expectedRevision: z.int().positive(),
+    contextRef: userContextReferenceSchema,
+    deliveryMode: z.enum(["next_boundary", "steer"]).optional(),
+  })
+  .strict();
+
+export const RemoveGoalContextRequestSchema = z
+  .object({
+    runtimeSessionId: identifierSchema,
+    expectedRevision: z.int().positive(),
+    contextRefId: identifierSchema,
+    deliveryMode: z.enum(["next_boundary", "steer"]).optional(),
+  })
+  .strict();
+
+export const IdempotencyKeySchema = identifierSchema;
+export const GoalIdSchema = z.uuid();
+
+export type ActivateGoalRequest = z.output<typeof ActivateGoalRequestSchema>;
+export type UpdateGoalRequest = z.output<typeof UpdateGoalRequestSchema>;
+export type UpsertGoalContextRequest = z.output<
+  typeof UpsertGoalContextRequestSchema
+>;
+export type RemoveGoalContextRequest = z.output<
+  typeof RemoveGoalContextRequestSchema
+>;

--- a/apps/web/lib/ai/runtime-instructions/api/server.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import { getChatById } from "@/lib/db/queries";
+
+import { getAgentGoalRuntime } from "../runtime";
+import { AgentGoalApiService } from "./service";
+
+export * from "./http";
+export * from "./schemas";
+export * from "./service";
+
+export function getAgentGoalApiService(): AgentGoalApiService {
+  const runtime = getAgentGoalRuntime();
+  return new AgentGoalApiService({
+    goals: runtime.goals,
+    queries: runtime.queries,
+    liveSessions: runtime.sessions,
+    sessionOwnership: {
+      isOwnedChat: async (ownerId, runtimeSessionId) => {
+        const chat = await getChatById({ id: runtimeSessionId });
+        return chat?.userId === ownerId;
+      },
+    },
+  });
+}

--- a/apps/web/lib/ai/runtime-instructions/api/service.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/service.ts
@@ -1,0 +1,227 @@
+import type {
+  AgentGoalUpdate,
+  CreateAgentGoalInput,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type { GoalCommandResult, GoalService } from "../goal-service";
+import type {
+  AgentGoalDetailView,
+  AgentGoalQueryService,
+  AgentGoalSummaryView,
+} from "../goal-query-service";
+import type { RuntimeSessionRegistry } from "../runtime-session-registry";
+import type {
+  ActivateGoalRequest,
+  RemoveGoalContextRequest,
+  UpdateGoalRequest,
+  UpsertGoalContextRequest,
+} from "./schemas";
+
+export interface AgentGoalApiDependencies {
+  goals: Pick<
+    GoalService,
+    "activate" | "update" | "upsertContext" | "removeContext"
+  >;
+  queries: Pick<AgentGoalQueryService, "listBySession" | "getById">;
+  liveSessions: Pick<RuntimeSessionRegistry, "resolve">;
+  sessionOwnership: {
+    isOwnedChat(ownerId: string, runtimeSessionId: string): Promise<boolean>;
+  };
+}
+
+export interface AgentGoalSessionView {
+  runtimeSessionId: string;
+  live: boolean;
+}
+
+export interface AgentGoalSessionListView extends AgentGoalSessionView {
+  goals: AgentGoalSummaryView[];
+  activeGoalId: string | null;
+}
+
+export class AgentGoalApiError extends Error {
+  constructor(
+    public readonly code: "goal_not_found" | "runtime_session_not_found",
+    message: string,
+  ) {
+    super(message);
+    this.name = "AgentGoalApiError";
+  }
+}
+
+/**
+ * Authenticated-user application boundary for Goal HTTP handlers.
+ *
+ * Routes provide only the authenticated owner ID and user-level DTOs. Source
+ * authority and provenance are materialized here so callers cannot impersonate
+ * a policy, automation, connector, or another user.
+ */
+export class AgentGoalApiService {
+  constructor(private readonly dependencies: AgentGoalApiDependencies) {}
+
+  async listBySession(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<AgentGoalSessionListView> {
+    const session = await this.requireSession(ownerId, runtimeSessionId);
+    const goals = await this.dependencies.queries.listBySession(
+      ownerId,
+      runtimeSessionId,
+    );
+    return {
+      runtimeSessionId,
+      live: session.live,
+      goals,
+      activeGoalId:
+        goals.find(({ goal }) => goal.goal.status === "active")?.goal.goal.id ??
+        null,
+    };
+  }
+
+  async getById(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+  }): Promise<AgentGoalDetailView & AgentGoalSessionView> {
+    const session = await this.requireSession(
+      input.ownerId,
+      input.runtimeSessionId,
+    );
+    const goal = await this.dependencies.queries.getById(input);
+    if (!goal) {
+      throw new AgentGoalApiError(
+        "goal_not_found",
+        "Goal was not found for this Runtime Session",
+      );
+    }
+    return {
+      ...goal,
+      runtimeSessionId: input.runtimeSessionId,
+      live: session.live,
+    };
+  }
+
+  async activate(
+    ownerId: string,
+    request: ActivateGoalRequest,
+    idempotencyKey: string,
+  ): Promise<GoalCommandResult> {
+    await this.requireSession(ownerId, request.runtimeSessionId);
+    return this.dependencies.goals.activate({
+      ownerId,
+      runtimeSessionId: request.runtimeSessionId,
+      idempotencyKey,
+      source: userCommandSource(),
+      goal: userGoalInput(request.goal),
+    });
+  }
+
+  async update(
+    ownerId: string,
+    goalId: string,
+    request: UpdateGoalRequest,
+    idempotencyKey: string,
+  ): Promise<GoalCommandResult> {
+    await this.requireSession(ownerId, request.runtimeSessionId);
+    return this.dependencies.goals.update({
+      ownerId,
+      runtimeSessionId: request.runtimeSessionId,
+      goalId,
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      source: userCommandSource(),
+      update: userGoalUpdate(request.update),
+    });
+  }
+
+  async upsertContext(
+    ownerId: string,
+    goalId: string,
+    request: UpsertGoalContextRequest,
+    idempotencyKey: string,
+  ): Promise<GoalCommandResult> {
+    await this.requireSession(ownerId, request.runtimeSessionId);
+    return this.dependencies.goals.upsertContext({
+      ownerId,
+      runtimeSessionId: request.runtimeSessionId,
+      goalId,
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      source: userCommandSource(),
+      contextRef: { ...request.contextRef, origin: "user" },
+      ...(request.deliveryMode === undefined
+        ? {}
+        : { deliveryMode: request.deliveryMode }),
+    });
+  }
+
+  async removeContext(
+    ownerId: string,
+    goalId: string,
+    request: RemoveGoalContextRequest,
+    idempotencyKey: string,
+  ): Promise<GoalCommandResult> {
+    await this.requireSession(ownerId, request.runtimeSessionId);
+    return this.dependencies.goals.removeContext({
+      ownerId,
+      runtimeSessionId: request.runtimeSessionId,
+      goalId,
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      source: userCommandSource(),
+      contextRefId: request.contextRefId,
+      ...(request.deliveryMode === undefined
+        ? {}
+        : { deliveryMode: request.deliveryMode }),
+    });
+  }
+
+  private async requireSession(ownerId: string, runtimeSessionId: string) {
+    if (
+      !(await this.dependencies.sessionOwnership.isOwnedChat(
+        ownerId,
+        runtimeSessionId,
+      ))
+    ) {
+      throw new AgentGoalApiError(
+        "runtime_session_not_found",
+        "Runtime Session was not found for this user",
+      );
+    }
+    return {
+      live: Boolean(
+        await this.dependencies.liveSessions.resolve(ownerId, runtimeSessionId),
+      ),
+    };
+  }
+}
+
+function userCommandSource() {
+  return { type: "user", authority: "user" } as const;
+}
+
+function userGoalInput(
+  input: ActivateGoalRequest["goal"],
+): CreateAgentGoalInput {
+  return {
+    ...input,
+    constraints: input.constraints.map((constraint) => ({
+      ...constraint,
+      authority: "user" as const,
+    })),
+    contextRefs: [],
+    source: { type: "user" },
+  };
+}
+
+function userGoalUpdate(input: UpdateGoalRequest["update"]): AgentGoalUpdate {
+  const { constraints, ...update } = input;
+  if (constraints === undefined) return update;
+  return {
+    ...update,
+    constraints: constraints.map((constraint) => ({
+      ...constraint,
+      authority: "user",
+    })),
+  };
+}

--- a/apps/web/lib/ai/runtime-instructions/goal-query-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-query-service.ts
@@ -1,0 +1,263 @@
+import type {
+  AgentGoalRun,
+  DeliveryState,
+  GoalEvidence,
+  PersistedAgentGoal,
+  RuntimeClockPort,
+  RuntimeInstruction,
+  RuntimeInstructionDelivery,
+  RuntimeInstructionKind,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+const MAX_VISIBLE_EVIDENCE = 100;
+
+export interface AgentGoalProgressView {
+  completedCriteria: number;
+  totalCriteria: number;
+  turnsUsed: number;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+  lastReason?: string;
+  lastEvidenceAt?: string;
+}
+
+/** Safe delivery projection used by the Goal API and UI. */
+export interface AgentGoalDeliveryView {
+  instructionId: string;
+  sequence: number;
+  kind: RuntimeInstructionKind;
+  goalRevision?: number;
+  state: DeliveryState;
+  attempt: number;
+  issuedAt: string;
+  updatedAt: string;
+  errorCode?: string;
+}
+
+export interface AgentGoalSummaryView {
+  goal: PersistedAgentGoal;
+  latestRun: AgentGoalRun | null;
+  latestDelivery: AgentGoalDeliveryView | null;
+  progress: AgentGoalProgressView;
+}
+
+export interface AgentGoalDetailView extends AgentGoalSummaryView {
+  evidence: GoalEvidence[];
+}
+
+export interface AgentGoalReadSource {
+  listGoals(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<PersistedAgentGoal[]>;
+  getGoal(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalId: string,
+  ): Promise<PersistedAgentGoal | null>;
+  listRuns(ownerId: string, runtimeSessionId: string): Promise<AgentGoalRun[]>;
+  listInstructions(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeInstruction[]>;
+  listDeliveries(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeInstructionDelivery[]>;
+  listEvidence(
+    ownerId: string,
+    runtimeSessionId: string,
+    goalRunId: string,
+    limit: number,
+  ): Promise<GoalEvidence[]>;
+}
+
+/** Owner-scoped read model shared by the HTTP API and the upcoming Goal UI. */
+export class AgentGoalQueryService {
+  constructor(
+    private readonly source: AgentGoalReadSource,
+    private readonly clock: RuntimeClockPort = { now: () => new Date() },
+  ) {}
+
+  async listBySession(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<AgentGoalSummaryView[]> {
+    const [goals, runs, instructions, deliveries] = await Promise.all([
+      this.source.listGoals(ownerId, runtimeSessionId),
+      this.source.listRuns(ownerId, runtimeSessionId),
+      this.source.listInstructions(ownerId, runtimeSessionId),
+      this.source.listDeliveries(ownerId, runtimeSessionId),
+    ]);
+    const deliveryIndex = indexLatestDeliveries(instructions, deliveries);
+    const now = this.clock.now();
+    return goals.map((goal) =>
+      summaryFor(
+        goal,
+        latestRunForGoal(runs, goal.goal.id),
+        deliveryIndex.get(goal.goal.id) ?? null,
+        [],
+        now,
+      ),
+    );
+  }
+
+  async getById(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    goalId: string;
+  }): Promise<AgentGoalDetailView | null> {
+    const goal = await this.source.getGoal(
+      input.ownerId,
+      input.runtimeSessionId,
+      input.goalId,
+    );
+    if (!goal) return null;
+
+    const [runs, instructions, deliveries] = await Promise.all([
+      this.source.listRuns(input.ownerId, input.runtimeSessionId),
+      this.source.listInstructions(input.ownerId, input.runtimeSessionId),
+      this.source.listDeliveries(input.ownerId, input.runtimeSessionId),
+    ]);
+
+    const latestRun = latestRunForGoal(runs, goal.goal.id);
+    const evidence = latestRun
+      ? await this.source.listEvidence(
+          input.ownerId,
+          input.runtimeSessionId,
+          latestRun.id,
+          MAX_VISIBLE_EVIDENCE,
+        )
+      : [];
+    return {
+      ...summaryFor(
+        goal,
+        latestRun,
+        indexLatestDeliveries(instructions, deliveries).get(goal.goal.id) ??
+          null,
+        evidence,
+        this.clock.now(),
+      ),
+      evidence: evidence.map((item) => structuredClone(item)),
+    };
+  }
+}
+
+function indexLatestDeliveries(
+  instructions: readonly RuntimeInstruction[],
+  deliveries: readonly RuntimeInstructionDelivery[],
+): Map<string, AgentGoalDeliveryView> {
+  const latestAttemptByInstruction = new Map<
+    string,
+    RuntimeInstructionDelivery
+  >();
+  for (const delivery of deliveries) {
+    const current = latestAttemptByInstruction.get(delivery.instructionId);
+    if (
+      !current ||
+      delivery.attempt > current.attempt ||
+      (delivery.attempt === current.attempt &&
+        delivery.updatedAt > current.updatedAt)
+    ) {
+      latestAttemptByInstruction.set(delivery.instructionId, delivery);
+    }
+  }
+
+  const result = new Map<string, AgentGoalDeliveryView>();
+  for (const instruction of instructions) {
+    if (instruction.goalId === undefined) continue;
+    const current = result.get(instruction.goalId);
+    if (current && current.sequence >= instruction.sequence) continue;
+    const delivery = latestAttemptByInstruction.get(instruction.id);
+    if (!delivery) continue;
+    result.set(instruction.goalId, {
+      instructionId: instruction.id,
+      sequence: instruction.sequence,
+      kind: instruction.kind,
+      ...(instruction.goalRevision === undefined
+        ? {}
+        : { goalRevision: instruction.goalRevision }),
+      state: delivery.state,
+      attempt: delivery.attempt,
+      issuedAt: instruction.issuedAt,
+      updatedAt: delivery.updatedAt,
+      ...(delivery.errorCode === undefined
+        ? {}
+        : { errorCode: delivery.errorCode }),
+    });
+  }
+  return result;
+}
+
+function latestRunForGoal(
+  runs: readonly AgentGoalRun[],
+  goalId: string,
+): AgentGoalRun | null {
+  return (
+    runs
+      .filter((run) => run.goalId === goalId)
+      .sort((left, right) => {
+        if (left.runEpoch !== right.runEpoch) {
+          return right.runEpoch - left.runEpoch;
+        }
+        const started = right.startedAt.localeCompare(left.startedAt);
+        return started === 0 ? right.id.localeCompare(left.id) : started;
+      })[0] ?? null
+  );
+}
+
+function summaryFor(
+  persistedGoal: PersistedAgentGoal,
+  latestRun: AgentGoalRun | null,
+  latestDelivery: AgentGoalDeliveryView | null,
+  evidence: readonly GoalEvidence[],
+  now: Date,
+): AgentGoalSummaryView {
+  const goal = structuredClone(persistedGoal);
+  const run = latestRun ? structuredClone(latestRun) : null;
+  const satisfied = new Set(run?.lastEvaluation?.satisfiedCriteria ?? []);
+  const completedCriteria = goal.goal.successCriteria.filter((criterion) =>
+    satisfied.has(criterion.id),
+  ).length;
+  const lastEvidenceAt = evidence
+    .map((item) => item.observedAt)
+    .sort((left, right) => right.localeCompare(left))[0];
+
+  return {
+    goal,
+    latestRun: run,
+    latestDelivery: latestDelivery ? structuredClone(latestDelivery) : null,
+    progress: {
+      completedCriteria,
+      totalCriteria: goal.goal.successCriteria.length,
+      turnsUsed: run?.turnsUsed ?? 0,
+      tokensUsed: run?.tokensUsed ?? 0,
+      timeUsedSeconds: run ? elapsedSeconds(run, now) : 0,
+      ...(run?.lastEvaluation?.reason === undefined
+        ? {}
+        : { lastReason: run.lastEvaluation.reason }),
+      ...(lastEvidenceAt === undefined ? {} : { lastEvidenceAt }),
+    },
+  };
+}
+
+function elapsedSeconds(run: AgentGoalRun, now: Date): number {
+  const start = Date.parse(run.startedAt);
+  const terminal = isTerminalRunStatus(run.status);
+  const end = Date.parse(
+    run.completedAt ?? (terminal ? run.lastActivityAt : now.toISOString()),
+  );
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return 0;
+  }
+  return Math.floor((end - start) / 1_000);
+}
+
+function isTerminalRunStatus(status: AgentGoalRun["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "cancelled" ||
+    status === "budget_limited" ||
+    status === "failed"
+  );
+}

--- a/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
@@ -134,6 +134,22 @@ export class InMemoryAgentGoalState
     return goal?.goal.status === "active" ? clone(goal) : null;
   }
 
+  async listGoals(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<PersistedAgentGoal[]> {
+    const scope = validatedScope(ownerId, runtimeSessionId);
+    const goals = this.sessions.get(scope.key)?.goals.values() ?? [];
+    return [...goals]
+      .sort((left, right) => {
+        const updated = right.goal.updatedAt.localeCompare(left.goal.updatedAt);
+        return updated === 0
+          ? right.goal.id.localeCompare(left.goal.id)
+          : updated;
+      })
+      .map((goal) => clone(goal));
+  }
+
   async findCommitByIdempotency(input: {
     ownerId: string;
     runtimeSessionId: string;

--- a/apps/web/lib/ai/runtime-instructions/runtime.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime.ts
@@ -9,6 +9,10 @@ import {
   GoalEvaluator,
   type GoalSemanticEvaluatorPort,
 } from "./goal-evaluator";
+import {
+  AgentGoalQueryService,
+  type AgentGoalReadSource,
+} from "./goal-query-service";
 import { GoalLifecycleService } from "./goal-lifecycle-service";
 import { GoalReplacementCoordinator } from "./goal-replacement-coordinator";
 import { InMemoryAgentGoalState } from "./in-memory-goal-state";
@@ -26,6 +30,7 @@ export interface InMemoryAgentGoalRuntime {
   readonly controller: GoalController;
   readonly goals: GoalService;
   readonly replacements: GoalReplacementCoordinator;
+  readonly queries: AgentGoalQueryService;
 }
 
 export interface AgentGoalRuntime {
@@ -34,6 +39,7 @@ export interface AgentGoalRuntime {
   readonly controller: GoalController;
   readonly observations: RuntimeProviderObservationPort;
   readonly replacements: GoalReplacementCoordinator;
+  readonly queries: AgentGoalQueryService;
 }
 
 export function createInMemoryAgentGoalRuntime(
@@ -57,6 +63,10 @@ export function createInMemoryAgentGoalRuntime(
     state,
     clock,
     observationIdGenerator,
+  );
+  const queries = new AgentGoalQueryService(
+    inMemoryGoalReadSource(state, observations),
+    clock,
   );
   const dispatcher = new RuntimeInstructionDispatcher(
     sessions,
@@ -104,10 +114,37 @@ export function createInMemoryAgentGoalRuntime(
     controller,
     goals,
     replacements,
+    queries,
   };
 }
 
-let agentGoalRuntime: InMemoryAgentGoalRuntime | undefined;
+function inMemoryGoalReadSource(
+  state: InMemoryAgentGoalState,
+  observations: InMemoryRuntimeObservationJournal,
+): AgentGoalReadSource {
+  return {
+    listGoals: (ownerId, runtimeSessionId) =>
+      state.listGoals(ownerId, runtimeSessionId),
+    getGoal: async (ownerId, runtimeSessionId, goalId) => {
+      const goal = await state.getGoal(ownerId, goalId);
+      return goal?.runtimeSessionId === runtimeSessionId ? goal : null;
+    },
+    listRuns: (ownerId, runtimeSessionId) =>
+      observations.listGoalRuns(ownerId, runtimeSessionId),
+    listInstructions: (ownerId, runtimeSessionId) =>
+      state.listInstructions(ownerId, runtimeSessionId),
+    listDeliveries: (ownerId, runtimeSessionId) =>
+      observations.listDeliveries(ownerId, runtimeSessionId),
+    listEvidence: async (ownerId, runtimeSessionId, goalRunId, limit) =>
+      (await observations.listEvidence(ownerId, runtimeSessionId))
+        .filter((evidence) => evidence.goalRunId === goalRunId)
+        .slice(-limit),
+  };
+}
+
+type AgentGoalRuntimeGlobal = typeof globalThis & {
+  __openLoomiAgentGoalRuntimeV1?: InMemoryAgentGoalRuntime;
+};
 
 /**
  * Process-local composition root used by Claude sessions and future Goal
@@ -115,8 +152,10 @@ let agentGoalRuntime: InMemoryAgentGoalRuntime | undefined;
  * without changing callers.
  */
 export function getAgentGoalRuntime(): AgentGoalRuntime {
-  agentGoalRuntime ??= createInMemoryAgentGoalRuntime({
-    semanticEvaluator: new OpenLoomiGoalSemanticEvaluator(),
-  });
-  return agentGoalRuntime;
+  const processGlobal = globalThis as AgentGoalRuntimeGlobal;
+  processGlobal.__openLoomiAgentGoalRuntimeV1 ??=
+    createInMemoryAgentGoalRuntime({
+      semanticEvaluator: new OpenLoomiGoalSemanticEvaluator(),
+    });
+  return processGlobal.__openLoomiAgentGoalRuntimeV1;
 }

--- a/apps/web/tests/api/agent-goals.route.test.ts
+++ b/apps/web/tests/api/agent-goals.route.test.ts
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AgentGoalStateError } from "@/lib/ai/runtime-instructions/goal-state-error";
+import {
+  AgentGoalApiService,
+  type AgentGoalApiDependencies,
+} from "@/lib/ai/runtime-instructions/api/service";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  user: { id: "user-a" } as object | null,
+}));
+const modeState = vi.hoisted(() => ({ tauri: true }));
+const apiState = vi.hoisted(() => ({
+  service: undefined as unknown as AgentGoalApiService,
+}));
+
+vi.mock("@/lib/auth/dual-auth", () => ({
+  getAuthUser: vi.fn(async () => authState.user),
+}));
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: vi.fn(() => modeState.tauri),
+}));
+vi.mock("@/lib/ai/runtime-instructions/api/server", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/ai/runtime-instructions/api/server")
+  >()),
+  getAgentGoalApiService: () => apiState.service,
+}));
+
+const goalId = "10000000-0000-4000-8000-000000000001";
+const runId = "10000000-0000-4000-8000-000000000002";
+const instructionId = "10000000-0000-4000-8000-000000000003";
+const runtimeSessionId = "runtime-session-a";
+const now = "2026-08-06T08:00:00.000Z";
+
+const persistedGoal = {
+  ownerId: "user-a",
+  runtimeSessionId,
+  slot: "primary" as const,
+  goal: {
+    id: goalId,
+    revision: 1,
+    objective: "Complete the frontend",
+    successCriteria: [
+      {
+        id: "build",
+        description: "The production build succeeds",
+        verification: { type: "model_evidence" as const },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 50,
+    status: "active" as const,
+    maxTurns: 20,
+    completionPolicy: "model_evaluator" as const,
+    source: { type: "user" as const },
+    createdAt: now,
+    updatedAt: now,
+  },
+};
+
+const acceptedCommand = {
+  goal: persistedGoal,
+  instruction: {
+    schemaVersion: "2" as const,
+    id: instructionId,
+    sequence: 1,
+    goalId,
+    goalRevision: 1,
+    kind: "goal.activate" as const,
+    deliveryMode: "steer" as const,
+    targetSessionId: runtimeSessionId,
+    payload: { goal: persistedGoal.goal },
+    source: { type: "user" as const, authority: "user" as const },
+    idempotencyKey: "request-1",
+    issuedAt: now,
+  },
+  deduplicated: false,
+  dispatch: {
+    status: "accepted" as const,
+    instructionId,
+    receipt: {
+      instructionId,
+      runtimeSessionId,
+      state: "queued" as const,
+      recordedAt: now,
+    },
+  },
+};
+
+const goalRun = {
+  id: runId,
+  ownerId: "user-a",
+  goalId,
+  goalRevision: 1,
+  runtimeSessionId,
+  providerSessionId: "private-claude-session",
+  runEpoch: 0,
+  status: "running" as const,
+  turnsUsed: 1,
+  tokensUsed: 42,
+  startedAt: now,
+  lastActivityAt: now,
+  lastEvaluation: {
+    completed: false,
+    confidence: 0.8,
+    satisfiedCriteria: [],
+    missingCriteria: ["build"],
+    evidence: [],
+    reason: "The build still needs to run",
+    nextInstruction: "private continuation prompt",
+  },
+};
+
+const goalEvidence = {
+  id: "10000000-0000-4000-8000-000000000004",
+  goalId,
+  goalRunId: runId,
+  goalRevision: 1,
+  instructionId,
+  type: "tool_result" as const,
+  sourceEventId: "tool-event-1",
+  summary: "The production build succeeded",
+  success: true,
+  payload: { privateOutput: "not for the UI" },
+  observedAt: now,
+};
+
+const dependencies = {
+  goals: {
+    activate: vi.fn(),
+    update: vi.fn(),
+    upsertContext: vi.fn(),
+    removeContext: vi.fn(),
+  },
+  queries: { listBySession: vi.fn(), getById: vi.fn() },
+  liveSessions: { resolve: vi.fn() },
+  sessionOwnership: { isOwnedChat: vi.fn() },
+} satisfies AgentGoalApiDependencies;
+
+const goalInput = {
+  objective: "Complete the frontend",
+  successCriteria: persistedGoal.goal.successCriteria,
+  constraints: [
+    {
+      id: "privacy",
+      description: "Keep the change privacy preserving",
+    },
+  ],
+  priority: 50,
+  maxTurns: 20,
+  completionPolicy: "model_evaluator",
+};
+
+const collectionRoute = await import("@/app/api/agent-goals/route");
+const goalRoute = await import("@/app/api/agent-goals/[goalId]/route");
+const contextRoute =
+  await import("@/app/api/agent-goals/[goalId]/context/route");
+
+beforeEach(() => {
+  authState.user = { id: "user-a" };
+  modeState.tauri = true;
+  for (const mock of [
+    ...Object.values(dependencies.goals),
+    ...Object.values(dependencies.queries),
+    dependencies.liveSessions.resolve,
+    dependencies.sessionOwnership.isOwnedChat,
+  ]) {
+    mock.mockReset();
+  }
+  dependencies.sessionOwnership.isOwnedChat.mockResolvedValue(true);
+  dependencies.liveSessions.resolve.mockResolvedValue({});
+  dependencies.goals.activate.mockResolvedValue(acceptedCommand);
+  dependencies.goals.update.mockResolvedValue(acceptedCommand);
+  dependencies.goals.upsertContext.mockResolvedValue(acceptedCommand);
+  dependencies.goals.removeContext.mockResolvedValue(acceptedCommand);
+  dependencies.queries.listBySession.mockResolvedValue([]);
+  dependencies.queries.getById.mockResolvedValue(null);
+  apiState.service = new AgentGoalApiService(dependencies);
+});
+
+describe("Agent Goal API", () => {
+  test("fails closed before reading Goal state", async () => {
+    authState.user = null;
+    const unauthorized = await collectionRoute.GET(
+      request("GET", `/api/agent-goals?runtimeSessionId=${runtimeSessionId}`),
+    );
+    authState.user = { id: "user-a" };
+    modeState.tauri = false;
+    const unavailable = await collectionRoute.POST(
+      request("POST", "/api/agent-goals", {
+        runtimeSessionId,
+        goal: goalInput,
+      }),
+    );
+
+    expect(unauthorized.status).toBe(401);
+    expect(unavailable.status).toBe(503);
+    expect(dependencies.sessionOwnership.isOwnedChat).not.toHaveBeenCalled();
+    expect(dependencies.goals.activate).not.toHaveBeenCalled();
+  });
+
+  test("does not reveal missing or foreign Chats", async () => {
+    dependencies.sessionOwnership.isOwnedChat.mockResolvedValue(false);
+    const response = await goalRoute.GET(
+      request(
+        "GET",
+        `/api/agent-goals/${goalId}?runtimeSessionId=${runtimeSessionId}`,
+      ),
+      goalContext(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      code: "runtime_session_not_found",
+    });
+    expect(dependencies.queries.getById).not.toHaveBeenCalled();
+  });
+
+  test("returns UI read models without runtime-private fields", async () => {
+    const summary = {
+      goal: persistedGoal,
+      latestRun: goalRun,
+      latestDelivery: {
+        instructionId,
+        sequence: 1,
+        kind: "goal.activate" as const,
+        goalRevision: 1,
+        state: "observed" as const,
+        attempt: 1,
+        issuedAt: now,
+        updatedAt: now,
+      },
+      progress: {
+        completedCriteria: 0,
+        totalCriteria: 1,
+        turnsUsed: 1,
+        tokensUsed: 42,
+        timeUsedSeconds: 0,
+      },
+    };
+    dependencies.queries.listBySession.mockResolvedValue([summary]);
+    dependencies.queries.getById.mockResolvedValue({
+      ...summary,
+      evidence: [goalEvidence],
+    });
+
+    const collection = await collectionRoute.GET(
+      request("GET", `/api/agent-goals?runtimeSessionId=${runtimeSessionId}`),
+    );
+    const detail = await goalRoute.GET(
+      request(
+        "GET",
+        `/api/agent-goals/${goalId}?runtimeSessionId=${runtimeSessionId}`,
+      ),
+      goalContext(),
+    );
+    const collectionBody = await collection.json();
+    const detailBody = await detail.json();
+
+    expect(collection.status).toBe(200);
+    expect(collection.headers.get("cache-control")).toBe("no-store");
+    expect(collectionBody).toMatchObject({ activeGoalId: goalId, live: true });
+    expect(detailBody.goal.ownerId).toBeUndefined();
+    expect(detailBody.latestRun.ownerId).toBeUndefined();
+    expect(detailBody.latestRun.providerSessionId).toBeUndefined();
+    expect(detailBody.latestRun.lastEvaluation.nextInstruction).toBeUndefined();
+    expect(detailBody.evidence[0].payload).toBeUndefined();
+  });
+
+  test("activates with server-owned provenance and strict input", async () => {
+    const accepted = await collectionRoute.POST(
+      request("POST", "/api/agent-goals", {
+        runtimeSessionId,
+        goal: goalInput,
+      }),
+    );
+    const spoofed = await collectionRoute.POST(
+      request("POST", "/api/agent-goals", {
+        runtimeSessionId,
+        ownerId: "other-user",
+        goal: { ...goalInput, allowedTools: ["shell"] },
+      }),
+    );
+    const missingKey = await collectionRoute.POST(
+      request(
+        "POST",
+        "/api/agent-goals",
+        { runtimeSessionId, goal: goalInput },
+        false,
+      ),
+    );
+
+    expect(accepted.status).toBe(201);
+    expect(spoofed.status).toBe(400);
+    expect(missingKey.status).toBe(400);
+    expect(dependencies.goals.activate).toHaveBeenCalledTimes(1);
+    expect(dependencies.goals.activate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerId: "user-a",
+        idempotencyKey: "request-1",
+        source: { type: "user", authority: "user" },
+        goal: expect.objectContaining({
+          contextRefs: [],
+          source: { type: "user" },
+          constraints: [
+            expect.objectContaining({
+              id: "privacy",
+              enforcement: "model_guidance",
+              authority: "user",
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  test("uses idempotent status codes and hides transport errors", async () => {
+    dependencies.goals.activate.mockResolvedValueOnce({
+      ...acceptedCommand,
+      deduplicated: true,
+    });
+    const retry = await collectionRoute.POST(
+      request("POST", "/api/agent-goals", {
+        runtimeSessionId,
+        goal: goalInput,
+      }),
+    );
+    dependencies.goals.activate.mockResolvedValueOnce({
+      ...acceptedCommand,
+      dispatch: {
+        status: "transport_failed",
+        runtimeSessionId,
+        instructionId,
+        error: new Error("private runtime path"),
+      },
+    });
+    const deferred = await collectionRoute.POST(
+      request("POST", "/api/agent-goals", {
+        runtimeSessionId,
+        goal: goalInput,
+      }),
+    );
+    const deferredBody = await deferred.json();
+
+    expect(retry.status).toBe(200);
+    expect(deferred.status).toBe(202);
+    expect(deferredBody.dispatch).toEqual({
+      status: "transport_failed",
+      runtimeSessionId,
+      instructionId,
+      code: "transport_failed",
+    });
+    expect(JSON.stringify(deferredBody)).not.toContain("private runtime path");
+  });
+
+  test("forces user authority on updates and maps revision conflicts", async () => {
+    const update = {
+      runtimeSessionId,
+      expectedRevision: 1,
+      update: {
+        constraints: [
+          { id: "privacy", description: "Do not retain customer data" },
+        ],
+      },
+    };
+    const accepted = await goalRoute.PATCH(
+      request("PATCH", `/api/agent-goals/${goalId}`, update),
+      goalContext(),
+    );
+    dependencies.goals.update.mockRejectedValueOnce(
+      new AgentGoalStateError("revision_conflict", "conflicting revision"),
+    );
+    const conflict = await goalRoute.PATCH(
+      request("PATCH", `/api/agent-goals/${goalId}`, update),
+      goalContext(),
+    );
+
+    expect(accepted.status).toBe(200);
+    expect(conflict.status).toBe(409);
+    expect(dependencies.goals.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          constraints: [
+            expect.objectContaining({
+              enforcement: "model_guidance",
+              authority: "user",
+            }),
+          ],
+        },
+      }),
+    );
+  });
+
+  test("routes context changes with user provenance", async () => {
+    const upsert = await contextRoute.PUT(
+      request("PUT", `/api/agent-goals/${goalId}/context`, {
+        runtimeSessionId,
+        expectedRevision: 1,
+        contextRef: {
+          id: "requirements",
+          kind: "document",
+          refId: "document-1",
+          summary: "Frontend requirements",
+        },
+      }),
+      goalContext(),
+    );
+    const removal = await contextRoute.DELETE(
+      request("DELETE", `/api/agent-goals/${goalId}/context`, {
+        runtimeSessionId,
+        expectedRevision: 2,
+        contextRefId: "requirements",
+      }),
+      goalContext(),
+    );
+
+    expect(upsert.status).toBe(200);
+    expect(removal.status).toBe(200);
+    expect(dependencies.goals.upsertContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextRef: expect.objectContaining({ origin: "user" }),
+        source: { type: "user", authority: "user" },
+      }),
+    );
+    expect(dependencies.goals.removeContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextRefId: "requirements",
+        source: { type: "user", authority: "user" },
+      }),
+    );
+  });
+});
+
+function request(
+  method: string,
+  path: string,
+  body?: unknown,
+  withIdempotencyKey = true,
+) {
+  const headers = new Headers();
+  if (body !== undefined) headers.set("content-type", "application/json");
+  if (withIdempotencyKey) headers.set("idempotency-key", "request-1");
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function goalContext() {
+  return { params: Promise.resolve({ goalId }) };
+}

--- a/apps/web/tests/unit/runtime-instructions/goal-query-service.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-query-service.test.ts
@@ -1,0 +1,159 @@
+import type {
+  AgentGoalRun,
+  GoalEvidence,
+  PersistedAgentGoal,
+  RuntimeInstruction,
+  RuntimeInstructionDelivery,
+} from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AgentGoalQueryService,
+  type AgentGoalReadSource,
+} from "@/lib/ai/runtime-instructions/goal-query-service";
+
+const ownerId = "query-owner";
+const runtimeSessionId = "query-session";
+const goalId = "10000000-0000-4000-8000-000000000001";
+const runId = "10000000-0000-4000-8000-000000000002";
+const instructionId = "10000000-0000-4000-8000-000000000003";
+const startedAt = "2026-08-06T08:00:00.000Z";
+
+const goal: PersistedAgentGoal = {
+  ownerId,
+  runtimeSessionId,
+  slot: "primary",
+  goal: {
+    id: goalId,
+    revision: 2,
+    objective: "Expose Goal progress to the UI",
+    successCriteria: [
+      {
+        id: "api-ready",
+        description: "The Goal API is ready",
+        verification: { type: "model_evidence" },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 50,
+    status: "active",
+    completionPolicy: "model_evaluator",
+    source: { type: "user" },
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  },
+};
+
+const run: AgentGoalRun = {
+  id: runId,
+  ownerId,
+  goalId,
+  goalRevision: 2,
+  runtimeSessionId,
+  runEpoch: 0,
+  status: "running",
+  turnsUsed: 2,
+  tokensUsed: 30,
+  startedAt,
+  lastActivityAt: startedAt,
+  lastEvaluation: {
+    completed: false,
+    confidence: 0.8,
+    satisfiedCriteria: ["api-ready"],
+    missingCriteria: [],
+    evidence: [],
+    reason: "The API is ready for review",
+  },
+};
+
+const instruction: RuntimeInstruction = {
+  schemaVersion: "2",
+  id: instructionId,
+  sequence: 2,
+  goalId,
+  goalRevision: 2,
+  kind: "goal.update",
+  deliveryMode: "steer",
+  targetSessionId: runtimeSessionId,
+  payload: { goal: goal.goal, previousRevision: 1 },
+  source: { type: "user", authority: "user" },
+  idempotencyKey: "query-update",
+  issuedAt: startedAt,
+};
+
+const delivery: RuntimeInstructionDelivery = {
+  id: "10000000-0000-4000-8000-000000000004",
+  ownerId,
+  runtimeSessionId,
+  instructionId,
+  goalRunId: runId,
+  state: "observed",
+  attempt: 1,
+  createdAt: startedAt,
+  updatedAt: startedAt,
+};
+
+const evidence: GoalEvidence = {
+  id: "10000000-0000-4000-8000-000000000005",
+  goalId,
+  goalRunId: runId,
+  goalRevision: 2,
+  instructionId,
+  type: "agent_report",
+  sourceEventId: "assistant-1",
+  summary: "The API is ready",
+  payload: {},
+  observedAt: startedAt,
+};
+
+describe("AgentGoalQueryService", () => {
+  it("builds the owner-scoped UI summary and bounded detail view", async () => {
+    const source = {
+      listGoals: vi.fn(async () => [goal]),
+      getGoal: vi.fn(async () => goal),
+      listRuns: vi.fn(async () => [run]),
+      listInstructions: vi.fn(async () => [instruction]),
+      listDeliveries: vi.fn(async () => [delivery]),
+      listEvidence: vi.fn(async () => [evidence]),
+    } satisfies AgentGoalReadSource;
+    const service = new AgentGoalQueryService(source, {
+      now: () => new Date("2026-08-06T08:00:10.000Z"),
+    });
+
+    const [summary] = await service.listBySession(ownerId, runtimeSessionId);
+    const detail = await service.getById({
+      ownerId,
+      runtimeSessionId,
+      goalId,
+    });
+
+    expect(summary).toMatchObject({
+      latestRun: { id: runId },
+      latestDelivery: { instructionId, kind: "goal.update", state: "observed" },
+      progress: {
+        completedCriteria: 1,
+        totalCriteria: 1,
+        turnsUsed: 2,
+        tokensUsed: 30,
+        timeUsedSeconds: 10,
+      },
+    });
+    expect(detail).toMatchObject({
+      evidence: [{ id: evidence.id, sourceEventId: "assistant-1" }],
+      progress: { lastEvidenceAt: startedAt },
+    });
+    expect(source.getGoal).toHaveBeenCalledWith(
+      ownerId,
+      runtimeSessionId,
+      goalId,
+    );
+    expect(source.listEvidence).toHaveBeenCalledWith(
+      ownerId,
+      runtimeSessionId,
+      runId,
+      100,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add an authenticated API layer for the Claude-first Goal Runtime, providing the backend contract required by the upcoming Goal UI.

Related to #176.

## What Changed

### Goal API

- `GET /api/agent-goals`
  - List Goals associated with a Runtime Session.
  - Return the latest execution state for each Goal.

- `POST /api/agent-goals`
  - Activate a new primary Goal.
  - Require an idempotency key to prevent duplicate commands.

- `GET /api/agent-goals/[goalId]`
  - Retrieve a Goal and its current execution details.
  - Include the latest Run, Delivery, progress, and bounded Evidence.

- `PATCH /api/agent-goals/[goalId]`
  - Update a Goal using revision-based compare-and-set semantics.
  - Reject stale revisions instead of overwriting newer state.

- `PUT /api/agent-goals/[goalId]/context`
  - Add or update trusted user context and untrusted external context.
  - Require the expected Goal revision.

- `DELETE /api/agent-goals/[goalId]/context`
  - Remove Goal context using the expected Goal revision.

### Authentication and Validation

- Require authentication and verify ownership of the Chat associated with the Runtime Session.
- Add strict validation for Goal definitions, revisions, context, constraints, and idempotency keys.
- Prevent callers from modifying tool permissions, approval policies, runtime authority, and other security-sensitive settings.
- Redact internal owner IDs, Claude provider session IDs, evaluator prompts, raw evidence payloads, and transport errors.

### Runtime Integration

- Add a UI-facing query model for Goal state, Runs, Deliveries, progress, and Evidence.
- Share one process-level Goal Runtime between Claude sessions and API route handlers.
- Add focused tests for authentication, ownership, validation, mutations, context operations, and response projection.

## Current Status

The Goal Runtime protocol, Claude integration, lifecycle handling, automatic evaluation, and SQLite persistence components are already available.

This PR adds the authenticated API surface. The default Runtime currently uses the shared process-local composition; connecting the existing SQLite components remains a follow-up step.

## Next Steps

- Switch the default Goal Runtime to SQLite.
- Add the Goal UI for creation, status, progress, Delivery, and Evidence.
- Add restart recovery and pending instruction replay.

## Validation

- 18 test files passed
- 102 tests passed
- TypeScript check passed
- Lint passed
- Format check passed
- `git diff --check` passed