### PR TITLE
feat(memory-store): extract memory storage layer into standalone @openloomi/memory-store SDK + HTTP + MCP package

### DIFF
--- a/apps/web/app/(chat)/api/chat/save-messages/route.ts
+++ b/apps/web/app/(chat)/api/chat/save-messages/route.ts
@@ -18,7 +18,7 @@ import {
   findChatMemoryRevisionConflict,
   writeSavedChatMessagesToMemory,
 } from "@/lib/memory/chat-memory-write";
-import { resolveMemoryGraphWritePolicy } from "@/lib/memory/memory-graph-write-policy";
+import { resolveMemoryGraphWritePolicy } from "@openloomi/memory-store/memory-graph-write-policy";
 import type { ChatMessage } from "@openloomi/shared";
 import type { Attachment } from "@openloomi/shared";
 import { NextResponse } from "next/server";

--- a/apps/web/app/api/memory/raw-messages/route.ts
+++ b/apps/web/app/api/memory/raw-messages/route.ts
@@ -1,18 +1,18 @@
 import { auth } from "@/app/(auth)/auth";
 import { botExists } from "@/lib/db/queries";
-import { resolveMemoryGraphCorrectionPolicy } from "@/lib/memory/memory-graph-correction-policy";
-import { upsertRawMessagesToChroma } from "@/lib/memory/chroma-memory-index";
+import { resolveMemoryGraphCorrectionPolicy } from "@openloomi/memory-store/memory-graph-correction-policy";
+import { upsertRawMessagesToChroma } from "@openloomi/memory-store/chroma-memory-index";
 import {
   isReservedChatMemoryEvidenceId,
   isReservedMemoryGraphSummaryId,
   resolveUntrustedRawMemoryGraphWritePolicy,
   sanitizeUntrustedMemoryMetadata,
-} from "@/lib/memory/memory-graph-write-policy";
+} from "@openloomi/memory-store/memory-graph-write-policy";
 import {
   getRawMessageManager,
   getRawMessageStorageBackend,
   isRawMessageStorageAvailable,
-} from "@/lib/memory/raw-message-store";
+} from "@openloomi/memory-store/raw-message-store";
 import type {
   MemorySummaryRecord,
   RawMessage,

--- a/apps/web/app/api/messages/check/route.ts
+++ b/apps/web/app/api/messages/check/route.ts
@@ -2,7 +2,7 @@ import { auth } from "@/app/(auth)/auth";
 import {
   getRawMessageManager,
   getRawMessageStorageBackend,
-} from "@/lib/memory/raw-message-store";
+} from "@openloomi/memory-store/raw-message-store";
 import { AppError } from "@openloomi/shared/errors";
 
 /**

--- a/apps/web/app/api/messages/raw/route.ts
+++ b/apps/web/app/api/messages/raw/route.ts
@@ -4,11 +4,11 @@ import {
   isReservedChatMemoryEvidenceId,
   resolveUntrustedRawMemoryGraphWritePolicy,
   sanitizeUntrustedMemoryMetadata,
-} from "@/lib/memory/memory-graph-write-policy";
+} from "@openloomi/memory-store/memory-graph-write-policy";
 import {
   getRawMessageManager,
   getRawMessageStorageBackend,
-} from "@/lib/memory/raw-message-store";
+} from "@openloomi/memory-store/raw-message-store";
 import {
   type RawMessage,
   storeRawMessagesWithGraphEvolution,

--- a/apps/web/lib/cron/insight-maintenance.ts
+++ b/apps/web/lib/cron/insight-maintenance.ts
@@ -9,8 +9,8 @@ import {
 } from "../db/queries";
 import { runWeeklyInsightMaintenance } from "@/lib/insights/maintenance";
 import { runInsightEmbeddingDream } from "@/lib/insights/dream";
-import { getRawMessageManager } from "@/lib/memory/raw-message-store";
-import { upsertRawMessagesToChroma } from "@/lib/memory/chroma-memory-index";
+import { getRawMessageManager } from "@openloomi/memory-store/raw-message-store";
+import { upsertRawMessagesToChroma } from "@openloomi/memory-store/chroma-memory-index";
 import { hasInsightEmbeddingProviderConfig } from "@/lib/insights/embedding-service";
 import {
   createUserEmbeddingProvider,

--- a/apps/web/lib/insights/embedding-service.ts
+++ b/apps/web/lib/insights/embedding-service.ts
@@ -9,11 +9,11 @@ import {
   isInsightChromaEnabled,
   type ChromaInsightVectorInput,
   upsertInsightsToChroma,
-} from "@/lib/memory/chroma-memory-index";
+} from "@openloomi/memory-store/chroma-memory-index";
 import {
   isInsightSQLiteVecEnabled,
   upsertInsightsToSQLiteVec,
-} from "@/lib/memory/sqlite-vector-index";
+} from "@openloomi/memory-store/sqlite-vector-index";
 import {
   createUserEmbeddingProvider,
   getUserEmbeddingModelName,

--- a/apps/web/lib/insights/search.ts
+++ b/apps/web/lib/insights/search.ts
@@ -4,11 +4,11 @@ import { isTauriMode } from "@/lib/env/constants";
 import {
   isInsightChromaEnabled,
   searchInsightsWithChroma,
-} from "@/lib/memory/chroma-memory-index";
+} from "@openloomi/memory-store/chroma-memory-index";
 import {
   isInsightSQLiteVecEnabled,
   searchInsightsWithSQLiteVec,
-} from "@/lib/memory/sqlite-vector-index";
+} from "@openloomi/memory-store/sqlite-vector-index";
 import {
   createUserEmbeddingProvider,
   hasUserEmbeddingProviderConfig,

--- a/apps/web/lib/integrations/feishu/handler.ts
+++ b/apps/web/lib/integrations/feishu/handler.ts
@@ -121,7 +121,7 @@ async function storeFeishuRawMessage(input: {
   try {
     const nowSec = Math.floor(Date.now() / 1000);
     const { getRawMessageManager } =
-      await import("@/lib/memory/raw-message-store");
+      await import("@openloomi/memory-store/raw-message-store");
     const manager = await getRawMessageManager();
     const rawMessage: RawMessage = {
       messageId: input.messageId,
@@ -149,7 +149,7 @@ async function storeFeishuRawMessage(input: {
     );
     await manager.storeMessage(messageWithEmbedding);
     const { upsertRawMessagesToChroma } =
-      await import("@/lib/memory/chroma-memory-index");
+      await import("@openloomi/memory-store/chroma-memory-index");
     await upsertRawMessagesToChroma([messageWithEmbedding]);
     console.log("[Feishu] Stored raw message", {
       messageId: input.messageId,

--- a/apps/web/lib/memory/chat-memory-write.ts
+++ b/apps/web/lib/memory/chat-memory-write.ts
@@ -5,7 +5,7 @@ import {
   type RawMessageStorageManagerWithSearch,
   getRawMessageManager,
   isRawMessageStorageAvailable,
-} from "@/lib/memory/raw-message-store";
+} from "@openloomi/memory-store/raw-message-store";
 import {
   type MemoryGraphLifecycleRuntimeResult,
   type RawMessage,
@@ -19,7 +19,7 @@ import {
   type MemoryGraphWritePolicyDecision,
   resolveMemoryGraphWritePolicy,
   sanitizeUntrustedMemoryMetadata,
-} from "./memory-graph-write-policy";
+} from "@openloomi/memory-store/memory-graph-write-policy";
 
 type SavedChatMessage = ChatMessage & { createdAt: Date };
 

--- a/apps/web/lib/memory/controlled-default-context.ts
+++ b/apps/web/lib/memory/controlled-default-context.ts
@@ -20,12 +20,12 @@ import {
   createGraphAwareRetrievalDryRunRetriever,
 } from "@openloomi/memory-consolidation";
 
-import { resolveMemoryGraphWritePolicy } from "@/lib/memory/memory-graph-write-policy";
+import { resolveMemoryGraphWritePolicy } from "@openloomi/memory-store/memory-graph-write-policy";
 import {
   type RawMessageStorageManagerWithSearch,
   getRawMessageManager,
   isRawMessageStorageAvailable,
-} from "@/lib/memory/raw-message-store";
+} from "@openloomi/memory-store/raw-message-store";
 
 const DEFAULT_MEMORY_CONTEXT_PAGE_SIZE = 6;
 const MAX_MEMORY_CONTEXT_ITEM_CHARS = 600;

--- a/apps/web/lib/memory/postgres-raw-message-store.ts
+++ b/apps/web/lib/memory/postgres-raw-message-store.ts
@@ -1106,3 +1106,23 @@ export async function closePostgresRawMessageManager(): Promise<void> {
   await manager.close();
   manager = null;
 }
+
+// ---------------------------------------------------------------------------
+// Register this Postgres manager with the standalone @openloomi/memory-store
+// package so the standalone HTTP/MCP server (running outside the web app)
+// can fall back to Postgres when not in Tauri mode. Registration is a no-op
+// for in-app imports — the route handlers continue to use
+// `getPostgresRawMessageManager()` directly.
+// ---------------------------------------------------------------------------
+import { registerPostgresFactory as registerPostgresRawMessageFactory } from "@openloomi/memory-store/postgres-raw-message-factory";
+
+registerPostgresRawMessageFactory(async () => {
+  if (!manager) {
+    const m = new PostgresRawMessageManager();
+    await m.init();
+    manager = m;
+  }
+  return manager as unknown as Awaited<
+    ReturnType<Parameters<typeof registerPostgresRawMessageFactory>[0]>
+  >;
+});

--- a/apps/web/lib/memory/unified-search-factory.ts
+++ b/apps/web/lib/memory/unified-search-factory.ts
@@ -1,0 +1,85 @@
+/**
+ * Bridge: wire the web app's cross-domain searchers (RAG, insights,
+ * embedding provider) into the standalone `@openloomi/memory-store`
+ * unified-search facade.
+ *
+ * This keeps the existing `searchUnifiedMemory()` callers in
+ * `apps/web/app/api/memory/search/route.ts` and
+ * `apps/web/lib/ai/mcp/tools/unified-memory.ts` working unchanged —
+ * they continue to import `searchUnifiedMemory` from `@/lib/memory/unified-search`,
+ * which now re-exports the wired-up version from this file.
+ */
+
+import { createUnifiedSearch } from "@openloomi/memory-store/unified-search";
+import { searchInsightsSemantically } from "@/lib/insights/search";
+import { searchSimilarChunks } from "@/lib/ai/rag/langchain-service";
+import {
+  createUserEmbeddingProvider,
+  hasUserEmbeddingProviderConfig,
+} from "@/lib/ai/user-embedding-settings";
+
+import type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+} from "@openloomi/memory-store/unified-search";
+import type {
+  RawMessageStorageManagerWithSearch,
+} from "@openloomi/memory-store/raw-message-store";
+import { getRawMessageManager } from "@openloomi/memory-store/raw-message-store";
+
+export const search = createUnifiedSearch({
+  embedQuery: async ({ userId, query, authToken }) => {
+    if (!(await hasUserEmbeddingProviderConfig({ userId, authToken }))) {
+      throw new Error("Embedding provider API key is not configured");
+    }
+    const embeddings = await createUserEmbeddingProvider({ userId, authToken });
+    return embeddings.embedQuery(query);
+  },
+  searchKnowledge: ({ userId, query, options, authToken }) =>
+    searchSimilarChunks(userId, query, options, authToken),
+  searchInsights: ({ userId, query, limit, threshold, botIds, includeArchived, authToken }) =>
+    searchInsightsSemantically({
+      userId,
+      query,
+      limit,
+      threshold,
+      botIds,
+      includeArchived,
+      authToken,
+    }),
+  searchRawMessagesAnn: async ({
+    userId,
+    queryEmbedding,
+    limit,
+    threshold,
+    botId,
+  }) => {
+    const manager = (await getRawMessageManager()) as unknown as RawMessageStorageManagerWithSearch & {
+      searchMessagesSemantically?: (input: unknown) => Promise<unknown[]>;
+    };
+    if (typeof manager.searchMessagesSemantically !== "function") {
+      return [];
+    }
+    const rows = (await manager.searchMessagesSemantically({
+      userId,
+      queryEmbedding,
+      limit,
+      threshold,
+      botId,
+    })) as Array<{
+      id: string;
+      content: string;
+      similarity: number;
+      metadata: Record<string, unknown>;
+    }>;
+    return rows;
+  },
+});
+
+export const searchUnifiedMemory = search.searchUnifiedMemory;
+export const searchRawMemorySemantically = search.searchRawMemorySemantically;
+
+export type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+} from "@openloomi/memory-store/unified-search";

--- a/apps/web/lib/memory/unified-search.ts
+++ b/apps/web/lib/memory/unified-search.ts
@@ -1,345 +1,38 @@
-import { searchSimilarChunks } from "@/lib/ai/rag/langchain-service";
-import { searchInsightsSemantically } from "@/lib/insights/search";
-import {
-  getRawMessageManager,
-  isRawMessageStorageAvailable,
-} from "@/lib/memory/raw-message-store";
-import {
-  isRawMessageChromaEnabled,
-  searchRawMessagesWithChroma,
-} from "@/lib/memory/chroma-memory-index";
-import {
-  createUserEmbeddingProvider,
-  hasUserEmbeddingProviderConfig,
-} from "@/lib/ai/user-embedding-settings";
+/**
+ * Back-compat re-export of the unified semantic search façade.
+ *
+ * The implementation now lives in `@openloomi/memory-store`. This
+ * file is kept as the import path that the rest of the web app uses
+ * (`@/lib/memory/unified-search`) so existing route handlers,
+ * MCP tools, and tests don't need to change their imports.
+ *
+ * The factory in `apps/web/lib/memory/unified-search-factory.ts`
+ * wires up the host-specific embedder + RAG + insights searchers.
+ */
 
-export type UnifiedMemorySearchSource = "memory" | "insights" | "knowledge";
+import { isRawMessageStorageAvailable } from "@openloomi/memory-store/raw-message-store";
 
-export interface UnifiedMemorySearchResult {
-  type: "memory" | "insight" | "knowledge";
-  id: string;
-  content: string;
-  similarity: number;
-  metadata: Record<string, unknown>;
-}
+export {
+  searchUnifiedMemory,
+  searchRawMemorySemantically,
+} from "./unified-search-factory";
+export {
+  clampUnifiedMemorySearchLimit,
+  clampUnifiedMemorySearchThreshold,
+  mergeUnifiedMemorySearchResults,
+  normalizeUnifiedMemorySearchSources,
+  toKnowledgeResult,
+  toMemoryResult,
+  isRawMemorySemanticResult,
+} from "@openloomi/memory-store/unified-search";
+export type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+  UnifiedMemorySearchResult,
+  UnifiedMemorySearchSource,
+  UnifiedMemorySearchWarning,
+} from "@openloomi/memory-store/unified-search";
 
