### PR TITLE
refactor(memory-store): break static @openloomi/indexeddb coupling (runtime/ui split phase 1)

### DIFF
--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -13,7 +13,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./storage": "./dist/storage.js"
   },
   "repository": {
     "type": "git",

--- a/packages/memory-store/package.json
+++ b/packages/memory-store/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./contracts": "./dist/contracts.js",
     "./http": {
       "types": "./dist/http.d.ts",
       "import": "./dist/http.js"
@@ -43,12 +44,19 @@
     "@hono/node-server": "^1.13.7",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@openloomi/ai": "workspace:*",
-    "@openloomi/indexeddb": "workspace:*",
     "@openloomi/rag": "workspace:*",
     "@openloomi/shared": "workspace:*",
     "@openloomi/sqlite": "workspace:*",
     "hono": "^4.6.14",
     "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "@openloomi/indexeddb": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@openloomi/indexeddb": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@openloomi/config": "workspace:*",

--- a/packages/memory-store/src/config.ts
+++ b/packages/memory-store/src/config.ts
@@ -24,7 +24,7 @@
  * warning — fine for a standalone memory daemon.
  */
 
-import type { RawMessage } from "@openloomi/indexeddb/storage";
+import type { RawMessage } from "./contracts";
 
 export interface MemoryStoreDb {
   /** Resolve the active Drizzle DB handle. Must be server-side. */

--- a/packages/memory-store/src/contracts.ts
+++ b/packages/memory-store/src/contracts.ts
@@ -1,0 +1,85 @@
+/**
+ * Memory-store contracts — types and constants that were originally re-exported
+ * from `@openloomi/indexeddb` but pulled in browser-only code (IndexedDB
+ * globals) at module evaluation time, breaking the standalone HTTP/MCP
+ * daemons.
+ *
+ * Anything defined here can be safely imported on the server without any
+ * browser globals being resolved. The `@openloomi/indexeddb` peer dependency
+ * is optional in `@openloomi/memory-store/package.json`; runtime consumers
+ * (apps/web) can still depend on it directly for IndexedDB-backed storage.
+ *
+ * Re-export from this module is stable. New domain types belong in
+ * dedicated files; this module only hosts the boundary contracts.
+ */
+
+import type { MemoryRecord } from "@openloomi/ai/memory";
+
+/** Prefix used to reserve chat-memory evidence IDs that must not collide. */
+export const CHAT_MEMORY_EVIDENCE_ID_PREFIX = "openloomi-chat:";
+
+/** A locally-defined re-export of the raw-message shape used by the SDK.
+ * Kept as a structural type so consumers (apps/web, SQLite, postgres
+ * factories) can pass either the IndexedDB `RawMessage` or this shape. */
+// biome-ignore lint/suspicious/noExplicitAny: structural mirror of `@openloomi/indexeddb/storage`'s `RawMessage`.
+export interface RawMessage {
+  id?: number;
+  messageId: string;
+  platform: string;
+  botId: string;
+  userId: string;
+  channel?: string;
+  person?: string;
+  timestamp: number;
+  content: string;
+  attachments?: Array<{
+    name: string;
+    url: string;
+    contentType?: string;
+    sizeBytes?: number;
+  }>;
+  embedding?: number[];
+  embeddingModel?: string;
+  embeddingContentHash?: string;
+  embeddingDimensions?: number;
+  embeddingUpdatedAt?: number;
+  // biome-ignore lint/suspicious/noExplicitAny: Preserve the public raw metadata contract.
+  metadata?: Record<string, any>;
+  createdAt: number;
+  memoryStage?: "short" | "mid" | "long";
+  accessCount?: number;
+  lastAccessAt?: number;
+  importanceScore?: number;
+  archivedAt?: number;
+  isPinned?: boolean;
+  summaryRefId?: string;
+  deprecatedAt?: number;
+  deprecationReason?: string;
+  supersededBySummaryId?: string;
+}
+
+function normalizeTimestampToMs(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if ((value as number) < 1e11) {
+    return Math.floor((value as number) * 1000);
+  }
+  return Math.floor(value as number);
+}
+
+/** Convert a RawMessage to a MemoryRecord for embedding. Local copy of the
+ * helper that previously lived in `@openloomi/indexeddb/embedding` and pulled
+ * in browser-only modules. */
+export function rawMessageToMemoryRecord(message: RawMessage): MemoryRecord {
+  return {
+    id: message.messageId,
+    userId: message.userId,
+    timestamp: normalizeTimestampToMs(message.timestamp),
+    text: message.archivedAt ? undefined : message.content,
+    mediaRefs: message.attachments?.map((item) => item.url).filter(Boolean),
+    embedding: message.embedding,
+    embeddingModel: message.embeddingModel,
+    embeddingContentHash: message.embeddingContentHash,
+  } as unknown as MemoryRecord;
+}

--- a/packages/memory-store/src/policies/memory-graph-write-policy.ts
+++ b/packages/memory-store/src/policies/memory-graph-write-policy.ts
@@ -5,7 +5,7 @@
  * explicitly. Used by the apps/web routes via `@openloomi/memory-store/memory-graph-write-policy`.
  */
 
-import { CHAT_MEMORY_EVIDENCE_ID_PREFIX } from "@openloomi/indexeddb";
+import { CHAT_MEMORY_EVIDENCE_ID_PREFIX } from "../contracts";
 
 export { CHAT_MEMORY_EVIDENCE_ID_PREFIX };
 

--- a/packages/memory-store/src/storage/chroma-memory-index.ts
+++ b/packages/memory-store/src/storage/chroma-memory-index.ts
@@ -8,12 +8,10 @@
  */
 
 import { buildMemoryRecordEmbeddingDocument } from "@openloomi/ai/memory";
-import {
-  rawMessageToMemoryRecord,
-  type RawMessage,
-} from "@openloomi/indexeddb";
 import { ChromaVectorStore } from "@openloomi/rag";
 import type { DocumentChunk } from "@openloomi/rag/vector-service";
+
+import { rawMessageToMemoryRecord, type RawMessage } from "../contracts";
 
 const DEFAULT_RAW_MESSAGES_COLLECTION = "openloomi_raw_messages";
 const DEFAULT_INSIGHTS_COLLECTION = "openloomi_insights";

--- a/packages/memory-store/tsup.config.ts
+++ b/packages/memory-store/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    contracts: "src/contracts.ts",
     http: "src/http.ts",
     mcp: "src/mcp.ts",
     "storage/raw-message-store": "src/storage/raw-message-store.ts",


### PR DESCRIPTION
## Summary

Phase 1 of the runtime/UI split plan. Decouples the standalone `@openloomi/memory-store` HTTP/MCP daemons from the browser-only `@openloomi/indexeddb` package, so the daemons can boot in a Node-only environment without crashing with `indexedDB is not defined`.

### Changes

| File | Change |
|---|---|
| `packages/memory-store/src/contracts.ts` (new) | Locally defines `CHAT_MEMORY_EVIDENCE_ID_PREFIX`, structural `RawMessage` mirror, and `rawMessageToMemoryRecord`. |
| `packages/memory-store/src/{config,storage/chroma-memory-index,policies/memory-graph-write-policy}.ts` | Switch value/type imports to local `./contracts`. |
| `packages/memory-store/package.json` | Drop `@openloomi/indexeddb` from `dependencies`; add as **optional** `peerDependenciesMeta`. Export `./contracts` subpath. |
| `packages/memory-store/tsup.config.ts` | Add `contracts` build entry. |
| `packages/indexeddb/package.json` | Add `./storage` subpath export for type-only `import type { RawMessageStorageManager } from "@openloomi/indexeddb/storage"`. |

### Why

- The standalone HTTP/MCP daemons (`openloomi-memory-http`, `openloomi-memory-mcp`) historically could not run on a clean Node host because the SDK transitively pulled in `manager.ts` from `@openloomi/indexeddb`, which references the `indexedDB` browser global at module evaluation.
- After this PR, the built `dist/` contains **zero** `@openloomi/indexeddb` runtime imports, only type-level ones (which are erased).
- `@openloomi/indexeddb` is now an optional peer dependency — apps/web (the in-process consumer) still installs it; standalone daemon hosts can omit it.

### Verification

- [x] `pnpm --filter @openloomi/memory-store build` → ESM + dts; `grep @openloomi/indexeddb dist/**/*.js` returns nothing.
- [x] `pnpm tsc` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 2209 tests pass
- [x] Smoke: `node dist/server/cli-http.js` boots and `/health` returns `{"ok":true,...}`. Previously this would fail with `indexedDB is not defined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)