### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "name": "openloomi",
       "source": "./plugins/claude",
       "description": "Connect Claude Code to your local OpenLoomi runtime. Sync ANTHROPIC_API_KEY, mirror lifecycle onto the Loomi Pet, auto-archive Stop events into OpenLoomi memory.",
-      "version": "0.8.8",
+      "version": "0.9.0",
       "author": {
         "name": "OpenLoomi"
       },

--- a/apps/marketing/content/plugins/claude.mdx
+++ b/apps/marketing/content/plugins/claude.mdx
@@ -111,7 +111,7 @@ The wizard auto-chains install → launch → wait API → guest login. When it 
 | ------------------ | ---------- |
 | Guest login        | Successful |
 | Runtime mode       | packaged   |
-| Version            | 0.8.8      |
+| Version            | 0.9.0      |
 | Local API          | Reachable  |
 | AI provider        | Configured |
 | Execution provider | Ready      |
@@ -244,11 +244,11 @@ The Loop ships with these decision types out of the box:
 | `EMAIL_REPLY`           | Pre-draft an outbound email                 | "Sarah needs the Q3 OKR draft status by Friday"                                       |
 | `LINEAR_REVIEW`         | Triage a Linear issue assigned to you       | "LIN-1234 (pet bubble drag-and-drop) is in In Review with you assigned"               |
 | `REQUIREMENT_SYNTHESIS` | Cluster PRs/issues into a requirements doc  | "14 PRs/issues tagged loop/v0.9 — needs a single requirements doc"                    |
-| `RELEASE_PLAN`          | Draft a release plan from merged PRs        | "12 PRs merged since v0.8.8 — time to draft the v0.8.8 release plan"                  |
+| `RELEASE_PLAN`          | Draft a release plan from merged PRs        | "12 PRs merged since v0.9.0 — time to draft the v0.9.0 release plan"                  |
 | `CONTACT_UPDATE`        | Update a contact record when memory drifts  | "Sarah's signature says 'Head of Product' — memory still says PM"                     |
-| `DOC_UPDATE`            | Refresh a stale doc for the next version    | "docs/getting-started.md is stale (42 days, pre-v0.8.8)"                              |
+| `DOC_UPDATE`            | Refresh a stale doc for the next version    | "docs/getting-started.md is stale (42 days, pre-v0.9.0)"                              |
 | `REVIEW_PR`             | Surface a PR waiting on your review         | "PR #220 (lifestyle image prompts) is waiting on your review"                         |
-| `DEADLINE_REMINDER`     | Surface an upcoming due date                | "v0.8.8 release plan due Friday — 3 PRs blocking the cut"                             |
+| `DEADLINE_REMINDER`     | Surface an upcoming due date                | "v0.9.0 release plan due Friday — 3 PRs blocking the cut"                             |
 | `TODO`                  | Add a follow-up to your todo list           | "Bug: historical self-owned calendar events surface as fake RSVP decisions"           |
 | `DIGEST` (QUIET)        | Consolidate a flood of low-priority signals | "8 GitHub notifications — none urgent individually, but here's the consolidated view" |
 
@@ -262,7 +262,7 @@ A few examples in detail:
 
 ![Loop card — REQUIREMENT_SYNTHESIS for 14 PRs/issues tagged loop/v0.9](/img/openloomi/plugins/claude/18-loop-requirement-synthesis.png)
 
