### PR TITLE
refactor(contracts): route IntegrationId through @openloomi/contracts (phase 3)

### DIFF
--- a/apps/web/hooks/use-integrations.ts
+++ b/apps/web/hooks/use-integrations.ts
@@ -3,35 +3,9 @@
 import useSWR from "swr";
 import { useMemo } from "react";
 import { getAuthToken } from "@/lib/auth/token-manager";
+import type { IntegrationId } from "@openloomi/contracts/integration-id";
 
-export type IntegrationId =
-  | "telegram"
-  | "whatsapp"
-  | "slack"
-  | "discord"
-  | "gmail"
-  | "outlook"
-  | "linkedin"
-  | "instagram"
-  | "twitter"
-  | "google_calendar"
-  | "google_meet"
-  | "outlook_calendar"
-  | "teams"
-  | "facebook_messenger"
-  | "google_drive"
-  | "google_docs"
-  | "hubspot"
-  | "notion"
-  | "github"
-  | "asana"
-  | "jira"
-  | "linear"
-  | "imessage"
-  | "feishu"
-  | "dingtalk"
-  | "qqbot"
-  | "weixin";
+export type { IntegrationId };
 
 export type IntegrationAccountClient = {
   id: string;

--- a/apps/web/lib/integrations/client.ts
+++ b/apps/web/lib/integrations/client.ts
@@ -1,33 +1,8 @@
 "use client";
 
-export type IntegrationId =
-  | "telegram"
-  | "whatsapp"
-  | "slack"
-  | "discord"
-  | "gmail"
-  | "outlook"
-  | "linkedin"
-  | "instagram"
-  | "twitter"
-  | "google_calendar"
-  | "google_meet"
-  | "outlook_calendar"
-  | "teams"
-  | "facebook_messenger"
-  | "google_drive"
-  | "google_docs"
-  | "hubspot"
-  | "notion"
-  | "github"
-  | "asana"
-  | "jira"
-  | "linear"
-  | "imessage"
-  | "feishu"
-  | "dingtalk"
-  | "qqbot"
-  | "weixin";
+import type { IntegrationId } from "@openloomi/contracts/integration-id";
+
+export type { IntegrationId };
 
 export type CreateIntegrationAccountPayload = {
   platform: IntegrationId;


### PR DESCRIPTION
## Summary
Make `apps/web`'s two parallel `IntegrationId` definitions re-export the canonical 27-platform union from `@openloomi/contracts/integration-id`. No runtime code changes; only the type source moves.

## Changes
- `apps/web/lib/integrations/client.ts` — import + re-export `IntegrationId` from `@openloomi/contracts/integration-id`
- `apps/web/hooks/use-integrations.ts` — same pattern

Both legacy unions had the same 27 platform strings as the contracts union, so every existing import site continues to typecheck.

## Verification
- `pnpm tsc` clean
- `pnpm format` clean
- `pnpm test` clean

## Next
Phase 4 — `apps/web/lib/db` → `@openloomi/db` (largest extraction; ~13,000 LOC across schema, queries, storage, migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)