-export interface UnifiedMemorySearchWarning {
-  source: UnifiedMemorySearchSource;
-  code: string;
-  message: string;
-}
-
-export interface UnifiedMemorySearchInput {
-  userId: string;
-  query: string;
-  sources?: UnifiedMemorySearchSource[];
-  limit?: number;
-  threshold?: number;
-  authToken?: string;
-  includeArchivedInsights?: boolean;
-  botIds?: string[];
-  documentIds?: string[];
-}
-
-export interface UnifiedMemorySearchOutput {
-  query: string;
-  sources: UnifiedMemorySearchSource[];
-  results: UnifiedMemorySearchResult[];
-  count: number;
-  warnings: UnifiedMemorySearchWarning[];
-}
-
-const DEFAULT_LIMIT = 10;
-const DEFAULT_THRESHOLD = 0.7;
-const DEFAULT_SOURCES: UnifiedMemorySearchSource[] = [
-  "memory",
-  "insights",
-  "knowledge",
-];
-const SOURCE_SET = new Set<UnifiedMemorySearchSource>(DEFAULT_SOURCES);
-
-export function normalizeUnifiedMemorySearchSources(
-  sources: unknown,
-): UnifiedMemorySearchSource[] {
-  if (!Array.isArray(sources) || sources.length === 0) {
-    return [...DEFAULT_SOURCES];
-  }
-
-  const normalized = sources
-    .filter((source): source is string => typeof source === "string")
-    .map((source) => source.trim().toLowerCase())
-    .filter((source): source is UnifiedMemorySearchSource =>
-      SOURCE_SET.has(source as UnifiedMemorySearchSource),
-    );
-
-  return normalized.length > 0
-    ? Array.from(new Set(normalized))
-    : [...DEFAULT_SOURCES];
-}
-
-export function clampUnifiedMemorySearchLimit(limit: unknown): number {
-  const parsed =
-    typeof limit === "number" ? limit : Number(limit ?? DEFAULT_LIMIT);
-  if (!Number.isFinite(parsed)) {
-    return DEFAULT_LIMIT;
-  }
-  return Math.min(50, Math.max(1, Math.floor(parsed)));
-}
-
-export function clampUnifiedMemorySearchThreshold(threshold: unknown): number {
-  const parsed =
-    typeof threshold === "number"
-      ? threshold
-      : Number(threshold ?? DEFAULT_THRESHOLD);
-  if (!Number.isFinite(parsed)) {
-    return DEFAULT_THRESHOLD;
-  }
-  return Math.min(1, Math.max(-1, parsed));
-}
-
-export function mergeUnifiedMemorySearchResults(
-  results: UnifiedMemorySearchResult[],
-  limit: number,
-): UnifiedMemorySearchResult[] {
-  return [...results]
-    .sort((a, b) => {
-      const scoreDelta = b.similarity - a.similarity;
-      if (scoreDelta !== 0) {
-        return scoreDelta;
-      }
-      return a.type.localeCompare(b.type) || a.id.localeCompare(b.id);
-    })
-    .slice(0, limit);
-}
-
-function toKnowledgeResult(result: {
-  chunkId: string;
-  documentId: string;
-  documentName: string;
-  content: string;
-  similarity: number;
-  chunkIndex: number;
-}): UnifiedMemorySearchResult {
-  return {
-    type: "knowledge",
-    id: result.chunkId,
-    content: result.content,
-    similarity: result.similarity,
-    metadata: {
-      documentId: result.documentId,
-      documentName: result.documentName,
-      chunkIndex: result.chunkIndex,
-    },
-  };
-}
-
-async function embedQuery(
-  userId: string,
-  query: string,
-  authToken?: string,
-): Promise<number[]> {
-  if (!(await hasUserEmbeddingProviderConfig({ userId, authToken }))) {
-    throw new Error("Embedding provider API key is not configured");
-  }
-
-  const embeddings = await createUserEmbeddingProvider({ userId, authToken });
-  return embeddings.embedQuery(query);
-}
-
-function toMemoryResult(result: {
-  id: string;
-  content: string;
-  similarity: number;
-  metadata: Record<string, unknown>;
-}): UnifiedMemorySearchResult {
-  return {
-    type: "memory",
-    id: result.id,
-    content: result.content,
-    similarity: result.similarity,
-    metadata: result.metadata,
-  };
-}
-
-function isRawMemorySemanticResult(result: unknown): result is {
-  id: string;
-  content: string;
-  similarity: number;
-  metadata: Record<string, unknown>;
-} {
-  if (!result || typeof result !== "object") {
-    return false;
-  }
-  const item = result as Record<string, unknown>;
-  return (
-    typeof item.id === "string" &&
-    typeof item.content === "string" &&
-    typeof item.similarity === "number" &&
-    Boolean(item.metadata) &&
-    typeof item.metadata === "object"
-  );
-}
-
-async function searchRawMemorySemantically(input: {
-  userId: string;
-  query: string;
-  authToken?: string;
-  botIds?: string[];
-  limit: number;
-  threshold: number;
-}): Promise<UnifiedMemorySearchResult[]> {
-  const manager = await getRawMessageManager();
-  const filters =
-    input.botIds && input.botIds.length > 0
-      ? input.botIds.map((botId) => ({ botId }))
-      : [{}];
-
-  let semanticResults: UnifiedMemorySearchResult[] = [];
-  let semanticBackendHandled = false;
-  if (
-    await hasUserEmbeddingProviderConfig({
-      userId: input.userId,
-      authToken: input.authToken,
-    })
-  ) {
-    const queryEmbedding = await embedQuery(
-      input.userId,
-      input.query,
-      input.authToken,
-    );
-    if (queryEmbedding.length > 0) {
-      if (isRawMessageChromaEnabled()) {
-        try {
-          semanticResults = (
-            await Promise.all(
-              filters.map((filter) => {
-                const botId = "botId" in filter ? filter.botId : undefined;
-                return searchRawMessagesWithChroma({
-                  userId: input.userId,
-                  queryEmbedding,
-                  limit: input.limit,
-                  threshold: input.threshold,
-                  botId,
-                });
-              }),
-            )
-          )
-            .flat()
-            .map(toMemoryResult);
-          semanticBackendHandled = true;
-          console.log("[UnifiedMemory] Raw message semantic search completed", {
-            backend: "chroma",
-            dimensions: queryEmbedding.length,
-            count: semanticResults.length,
-          });
-        } catch (error) {
-          console.warn(
-            "[UnifiedMemory] Chroma raw message search failed; falling back to database search:",
-            error,
-          );
-        }
-      }
-
-      if (
-        !semanticBackendHandled &&
-        typeof manager.searchMessagesSemantically === "function"
-      ) {
-        semanticResults = (
-          await Promise.all(
-            filters.map((filter) =>
-              manager.searchMessagesSemantically?.({
-                userId: input.userId,
-                queryEmbedding,
-                limit: input.limit,
-                threshold: input.threshold,
-                ...filter,
-              }),
-            ),
-          )
-        )
-          .flat()
-          .filter(isRawMemorySemanticResult)
-          .map(toMemoryResult);
-      }
-    }
-  }
-
-  return mergeUnifiedMemorySearchResults(semanticResults, input.limit);
-}
-
-export async function searchUnifiedMemory(
-  input: UnifiedMemorySearchInput,
-): Promise<UnifiedMemorySearchOutput> {
-  const query = input.query.trim();
-  const sources = normalizeUnifiedMemorySearchSources(input.sources);
-  const limit = clampUnifiedMemorySearchLimit(input.limit);
-  const threshold = clampUnifiedMemorySearchThreshold(input.threshold);
-  const warnings: UnifiedMemorySearchWarning[] = [];
-  const results: UnifiedMemorySearchResult[] = [];
-
-  if (!query) {
-    return {
-      query,
-      sources,
-      results: [],
-      count: 0,
-      warnings,
-    };
-  }
-
-  if (sources.includes("memory")) {
-    if (isRawMessageStorageAvailable()) {
-      const memoryResults = await searchRawMemorySemantically({
-        userId: input.userId,
-        query,
-        authToken: input.authToken,
-        botIds: input.botIds,
-        limit,
-        threshold,
-      });
-      results.push(...memoryResults);
-    } else {
-      warnings.push({
-        source: "memory",
-        code: "raw_message_storage_unavailable",
-        message: "Raw memory storage is not available in this environment.",
-      });
-    }
-  }
-
-  if (sources.includes("insights")) {
-    const insightResults = await searchInsightsSemantically({
-      userId: input.userId,
-      query,
-      limit,
-      threshold,
-      botIds: input.botIds,
-      includeArchived: input.includeArchivedInsights,
-      authToken: input.authToken,
-    });
-    results.push(...insightResults);
-  }
-
-  if (sources.includes("knowledge")) {
-    const knowledgeResults = await searchSimilarChunks(
-      input.userId,
-      query,
-      {
-        limit,
-        threshold,
-        documentIds: input.documentIds,
-      },
-      input.authToken,
-    );
-    results.push(...knowledgeResults.map(toKnowledgeResult));
-  }
-
-  const merged = mergeUnifiedMemorySearchResults(results, limit);
-  return {
-    query,
-    sources,
-    results: merged,
-    count: merged.length,
-    warnings,
-  };
-}
+// Keep `isRawMessageStorageAvailable` available via the old path so
+// callers like the API routes keep working.
+export { isRawMessageStorageAvailable };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,9 @@
 		"tauri:build": "pnpm tauri build && node scripts/check-cli-bundled.js . && node scripts/optimize-tauri-bundle.js",
 		"tauri:build:debug": "node ./scripts/run-cross-env.cjs IS_TAURI=true SKIP_TYPE_CHECK=true NODE_OPTIONS=--max-old-space-size=16384 tsx lib/db/migrate && next build && pnpm tauri build && node scripts/optimize-tauri-bundle.js",
 		"db:generate:sqlite": "drizzle-kit generate --config=drizzle.config.sqlite.ts",
-		"loop": "node ./scripts/loop-cli.mjs"
+		"loop": "node ./scripts/loop-cli.mjs",
+		"memory:http": "openloomi-memory-http",
+		"memory:mcp": "openloomi-memory-mcp"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.22.1",
@@ -55,6 +57,7 @@
 		"@openloomi/insights": "workspace:*",
 		"@openloomi/integrations": "workspace:*",
 		"@openloomi/memory-consolidation": "workspace:*",
+		"@openloomi/memory-store": "workspace:*",
 		"@openloomi/rag": "workspace:*",
 		"@openloomi/rss": "workspace:*",
 		"@openloomi/search": "workspace:*",

--- a/apps/web/tests/unit/chat-memory-write-route.test.ts
+++ b/apps/web/tests/unit/chat-memory-write-route.test.ts
@@ -68,10 +68,10 @@ vi.mock("@/lib/db/queries", () => ({
   saveMessages: saveMessagesMock,
 }));
 vi.mock("@/lib/env", () => ({ isTauriMode: isTauriModeMock }));
-vi.mock("@/lib/memory/chroma-memory-index", () => ({
+vi.mock("@openloomi/memory-store/chroma-memory-index", () => ({
   upsertRawMessagesToChroma: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   getRawMessageManager: getRawMessageManagerMock,
   getRawMessageStorageBackend: getRawMessageStorageBackendMock,
   isRawMessageStorageAvailable: isRawMessageStorageAvailableMock,

--- a/apps/web/tests/unit/controlled-default-memory-context.test.ts
+++ b/apps/web/tests/unit/controlled-default-memory-context.test.ts
@@ -14,11 +14,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/memory/memory-graph-write-policy", () => ({
+vi.mock("@openloomi/memory-store/memory-graph-write-policy", () => ({
   resolveMemoryGraphWritePolicy: mocks.policy,
 }));
 
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   isRawMessageStorageAvailable: mocks.storageAvailable,
   getRawMessageManager: mocks.getManager,
 }));

--- a/apps/web/tests/unit/memory-graph-correction-policy.test.ts
+++ b/apps/web/tests/unit/memory-graph-correction-policy.test.ts
@@ -1,4 +1,4 @@
-import { resolveMemoryGraphCorrectionPolicy } from "@/lib/memory/memory-graph-correction-policy";
+import { resolveMemoryGraphCorrectionPolicy } from "@openloomi/memory-store/memory-graph-correction-policy";
 import { describe, expect, it } from "vitest";
 
 describe("memory graph correction policy", () => {

--- a/apps/web/tests/unit/memory-graph-governance-route.test.ts
+++ b/apps/web/tests/unit/memory-graph-governance-route.test.ts
@@ -18,7 +18,7 @@ const {
 }));
 
 vi.mock("@/app/(auth)/auth", () => ({ auth: authMock }));
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   getRawMessageManager: getRawMessageManagerMock,
   getRawMessageStorageBackend: vi.fn(),
   isRawMessageStorageAvailable: isRawMessageStorageAvailableMock,

--- a/apps/web/tests/unit/native-agent-memory-context-route.test.ts
+++ b/apps/web/tests/unit/native-agent-memory-context-route.test.ts
@@ -43,7 +43,7 @@ vi.mock("@openloomi/ai/agent/registry", () => ({
   }),
 }));
 
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   isRawMessageStorageAvailable: () => true,
   getRawMessageManager: async () => mocks.manager,
 }));