-![Loop card — RELEASE_PLAN for v0.8.8 "classifier-rules UX + custom channels"](/img/openloomi/plugins/claude/19-loop-release-plan.png)
+![Loop card — RELEASE_PLAN for v0.9.0 "classifier-rules UX + custom channels"](/img/openloomi/plugins/claude/19-loop-release-plan.png)
 
 ![Loop card — CONTACT_UPDATE for Sarah Chen's new "Head of Product" role](/img/openloomi/plugins/claude/20-loop-contact-update.png)
 

--- a/apps/marketing/content/plugins/codex.mdx
+++ b/apps/marketing/content/plugins/codex.mdx
@@ -102,7 +102,7 @@ The install skill auto-chains install → launch → wait API → guest login. W
 | ------------------ | ---------- |
 | Guest login        | Successful |
 | Runtime mode       | packaged   |
-| Version            | 0.8.8      |
+| Version            | 0.9.0      |
 | Local API          | Reachable  |
 | AI provider        | Configured |
 | Execution provider | Ready      |
@@ -235,11 +235,11 @@ The Loop ships with these decision types out of the box:
 | `EMAIL_REPLY`           | Pre-draft an outbound email                 | "Sarah needs the Q3 OKR draft status by Friday"                                       |
 | `LINEAR_REVIEW`         | Triage a Linear issue assigned to you       | "LIN-1234 (pet bubble drag-and-drop) is in In Review with you assigned"               |
 | `REQUIREMENT_SYNTHESIS` | Cluster PRs/issues into a requirements doc  | "14 PRs/issues tagged loop/v0.9 — needs a single requirements doc"                    |
-| `RELEASE_PLAN`          | Draft a release plan from merged PRs        | "12 PRs merged since v0.8.8 — time to draft the v0.8.8 release plan"                  |
+| `RELEASE_PLAN`          | Draft a release plan from merged PRs        | "12 PRs merged since v0.9.0 — time to draft the v0.9.0 release plan"                  |
 | `CONTACT_UPDATE`        | Update a contact record when memory drifts  | "Sarah's signature says 'Head of Product' — memory still says PM"                     |
-| `DOC_UPDATE`            | Refresh a stale doc for the next version    | "docs/getting-started.md is stale (42 days, pre-v0.8.8)"                              |
+| `DOC_UPDATE`            | Refresh a stale doc for the next version    | "docs/getting-started.md is stale (42 days, pre-v0.9.0)"                              |
 | `REVIEW_PR`             | Surface a PR waiting on your review         | "PR #220 (lifestyle image prompts) is waiting on your review"                         |
-| `DEADLINE_REMINDER`     | Surface an upcoming due date                | "v0.8.8 release plan due Friday — 3 PRs blocking the cut"                             |
+| `DEADLINE_REMINDER`     | Surface an upcoming due date                | "v0.9.0 release plan due Friday — 3 PRs blocking the cut"                             |
 | `TODO`                  | Add a follow-up to your todo list           | "Bug: historical self-owned calendar events surface as fake RSVP decisions"           |
 | `DIGEST` (QUIET)        | Consolidate a flood of low-priority signals | "8 GitHub notifications — none urgent individually, but here's the consolidated view" |
 
@@ -253,7 +253,7 @@ A few examples in detail:
 
 ![Loop card — REQUIREMENT_SYNTHESIS for 14 PRs/issues tagged loop/v0.9](/img/openloomi/plugins/codex/18-loop-requirement-synthesis.png)
 
-![Loop card — RELEASE_PLAN for v0.8.8 "classifier-rules UX + custom channels"](/img/openloomi/plugins/codex/19-loop-release-plan.png)
+![Loop card — RELEASE_PLAN for v0.9.0 "classifier-rules UX + custom channels"](/img/openloomi/plugins/codex/19-loop-release-plan.png)
 
 ![Loop card — CONTACT_UPDATE for Sarah Chen's new "Head of Product" role](/img/openloomi/plugins/codex/20-loop-contact-update.png)
 
@@ -365,7 +365,7 @@ The wizard returns structured JSON so Codex (or any other caller) can render eac
     "installed": true,
     "appPath": "/Applications/OpenLoomi.app",
     "appRunning": true,
-    "version": "openloomi-desktop 0.8.8",
+    "version": "openloomi-desktop 0.9.0",
     "tokenPresent": true,
     "executionProviderReady": true,
     "executionProviderSource": "native_codex_runtime",
@@ -408,7 +408,7 @@ node plugins/codex/scripts/loomi-bridge.mjs help
 ```json
 {
   "name": "openloomi-codex-bridge",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "pluginPhase": "runtime-provider-readiness",
   "commands": [
     "codex-runtime-info",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web",
-	"version": "0.8.8",
+	"version": "0.9.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openloomi"
-version = "0.8.8"
+version = "0.9.0"
 description = "openloomi AI Assistant - Your Personal Productivity Tool"
 authors = ["OpenLoomi Team"]
 edition = "2021"

--- a/apps/web/src-tauri/tauri.conf.dev.json
+++ b/apps/web/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "openloomi",
-	"version": "0.8.8",
+	"version": "0.9.0",
 	"identifier": "com.openloomi.app",
 	"build": {
 		"beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "openloomi",
-	"version": "0.8.8",
+	"version": "0.9.0",
 	"identifier": "com.openloomi.app",
 	"build": {
 		"beforeDevCommand": "node scripts/run-tauri-dev.js",

--- a/benchmark/jobbench-official/eval/README.md
+++ b/benchmark/jobbench-official/eval/README.md
@@ -21,7 +21,7 @@ the upstream JobBench judge score them.
 2. **Node.js 22+** — required by `openloomi-ctl` packaged mode.
 3. **Python 3.10+** — required by the runner and the judge.
 4. **`uv`** — the JobBench upstream uses it for Python dependency management.
-5. **OpenLoomi Desktop 0.8.8+** — install the official package and log in
+5. **OpenLoomi Desktop 0.9.0+** — install the official package and log in
    once so the auth token is created.
 6. **`openloomi-ctl.exe`** — bundled with the desktop installer. Default
    path on Windows:
@@ -169,7 +169,7 @@ Then start `pnpm tauri:dev` again.
 
 ### `failed to load saved auth token`
 
-The packaged `openloomi-ctl 0.8.8` tries to Base64-decode the saved token,
+The packaged `openloomi-ctl 0.9.0` tries to Base64-decode the saved token,
 but `~/.openloomi/token` is a plain JWT. Set `OPENLOOMI_AUTH_TOKEN` to the
 file contents to bypass the broken decoder.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openloomi-monorepo",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai/mcp/package.json
+++ b/packages/ai/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/mcp",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/ai/mcp/src/server.ts
+++ b/packages/ai/mcp/src/server.ts
@@ -12,7 +12,7 @@ import {
 import { registerOpenLoomiTools } from "./tools";
 
 const DEFAULT_SERVER_NAME = "@openloomi/mcp";
-const DEFAULT_SERVER_VERSION = "0.8.8";
+const DEFAULT_SERVER_VERSION = "0.9.0";
 
 export interface CreateOpenLoomiMcpServerOptions extends OpenLoomiClientOptions {
   name?: string;

--- a/packages/ai/memory-consolidation/package.json
+++ b/packages/ai/memory-consolidation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/memory-consolidation",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/ai",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/ai/rag/package.json
+++ b/packages/ai/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/ai-rag",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/api",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/audit",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/config",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": ["dist", "src/tsup-preset.mjs", "README.md", "LICENSE"],
   "publishConfig": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/hooks",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/i18n",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/indexeddb",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/insights",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/asana/package.json
+++ b/packages/integrations/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-asana",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/calendar/package.json
+++ b/packages/integrations/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-calendar",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/channels/package.json
+++ b/packages/integrations/channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-channels",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/composio/package.json
+++ b/packages/integrations/composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-composio",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/dingtalk/package.json
+++ b/packages/integrations/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-dingtalk",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/facebook-messenger/package.json
+++ b/packages/integrations/facebook-messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-facebook-messenger",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/feishu/package.json
+++ b/packages/integrations/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-feishu",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/gmail/package.json
+++ b/packages/integrations/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-gmail",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/google-docs/package.json
+++ b/packages/integrations/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-docs",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/google-meet/package.json
+++ b/packages/integrations/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-google-meet",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/hubspot/package.json
+++ b/packages/integrations/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-hubspot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/imessage/package.json
+++ b/packages/integrations/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-imessage",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/instagram/package.json
+++ b/packages/integrations/instagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-instagram",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/jira/package.json
+++ b/packages/integrations/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-jira",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/linkedin/package.json
+++ b/packages/integrations/linkedin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-linkedin",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/integrations/qqbot/package.json
+++ b/packages/integrations/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-qqbot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/rss/package.json
+++ b/packages/integrations/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rss",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/telegram/package.json
+++ b/packages/integrations/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-telegram",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/weixin/package.json
+++ b/packages/integrations/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-weixin",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/whatsapp/package.json
+++ b/packages/integrations/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-whatsapp",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/integrations/x/package.json
+++ b/packages/integrations/x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/integrations-x",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/rag",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/search",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/security",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/shared",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/sqlite",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/storage",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/voice-kokoro/package.json
+++ b/packages/voice-kokoro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/voice-kokoro",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/voice-whisper/package.json
+++ b/packages/voice-whisper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openloomi/voice-whisper",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openloomi",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Connect Claude Code to your local OpenLoomi runtime. One-command install, mirror Claude's lifecycle onto the Loomi Pet, and auto-archive every Stop into your OpenLoomi memory. Talks to your local OpenLoomi over HTTP and the OpenLoomi helper CLI. AI provider config is owned by OpenLoomi itself — this plugin never reads or pushes API keys.",
   "author": { "name": "OpenLoomi" },
   "homepage": "https://openloomi.ai",

--- a/plugins/claude/scripts/install-assets/setup.linux.sh
+++ b/plugins/claude/scripts/install-assets/setup.linux.sh
@@ -43,7 +43,7 @@ fi
 #   3. `OPENLOOMI_DMG` env var (legacy alias)
 #   4. `OPENLOOMI_VERSION` IF it happens to point at an existing file
 #      (back-compat with a pre-#401 side-channel convention). A literal
-#      semver like OPENLOOMI_VERSION=v0.8.8 is NOT treated as a path.
+#      semver like OPENLOOMI_VERSION=v0.9.0 is NOT treated as a path.
 OFFLINE_ARTIFACT=""
 prev=""
 for arg in "$@"; do

--- a/plugins/claude/scripts/install-assets/setup.macos.sh
+++ b/plugins/claude/scripts/install-assets/setup.macos.sh
@@ -22,7 +22,7 @@
 # Env-var contract (issue #401, restricted-network install):
 #   OPENLOOMI_REPO         Override the GitHub `owner/repo` slug.
 #                          Default: `melandlabs/openloomi`.
-#   OPENLOOMI_VERSION      Pin the release tag (e.g. `v0.8.8`). Replaces
+#   OPENLOOMI_VERSION      Pin the release tag (e.g. `v0.9.0`). Replaces
 #                          `/releases/latest` with `/releases/tags/<tag>`.
 #                          Ignored if OPENLOOMI_DMG_PATH is set.
 #   OPENLOOMI_DMG_PATH     macOS-only. Absolute path to a pre-staged .dmg
@@ -304,7 +304,7 @@ if [[ -n "${offline_dmg}" ]]; then
   cp "${offline_dmg}" "${dmg}"
   asset_url="file://${offline_dmg}"
   # Best-effort: derive tag/version from a filename like
-  # `OpenLoomi-0.8.8.dmg` (or `OpenLoomi_1.2.3-rc.1.dmg`) so downstream
+  # `OpenLoomi-0.9.0.dmg` (or `OpenLoomi_1.2.3-rc.1.dmg`) so downstream
   # consumers still see a version. Strip the `.dmg` suffix first so the
   # dot inside pre-release identifiers (e.g. `1.2.3-rc.1`) doesn't
   # terminate the match.
@@ -373,7 +373,7 @@ else
       ' || true)
 
   # Strip a leading "v" / "V" from tag_name so downstream consumers get a
-  # clean semver-ish version (e.g. "v0.8.8" → "0.8.8"). Fall back to ""
+  # clean semver-ish version (e.g. "v0.9.0" → "0.9.0"). Fall back to ""
   # if the API didn't return a tag_name.
   version=$(printf '%s' "${tag_name}" | sed -E 's/^[vV]//')
 

--- a/plugins/claude/scripts/install-assets/setup.windows.ps1
+++ b/plugins/claude/scripts/install-assets/setup.windows.ps1
@@ -37,7 +37,7 @@ if ($Token) { $ApiHeaders["Authorization"] = "Bearer $Token" }
 #   3. `OPENLOOMI_DMG` env var (legacy alias)
 #   4. `OPENLOOMI_VERSION` IF it happens to point at an existing file
 #      (back-compat with a pre-#401 side-channel convention). A literal
-#      semver like OPENLOOMI_VERSION=v0.8.8 is NOT treated as a path.
+#      semver like OPENLOOMI_VERSION=v0.9.0 is NOT treated as a path.
 $OfflineMsi = $null
 $OfflineArg = $null
 for ($i = 0; $i -lt $args.Count; $i++) {

--- a/plugins/claude/scripts/loomi-bridge.mjs
+++ b/plugins/claude/scripts/loomi-bridge.mjs
@@ -1628,8 +1628,8 @@ async function readBundleVersion(appPath) {
   // Try plutil first — it prints a stable `key: "value"` text format.
   const r = await runBin("plutil", ["-p", infoPlist], { timeoutMs: 3000 });
   if (r.ok && r.stdout) {
-    // plutil output is like:  "CFBundleShortVersionString" => "0.8.8"
-    // or (older):            CFBundleShortVersionString = "0.8.8"
+    // plutil output is like:  "CFBundleShortVersionString" => "0.9.0"
+    // or (older):            CFBundleShortVersionString = "0.9.0"
     const m = r.stdout.match(
       /["']?CFBundleShortVersionString["']?\s*(?:=>|=)\s*["']([^"']+)["']/,
     );
@@ -1674,8 +1674,8 @@ async function readBinVersion(binPath) {
   // --version is safe and doesn't flash a GUI.
   const r = await runBin(binPath, ["--version"], { timeoutMs: 5000 });
   if (!r.ok) return null;
-  // Match a semver-ish version (e.g. "0.8.8", "1.2.3-rc.1") anywhere in
-  // the --version output. Real binaries print "<name> 0.8.8"; tests
+  // Match a semver-ish version (e.g. "0.9.0", "1.2.3-rc.1") anywhere in
+  // the --version output. Real binaries print "<name> 0.9.0"; tests
   // just print "9.9.9" — both should parse.
   const m = (r.stdout || "").match(/(\d+\.\d+\.\d+(?:[-+][\w.\-]+)?)/);
   return m ? m[1].trim() : (r.stdout || "").trim();

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openloomi",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Use local OpenLoomi from Codex as a personal assistant, memory layer, and self-healing setup bridge (auto-recovers from Codex sandbox loopback false negatives via a host-side probe cache).",
   "author": {
     "name": "OpenLoomi"

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -612,7 +612,7 @@ For source checkouts, project markers:
   "mode": "packaged | source | unconfigured",
   "installed": true,
   "appPath": "<resolved OpenLoomi Desktop app path>",
-  "version": "openloomi-desktop 0.8.8",
+  "version": "openloomi-desktop 0.9.0",
   "tokenPresent": true,
   "session": {
     "tokenPresent": true,

--- a/plugins/codex/scripts/loomi-bridge.mjs
+++ b/plugins/codex/scripts/loomi-bridge.mjs
@@ -18,7 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const BRIDGE_VERSION = "0.8.8";
+const BRIDGE_VERSION = "0.9.0";
 const PLUGIN_PHASE = "runtime-provider-readiness";
 const COMMAND_TIMEOUT_MS = 5000;
 const INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
@@ -88,7 +88,7 @@ const OFFICIAL_RELEASE_SOURCE = {
 };
 
 // Restricted-network install (issue #401). When `OPENLOOMI_VERSION` is set
-// to a literal semver (e.g. `v0.8.8`), resolve that tag's release API
+// to a literal semver (e.g. `v0.9.0`), resolve that tag's release API
 // instead of /releases/latest. `OPENLOOMI_REPO` overrides the `owner/repo`
 // slug. Both are honored here AND forwarded to the install helper script
 // when the bridge spawns it. When one of the manual-path env vars

--- a/skills/openloomi-connectors/SKILL.md
+++ b/skills/openloomi-connectors/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-connectors
 description: "openloomi Connectors tools - manage the native 7 messaging integrations and pair with the composio skill for the 1000+ apps OAuth layer (Slack, Discord, X, Gmail, Outlook, Google Calendar/Drive/Docs, GitHub, Notion, Linear, HubSpot, LinkedIn, Jira, Asana). Triggers: connect platform, integration status, list accounts, disconnect, list-accounts, status, connect, send-reply, native vs composio, 1000+ apps, list connections."
 metadata:
-  version: 0.8.8
+  version: 0.9.0
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-connectors.cjs *)
 ---
 

--- a/skills/openloomi-feature-guide/SKILL.md
+++ b/skills/openloomi-feature-guide/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-feature-guide
 description: "Use this when users ask about openloomi features, capabilities, or how to use it. Examples: 'openloomi 怎么用', '你能做什么', 'What can you do?', 'How does openloomi work?', 'Tell me about openloomi features', 'What platforms does openloomi support?', 'How do I use scheduled tasks?', 'What is Loop?', 'How does the attention agent work?', 'What is a Decision Card?', 'How do connectors work?', 'How do I extend Loop with custom types?', 'What is a classifier rule?', 'How do I plug openloomi into Claude Code / Codex?'"
 metadata:
-  version: 0.8.8
+  version: 0.9.0
 ---
 
 > **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).

--- a/skills/openloomi-loop/SKILL.md
+++ b/skills/openloomi-loop/SKILL.md
@@ -3,7 +3,7 @@ name: openloomi-loop
 description: "openloomi's Loop — the proactive execution brain that runs inside the OpenLoomi desktop app. Use this skill to inspect state, run a tick, schedule / cancel decision actions, tune preferences, and extend Loop with user-defined decision types, Composio-backed signal channels, or deterministic classifier rules. Triggers: 'openloomi loop', 'loop tick', 'loop schedule', 'loop inbox', 'loop run', 'proactive decisions', 'signal → decision → execute', 'pull signals', 'decision queue', 'register loop type', 'add loop decision type', 'register custom channel', 'add composio channel', 'add loop rule', 'register classifier rule', 'force loop type', 'dry-run loop rule', 'list my loop extensions', 'remove loop type', 'delete loop channel'"
 allowed-tools: Bash(curl *), Bash(jq *), Bash(cat ~/.openloomi/token *), Bash(base64 -d *), Bash(ls ~/.openloomi/loop/*), Read(~/.openloomi/loop/custom-types.json), Read(~/.openloomi/loop/custom-channels.json), Read(~/.openloomi/loop/classifier-rules.json)
 metadata:
-  version: 0.8.8
+  version: 0.9.0
 ---
 
 > **Note:** If OpenLoomi readiness is unknown, use `openloomi-setup` first. If OpenLoomi Desktop is not installed, follow [Getting Started](https://openloomi.ai/docs/getting-started).

--- a/skills/openloomi-memory/SKILL.md
+++ b/skills/openloomi-memory/SKILL.md
@@ -2,7 +2,7 @@
 name: openloomi-memory
 description: "openloomi Memory tools - search and manage the holistic context (people, projects, decisions, knowledge base, chat insights). Triggers: memory search, knowledge base, search documents, list insights, who is John, what did we decide about X, tiered memory, knowledge graph, people/projects/decisions, search-all, conversation memory"
 metadata:
-  version: 0.8.8
+  version: 0.9.0
 allowed-tools: Bash(node $SKILL_DIR/scripts/openloomi-memory.cjs *)
 ---
 


### PR DESCRIPTION
## Summary

Bumps the OpenLoomi monorepo version from `0.8.8` to `0.9.0`.

This is a pure version-bump release commit — every changed line is a `0.8.8` → `0.9.0` replacement, with no functional or behavioral changes.

## Scope

- **Root & apps** — `package.json`, `apps/web/package.json`, `apps/web/src-tauri/Cargo.toml`, `tauri.conf.json`, `tauri.conf.dev.json`
- **Workspace packages** — all `packages/**/package.json` (ai, api, audit, config, hooks, i18n, indexeddb, insights, rag, search, security, shared, sqlite, storage, voice-*, and every `packages/integrations/*`)
- **Plugins** — `plugins/claude/.claude-plugin/plugin.json`, `plugins/codex/.codex-plugin/plugin.json`, both `loomi-bridge.mjs` bridges, and the Claude install scripts (`setup.macos.sh`, `setup.linux.sh`, `setup.windows.ps1`)
- **Marketplace & docs** — `.claude-plugin/marketplace.json`, `apps/marketing/content/plugins/{claude,codex}.mdx`, `plugins/codex/README.md`, `benchmark/jobbench-official/eval/README.md`
- **Skills** — version references in `skills/openloomi-{connectors,feature-guide,loop,memory}/SKILL.md`

63 files changed, 80 insertions(+), 80 deletions(-).

## Test plan

- [x] Verified via `git diff` that no changed line contains anything other than the `0.8.8` → `0.9.0` version string
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)