### PR TITLE
docs(memory): correct the execution plan status after Phase 4 shipped

### DIFF
--- a/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
+++ b/packages/ai/memory-consolidation/docs/memory-graph-evolution-execution-plan.md
@@ -1,6 +1,6 @@
 # Dynamic Memory Cluster Evolution Execution Plan
 
-Status: `PHASE_0_3_DRAFT_PR_STACK`
+Status: `PHASE_0_3_SHIPPED_PHASE_4_GATES_MET`
 
 ## Objective
 
@@ -8,6 +8,10 @@ Prepare the accepted foundation and controlled write loop, controlled retrieval
 loop, and authorized correction loop as three serial, reviewable experimental
 Draft PR candidates. The stack remains disabled by default and does not
 authorize a runtime cohort or rollout.
+
+That stack shipped, and the Phase 4 demonstrations and gate work shipped on top
+of it. The default-off constraint above is unchanged by either: nothing in this
+plan has authorized enabling anything for a real user.
 
 ## Delivery Rules
 
@@ -421,7 +425,13 @@ empty until something concrete needs to go in it.
 
 ## Stop Line
 
-Stop at `PHASE_0_3_DRAFT_PR_STACK` or
-`PHASE_0_3_DRAFT_PR_SPLIT_BLOCKED`. Do not collect cohort observations,
-implement Phase 4 persistence, expand runtime exposure, merge a pull request,
-or enter the next phase without explicit approval.
+Stop at `PHASE_0_3_SHIPPED_PHASE_4_GATES_MET`. Phases 0-3 are merged and the six
+Phase 4 gates are met, which establishes that enabling the defaults would be
+safe — not that it should happen. Everything remains default-off.
+
+Do not enable a default, expand a runtime cohort, collect cohort observations,
+or begin Phase 5 without the project owner's explicit approval. Phase 5 also has
+an unresolved design question recorded above: graph write and graph-aware
+retrieval share one policy, so the behaviour with the strongest evidence cannot
+be enabled without the ones that have none. Settle that before any rollout, not
+during one.


### PR DESCRIPTION
Documentation only.

After #506, #507 and #508 merged, the execution plan still read
`PHASE_0_3_DRAFT_PR_STACK` and its stop line still said "do not merge a pull
request". The handoff names this plan as the sole authority for status, so
anyone reading it to decide whether to authorize a rollout would find a document
saying Phase 4 had not begun.

The drift came from editing the phase sections throughout Phase 4 without
revisiting the header and stop line, which were correct right up until the work
merged.

What changes:

- Status matches the handoff: `PHASE_0_3_SHIPPED_PHASE_4_GATES_MET`.
- The stop line states what is true rather than what was true. The six gates
  establish that enabling the defaults would be *safe*, not that it *should*
  happen. Everything stays default-off pending the project owner's approval.
- The stop line carries the open design question forward, because it has to be
  settled before a rollout rather than during one: graph write and graph-aware
  retrieval share a single policy, so the behaviour with the strongest evidence
  cannot be enabled without the ones that have none.
- The objective section notes the stack shipped, and that this changes nothing
  about the default-off constraint stated there.

No code, no defaults, no authorization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