--- a/apps/web/tests/unit/raw-message-owner-isolation-route.test.ts
+++ b/apps/web/tests/unit/raw-message-owner-isolation-route.test.ts
@@ -21,10 +21,10 @@ const {
 vi.mock("server-only", () => ({}));
 vi.mock("@/app/(auth)/auth", () => ({ auth: authMock }));
 vi.mock("@/lib/db/queries", () => ({ botExists: botExistsMock }));
-vi.mock("@/lib/memory/chroma-memory-index", () => ({
+vi.mock("@openloomi/memory-store/chroma-memory-index", () => ({
   upsertRawMessagesToChroma: upsertRawMessagesToChromaMock,
 }));
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   getRawMessageManager: getRawMessageManagerMock,
   getRawMessageStorageBackend: getRawMessageStorageBackendMock,
   isRawMessageStorageAvailable: isRawMessageStorageAvailableMock,

--- a/apps/web/tests/unit/unified-memory-search.test.ts
+++ b/apps/web/tests/unit/unified-memory-search.test.ts
@@ -26,12 +26,12 @@ const {
   hasUserEmbeddingProviderConfigMock: vi.fn(),
 }));
 
-vi.mock("@/lib/memory/raw-message-store", () => ({
+vi.mock("@openloomi/memory-store/raw-message-store", () => ({
   getRawMessageManager: getRawMessageManagerMock,
   isRawMessageStorageAvailable: isRawMessageStorageAvailableMock,
 }));
 
-vi.mock("@/lib/memory/chroma-memory-index", () => ({
+vi.mock("@openloomi/memory-store/chroma-memory-index", () => ({
   isRawMessageChromaEnabled: isRawMessageChromaEnabledMock,
   searchRawMessagesWithChroma: searchRawMessagesWithChromaMock,
 }));

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -225,7 +225,15 @@
 			"@openloomi/voice-kokoro": ["../../packages/voice-kokoro/src/index.ts"],
 			"@openloomi/voice-kokoro/*": ["../../packages/voice-kokoro/src/*"],
 			"@openloomi/voice-whisper": ["../../packages/voice-whisper/src/index.ts"],
-			"@openloomi/voice-whisper/*": ["../../packages/voice-whisper/src/*"]
+			"@openloomi/voice-whisper/*": ["../../packages/voice-whisper/src/*"],
+			"@openloomi/memory-store": ["../../packages/memory-store/src/index.ts"],
+			"@openloomi/memory-store/*": [
+				"../../packages/memory-store/src/*",
+				"../../packages/memory-store/src/storage/*",
+				"../../packages/memory-store/src/search/*",
+				"../../packages/memory-store/src/policies/*",
+				"../../packages/memory-store/src/server/*"
+			]
 		},
 		"typeRoots": ["./node_modules/@types"]
 	},

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -300,6 +300,47 @@ export default defineConfig({
         find: "@openloomi/storage",
         replacement: alias("../../packages/storage/src/local.ts"),
       },
+      // @openloomi/memory-store subpaths - must come before the bare package alias
+      {
+        find: "@openloomi/memory-store/unified-search",
+        replacement: alias("../../packages/memory-store/src/search/unified-search.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/raw-message-store",
+        replacement: alias("../../packages/memory-store/src/storage/raw-message-store.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/sqlite-raw-message-store",
+        replacement: alias("../../packages/memory-store/src/storage/sqlite-raw-message-store.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/sqlite-vector-index",
+        replacement: alias("../../packages/memory-store/src/storage/sqlite-vector-index.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/chroma-memory-index",
+        replacement: alias("../../packages/memory-store/src/storage/chroma-memory-index.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/postgres-raw-message-factory",
+        replacement: alias("../../packages/memory-store/src/storage/postgres-raw-message-factory.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/memory-graph-write-policy",
+        replacement: alias("../../packages/memory-store/src/policies/memory-graph-write-policy.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/memory-graph-correction-policy",
+        replacement: alias("../../packages/memory-store/src/policies/memory-graph-correction-policy.ts"),
+      },
+      {
+        find: "@openloomi/memory-store/*",
+        replacement: alias("../../packages/memory-store/src/*"),
+      },
+      {
+        find: "@openloomi/memory-store",
+        replacement: alias("../../packages/memory-store/src/index.ts"),
+      },
       {
         find: "@openloomi/integrations/channels",
         replacement: alias("../../packages/integrations/channels/src/index.ts"),

--- a/packages/memory-store/LICENSE
+++ b/packages/memory-store/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Copyright 2026 Meland Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/memory-store/README.md
+++ b/packages/memory-store/README.md
@@ -1,0 +1,68 @@
+# @openloomi/memory-store
+
+OpenLoomi memory storage + search SDK with optional HTTP and MCP server
+entry points. The package is intentionally decoupled from the openloomi
+web app's database and env layers — every consumer wires up its own
+implementation via `MemoryStoreConfig`.
+
+## Install
+
+```bash
+pnpm add @openloomi/memory-store
+```
+
+## SDK usage
+
+```ts
+import { createMemoryStore } from "@openloomi/memory-store";
+
+const store = await createMemoryStore({
+  db: { getDb: () => drizzleDb() },
+  env: { isTauriMode: () => false },
+  unified: {
+    embedQuery: async ({ userId, query }) => myEmbed(query),
+  },
+});
+
+await store.getRawMessageManager();
+const hits = await store.searchUnifiedMemory({ userId, query });
+```
+
+## HTTP daemon
+
+```bash
+openloomi-memory-http --port 7421
+# or
+pnpm --filter @openloomi/memory-store exec openloomi-memory-http
+```
+
+Endpoints (all POST, JSON in/out):
+
+- `GET  /health` — health check
+- `POST /v1/search` — unified search across raw messages + insights + knowledge
+- `POST /v1/raw-messages` — upsert raw messages
+- `GET  /v1/raw-messages/:id` — fetch a single raw message
+
+## MCP daemon
+
+```bash
+openloomi-memory-mcp
+```
+
+Tools:
+
+- `memory.health`
+- `memory.searchUnified`
+- `memory.writeRawMessage`
+- `memory.getRawMessage`
+
+## Configuration
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `db.getDb()` | yes for persistence | Drizzle DB handle factory |
+| `env.isTauriMode()` | yes | selects sqlite vs postgres backend |
+| `vector.backend` | one of | `sqlite-vec` or `chroma` |
+| `unified.embedQuery` | yes for unified search | query embedder |
+
+See `src/config.ts` for the full type surface.

--- a/packages/memory-store/package.json
+++ b/packages/memory-store/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@openloomi/memory-store",
+  "version": "0.9.0",
+  "type": "module",
+  "files": ["dist", "README.md", "LICENSE"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./http": {
+      "types": "./dist/http.d.ts",
+      "import": "./dist/http.js"
+    },
+    "./mcp": {
+      "types": "./dist/mcp.d.ts",
+      "import": "./dist/mcp.js"
+    },
+    "./raw-message-store": "./dist/storage/raw-message-store.js",
+    "./sqlite-raw-message-store": "./dist/storage/sqlite-raw-message-store.js",
+    "./postgres-raw-message-factory": "./dist/storage/postgres-raw-message-factory.js",
+    "./sqlite-vector-index": "./dist/storage/sqlite-vector-index.js",
+    "./chroma-memory-index": "./dist/storage/chroma-memory-index.js",
+    "./unified-search": "./dist/search/unified-search.js",
+    "./memory-graph-write-policy": "./dist/policies/memory-graph-write-policy.js",
+    "./memory-graph-correction-policy": "./dist/policies/memory-graph-correction-policy.js"
+  },
+  "bin": {
+    "openloomi-memory-http": "./dist/server/cli-http.js",
+    "openloomi-memory-mcp": "./dist/server/cli-mcp.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/melandlabs/openloomi.git",
+    "directory": "packages/memory-store"
+  },
+  "license": "Apache-2.0",
+  "description": "OpenLoomi memory storage + search SDK with HTTP and MCP server entry points.",
+  "keywords": ["openloomi", "memory", "storage", "search", "sdk", "mcp", "http"],
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "@openloomi/ai": "workspace:*",
+    "@openloomi/indexeddb": "workspace:*",
+    "@openloomi/rag": "workspace:*",
+    "@openloomi/shared": "workspace:*",
+    "@openloomi/sqlite": "workspace:*",
+    "hono": "^4.6.14",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@openloomi/config": "workspace:*",
+    "@types/node": "^22.13.10",
+    "typescript": "^5.6.3"
+  },
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "pnpm build"
+  }
+}

--- a/packages/memory-store/src/config.ts
+++ b/packages/memory-store/src/config.ts
@@ -1,0 +1,159 @@
+/**
+ * Memory store configuration — injected by the host application.
+ *
+ * The memory-store package is intentionally decoupled from the
+ * openloomi web app's database and env layers. Each consumer wires up
+ * its own implementation of these contracts.
+ *
+ * Required for raw-message persistence:
+ *   - `db.getDb()` — returns a Drizzle DB handle
+ *   - `env.isTauriMode()` — for sqlite vs postgres selection
+ *
+ * Required for vector indexing:
+ *   - one of `vector.sqlite-vec.dbPath` or `vector.chroma.url`
+ *
+ * Required for unified semantic search:
+ *   - `unified.embedQuery` — the embedding provider's query embedder
+ *
+ * Optional for cross-source unified search:
+ *   - `unified.searchKnowledge` — RAG over uploaded documents
+ *   - `unified.searchInsights`   — over extracted insights
+ *
+ * If `unified.*` are absent, the SDK still works but the corresponding
+ * sources in `searchUnifiedMemory` will return empty results with a
+ * warning — fine for a standalone memory daemon.
+ */
+
+import type { RawMessage } from "@openloomi/indexeddb/storage";
+
+export interface MemoryStoreDb {
+  /** Resolve the active Drizzle DB handle. Must be server-side. */
+  getDb(): unknown;
+  /** Whether the DB has finished initializing (optional, for startup gating). */
+  isDbInitialized?(): boolean;
+  /** Initialize the DB (optional, called by `createMemoryStore` if present). */
+  initDb?(): unknown;
+  /**
+   * Drizzle table references for the postgres backend. Required when
+   * running outside Tauri mode without a registered factory. The host
+   * application owns the actual schema.
+   */
+  tables?: {
+    rawMessages?: unknown;
+    memorySummaries?: unknown;
+  };
+}
+
+export interface MemoryStoreEnv {
+  /** True when running under Tauri (sqlite local). */
+  isTauriMode(): boolean;
+  /** Where to place the SQLite DB file (Tauri mode only). */
+  getTauriDbPath?(): string;
+  /**
+   * Tauri data dir for mkdirSync. Defaults to dirname(getTauriDbPath()).
+   * Provided so callers that use a custom layout don't need to expose
+   * their internal helpers.
+   */
+  getTauriDataDir?(): string;
+}
+
+export type VectorBackend = "sqlite-vec" | "chroma";
+
+export interface MemoryStoreVectorConfig {
+  /** Active backend selector. Defaults to env-based detection. */
+  backend?: VectorBackend;
+  /** SQLite-vec options (used when backend === "sqlite-vec"). */
+  sqliteVec?: {
+    dbPath?: string;
+    insightsCollection?: string;
+  };
+  /** Chroma options (used when backend === "chroma"). */
+  chroma?: {
+    url?: string;
+    rawMessagesCollection?: string;
+    insightsCollection?: string;
+  };
+}
+
+export type EmbedQueryFn = {
+  (input: { userId: string; query: string; authToken?: string }): Promise<
+    number[]
+  >;
+};
+
+export interface UnifiedSearchKnowledgeResult {
+  chunkId: string;
+  documentId: string;
+  documentName: string;
+  content: string;
+  similarity: number;
+  chunkIndex: number;
+}
+
+export interface UnifiedSearchInsightsResult {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface UnifiedSearchDeps {
+  /** Embed a query string using the active user's provider. */
+  embedQuery?: EmbedQueryFn;
+  /**
+   * Postgres-side ANN search over `raw_messages`. Used when chroma is
+   * not enabled but the host has a postgres-backed manager. If both
+   * chroma and this are absent, the memory source will return empty
+   * (with a warning) in standalone mode.
+   */
+  searchRawMessagesAnn?: (input: {
+    userId: string;
+    queryEmbedding: number[];
+    limit: number;
+    threshold: number;
+    botId?: string;
+  }) => Promise<
+    Array<{
+      id: string;
+      content: string;
+      similarity: number;
+      metadata: Record<string, unknown>;
+    }>
+  >;
+  /** RAG over uploaded knowledge documents. Returns a list of chunk hits. */
+  searchKnowledge?: (input: {
+    userId: string;
+    query: string;
+    options: { limit: number; threshold: number; documentIds?: string[] };
+    authToken?: string;
+  }) => Promise<UnifiedSearchKnowledgeResult[]>;
+  /** Semantic search over extracted insights. */
+  searchInsights?: (input: {
+    userId: string;
+    query: string;
+    limit: number;
+    threshold: number;
+    botIds?: string[];
+    includeArchived?: boolean;
+    authToken?: string;
+  }) => Promise<UnifiedSearchInsightsResult[]>;
+}
+
+export interface MemoryStoreConfig {
+  /** Database handle factory. Required for any persistence. */
+  db?: MemoryStoreDb;
+  /** Environment helpers. Defaults to a process.env-only stub if omitted. */
+  env?: MemoryStoreEnv;
+  /** Vector backend config. Defaults to env-based detection. */
+  vector?: MemoryStoreVectorConfig;
+  /** Optional cross-source search providers. */
+  unified?: UnifiedSearchDeps;
+  /** Optional logger. Defaults to console. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+}
+
+/**
+ * Minimal RawMessage shape. Re-exported from indexeddb so callers can
+ * construct messages without depending on the package's full schema.
+ */
+export type { RawMessage };

--- a/packages/memory-store/src/http.ts
+++ b/packages/memory-store/src/http.ts
@@ -1,0 +1,126 @@
+/**
+ * @openloomi/memory-store/http — HTTP server entry.
+ *
+ * Usage:
+ *   import { startHttpServer } from "@openloomi/memory-store/http";
+ *   const { url, stop } = await startHttpServer({
+ *     port: 7421,
+ *     db: { getDb: () => drizzleDb() },
+ *     env: { isTauriMode: () => false },
+ *   });
+ *
+ * Endpoints (all POST, JSON in/out):
+ *   GET  /health            → { ok: true }
+ *   POST /v1/search         → UnifiedMemorySearchOutput
+ *   POST /v1/raw-messages   → upsert raw messages (returns count)
+ *   GET  /v1/raw-messages/:id  → single raw message
+ *
+ * The HTTP server speaks only to the raw-message + vector layers; it does
+ * not expose RAG/insights cross-source search (callers wire those up
+ * server-side or use the MCP server with a fully-wired store).
+ */
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { type MemoryStoreConfig } from "./index";
+import { createRawMessageStore } from "./storage/raw-message-store";
+import { createUnifiedSearch } from "./search/unified-search";
+import { upsertRawMessagesToChroma } from "./storage/chroma-memory-index";
+
+export interface StartHttpServerOptions extends MemoryStoreConfig {
+  /** Port to bind. Defaults to 7421. */
+  port?: number;
+  /** Bind address. Defaults to 127.0.0.1 (loopback only — change to 0.0.0.0 for LAN). */
+  host?: string;
+}
+
+export interface StartedHttpServer {
+  url: string;
+  port: number;
+  stop(): Promise<void>;
+}
+
+export async function startHttpServer(
+  options: StartHttpServerOptions = {},
+): Promise<StartedHttpServer> {
+  const port = options.port ?? Number.parseInt(process.env.MEMORY_HTTP_PORT ?? "7421", 10);
+  const host = options.host ?? process.env.MEMORY_HTTP_HOST ?? "127.0.0.1";
+
+  const rawStore = createRawMessageStore({
+    env: options.env,
+  });
+  const search = createUnifiedSearch(options.unified);
+
+  const app = new Hono();
+
+  app.get("/health", (c) => c.json({ ok: true, store: "memory", ts: Date.now() }));
+
+  app.post("/v1/search", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const userId = typeof body.userId === "string" ? body.userId : null;
+    const query = typeof body.query === "string" ? body.query : "";
+    if (!userId || !query) {
+      return c.json({ error: "userId and query are required" }, 400);
+    }
+    const result = await search.searchUnifiedMemory({
+      userId,
+      query,
+      sources: body.sources,
+      limit: body.limit,
+      threshold: body.threshold,
+      botIds: body.botIds,
+      documentIds: body.documentIds,
+      includeArchivedInsights: body.includeArchivedInsights,
+      authToken: body.authToken,
+    });
+    return c.json(result);
+  });
+
+  app.post("/v1/raw-messages", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    if (!Array.isArray(body.messages) || !body.userId) {
+      return c.json({ error: "userId and messages[] required" }, 400);
+    }
+    const manager = await rawStore.getManager();
+    const result = await (manager as unknown as {
+      upsertRawMessages?: (input: {
+        userId: string;
+        messages: unknown[];
+      }) => Promise<unknown>;
+    }).upsertRawMessages?.({
+      userId: body.userId,
+      messages: body.messages,
+    });
+    try {
+      await upsertRawMessagesToChroma(body.messages as never);
+    } catch (error) {
+      console.warn("[memory-store/http] chroma upsert failed:", error);
+    }
+    return c.json({ ok: true, result });
+  });
+
+  app.get("/v1/raw-messages/:id", async (c) => {
+    const id = c.req.param("id");
+    const userId = c.req.query("userId");
+    if (!userId) return c.json({ error: "userId query param required" }, 400);
+    const manager = await rawStore.getManager();
+    const row = await (manager as unknown as {
+      getMessageById?: (messageId: string) => Promise<unknown>;
+    }).getMessageById?.(id);
+    if (!row) return c.json({ error: "not found" }, 404);
+    return c.json({ message: row });
+  });
+
+  const server = serve({ fetch: app.fetch, port, hostname: host });
+
+  return {
+    url: `http://${host}:${port}`,
+    port,
+    async stop() {
+      await rawStore.close();
+      server.close();
+    },
+  };
+}
+
+export { type MemoryStoreConfig };

--- a/packages/memory-store/src/index.ts
+++ b/packages/memory-store/src/index.ts
@@ -1,0 +1,91 @@
+/**
+ * @openloomi/memory-store — SDK entry point.
+ *
+ * Wires up a top-level `MemoryStore` facade combining the raw message
+ * manager, the unified search facade, and vector index helpers. Hosts
+ * that want a non-web backend (CLI daemon, custom server) can use
+ * this as the only entry point.
+ */
+
+import type { MemoryStoreConfig } from "./config";
+import {
+  configureRawMessageStore,
+  createRawMessageStore,
+  getRawMessageManager,
+  type RawMessageStore,
+} from "./storage/raw-message-store";
+import { createUnifiedSearch, type UnifiedSearch } from "./search/unified-search";
+
+export interface MemoryStore {
+  /** Underlying raw-message store (sqlite vs postgres). */
+  raw: RawMessageStore;
+  /** Unified semantic search facade (memory + insights + knowledge). */
+  search: UnifiedSearch;
+  /** Resolve the active raw-message manager. */
+  getRawMessageManager: typeof getRawMessageManager;
+  /** Run `searchUnifiedMemory` against the wired-up unified search. */
+  searchUnifiedMemory: UnifiedSearch["searchUnifiedMemory"];
+  /** Convenience: semantic search over raw messages only. */
+  searchRawMemorySemantically: UnifiedSearch["searchRawMemorySemantically"];
+}
+
+export async function createMemoryStore(
+  config: MemoryStoreConfig = {},
+): Promise<MemoryStore> {
+  const raw = createRawMessageStore({ env: config.env });
+  const search = createUnifiedSearch(config.unified);
+
+  // Make the legacy `getRawMessageManager()` module-level facade
+  // point at this configuration so callers that don't go through
+  // `createMemoryStore` still get the right backend.
+  configureRawMessageStore(config);
+
+  return {
+    raw,
+    search,
+    getRawMessageManager,
+    searchUnifiedMemory: search.searchUnifiedMemory,
+    searchRawMemorySemantically: search.searchRawMemorySemantically,
+  };
+}
+
+export type { MemoryStoreConfig };
+export {
+  createRawMessageStore,
+  getRawMessageManager,
+  isRawMessageStorageAvailable,
+  getRawMessageStorageBackend,
+  closeRawMessageStore,
+  type RawMessageStorageBackend,
+  type RawMessageStorageManagerWithSearch,
+} from "./storage/raw-message-store";
+export {
+  registerPostgresFactory,
+  clearPostgresFactory,
+  hasPostgresFactory,
+  resolvePostgresFactory,
+  type PostgresFactoryFn,
+  type PostgresRawMessageManagerLike,
+} from "./storage/postgres-raw-message-factory";
+export {
+  createUnifiedSearch,
+  type UnifiedSearch,
+} from "./search/unified-search";
+export type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+  UnifiedMemorySearchResult,
+  UnifiedMemorySearchSource,
+  UnifiedMemorySearchWarning,
+} from "./search/utilities";
+export {
+  clampUnifiedMemorySearchLimit,
+  clampUnifiedMemorySearchThreshold,
+  isRawMemorySemanticResult,
+  mergeUnifiedMemorySearchResults,
+  normalizeUnifiedMemorySearchSources,
+  toKnowledgeResult,
+  toMemoryResult,
+} from "./search/utilities";
+export type { MemoryStoreDb, MemoryStoreEnv, VectorBackend, EmbedQueryFn, UnifiedSearchKnowledgeResult, UnifiedSearchInsightsResult } from "./config";
+export type { RawMessage } from "./config";

--- a/packages/memory-store/src/mcp.ts
+++ b/packages/memory-store/src/mcp.ts
@@ -1,0 +1,191 @@
+/**
+ * @openloomi/memory-store/mcp — MCP server entry.
+ *
+ * Spawns an MCP server (stdio transport by default) that exposes the
+ * memory-store as tools any MCP client (Claude Code, etc.) can invoke.
+ *
+ * Tools registered:
+ *   - memory.searchUnified   → UnifiedMemorySearchOutput
+ *   - memory.writeRawMessage → { ok: boolean }
+ *   - memory.getRawMessage   → RawMessage | null
+ *   - memory.health          → { ok: true }
+ *
+ * Usage:
+ *   import { startMcpServer } from "@openloomi/memory-store/mcp";
+ *   await startMcpServer({ db: { getDb }, env: { isTauriMode } });
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import type { MemoryStoreConfig } from "./index";
+import { createRawMessageStore } from "./storage/raw-message-store";
+import { createUnifiedSearch } from "./search/unified-search";
+import { upsertRawMessagesToChroma } from "./storage/chroma-memory-index";
+
+export interface StartMcpServerOptions extends MemoryStoreConfig {
+  /** Server name surfaced to the MCP client. */
+  name?: string;
+  /** Server version surfaced to the MCP client. */
+  version?: string;
+}
+
+const DEFAULT_NAME = "@openloomi/memory-store";
+const DEFAULT_VERSION = "0.9.0";
+
+export async function startMcpServer(
+  options: StartMcpServerOptions = {},
+): Promise<McpServer> {
+  const server = new McpServer({
+    name: options.name ?? DEFAULT_NAME,
+    version: options.version ?? DEFAULT_VERSION,
+  });
+
+  const rawStore = createRawMessageStore({
+    env: options.env,
+  });
+  const search = createUnifiedSearch(options.unified);
+
+  server.tool(
+    "memory.health",
+    "Returns the health status of the memory store.",
+    async () => ({
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }],
+    }),
+  );
+
+  const searchSchema: ZodRawShape = {
+    userId: z.string(),
+    query: z.string().min(1),
+    sources: z
+      .array(z.enum(["memory", "insights", "knowledge"]))
+      .optional()
+      .describe("Default: ['memory','insights','knowledge']"),
+    limit: z.number().int().min(1).max(50).default(10),
+    threshold: z.number().min(-1).max(1).default(0.7),
+    botIds: z.array(z.string()).optional(),
+    documentIds: z.array(z.string()).optional(),
+    includeArchivedInsights: z.boolean().default(false),
+    authToken: z.string().optional(),
+  };
+
+  const writeSchema: ZodRawShape = {
+    userId: z.string(),
+    message: z
+      .object({
+        id: z.string().optional(),
+        messageId: z.string().optional(),
+        role: z.string(),
+        content: z.union([z.string(), z.array(z.unknown())]),
+        platform: z.string().optional(),
+        botId: z.string().optional(),
+        channel: z.string().optional(),
+        person: z.string().optional(),
+        timestamp: z.number().optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      })
+      .passthrough(),
+  };
+
+  const getSchema: ZodRawShape = {
+    userId: z.string(),
+    messageId: z.string(),
+  };
+
+  // Zod 4 schemas are not directly assignable to the MCP SDK's
+  // AnySchema (z3.ZodTypeAny | z4.$ZodType) due to TypeScript's
+  // structural checks. The runtime works correctly — only the
+  // static type relationship needs the explicit cast.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.registerTool(
+    "memory.searchUnified",
+    {
+      title: "Search Unified Memory",
+      description:
+        "Semantic search across raw messages (always), and optionally insights and uploaded knowledge.",
+      inputSchema: searchSchema as any,
+    },
+    async (args: unknown) => {
+      const a = args as {
+        userId: string;
+        query: string;
+        sources?: ("memory" | "insights" | "knowledge")[];
+        limit?: number;
+        threshold?: number;
+        botIds?: string[];
+        documentIds?: string[];
+        includeArchivedInsights?: boolean;
+        authToken?: string;
+      };
+      const result = await search.searchUnifiedMemory(a);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.registerTool(
+    "memory.writeRawMessage",
+    {
+      title: "Write Raw Message",
+      description: "Persist a single raw message to the user's memory store.",
+      inputSchema: writeSchema as any,
+    },
+    async (args: unknown) => {
+      const a = args as { userId: string; message: unknown };
+      const manager = await rawStore.getManager();
+      const result = await (manager as unknown as {
+        upsertRawMessages?: (input: {
+          userId: string;
+          messages: unknown[];
+        }) => Promise<unknown>;
+      }).upsertRawMessages?.({
+        userId: a.userId,
+        messages: [a.message],
+      });
+      try {
+        await upsertRawMessagesToChroma([a.message as never]);
+      } catch (error) {
+        console.warn("[memory-store/mcp] chroma upsert failed:", error);
+      }
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify({ ok: true, result }) },
+        ],
+      };
+    },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.registerTool(
+    "memory.getRawMessage",
+    {
+      title: "Get Raw Message",
+      description: "Fetch a single raw message by its message id.",
+      inputSchema: getSchema as any,
+    },
+    async (args: unknown) => {
+      const a = args as { userId: string; messageId: string };
+      const manager = await rawStore.getManager();
+      const row = await (manager as unknown as {
+        getMessageById?: (messageId: string) => Promise<unknown>;
+      }).getMessageById?.(a.messageId);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ message: row ?? null }),
+          },
+        ],
+      };
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return server;
+}
+
+export { type MemoryStoreConfig };

--- a/packages/memory-store/src/policies/memory-graph-correction-policy.ts
+++ b/packages/memory-store/src/policies/memory-graph-correction-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * Memory-graph correction policy.
+ *
+ * Wraps the same allowlist machinery as the write policy but with
+ * correction-specific env keys and reason codes.
+ */
+
+import {
+  type MemoryGraphWriteEnvironment,
+  type MemoryGraphWritePolicyDecision,
+  resolveAllowlistedMemoryGraphPolicy,
+} from "./memory-graph-write-policy";
+
+export function resolveMemoryGraphCorrectionPolicy(
+  userId: string,
+  environment: MemoryGraphWriteEnvironment = process.env,
+): MemoryGraphWritePolicyDecision {
+  return resolveAllowlistedMemoryGraphPolicy({
+    userId,
+    enabled: environment.OPENLOOMI_MEMORY_GRAPH_CORRECTION_ENABLED,
+    killSwitch: environment.OPENLOOMI_MEMORY_GRAPH_CORRECTION_KILL_SWITCH,
+    allowlist: environment.OPENLOOMI_MEMORY_GRAPH_CORRECTION_OPERATOR_USER_IDS,
+    reasonCodes: {
+      killed: "memory_graph_correction_kill_switch",
+      disabled: "memory_graph_correction_disabled",
+      missed: "memory_graph_correction_operator_miss",
+      enabled: "memory_graph_correction_operator_enabled",
+    },
+  });
+}

--- a/packages/memory-store/src/policies/memory-graph-write-policy.ts
+++ b/packages/memory-store/src/policies/memory-graph-write-policy.ts
@@ -1,0 +1,128 @@
+/**
+ * Memory-graph write policy.
+ *
+ * Pure functions, no env imports — callers pass the env snapshot
+ * explicitly. Used by the apps/web routes via `@openloomi/memory-store/memory-graph-write-policy`.
+ */
+
+import { CHAT_MEMORY_EVIDENCE_ID_PREFIX } from "@openloomi/indexeddb";
+
+export { CHAT_MEMORY_EVIDENCE_ID_PREFIX };
+
+export const MEMORY_GRAPH_SUMMARY_ID_PREFIXES = [
+  "memory-graph-summary:",
+  "memory-graph-correction:",
+] as const;
+
+export interface MemoryGraphWritePolicyDecision {
+  enabled: boolean;
+  reasonCodes: string[];
+}
+
+export type MemoryGraphWriteEnvironment = Readonly<
+  Record<string, string | undefined>
+>;
+
+export function isReservedChatMemoryEvidenceId(messageId: string): boolean {
+  return messageId.startsWith(CHAT_MEMORY_EVIDENCE_ID_PREFIX);
+}
+
+export function isReservedMemoryGraphSummaryId(summaryId: string): boolean {
+  return MEMORY_GRAPH_SUMMARY_ID_PREFIXES.some((prefix) =>
+    summaryId.startsWith(prefix),
+  );
+}
+
+function enabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+function cohortUserIds(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+export function resolveAllowlistedMemoryGraphPolicy(input: {
+  userId: string;
+  enabled: string | undefined;
+  killSwitch: string | undefined;
+  allowlist: string | undefined;
+  reasonCodes: {
+    killed: string;
+    disabled: string;
+    missed: string;
+    enabled: string;
+  };
+}): MemoryGraphWritePolicyDecision {
+  if (enabled(input.killSwitch)) {
+    return { enabled: false, reasonCodes: [input.reasonCodes.killed] };
+  }
+  if (!enabled(input.enabled)) {
+    return { enabled: false, reasonCodes: [input.reasonCodes.disabled] };
+  }
+  if (!cohortUserIds(input.allowlist).has(input.userId)) {
+    return { enabled: false, reasonCodes: [input.reasonCodes.missed] };
+  }
+  return { enabled: true, reasonCodes: [input.reasonCodes.enabled] };
+}
+
+export function resolveMemoryGraphWritePolicy(
+  userId: string,
+  environment: MemoryGraphWriteEnvironment = process.env,
+): MemoryGraphWritePolicyDecision {
+  return resolveAllowlistedMemoryGraphPolicy({
+    userId,
+    enabled: environment.OPENLOOMI_MEMORY_GRAPH_WRITE_ENABLED,
+    killSwitch: environment.OPENLOOMI_MEMORY_GRAPH_WRITE_KILL_SWITCH,
+    allowlist: environment.OPENLOOMI_MEMORY_GRAPH_WRITE_COHORT_USER_IDS,
+    reasonCodes: {
+      killed: "memory_graph_write_kill_switch",
+      disabled: "memory_graph_write_disabled",
+      missed: "memory_graph_write_cohort_miss",
+      enabled: "memory_graph_write_cohort_enabled",
+    },
+  });
+}
+
+const UNTRUSTED_GRAPH_METADATA_KEYS = [
+  "relationGroup",
+  "relationValue",
+  "topicKeys",
+  "memoryTopicKeys",
+  "memoryApplicability",
+  "memoryRelation",
+  "sourceIdentity",
+  "memoryOwnerScope",
+] as const;
+
+export function sanitizeUntrustedMemoryMetadata(
+  metadata: unknown,
+): Record<string, unknown> | undefined {
+  if (
+    typeof metadata !== "object" ||
+    metadata === null ||
+    Array.isArray(metadata)
+  ) {
+    return undefined;
+  }
+
+  const sanitized = { ...metadata } as Record<string, unknown>;
+  for (const key of UNTRUSTED_GRAPH_METADATA_KEYS) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}
+
+export function resolveUntrustedRawMemoryGraphWritePolicy(): MemoryGraphWritePolicyDecision {
+  return {
+    enabled: false,
+    reasonCodes: [
+      "memory_graph_write_untrusted_raw_baseline_only",
+      "untrusted_graph_metadata_discarded",
+    ],
+  };
+}

--- a/packages/memory-store/src/search/unified-search.ts
+++ b/packages/memory-store/src/search/unified-search.ts
@@ -1,0 +1,217 @@
+/**
+ * Unified semantic search facade.
+ *
+ * Cross-source search over raw messages (always), insights, and
+ * uploaded knowledge documents. The host wires up the cross-domain
+ * dependencies via `UnifiedSearchDeps` so this module stays
+ * framework-agnostic.
+ */
+
+import type { UnifiedSearchDeps } from "../config";
+import { isRawMessageChromaEnabled, searchRawMessagesWithChroma } from "../storage/chroma-memory-index";
+import {
+  clampUnifiedMemorySearchLimit,
+  clampUnifiedMemorySearchThreshold,
+  mergeUnifiedMemorySearchResults,
+  normalizeUnifiedMemorySearchSources,
+  toKnowledgeResult,
+  toMemoryResult,
+  type UnifiedMemorySearchInput,
+  type UnifiedMemorySearchOutput,
+  type UnifiedMemorySearchResult,
+  type UnifiedMemorySearchSource,
+  type UnifiedMemorySearchWarning,
+} from "./utilities";
+
+export type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+  UnifiedMemorySearchResult,
+  UnifiedMemorySearchSource,
+  UnifiedMemorySearchWarning,
+} from "./utilities";
+
+export {
+  clampUnifiedMemorySearchLimit,
+  clampUnifiedMemorySearchThreshold,
+  isRawMemorySemanticResult,
+  mergeUnifiedMemorySearchResults,
+  normalizeUnifiedMemorySearchSources,
+  toKnowledgeResult,
+  toMemoryResult,
+} from "./utilities";
+
+export interface UnifiedSearch {
+  searchUnifiedMemory(input: UnifiedMemorySearchInput): Promise<UnifiedMemorySearchOutput>;
+  searchRawMemorySemantically(input: UnifiedMemorySearchInput): Promise<UnifiedMemorySearchResult[]>;
+}
+
+export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch {
+  const logger = (deps as { logger?: Console }).logger ?? console;
+
+  async function searchUnifiedMemory(
+    input: UnifiedMemorySearchInput,
+  ): Promise<UnifiedMemorySearchOutput> {
+    const sources = normalizeUnifiedMemorySearchSources(input.sources);
+    const limit = clampUnifiedMemorySearchLimit(input.limit);
+    const threshold = clampUnifiedMemorySearchThreshold(input.threshold);
+    const warnings: UnifiedMemorySearchWarning[] = [];
+
+    const results: UnifiedMemorySearchResult[] = [];
+
+    if (sources.includes("memory")) {
+      try {
+        const memoryHits = await runMemorySource(input, limit, threshold);
+        results.push(...memoryHits);
+      } catch (error) {
+        logger.warn?.("[memory-store] memory source failed:", error);
+        warnings.push({
+          source: "memory",
+          code: "memory_search_failed",
+          message: (error as Error).message ?? "memory_search_failed",
+        });
+      }
+    }
+
+    if (sources.includes("insights") && typeof deps.searchInsights === "function") {
+      try {
+        const insightHits = await deps.searchInsights({
+          userId: input.userId,
+          query: input.query,
+          limit,
+          threshold,
+          botIds: input.botIds,
+          includeArchived: input.includeArchivedInsights,
+          authToken: input.authToken,
+        });
+        for (const hit of insightHits) {
+          results.push({
+            type: "insight",
+            id: hit.id,
+            content: hit.content,
+            similarity: hit.similarity,
+            metadata: hit.metadata,
+          });
+        }
+      } catch (error) {
+        logger.warn?.("[memory-store] insights source failed:", error);
+        warnings.push({
+          source: "insights",
+          code: "insights_search_failed",
+          message: (error as Error).message ?? "insights_search_failed",
+        });
+      }
+    } else if (sources.includes("insights")) {
+      warnings.push({
+        source: "insights",
+        code: "insights_search_not_configured",
+        message: "Insights search is not configured for this host.",
+      });
+    }
+
+    if (sources.includes("knowledge") && typeof deps.searchKnowledge === "function") {
+      try {
+        const knowledgeHits = await deps.searchKnowledge({
+          userId: input.userId,
+          query: input.query,
+          options: {
+            limit,
+            threshold,
+            documentIds: input.documentIds,
+          },
+          authToken: input.authToken,
+        });
+        for (const hit of knowledgeHits) {
+          results.push(toKnowledgeResult(hit));
+        }
+      } catch (error) {
+        logger.warn?.("[memory-store] knowledge source failed:", error);
+        warnings.push({
+          source: "knowledge",
+          code: "knowledge_search_failed",
+          message: (error as Error).message ?? "knowledge_search_failed",
+        });
+      }
+    } else if (sources.includes("knowledge")) {
+      warnings.push({
+        source: "knowledge",
+        code: "knowledge_search_not_configured",
+        message: "Knowledge search is not configured for this host.",
+      });
+    }
+
+    const merged = mergeUnifiedMemorySearchResults(results, limit);
+
+    return {
+      query: input.query,
+      sources,
+      results: merged,
+      count: merged.length,
+      warnings,
+    };
+  }
+
+  async function runMemorySource(
+    input: UnifiedMemorySearchInput,
+    limit: number,
+    threshold: number,
+  ): Promise<UnifiedMemorySearchResult[]> {
+    if (typeof deps.embedQuery !== "function") {
+      throw new Error("embedQuery is not configured");
+    }
+
+    const queryEmbedding = await deps.embedQuery({
+      userId: input.userId,
+      query: input.query,
+      authToken: input.authToken,
+    });
+
+    if (isRawMessageChromaEnabled()) {
+      const chromaHits = await searchRawMessagesWithChroma({
+        userId: input.userId,
+        queryEmbedding,
+        limit: limit * 5,
+        threshold,
+        botId: input.botIds?.[0],
+      });
+      return chromaHits.map((hit) =>
+        toMemoryResult({
+          id: hit.id,
+          content: hit.content,
+          similarity: hit.similarity,
+          metadata: hit.metadata,
+        }),
+      );
+    }
+
+    if (typeof deps.searchRawMessagesAnn === "function") {
+      const rows = await deps.searchRawMessagesAnn({
+        userId: input.userId,
+        queryEmbedding,
+        limit: limit * 5,
+        threshold,
+        botId: input.botIds?.[0],
+      });
+      return rows.map((row) =>
+        toMemoryResult({
+          id: row.id,
+          content: row.content,
+          similarity: row.similarity,
+          metadata: row.metadata,
+        }),
+      );
+    }
+
+    return [];
+  }
+
+  async function searchRawMemorySemantically(
+    input: UnifiedMemorySearchInput,
+  ): Promise<UnifiedMemorySearchResult[]> {
+    const limit = clampUnifiedMemorySearchLimit(input.limit);
+    const threshold = clampUnifiedMemorySearchThreshold(input.threshold);
+    return runMemorySource(input, limit, threshold);
+  }
+
+  return { searchUnifiedMemory, searchRawMemorySemantically };
+}

--- a/packages/memory-store/src/search/unified-search.ts
+++ b/packages/memory-store/src/search/unified-search.ts
@@ -9,9 +9,11 @@
 
 import type { UnifiedSearchDeps } from "../config";
 import { isRawMessageChromaEnabled, searchRawMessagesWithChroma } from "../storage/chroma-memory-index";
+import { isRawMessageStorageAvailable } from "../storage/raw-message-store";
 import {
   clampUnifiedMemorySearchLimit,
   clampUnifiedMemorySearchThreshold,
+  isRawMemorySemanticResult,
   mergeUnifiedMemorySearchResults,
   normalizeUnifiedMemorySearchSources,
   toKnowledgeResult,
@@ -52,23 +54,41 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
   async function searchUnifiedMemory(
     input: UnifiedMemorySearchInput,
   ): Promise<UnifiedMemorySearchOutput> {
+    const query = input.query.trim();
     const sources = normalizeUnifiedMemorySearchSources(input.sources);
     const limit = clampUnifiedMemorySearchLimit(input.limit);
     const threshold = clampUnifiedMemorySearchThreshold(input.threshold);
     const warnings: UnifiedMemorySearchWarning[] = [];
-
     const results: UnifiedMemorySearchResult[] = [];
 
+    if (!query) {
+      return {
+        query,
+        sources,
+        results: [],
+        count: 0,
+        warnings,
+      };
+    }
+
     if (sources.includes("memory")) {
-      try {
-        const memoryHits = await runMemorySource(input, limit, threshold);
-        results.push(...memoryHits);
-      } catch (error) {
-        logger.warn?.("[memory-store] memory source failed:", error);
+      if (isRawMessageStorageAvailable()) {
+        try {
+          const memoryHits = await runMemorySource(input, limit, threshold);
+          results.push(...memoryHits);
+        } catch (error) {
+          logger.warn?.("[memory-store] memory source failed:", error);
+          warnings.push({
+            source: "memory",
+            code: "memory_search_failed",
+            message: (error as Error).message ?? "memory_search_failed",
+          });
+        }
+      } else {
         warnings.push({
           source: "memory",
-          code: "memory_search_failed",
-          message: (error as Error).message ?? "memory_search_failed",
+          code: "raw_message_storage_unavailable",
+          message: "Raw memory storage is not available in this environment.",
         });
       }
     }
@@ -166,40 +186,61 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
       authToken: input.authToken,
     });
 
+    const filters =
+      input.botIds && input.botIds.length > 0
+        ? input.botIds.map((botId) => ({ botId }))
+        : [{}];
+
     if (isRawMessageChromaEnabled()) {
-      const chromaHits = await searchRawMessagesWithChroma({
-        userId: input.userId,
-        queryEmbedding,
-        limit: limit * 5,
-        threshold,
-        botId: input.botIds?.[0],
-      });
-      return chromaHits.map((hit) =>
-        toMemoryResult({
-          id: hit.id,
-          content: hit.content,
-          similarity: hit.similarity,
-          metadata: hit.metadata,
-        }),
-      );
+      try {
+        const chromaHits = (
+          await Promise.all(
+            filters.map((filter) => {
+              const botId = "botId" in filter ? filter.botId : undefined;
+              return searchRawMessagesWithChroma({
+                userId: input.userId,
+                queryEmbedding,
+                limit,
+                threshold,
+                botId,
+              });
+            }),
+          )
+        )
+          .flat()
+          .map(toMemoryResult);
+        logger.log?.(
+          "[memory-store] Raw message semantic search completed",
+          { backend: "chroma", dimensions: queryEmbedding.length, count: chromaHits.length },
+        );
+        return chromaHits;
+      } catch (error) {
+        logger.warn?.(
+          "[memory-store] Chroma raw message search failed; falling back to database search:",
+          error,
+        );
+        // fall through to the ANN/database search below
+      }
     }
 
     if (typeof deps.searchRawMessagesAnn === "function") {
-      const rows = await deps.searchRawMessagesAnn({
-        userId: input.userId,
-        queryEmbedding,
-        limit: limit * 5,
-        threshold,
-        botId: input.botIds?.[0],
-      });
-      return rows.map((row) =>
-        toMemoryResult({
-          id: row.id,
-          content: row.content,
-          similarity: row.similarity,
-          metadata: row.metadata,
-        }),
-      );
+      const rows = (
+        await Promise.all(
+          filters.map((filter) =>
+            deps.searchRawMessagesAnn!({
+              userId: input.userId,
+              queryEmbedding,
+              limit,
+              threshold,
+              botId: "botId" in filter ? filter.botId : undefined,
+            }),
+          ),
+        )
+      )
+        .flat()
+        .filter(isRawMemorySemanticResult)
+        .map(toMemoryResult);
+      return rows;
     }
 
     return [];

--- a/packages/memory-store/src/search/utilities.ts
+++ b/packages/memory-store/src/search/utilities.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure helpers used by the unified memory search pipeline.
+ *
+ * Kept side-effect free so they can be reused by tests, MCP tools,
+ * and the HTTP daemon without pulling in any of the heavier
+ * storage/search implementations.
+ */
+
+export type UnifiedMemorySearchSource = "memory" | "insights" | "knowledge";
+
+export interface UnifiedMemorySearchWarning {
+  source: UnifiedMemorySearchSource;
+  code: string;
+  message: string;
+}
+
+export interface UnifiedMemorySearchInput {
+  userId: string;
+  query: string;
+  sources?: UnifiedMemorySearchSource[];
+  limit?: number;
+  threshold?: number;
+  authToken?: string;
+  includeArchivedInsights?: boolean;
+  botIds?: string[];
+  documentIds?: string[];
+}
+
+export interface UnifiedMemorySearchResult {
+  type: "memory" | "insight" | "knowledge";
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface UnifiedMemorySearchOutput {
+  query: string;
+  sources: UnifiedMemorySearchSource[];
+  results: UnifiedMemorySearchResult[];
+  count: number;
+  warnings: UnifiedMemorySearchWarning[];
+}
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_THRESHOLD = 0.7;
+const DEFAULT_SOURCES: UnifiedMemorySearchSource[] = [
+  "memory",
+  "insights",
+  "knowledge",
+];
+const SOURCE_SET = new Set<UnifiedMemorySearchSource>(DEFAULT_SOURCES);
+
+export function normalizeUnifiedMemorySearchSources(
+  sources: unknown,
+): UnifiedMemorySearchSource[] {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return [...DEFAULT_SOURCES];
+  }
+
+  const normalized = sources
+    .filter((source): source is string => typeof source === "string")
+    .map((source) => source.trim().toLowerCase())
+    .filter((source): source is UnifiedMemorySearchSource =>
+      SOURCE_SET.has(source as UnifiedMemorySearchSource),
+    );
+
+  return normalized.length > 0
+    ? Array.from(new Set(normalized))
+    : [...DEFAULT_SOURCES];
+}
+
+export function clampUnifiedMemorySearchLimit(limit: unknown): number {
+  const parsed =
+    typeof limit === "number" ? limit : Number(limit ?? DEFAULT_LIMIT);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(50, Math.max(1, Math.floor(parsed)));
+}
+
+export function clampUnifiedMemorySearchThreshold(threshold: unknown): number {
+  const parsed =
+    typeof threshold === "number"
+      ? threshold
+      : Number(threshold ?? DEFAULT_THRESHOLD);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_THRESHOLD;
+  }
+  return Math.min(1, Math.max(-1, parsed));
+}
+
+export function mergeUnifiedMemorySearchResults(
+  results: UnifiedMemorySearchResult[],
+  limit: number,
+): UnifiedMemorySearchResult[] {
+  return [...results]
+    .sort((a, b) => {
+      const scoreDelta = b.similarity - a.similarity;
+      if (scoreDelta !== 0) {
+        return scoreDelta;
+      }
+      return a.type.localeCompare(b.type) || a.id.localeCompare(b.id);
+    })
+    .slice(0, limit);
+}
+
+export function toKnowledgeResult(result: {
+  chunkId: string;
+  documentId: string;
+  documentName: string;
+  content: string;
+  similarity: number;
+  chunkIndex: number;
+}): UnifiedMemorySearchResult {
+  return {
+    type: "knowledge",
+    id: result.chunkId,
+    content: result.content,
+    similarity: result.similarity,
+    metadata: {
+      documentId: result.documentId,
+      documentName: result.documentName,
+      chunkIndex: result.chunkIndex,
+    },
+  };
+}
+
+export function toMemoryResult(result: {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+}): UnifiedMemorySearchResult {
+  return {
+    type: "memory",
+    id: result.id,
+    content: result.content,
+    similarity: result.similarity,
+    metadata: result.metadata,
+  };
+}
+
+export function isRawMemorySemanticResult(result: unknown): result is {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: Record<string, unknown>;
+} {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const item = result as Record<string, unknown>;
+  return (
+    typeof item.id === "string" &&
+    typeof item.content === "string" &&
+    typeof item.similarity === "number" &&
+    Boolean(item.metadata) &&
+    typeof item.metadata === "object"
+  );
+}

--- a/packages/memory-store/src/server/cli-http.ts
+++ b/packages/memory-store/src/server/cli-http.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * CLI entry for the memory-store HTTP daemon.
+ *
+ * Usage:
+ *   openloomi-memory-http --port 7421 --host 127.0.0.1
+ *
+ * Reads `MEMORY_HTTP_PORT` and `MEMORY_HTTP_HOST` env vars as
+ * defaults. Wires up the standalone memory store (no Drizzle — only
+ * sqlite-vec-backed reads are available).
+ */
+
+import { startHttpServer } from "../http";
+
+interface CliArgs {
+  port: number;
+  host: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    port: Number.parseInt(process.env.MEMORY_HTTP_PORT ?? "7421", 10),
+    host: process.env.MEMORY_HTTP_HOST ?? "127.0.0.1",
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--port" && next) {
+      args.port = Number.parseInt(next, 10);
+      i += 1;
+    } else if (arg === "--host" && next) {
+      args.host = next;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: openloomi-memory-http [--port <port>] [--host <host>]",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const { url, port, stop } = await startHttpServer({
+    port: args.port,
+    host: args.host,
+  });
+  console.log(`[memory-store/http] listening at ${url}`);
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    console.log(`[memory-store/http] ${signal} received, shutting down…`);
+    await stop();
+    process.exit(0);
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  console.error("[memory-store/http] fatal:", error);
+  process.exit(1);
+});

--- a/packages/memory-store/src/server/cli-mcp.ts
+++ b/packages/memory-store/src/server/cli-mcp.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * CLI entry for the memory-store MCP daemon.
+ *
+ * Usage:
+ *   openloomi-memory-mcp
+ *
+ * Exposes the standalone memory store over MCP stdio. To enable
+ * unified search, hosts must register a postgres factory via
+ * `registerPostgresFactory(...)` before spawning this CLI.
+ */
+
+import { startMcpServer } from "../mcp";
+
+async function main(): Promise<void> {
+  const server = await startMcpServer();
+  console.error("[memory-store/mcp] listening on stdio");
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    console.error(`[memory-store/mcp] ${signal} received, shutting down…`);
+    await server.close();
+    process.exit(0);
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  console.error("[memory-store/mcp] fatal:", error);
+  process.exit(1);
+});

--- a/packages/memory-store/src/storage/chroma-memory-index.ts
+++ b/packages/memory-store/src/storage/chroma-memory-index.ts
@@ -1,0 +1,349 @@
+/**
+ * Chroma-backed raw-message + insight vector index.
+ *
+ * Detects the active backend at call time (defaults to sqlite-vec if
+ * no env override is present). The actual URL/collection values come
+ * from env vars so the standalone memory daemon can pick them up
+ * without an injected config.
+ */
+
+import { buildMemoryRecordEmbeddingDocument } from "@openloomi/ai/memory";
+import {
+  rawMessageToMemoryRecord,
+  type RawMessage,
+} from "@openloomi/indexeddb";
+import { ChromaVectorStore } from "@openloomi/rag";
+import type { DocumentChunk } from "@openloomi/rag/vector-service";
+
+const DEFAULT_RAW_MESSAGES_COLLECTION = "openloomi_raw_messages";
+const DEFAULT_INSIGHTS_COLLECTION = "openloomi_insights";
+const RAW_VECTOR_BACKEND_ENV_KEYS = [
+  "RAW_MESSAGE_VECTOR_STORE_BACKEND",
+  "MEMORY_VECTOR_STORE_BACKEND",
+  "VECTOR_STORE_BACKEND",
+] as const;
+const INSIGHT_VECTOR_BACKEND_ENV_KEYS = [
+  "INSIGHT_VECTOR_STORE_BACKEND",
+  "MEMORY_VECTOR_STORE_BACKEND",
+  "VECTOR_STORE_BACKEND",
+] as const;
+
+export interface ChromaInsightVectorInput {
+  insightId: string;
+  userId: string;
+  botId: string;
+  content: string;
+  contentHash: string;
+  embedding: number[];
+  embeddingModel: string;
+  embeddingDimensions: number;
+  title?: unknown;
+  description?: unknown;
+  taskLabel?: unknown;
+  importance?: unknown;
+  urgency?: unknown;
+  platform?: unknown;
+  account?: unknown;
+  time?: unknown;
+  archived?: unknown;
+}
+
+export interface ChromaInsightSearchResult {
+  id: string;
+  content: string;
+  similarity: number;
+  metadata: {
+    botId: string;
+    title: string;
+    description: string;
+    taskLabel: string;
+    importance: string;
+    urgency: string;
+    platform: string | null;
+    account: string | null;
+    time: Date | null;
+    embeddingModel: string;
+    embeddingDimensions: number;
+    contentHash: string;
+  };
+}
+
+function getBackend(keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]?.trim().toLowerCase();
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+export function isRawMessageChromaEnabled(): boolean {
+  return getBackend(RAW_VECTOR_BACKEND_ENV_KEYS) === "chroma";
+}
+
+export function isInsightChromaEnabled(): boolean {
+  return getBackend(INSIGHT_VECTOR_BACKEND_ENV_KEYS) === "chroma";
+}
+
+function getRawMessagesCollectionName(): string {
+  return (
+    process.env.CHROMA_RAW_MESSAGES_COLLECTION ||
+    process.env.CHROMA_MEMORY_COLLECTION ||
+    DEFAULT_RAW_MESSAGES_COLLECTION
+  );
+}
+
+function getInsightsCollectionName(): string {
+  return process.env.CHROMA_INSIGHTS_COLLECTION || DEFAULT_INSIGHTS_COLLECTION;
+}
+
+function getChromaStore(collectionName: string): ChromaVectorStore {
+  return new ChromaVectorStore({
+    url: process.env.CHROMA_URL,
+    collectionName,
+  });
+}
+
+function normalizeTimestampToMs(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if ((value as number) < 1e11) {
+    return Math.floor((value as number) * 1000);
+  }
+  return Math.floor(value as number);
+}
+
+function toStringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : fallback;
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function toBooleanValue(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function toDateValue(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function rawMessageToChunk(message: RawMessage): DocumentChunk | null {
+  if (!message.embedding || message.embedding.length === 0) {
+    return null;
+  }
+
+  const record = rawMessageToMemoryRecord(message);
+  const document = buildMemoryRecordEmbeddingDocument(record);
+  if (!document.content) {
+    return null;
+  }
+
+  return {
+    id: message.messageId,
+    documentId: message.messageId,
+    content: document.content,
+    embedding: message.embedding,
+    metadata: {
+      sourceType: "raw_message",
+      userId: message.userId,
+      platform: message.platform,
+      botId: message.botId,
+      channel: message.channel,
+      person: message.person,
+      timestamp: normalizeTimestampToMs(message.timestamp),
+      memoryStage: message.memoryStage,
+      embeddingModel: message.embeddingModel,
+      embeddingDimensions: message.embeddingDimensions,
+      contentHash: message.embeddingContentHash,
+      archived: Boolean(message.archivedAt),
+      role:
+        typeof message.metadata?.role === "string"
+          ? message.metadata.role
+          : undefined,
+    },
+  };
+}
+
+export async function upsertRawMessagesToChroma(
+  messages: RawMessage[],
+): Promise<number> {
+  if (!isRawMessageChromaEnabled() || messages.length === 0) {
+    return 0;
+  }
+
+  const chunks = messages
+    .map(rawMessageToChunk)
+    .filter((chunk): chunk is DocumentChunk => chunk !== null);
+  if (chunks.length === 0) {
+    return 0;
+  }
+
+  const store = getChromaStore(getRawMessagesCollectionName());
+  await store.addChunks(chunks);
+  return chunks.length;
+}
+
+export async function searchRawMessagesWithChroma(input: {
+  userId: string;
+  queryEmbedding: number[];
+  limit: number;
+  threshold: number;
+  botId?: string;
+}): Promise<
+  Array<{
+    id: string;
+    content: string;
+    similarity: number;
+    metadata: Record<string, unknown>;
+  }>
+> {
+  if (!isRawMessageChromaEnabled() || input.queryEmbedding.length === 0) {
+    return [];
+  }
+
+  const store = getChromaStore(getRawMessagesCollectionName());
+  const results = await store.similaritySearch(
+    input.queryEmbedding,
+    Math.max(input.limit * 5, input.limit),
+    input.userId,
+  );
+
+  return results
+    .filter((result) => {
+      const metadata = result.metadata ?? {};
+      if (toBooleanValue(metadata.archived)) {
+        return false;
+      }
+      if (input.botId && metadata.botId !== input.botId) {
+        return false;
+      }
+      return result.score >= input.threshold;
+    })
+    .map((result) => ({
+      id: result.id,
+      content: result.content,
+      similarity: result.score,
+      metadata: result.metadata ?? {},
+    }))
+    .slice(0, input.limit);
+}
+
+export async function upsertInsightsToChroma(
+  insights: ChromaInsightVectorInput[],
+): Promise<number> {
+  if (!isInsightChromaEnabled() || insights.length === 0) {
+    return 0;
+  }
+
+  const chunks = insights
+    .filter(
+      (item) =>
+        item.content.trim().length > 0 &&
+        Array.isArray(item.embedding) &&
+        item.embedding.length > 0,
+    )
+    .map<DocumentChunk>((item) => ({
+      id: item.insightId,
+      documentId: item.insightId,
+      content: item.content,
+      embedding: item.embedding,
+      metadata: {
+        sourceType: "insight",
+        insightId: item.insightId,
+        userId: item.userId,
+        botId: item.botId,
+        title: toStringValue(item.title),
+        description: toStringValue(item.description),
+        taskLabel: toStringValue(item.taskLabel),
+        importance: toStringValue(item.importance),
+        urgency: toStringValue(item.urgency),
+        platform: toNullableString(item.platform),
+        account: toNullableString(item.account),
+        time: toDateValue(item.time)?.toISOString(),
+        embeddingModel: item.embeddingModel,
+        embeddingDimensions: item.embeddingDimensions,
+        contentHash: item.contentHash,
+        archived: toBooleanValue(item.archived),
+      },
+    }));
+
+  if (chunks.length === 0) {
+    return 0;
+  }
+
+  const store = getChromaStore(getInsightsCollectionName());
+  await store.addChunks(chunks);
+  return chunks.length;
+}
+
+export async function searchInsightsWithChroma(input: {
+  userId: string;
+  queryEmbedding: number[];
+  limit: number;
+  threshold: number;
+  botIds?: string[];
+  includeArchived?: boolean;
+}): Promise<ChromaInsightSearchResult[]> {
+  if (!isInsightChromaEnabled() || input.queryEmbedding.length === 0) {
+    return [];
+  }
+
+  const botIdSet =
+    input.botIds && input.botIds.length > 0 ? new Set(input.botIds) : null;
+  const store = getChromaStore(getInsightsCollectionName());
+  const results = await store.similaritySearch(
+    input.queryEmbedding,
+    Math.max(input.limit * 5, input.limit),
+    input.userId,
+  );
+
+  return results
+    .filter((result) => {
+      const metadata = result.metadata ?? {};
+      if (!input.includeArchived && toBooleanValue(metadata.archived)) {
+        return false;
+      }
+      if (botIdSet && !botIdSet.has(String(metadata.botId ?? ""))) {
+        return false;
+      }
+      return result.score >= input.threshold;
+    })
+    .map((result) => {
+      const metadata = result.metadata ?? {};
+      return {
+        id: result.id,
+        content: result.content,
+        similarity: result.score,
+        metadata: {
+          botId: toStringValue(metadata.botId),
+          title: toStringValue(metadata.title),
+          description: toStringValue(metadata.description),
+          taskLabel: toStringValue(metadata.taskLabel),
+          importance: toStringValue(metadata.importance),
+          urgency: toStringValue(metadata.urgency),
+          platform: toNullableString(metadata.platform),
+          account: toNullableString(metadata.account),
+          time: toDateValue(metadata.time),
+          embeddingModel: toStringValue(metadata.embeddingModel),
+          embeddingDimensions: Number(metadata.embeddingDimensions ?? 0),
+          contentHash: toStringValue(metadata.contentHash),
+        },
+      };
+    })
+    .slice(0, input.limit);
+}

--- a/packages/memory-store/src/storage/postgres-raw-message-factory.ts
+++ b/packages/memory-store/src/storage/postgres-raw-message-factory.ts
@@ -1,0 +1,64 @@
+/**
+ * Lazy registration slot for the host's Postgres-backed raw message
+ * manager. The actual `PostgresRawMessageManager` class lives in
+ * `apps/web/lib/memory/postgres-raw-message-store.ts` because it owns
+ * the schema-bound Drizzle table references.
+ *
+ * The package ships this factory so consumers can wire up their own
+ * postgres implementation without forcing the package to take a
+ * hard dependency on Drizzle schema files.
+ */
+
+import type { MemoryStoreEnv } from "../config";
+
+export interface PostgresRawMessageManagerLike {
+  init?(): Promise<void>;
+  close?(): Promise<void>;
+  upsertRawMessages?(input: {
+    userId: string;
+    messages: unknown[];
+  }): Promise<unknown>;
+  getMessageById?(input: {
+    userId: string;
+    messageId: string;
+  }): Promise<unknown>;
+  searchMessagesSemantically?(input: {
+    userId: string;
+    queryEmbedding: number[];
+    embeddingModel?: string;
+    limit?: number;
+    scanLimit?: number;
+    threshold?: number;
+    includeArchived?: boolean;
+    includeDeprecated?: boolean;
+    platform?: string;
+    botId?: string;
+    channel?: string;
+    person?: string;
+    startTime?: number;
+    endTime?: number;
+  }): Promise<unknown[]>;
+}
+
+export type PostgresFactoryFn = (env?: MemoryStoreEnv) => Promise<PostgresRawMessageManagerLike>;
+
+let factory: PostgresFactoryFn | null = null;
+
+export function registerPostgresFactory(fn: PostgresFactoryFn): void {
+  factory = fn;
+}
+
+export function clearPostgresFactory(): void {
+  factory = null;
+}
+
+export async function resolvePostgresFactory(
+  env?: MemoryStoreEnv,
+): Promise<PostgresRawMessageManagerLike | null> {
+  if (!factory) return null;
+  return await factory(env);
+}
+
+export function hasPostgresFactory(): boolean {
+  return factory !== null;
+}

--- a/packages/memory-store/src/storage/raw-message-store.ts
+++ b/packages/memory-store/src/storage/raw-message-store.ts
@@ -1,0 +1,137 @@
+/**
+ * Top-level raw-message store facade.
+ *
+ * Selects between sqlite (Tauri) and postgres (host-registered)
+ * backends based on `MemoryStoreEnv.isTauriMode()`. The facade exposes
+ * the common `RawMessageStorageManager` contract plus a typed
+ * `searchMessagesSemantically` extension when present.
+ */
+
+import type { RawMessageStorageManager } from "@openloomi/indexeddb/storage";
+import type { MemoryStoreConfig, MemoryStoreEnv } from "../config";
+import {
+  getSQLiteRawMessageManager,
+  isSQLiteRawMessageStorageAvailable,
+  closeSQLiteRawMessageManager,
+} from "./sqlite-raw-message-store";
+import {
+  hasPostgresFactory,
+  resolvePostgresFactory,
+} from "./postgres-raw-message-factory";
+
+export type RawMessageStorageBackend = "sqlite" | "postgres";
+
+export type RawMessageStorageManagerWithSearch =
+  RawMessageStorageManager & {
+    searchMessagesSemantically?: (input: {
+      userId: string;
+      queryEmbedding: number[];
+      embeddingModel?: string;
+      limit?: number;
+      scanLimit?: number;
+      threshold?: number;
+      includeArchived?: boolean;
+      platform?: string;
+      botId?: string;
+      channel?: string;
+      person?: string;
+      startTime?: number;
+      endTime?: number;
+    }) => Promise<unknown[]>;
+  };
+
+export interface CreateRawMessageStoreOptions {
+  env?: MemoryStoreEnv;
+}
+
+export interface RawMessageStore {
+  getManager(): Promise<RawMessageStorageManagerWithSearch>;
+  getBackend(): RawMessageStorageBackend;
+  isAvailable(): boolean;
+  close(): Promise<void>;
+}
+
+function resolveEnv(env?: MemoryStoreEnv): MemoryStoreEnv {
+  if (env) return env;
+  return {
+    isTauriMode: () =>
+      process.env.IS_TAURI === "true" ||
+      typeof process.env.TAURI_MODE === "string",
+    getTauriDbPath: () => process.env.TAURI_DB_PATH ?? "",
+    getTauriDataDir: () => process.env.TAURI_DATA_DIR ?? "",
+  };
+}
+
+export function createRawMessageStore(
+  options: CreateRawMessageStoreOptions = {},
+): RawMessageStore {
+  const env = resolveEnv(options.env);
+
+  return {
+    getBackend(): RawMessageStorageBackend {
+      return isSQLiteRawMessageStorageAvailable(env) ? "sqlite" : "postgres";
+    },
+    isAvailable(): boolean {
+      return (
+        isSQLiteRawMessageStorageAvailable(env) || hasPostgresFactory()
+      );
+    },
+    async getManager(): Promise<RawMessageStorageManagerWithSearch> {
+      if (isSQLiteRawMessageStorageAvailable(env)) {
+        return (await getSQLiteRawMessageManager(env)) as unknown as RawMessageStorageManagerWithSearch;
+      }
+      const pg = await resolvePostgresFactory(env);
+      if (!pg) {
+        throw new Error(
+          "No raw-message backend available. SQLite is disabled (not Tauri) and no Postgres factory is registered.",
+        );
+      }
+      return pg as unknown as RawMessageStorageManagerWithSearch;
+    },
+    async close(): Promise<void> {
+      if (isSQLiteRawMessageStorageAvailable(env)) {
+        await closeSQLiteRawMessageManager();
+      }
+    },
+  };
+}
+
+// Module-level singleton so existing call sites that imported the
+// legacy `getRawMessageManager()` keep working without a refactor.
+let moduleStore: RawMessageStore | null = null;
+let moduleConfig: MemoryStoreConfig | null = null;
+
+export function configureRawMessageStore(
+  config: MemoryStoreConfig,
+): RawMessageStore {
+  moduleConfig = config;
+  moduleStore = createRawMessageStore({ env: config.env });
+  return moduleStore;
+}
+
+export function getRawMessageStorageBackend(): RawMessageStorageBackend {
+  if (!moduleStore) {
+    moduleStore = createRawMessageStore({ env: moduleConfig?.env });
+  }
+  return moduleStore.getBackend();
+}
+
+export function isRawMessageStorageAvailable(): boolean {
+  if (!moduleStore) {
+    moduleStore = createRawMessageStore({ env: moduleConfig?.env });
+  }
+  return moduleStore.isAvailable();
+}
+
+export async function getRawMessageManager(): Promise<RawMessageStorageManagerWithSearch> {
+  if (!moduleStore) {
+    moduleStore = createRawMessageStore({ env: moduleConfig?.env });
+  }
+  return moduleStore.getManager();
+}
+
+export async function closeRawMessageStore(): Promise<void> {
+  if (!moduleStore) return;
+  await moduleStore.close();
+  moduleStore = null;
+}

--- a/packages/memory-store/src/storage/sqlite-raw-message-store.ts
+++ b/packages/memory-store/src/storage/sqlite-raw-message-store.ts
@@ -1,0 +1,69 @@
+/**
+ * SQLite-backed raw message store.
+ *
+ * Singleton manager used in Tauri (local) mode. The Tauri env is
+ * sourced from the injected `MemoryStoreConfig.env`.
+ */
+
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { SQLiteRawMessageManager } from "@openloomi/sqlite";
+import type { MemoryStoreEnv } from "../config";
+import { isRawMessageChromaEnabled } from "./chroma-memory-index";
+
+let manager: SQLiteRawMessageManager | null = null;
+
+export function isSQLiteRawMessageStorageAvailable(
+  env?: MemoryStoreEnv,
+): boolean {
+  return resolveEnv(env).isTauriMode();
+}
+
+export async function getSQLiteRawMessageManager(
+  env?: MemoryStoreEnv,
+): Promise<SQLiteRawMessageManager> {
+  const e = resolveEnv(env);
+  if (!e.isTauriMode()) {
+    throw new Error(
+      "SQLite raw message storage is only available in Tauri mode.",
+    );
+  }
+
+  if (!manager) {
+    const dbPath = e.getTauriDbPath?.() ?? process.env.TAURI_DB_PATH ?? "";
+    mkdirSync(dirname(dbPath), { recursive: true });
+    manager = new SQLiteRawMessageManager({
+      dbPath,
+      enableVectorSearch: !isRawMessageChromaEnabled(),
+    });
+    await manager.init();
+  }
+
+  return manager;
+}
+
+export async function closeSQLiteRawMessageManager(): Promise<void> {
+  if (!manager) {
+    return;
+  }
+  await manager.close();
+  manager = null;
+}
+
+/**
+ * Test-only: reset the singleton. Used by vitest between test cases.
+ */
+export function __resetSQLiteRawMessageManagerForTests(): void {
+  manager = null;
+}
+
+function resolveEnv(env?: MemoryStoreEnv): MemoryStoreEnv {
+  if (env) return env;
+  return {
+    isTauriMode: () =>
+      process.env.IS_TAURI === "true" ||
+      typeof process.env.TAURI_MODE === "string",
+    getTauriDbPath: () => process.env.TAURI_DB_PATH ?? "",
+    getTauriDataDir: () => process.env.TAURI_DATA_DIR ?? "",
+  };
+}

--- a/packages/memory-store/src/storage/sqlite-vector-index.ts
+++ b/packages/memory-store/src/storage/sqlite-vector-index.ts
@@ -1,0 +1,160 @@
+/**
+ * SQLite-vec-backed raw-message + insight vector index.
+ *
+ * Mirrors the chroma-memory-index interface but uses the local
+ * sqlite-vec store. The DB path is resolved via `MemoryStoreEnv`.
+ */
+
+import type { VectorSearchResult } from "@openloomi/rag/vector-service";
+import type { MemoryStoreEnv } from "../config";
+
+export interface SQLiteInsightVectorInput {
+  insightId: string;
+  userId: string;
+  botId: string;
+  content: string;
+  contentHash: string;
+  embedding: number[];
+  embeddingModel: string;
+  embeddingDimensions: number;
+  title?: unknown;
+  description?: unknown;
+  taskLabel?: unknown;
+  importance?: unknown;
+  urgency?: unknown;
+  platform?: unknown;
+  account?: unknown;
+  time?: unknown;
+  archived?: unknown;
+}
+
+export interface SQLiteInsightSearchInput {
+  userId: string;
+  queryEmbedding: number[];
+  limit: number;
+  threshold: number;
+  botIds?: string[];
+  includeArchived?: boolean;
+}
+
+function getMemoryVectorStoreBackend(): "chroma" | "sqlite-vec" {
+  const backend = (
+    process.env.INSIGHT_VECTOR_STORE_BACKEND ||
+    process.env.MEMORY_VECTOR_STORE_BACKEND ||
+    process.env.VECTOR_STORE_BACKEND ||
+    "sqlite-vec"
+  ).toLowerCase();
+  return backend === "chroma" ? "chroma" : "sqlite-vec";
+}
+
+export function isInsightSQLiteVecEnabled(env?: MemoryStoreEnv): boolean {
+  return resolveEnv(env).isTauriMode() && getMemoryVectorStoreBackend() === "sqlite-vec";
+}
+
+function resolveEnv(env?: MemoryStoreEnv): MemoryStoreEnv {
+  if (env) return env;
+  return {
+    isTauriMode: () =>
+      process.env.IS_TAURI === "true" ||
+      typeof process.env.TAURI_MODE === "string",
+    getTauriDbPath: () => process.env.TAURI_DB_PATH ?? "",
+    getTauriDataDir: () => process.env.TAURI_DATA_DIR ?? "",
+  };
+}
+
+async function getInsightSQLiteVecStore(env: MemoryStoreEnv) {
+  const e = resolveEnv(env);
+  const dbPath = e.getTauriDbPath?.() ?? process.env.TAURI_DB_PATH ?? "";
+  const { getSQLiteVecStore } = await import("@openloomi/rag/sqlite-vec-store");
+  return await getSQLiteVecStore(dbPath, undefined, {
+    collectionName:
+      process.env.SQLITE_VEC_INSIGHTS_COLLECTION || "openloomi_insights",
+  });
+}
+
+export async function upsertInsightsToSQLiteVec(
+  insights: SQLiteInsightVectorInput[],
+  env?: MemoryStoreEnv,
+): Promise<number> {
+  if (!isInsightSQLiteVecEnabled(env) || insights.length === 0) {
+    return 0;
+  }
+
+  const store = await getInsightSQLiteVecStore(resolveEnv(env));
+  await store.addChunks(
+    insights.map((item) => ({
+      id: item.insightId,
+      documentId: item.insightId,
+      content: item.content,
+      embedding: item.embedding,
+      metadata: {
+        userId: item.userId,
+        botId: item.botId,
+        contentHash: item.contentHash,
+        embeddingModel: item.embeddingModel,
+        embeddingDimensions: item.embeddingDimensions,
+        title: toStringValue(item.title),
+        description: toStringValue(item.description),
+        taskLabel: toStringValue(item.taskLabel),
+        importance: toStringValue(item.importance),
+        urgency: toStringValue(item.urgency),
+        platform: toNullableString(item.platform),
+        account: toNullableString(item.account),
+        time: normalizeTime(item.time),
+        archived: toBooleanValue(item.archived),
+      },
+    })),
+  );
+  return insights.length;
+}
+
+export async function searchInsightsWithSQLiteVec(
+  input: SQLiteInsightSearchInput,
+  env?: MemoryStoreEnv,
+): Promise<VectorSearchResult[]> {
+  const store = await getInsightSQLiteVecStore(resolveEnv(env));
+  const overfetchLimit = Math.max(input.limit * 8, input.limit);
+  const results = await store.similaritySearchWithOptions(
+    input.queryEmbedding,
+    {
+      limit: overfetchLimit,
+      filter: { userId: input.userId },
+    },
+  );
+
+  return results
+    .filter((result) => result.score >= input.threshold)
+    .filter((result) => {
+      const metadata = result.metadata ?? {};
+      if (
+        input.botIds?.length &&
+        !input.botIds.includes(String(metadata.botId ?? ""))
+      ) {
+        return false;
+      }
+      return input.includeArchived || metadata.archived !== true;
+    })
+    .slice(0, input.limit);
+}
+
+function normalizeTime(value: unknown): number | null {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function toBooleanValue(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}

--- a/packages/memory-store/src/types.ts
+++ b/packages/memory-store/src/types.ts
@@ -1,0 +1,25 @@
+/**
+ * @openloomi/memory-store public types re-exports.
+ */
+
+export type {
+  EmbedQueryFn,
+  MemoryStoreConfig,
+  MemoryStoreDb,
+  MemoryStoreEnv,
+  MemoryStoreVectorConfig,
+  UnifiedSearchDeps,
+  UnifiedSearchInsightsResult,
+  UnifiedSearchKnowledgeResult,
+  VectorBackend,
+} from "./config";
+
+export type {
+  UnifiedMemorySearchInput,
+  UnifiedMemorySearchOutput,
+  UnifiedMemorySearchResult,
+  UnifiedMemorySearchSource,
+  UnifiedMemorySearchWarning,
+} from "./search/utilities";
+
+export type { RawMessage } from "./config";

--- a/packages/memory-store/tsconfig.json
+++ b/packages/memory-store/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../config/src/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "incremental": false,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "noEmit": false,
+    "paths": {
+      "@openloomi/indexeddb": ["../../packages/indexeddb/src/index.ts"],
+      "@openloomi/indexeddb/*": ["../../packages/indexeddb/src/*"],
+      "@openloomi/sqlite": ["../../packages/sqlite/src/index.ts"],
+      "@openloomi/sqlite/*": ["../../packages/sqlite/src/*"],
+      "@openloomi/ai": ["../../packages/ai/src/index.ts"],
+      "@openloomi/ai/*": ["../../packages/ai/src/*"],
+      "@openloomi/rag": ["../../packages/ai/rag/src/index.ts"],
+      "@openloomi/rag/*": ["../../packages/ai/rag/src/*"],
+      "@openloomi/shared": ["../../packages/shared/src/index.ts"],
+      "@openloomi/shared/*": ["../../packages/shared/src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/memory-store/tsup.config.ts
+++ b/packages/memory-store/tsup.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    http: "src/http.ts",
+    mcp: "src/mcp.ts",
+    "storage/raw-message-store": "src/storage/raw-message-store.ts",
+    "storage/sqlite-raw-message-store":
+      "src/storage/sqlite-raw-message-store.ts",
+    "storage/postgres-raw-message-factory":
+      "src/storage/postgres-raw-message-factory.ts",
+    "storage/sqlite-vector-index": "src/storage/sqlite-vector-index.ts",
+    "storage/chroma-memory-index": "src/storage/chroma-memory-index.ts",
+    "search/unified-search": "src/search/unified-search.ts",
+    "policies/memory-graph-write-policy":
+      "src/policies/memory-graph-write-policy.ts",
+    "policies/memory-graph-correction-policy":
+      "src/policies/memory-graph-correction-policy.ts",
+    "server/cli-http": "src/server/cli-http.ts",
+    "server/cli-mcp": "src/server/cli-mcp.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  treeshake: true,
+  shims: false,
+  external: [
+    "react",
+    "react-dom",
+    "@tauri-apps/api",
+    "@tauri-apps/plugin-*",
+    "better-sqlite3",
+    "sqlite-vec",
+    "server-only",
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
         version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(e7ab47939deb75316c7044f5eae41df6)
+        version: 1.1.27(wz4kykinf3fgpv65yokur3734q)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -898,7 +898,7 @@ importers:
         specifier: ^7.1.12
         version: 7.3.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
-        specifier: ^4.0.6
+        specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@28.1.0)(vite@7.3.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       wait-on:
         specifier: ^9.0.3
@@ -1112,7 +1112,7 @@ importers:
         version: 3.8.1
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(682d69bd7ddfb40d75b1dfddac441b4c)
+        version: 1.1.27(wfqjx7vnf6ljs62l2e6lsxmqc4)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -1651,7 +1651,7 @@ importers:
     dependencies:
       '@langchain/community':
         specifier: ^1.1.1
-        version: 1.1.27(682d69bd7ddfb40d75b1dfddac441b4c)
+        version: 1.1.27(wfqjx7vnf6ljs62l2e6lsxmqc4)
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -7793,6 +7793,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -15875,7 +15876,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.27(682d69bd7ddfb40d75b1dfddac441b4c)':
+  '@langchain/community@1.1.27(wfqjx7vnf6ljs62l2e6lsxmqc4)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
@@ -15927,7 +15928,7 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/community@1.1.27(e7ab47939deb75316c7044f5eae41df6)':
+  '@langchain/community@1.1.27(wz4kykinf3fgpv65yokur3734q)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@16.6.1)(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
@@ -20575,8 +20576,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -20602,6 +20603,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -20617,21 +20633,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -20643,14 +20644,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -20683,7 +20684,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20694,7 +20695,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@openloomi/memory-consolidation':
         specifier: workspace:*
         version: link:../../packages/ai/memory-consolidation
+      '@openloomi/memory-store':
+        specifier: workspace:*
+        version: link:../../packages/memory-store
       '@openloomi/rag':
         specifier: workspace:*
         version: link:../../packages/rag
@@ -980,38 +983,6 @@ importers:
         specifier: ^5.5.0
         version: 5.9.3
 
-  benchmark/gdpval:
-    dependencies:
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.17
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: ^5.6.3
-        version: 5.9.3
-
-  benchmark/gdpval-aa-v2:
-    dependencies:
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.17
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: ^5.6.3
-        version: 5.9.3
-
   benchmark/jobbench:
     dependencies:
       dotenv:
@@ -1162,7 +1133,7 @@ importers:
         version: 3.10.1
       langchain:
         specifier: ^1.2.3
-        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
@@ -1636,6 +1607,46 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  packages/memory-store:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.14)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.25.3
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@openloomi/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@openloomi/indexeddb':
+        specifier: workspace:*
+        version: link:../indexeddb
+      '@openloomi/rag':
+        specifier: workspace:*
+        version: link:../rag
+      '@openloomi/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@openloomi/sqlite':
+        specifier: workspace:*
+        version: link:../sqlite
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.14
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@openloomi/config':
+        specifier: workspace:*
+        version: link:../config
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.19.17
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   packages/rag:
     dependencies:
       '@langchain/community':
@@ -1658,7 +1669,7 @@ importers:
         version: 3.10.1
       langchain:
         specifier: ^1.2.3
-        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6))
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
@@ -10013,8 +10024,8 @@ packages:
   libqp@2.1.1:
     resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
-  libsignal@git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7:
-    resolution: {commit: bcea72df9ec34d9d9140ab30619cf479c7c144c7, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
+  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
     version: 6.0.0
 
   lie@3.3.0:
@@ -16021,7 +16032,7 @@ snapshots:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))':
+  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -16029,8 +16040,6 @@ snapshots:
       uuid: 13.0.0
     optionalDependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
       svelte: 5.56.1(@typescript-eslint/types@8.59.3)
       vue: 3.5.35(typescript@5.9.3)
 
@@ -16047,11 +16056,11 @@ snapshots:
       svelte: 5.56.1(@typescript-eslint/types@8.59.3)
       vue: 3.5.35(typescript@5.9.3)
 
-  '@langchain/langgraph@1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)':
+  '@langchain/langgraph@1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.4.3
@@ -18909,7 +18918,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7
+      libsignal: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
       lru-cache: 11.3.5
       music-metadata: 11.12.3
       p-queue: 9.1.2
@@ -20566,8 +20575,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -20593,21 +20602,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -20623,6 +20617,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -20634,14 +20643,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -20674,7 +20683,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20685,7 +20694,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -22075,7 +22084,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.0)
+      retry-axios: 2.6.0(axios@1.15.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -22595,10 +22604,10 @@ snapshots:
 
   kysely@0.29.2: {}
 
-  langchain@1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6)):
+  langchain@1.3.3(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)
+      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(svelte@5.56.1(@typescript-eslint/types@8.59.3))(vue@3.5.35(typescript@5.9.3))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
       langsmith: 0.5.21(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       uuid: 11.1.0
@@ -22686,7 +22695,7 @@ snapshots:
 
   libqp@2.1.1: {}
 
-  libsignal@git+https://github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 7.5.5
@@ -25034,7 +25043,7 @@ snapshots:
 
   resumable-stream@2.2.12: {}
 
-  retry-axios@2.6.0(axios@1.15.0):
+  retry-axios@2.6.0(axios@1.15.0(debug@4.4.3)):
     dependencies:
       axios: 1.15.0(debug@4.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,7 +898,7 @@ importers:
         specifier: ^7.1.12
         version: 7.3.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
-        specifier: ^4.1.5
+        specifier: ^4.0.6
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@28.1.0)(vite@7.3.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       wait-on:
         specifier: ^9.0.3


### PR DESCRIPTION
## Summary

Extract the memory storage / search layer out of `apps/web` into a reusable
workspace package (`@openloomi/memory-store`) so non-web hosts (CLI daemons,
custom servers) can consume it through three entry points:

- **SDK** (`@openloomi/memory-store`): `createMemoryStore({ db, env, vector, unified })`
  returns a `MemoryStore` facade.
- **HTTP** (`@openloomi/memory-store/http`): Hono app exposing
  `/health`, `/v1/search`, `/v1/raw-messages`.
- **MCP** (`@openloomi/memory-store/mcp`): 4 tools wired through
  `@modelcontextprotocol/sdk` over stdio:
  `memory.health`, `memory.searchUnified`, `memory.writeRawMessage`,
  `memory.getRawMessage`.

CLI bins:
- `openloomi-memory-http` (port 7421)
- `openloomi-memory-mcp` (stdio)

Storage backend is DI'd through `MemoryStoreEnv` / `MemoryStoreDb`; the host
passes its env + Drizzle tables. The package also re-exports
`@openloomi/memory-store/{raw-message-store, sqlite-raw-message-store,
sqlite-vector-index, chroma-memory-index, postgres-raw-message-factory,
unified-search, memory-graph-write-policy,
memory-graph-correction-policy}` as subpath entry points so callers can
compose only the bits they need.

The `unified-search` facade accepts `UnifiedSearchDeps` so cross-domain
searchers (insights, knowledge, embedding provider, raw-memory ANN) are
supplied by the host.

## apps/web migration

- `apps/web/package.json` — add `@openloomi/memory-store` workspace dep +
  `memory:http` / `memory:mcp` scripts.
- `apps/web/tsconfig.json` — register the package path mappings (root +
  storage / search / policies / server subdirs).
- `apps/web/lib/memory/unified-search-factory.ts` — bridge that wires
  apps/web's cross-domain deps (insights search, knowledge RAG, user
  embedding provider, raw-memory ANN) into the new unified-search facade.
- `apps/web/lib/memory/unified-search.ts` — slimmed to a thin re-export
  of the wired-up `searchUnifiedMemory` so existing callers
  (`@/lib/memory/unified-search` imports across routes, mcp tools, cron
  jobs) keep working unchanged.
- All routes (`save-messages`, `memory/raw-messages`, `messages/check`,
  `messages/raw`) and lib callers (`chat-memory-write`, `controlled-default-context`,
  `insights/embedding-service`, `insights/search`, `cron/insight-maintenance`,
  `integrations/feishu/handler`, `postgres-raw-message-store`) updated to
  import storage / search / policy utilities from
  `@openloomi/memory-store/...` subpaths instead of `apps/web/lib/memory/...`.
- `apps/web/vitest.config.ts` — added `@openloomi/memory-store/*` resolve
  aliases (root + each subpath).

Net: 437 lines removed from apps/web, 170 added — the heavy lifting now
lives in the standalone package and can be reused by other hosts.

## Behavior preservation

The extraction initially simplified `runMemorySource` too aggressively and
dropped five behaviors the original `apps/web/lib/memory/unified-search.ts`
had. All restored in `7f2ce68f`:

1. Empty-query short-circuit.
2. `isRawMessageStorageAvailable()` gating → `raw_message_storage_unavailable` warning.
3. Per-botId iteration via `Promise.all(filters.map(...))`.
4. `limit` passed directly (no `* 5` over-shoot).
5. Chroma → database `searchMessagesSemantically` fallback.

## Test plan — actually exercised

- [x] `pnpm --filter @openloomi/memory-store build` (ESM + DTS) — pass
- [x] `pnpm tsc` (apps/web) — exit 0
- [x] `cd apps/web && vitest run` — **188 files / 2209 passed / 17 skipped**
      (matches pre-extraction baseline; no regressions)
- [x] Memory-specific tests run explicitly:
      `unified-memory-search`, `memory-graph-correction-policy`,
      `controlled-default-memory-context`, `memory-graph-governance-route`,
      `raw-message-owner-isolation-route`,
      `native-agent-memory-context-route`, `chat-memory-write-route` — 68 tests
      total, all pass.
- [x] **HTTP CLI smoke-tested** with `node packages/memory-store/dist/server/cli-http.js`:
  - `GET /health` → `{"ok":true,"store":"memory","ts":...}` ✅
  - `POST /v1/search` (full input) → returns `UnifiedMemorySearchOutput` with
    `warnings[]` describing each unavailable source ✅
  - `POST /v1/search` (missing userId) → `400 {"error":"userId and query are required"}` ✅
  - `POST /v1/raw-messages` (missing fields) → `400 {"error":"userId and messages[] required"}` ✅
  - `GET /v1/raw-messages/:id` (missing userId) → `400 {"error":"userId query param required"}` ✅
- [x] **MCP CLI smoke-tested** over stdio with `node packages/memory-store/dist/server/cli-mcp.js`:
  - `initialize` → returns `protocolVersion:2024-11-05`,
    `serverInfo:@openloomi/memory-store@0.9.0` ✅
  - `tools/list` → 4 tools: `memory.health`, `memory.searchUnified`,
    `memory.writeRawMessage`, `memory.getRawMessage` ✅
  - `tools/call memory.health {}` → `{"ok":true}` ✅
  - `tools/call memory.searchUnified {userId,query,limit}` →
    `UnifiedMemorySearchOutput` (empty results + warnings) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)