### PR TITLE
Feat/claude goal runtime restart recovery

### DIFF
--- a/apps/web/app/(chat)/home.tsx
+++ b/apps/web/app/(chat)/home.tsx
@@ -42,8 +42,10 @@ import { FilePreviewOverlay } from "@/components/file-preview-overlay";
 import { ChatHistorySidePanel } from "@/components/agent/chat-history-side-panel";
 import { AgentGoalSidePanel } from "@/components/agent/goal-side-panel";
 import type { ChatHistoryResponse } from "@/lib/ai/chat/api";
+import { selectStartupChat } from "@/lib/ai/chat/startup-selection";
+import type { AgentGoalRecoverySessionsResponse } from "@/lib/ai/runtime-instructions/api";
 import { decodeSearchParamText } from "@/lib/chat/query-text";
-import { mutate } from "swr";
+import useSWR, { mutate } from "swr";
 import useSWRInfinite from "swr/infinite";
 import { AddPlatformDialog } from "@/components/add-platform-dialog";
 import { useIntegrations } from "@/hooks/use-integrations";
@@ -121,8 +123,8 @@ export function Home() {
     messages,
     setMessages,
     isAgentRunning,
+    isSending,
     activeChatId,
-    setActiveChatId: contextSetActiveChatId,
     switchChatId,
     previewFile,
     closeFilePreviewPanel,
@@ -190,33 +192,72 @@ export function Home() {
   // it at the layout level keeps the navigation working from any (chat)
   // route, not only the home page.
 
-  // Listen for integration authorization completion → retry the tool call
+  const shouldReadRecoverySessions =
+    pathname === "/" && (page === null || page === "chat");
+  const { data: recoverySessions, error: recoverySessionsError } =
+    useSWR<AgentGoalRecoverySessionsResponse>(
+      shouldReadRecoverySessions ? "/api/agent-goals/runtime-sessions" : null,
+      fetcher,
+      {
+        refreshInterval: 2000,
+        revalidateOnFocus: true,
+        dedupingInterval: 1000,
+      },
+    );
+  const newChatIdRef = useRef(generateUUID());
+  const startupSelection = useMemo(
+    () =>
+      selectStartupChat({
+        pathname,
+        page,
+        urlChatId,
+        recoveryLoaded:
+          !shouldReadRecoverySessions ||
+          recoverySessions !== undefined ||
+          recoverySessionsError !== undefined,
+        recoveryChatId: recoverySessions?.sessions[0]?.runtimeSessionId,
+        restoredChatId: activeChatId,
+        newChatId: newChatIdRef.current,
+      }),
+    [
+      activeChatId,
+      page,
+      pathname,
+      recoverySessions,
+      recoverySessionsError,
+      shouldReadRecoverySessions,
+      urlChatId,
+    ],
+  );
+  const effectiveChatId = startupSelection.chatId;
+  const selectedRecoverySession = recoverySessions?.sessions.find(
+    (session) => session.runtimeSessionId === effectiveChatId,
+  );
+  const isSelectedRecoveryActive = selectedRecoverySession !== undefined;
+  const recoveryPresentationPending =
+    shouldReadRecoverySessions &&
+    recoverySessions === undefined &&
+    recoverySessionsError === undefined;
+  const recoverySessionsLoaded = recoverySessions !== undefined;
+
+  // Retrying an authorized integration starts a new provider turn directly
+  // through ChatContext. Apply the same recovery ownership gate as the
+  // composer so a browser turn cannot race the server-owned resumed Query.
   useEffect(() => {
     const handler = () => {
       mutateIntegrations();
-      // Send "continue" to retry the tool call with the newly connected integration
+      if (recoveryPresentationPending || isSelectedRecoveryActive) return;
       sendMessage({ parts: [{ type: "text", text: "continue" }] });
     };
     window.addEventListener("integration:accountAuthorized", handler);
     return () =>
       window.removeEventListener("integration:accountAuthorized", handler);
-  }, [mutateIntegrations, sendMessage]);
-
-  // Use ref to track activeChatId in context, avoid adding it to useEffect dependency array
-  const contextActiveChatIdRef = useRef(activeChatId);
-  contextActiveChatIdRef.current = activeChatId;
-
-  // Client-side selected chat ID (for highlighting, separated from chatId in URL)
-  const [localActiveChatId] = useState<string | null>(() => {
-    // If no chatId (new conversation), generate a new UUID
-    return generateUUID();
-  });
-
-  /** Actually used chatId: Chat page prioritizes URL's chatId, otherwise uses activeChatId or props.chatId */
-  const effectiveChatId = useMemo(() => {
-    if (page === "chat" && urlChatId) return urlChatId;
-    return localActiveChatId;
-  }, [page, urlChatId, localActiveChatId]);
+  }, [
+    isSelectedRecoveryActive,
+    mutateIntegrations,
+    recoveryPresentationPending,
+    sendMessage,
+  ]);
 
   // Data for Chat page right sidebar history (independent of Header, avoid
   // dependency on internal implementation). SWR Infinite handles dedup,
@@ -268,27 +309,60 @@ export function Home() {
     });
   }, [chatsList]);
 
-  // Sync effectiveChatId to ChatContext
-  // When chatId exists in URL (jumped from scheduled job or execution history), call switchChatId to load messages
+  // Every startup source goes through switchChatId. Merely setting the ID leaves
+  // messagesMap empty after a process restart, which makes the restored chat
+  // look like a new conversation even though its messages are durable.
   useEffect(() => {
     if (!effectiveChatId) return;
+    switchChatId(effectiveChatId);
+  }, [effectiveChatId, switchChatId]);
 
-    // If chatId exists in URL (jumped from scheduled job etc.), call switchChatId to load messages
-    if (urlChatId) {
-      // Always call switchChatId, let it handle caching logic internally
-      // Avoid message not loaded due to async loading not completing
-      switchChatId(effectiveChatId);
-    } else {
-      contextSetActiveChatId(effectiveChatId);
+  // A recovered Runtime has no browser SSE connection. Refresh only the chat
+  // that the server explicitly reports as recovery-active, and never replace
+  // local optimistic state while an ordinary browser send is in progress.
+  const lastRecoveryChatRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!effectiveChatId || !recoverySessionsLoaded) return;
+
+    if (isSelectedRecoveryActive) {
+      lastRecoveryChatRef.current = effectiveChatId;
+      if (isSending || isAgentRunning) return;
+      const interval = window.setInterval(() => {
+        switchChatId(effectiveChatId, true);
+      }, 2000);
+      return () => window.clearInterval(interval);
     }
-  }, [effectiveChatId, contextSetActiveChatId, switchChatId, urlChatId]);
 
-  // When localActiveChatId changes, synchronously update chatId parameter in URL (only on chat page)
+    if (lastRecoveryChatRef.current !== effectiveChatId) {
+      lastRecoveryChatRef.current = null;
+      return;
+    }
+    if (isSending || isAgentRunning) return;
+
+    // The session just left the recovery read model (normally completion).
+    // Pull its final message once and refresh history so the recovered tab
+    // seamlessly becomes an ordinary completed chat.
+    switchChatId(effectiveChatId, true);
+    void mutate(
+      (key) => typeof key === "string" && key.startsWith("/api/history"),
+    );
+    lastRecoveryChatRef.current = null;
+  }, [
+    effectiveChatId,
+    isAgentRunning,
+    isSending,
+    isSelectedRecoveryActive,
+    recoverySessionsLoaded,
+    switchChatId,
+  ]);
+
+  // When the selected ID has no URL representation yet, add it without
+  // overriding a chat explicitly supplied by navigation.
   // This can avoid effectiveChatId still using old value due to URL update delay
   // Note: Only need to sync when there's no chatId in URL (avoid overwriting existing chatId, e.g., when jumped from scheduled job)
   useEffect(() => {
     // Skip initial render
-    if (!localActiveChatId) return;
+    if (!effectiveChatId) return;
     // Only synchronously update URL on chat page
     if (page !== "chat") return;
     // If chatId already exists in URL, no need to update (possibly jumped from scheduled job etc.)
@@ -299,16 +373,17 @@ export function Home() {
       searchParams,
       paramsToUpdate: {
         page: "chat",
-        chatId: localActiveChatId,
+        chatId: effectiveChatId,
       },
     });
     router.replace(newPath, { scroll: false });
-  }, [localActiveChatId, page, searchParams, router]);
+  }, [effectiveChatId, page, searchParams, router, urlChatId]);
 
   // Initial redirect: when page is null (first load), redirect to chat page
   useEffect(() => {
-    // Only redirect when page is null and localActiveChatId is available
-    if (page !== null || !localActiveChatId) return;
+    // Wait for the recovery read before deciding between a recovered, restored,
+    // or brand-new chat.
+    if (page !== null || !effectiveChatId) return;
 
     if (pathname !== "/") return;
 
@@ -317,11 +392,11 @@ export function Home() {
       searchParams,
       paramsToUpdate: {
         page: "chat",
-        chatId: localActiveChatId,
+        chatId: effectiveChatId,
       },
     });
     router.replace(newPath, { scroll: false });
-  }, [page, localActiveChatId, pathname, searchParams, router]);
+  }, [page, effectiveChatId, pathname, searchParams, router]);
 
   // ============================================================================
   // Chat Hook & Refs
@@ -544,6 +619,7 @@ export function Home() {
               <div className="flex min-w-0 flex-1 flex-col">
                 <ChatHeaderPanel
                   chatId={effectiveChatId}
+                  recoverySessions={recoverySessions?.sessions}
                   onChatIdChange={handleChatIdChange}
                   isHistoryPanelOpen={isChatHistoryOpen}
                   onToggleHistoryPanel={() => {
@@ -579,6 +655,8 @@ export function Home() {
                     initialInput={initialInput}
                     prefillToken={prefillToken}
                     initialMessageToSend={initialMessageToSend}
+                    serverRecoveryActive={isSelectedRecoveryActive}
+                    serverRecoveryPending={recoveryPresentationPending}
                   />
                 </div>
               </div>
@@ -630,13 +708,13 @@ export function Home() {
     }
 
     return (
-        <AgentLayout
-          centerTitle={t("nav.newChat")} 
-          hideCenterHeader={true}
-          centerOverlay={undefined}
-        >
-          <ChatSkeleton key="chat-skeleton" />
-        </AgentLayout>
+      <AgentLayout
+        centerTitle={t("nav.newChat")}
+        hideCenterHeader={true}
+        centerOverlay={undefined}
+      >
+        <ChatSkeleton key="chat-skeleton" />
+      </AgentLayout>
     );
   }
 

--- a/apps/web/app/api/agent-goals/[goalId]/resume/route.ts
+++ b/apps/web/app/api/agent-goals/[goalId]/resume/route.ts
@@ -1,0 +1,42 @@
+import {
+  GoalIdSchema,
+  ResumeGoalRequestSchema,
+  getAgentGoalApiService,
+  goalCommandResponse,
+  invalidGoalApiRequest,
+  parseGoalApiBody,
+  readIdempotencyKey,
+  withAuthenticatedGoalApi,
+} from "@/lib/ai/runtime-instructions/api/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface GoalResumeRouteContext {
+  params: Promise<{ goalId: string }>;
+}
+
+export async function POST(request: Request, context: GoalResumeRouteContext) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId, service }) => {
+      const goalId = GoalIdSchema.safeParse((await context.params).goalId);
+      if (!goalId.success) {
+        return invalidGoalApiRequest(goalId.error.issues[0]?.message);
+      }
+      const idempotency = readIdempotencyKey(request);
+      if ("response" in idempotency) return idempotency.response;
+      const parsed = await parseGoalApiBody(request, ResumeGoalRequestSchema);
+      if ("response" in parsed) return parsed.response;
+      return goalCommandResponse(
+        await service.resume(
+          ownerId,
+          goalId.data,
+          parsed.data,
+          idempotency.data,
+        ),
+      );
+    },
+  );
+}

--- a/apps/web/app/api/agent-goals/runtime-sessions/route.ts
+++ b/apps/web/app/api/agent-goals/runtime-sessions/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+import type {
+  AgentGoalRecoverySession,
+  AgentGoalRecoverySessionsResponse,
+} from "@/lib/ai/runtime-instructions/api";
+import {
+  NO_STORE_HEADERS,
+  getAgentGoalApiService,
+  withAuthenticatedGoalApi,
+} from "@/lib/ai/runtime-instructions/api/server";
+import {
+  getAgentGoalRuntime,
+  type SqliteAgentGoalRuntime,
+} from "@/lib/ai/runtime-instructions/runtime";
+import { getChatById } from "@/lib/db/queries";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Minimal, owner-scoped read model used to reconnect the desktop chat UI to a
+ * Goal Runtime that the server is recovering after process restart.
+ */
+export async function GET(request: Request) {
+  return withAuthenticatedGoalApi(
+    request,
+    getAgentGoalApiService,
+    async ({ ownerId }) => {
+      const goalRuntime = getAgentGoalRuntime();
+      if (!("state" in goalRuntime)) {
+        return NextResponse.json<AgentGoalRecoverySessionsResponse>(
+          { sessions: [] },
+          { headers: NO_STORE_HEADERS },
+        );
+      }
+
+      const sqliteRuntime = goalRuntime as SqliteAgentGoalRuntime;
+      const persisted =
+        await sqliteRuntime.runtimeSessions.listRecoveryPresentationSessions(
+          ownerId,
+        );
+      const candidates = await Promise.all(
+        persisted.map(async (session) => {
+          const chat = await getChatById({ id: session.runtimeSessionId });
+          // Runtime rows are owner-scoped already. Re-check the Chat owner at
+          // the HTTP boundary because its title is part of the response.
+          if (!chat || chat.userId !== ownerId) return null;
+          return {
+            runtimeSessionId: session.runtimeSessionId,
+            state: session.state,
+            live: sqliteRuntime.sessions.has(ownerId, session.runtimeSessionId),
+            chat: {
+              id: chat.id,
+              title: chat.title,
+              createdAt: chat.createdAt.toISOString(),
+            },
+          };
+        }),
+      );
+      const sessions = candidates.filter(
+        (session): session is AgentGoalRecoverySession => session !== null,
+      );
+
+      return NextResponse.json<AgentGoalRecoverySessionsResponse>(
+        { sessions },
+        { headers: NO_STORE_HEADERS },
+      );
+    },
+  );
+}

--- a/apps/web/components/agent/chat-header-panel.tsx
+++ b/apps/web/components/agent/chat-header-panel.tsx
@@ -11,6 +11,7 @@ import { Badge, Button } from "@openloomi/ui";
 import { HorizontalScrollContainer, hasDragged } from "@openloomi/ui";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@openloomi/ui";
 import type { ChatHistoryResponse } from "@/lib/ai/chat/api";
+import type { AgentGoalRecoverySession } from "@/lib/ai/runtime-instructions/api";
 import { buildNavigationUrl } from "@/lib/utils";
 import { fetcher } from "@/lib/utils";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,17 @@ interface ChatHeaderPanelProps {
    * Toggle right history panel (controlled by parent whether to show)
    */
   onToggleHistoryPanel?: () => void;
+  /** Server-owned Goal sessions still running after a desktop restart. */
+  recoverySessions?: readonly AgentGoalRecoverySession[];
+}
+
+interface HeaderChat {
+  id: string;
+  title: string;
+  createdAt: Date;
+  latestMessageContent: string | null;
+  latestMessageTime: Date | null;
+  messageCount: number;
 }
 
 /**
@@ -52,6 +64,7 @@ export function ChatHeaderPanel({
   children,
   isHistoryPanelOpen,
   onToggleHistoryPanel,
+  recoverySessions = [],
 }: ChatHeaderPanelProps = {}) {
   const { t } = useTranslation();
 
@@ -79,11 +92,15 @@ export function ChatHeaderPanel({
   // Check if agent for the specified chatId is running
   const isChatRunning = useCallback(
     (chatId: string): boolean => {
+      if (
+        recoverySessions.some((session) => session.runtimeSessionId === chatId)
+      ) {
+        return true;
+      }
       if (!getChatSessionStates) return false;
-      const states = getChatSessionStates();
-      return states.get(chatId)?.isAgentRunning ?? false;
+      return getChatSessionStates().get(chatId)?.isAgentRunning ?? false;
     },
-    [getChatSessionStates],
+    [getChatSessionStates, recoverySessions],
   );
 
   // Prefer context's activeChatId (for highlighting), otherwise use externally passed chatId
@@ -106,11 +123,28 @@ export function ChatHeaderPanel({
     },
   );
 
-  // Find current chat from history
+  const recoveryChats = useMemo<HeaderChat[]>(
+    () =>
+      recoverySessions.map((session) => ({
+        id: session.chat.id,
+        title: session.chat.title,
+        createdAt: new Date(session.chat.createdAt),
+        latestMessageContent: null,
+        latestMessageTime: new Date(session.chat.createdAt),
+        messageCount: 1,
+      })),
+    [recoverySessions],
+  );
+
+  // Find current chat from history or the server recovery read model.
   const currentChat = useMemo(() => {
-    if (!chatHistory?.chats || !currentChatId) return null;
-    return chatHistory.chats.find((chat) => chat.id === currentChatId) || null;
-  }, [chatHistory, currentChatId]);
+    if (!currentChatId) return null;
+    return (
+      chatHistory?.chats.find((chat) => chat.id === currentChatId) ??
+      recoveryChats.find((chat) => chat.id === currentChatId) ??
+      null
+    );
+  }, [chatHistory, currentChatId, recoveryChats]);
 
   // Sort all chats by time (newest first)
   const sortedChats = useMemo(() => {
@@ -130,42 +164,40 @@ export function ChatHeaderPanel({
 
   // Get chat list for display title (up to 5)
   const displayChats = useMemo(() => {
-    if (!sortedChats || sortedChats.length === 0) {
-      if (currentChatId && currentChat) {
-        return [currentChat];
+    // Recovery sessions take priority even when the corresponding Chat is too
+    // old to be present in the first history page.
+    const display: HeaderChat[] = recoveryChats.slice(0, 5);
+    const seen = new Set(display.map((chat) => chat.id));
+    for (const chat of sortedChats) {
+      if (display.length >= 5) break;
+      if (!seen.has(chat.id)) {
+        display.push(chat);
+        seen.add(chat.id);
       }
-      if (!currentChatId) {
-        return [];
-      }
-      return [];
     }
 
-    // Take top 5 chats
-    const top5Chats = sortedChats.slice(0, 5);
-    const currentChatInTop5 = currentChatId
-      ? top5Chats.some((chat) => chat.id === currentChatId)
+    const currentChatIsDisplayed = currentChatId
+      ? display.some((chat) => chat.id === currentChatId)
       : false;
 
-    // If current chat is not in top 5, include it and place at the end (rightmost)
-    if (currentChatId && !currentChatInTop5) {
+    // If current chat is not in the first five, keep it visible at the end.
+    if (currentChatId && !currentChatIsDisplayed) {
       if (currentChat) {
-        return [...top5Chats, currentChat];
+        return [...display, currentChat];
       }
-      if (currentChatId) {
-        const newChatPlaceholder = {
-          id: currentChatId,
-          title: t("common.newChat"),
-          createdAt: new Date(),
-          latestMessageContent: null,
-          latestMessageTime: new Date(),
-          messageCount: 0,
-        };
-        return [...top5Chats, newChatPlaceholder];
-      }
+      const newChatPlaceholder = {
+        id: currentChatId,
+        title: t("common.newChat"),
+        createdAt: new Date(),
+        latestMessageContent: null,
+        latestMessageTime: new Date(),
+        messageCount: 0,
+      };
+      return [...display, newChatPlaceholder];
     }
 
-    return top5Chats;
-  }, [sortedChats, currentChatId, currentChat, t]);
+    return display;
+  }, [sortedChats, recoveryChats, currentChatId, currentChat, t]);
 
   // Stable display list reference to avoid flicker during data loading
   const prevDisplayChatsRef = useRef<typeof displayChats>([]);

--- a/apps/web/components/agent/chat-panel.tsx
+++ b/apps/web/components/agent/chat-panel.tsx
@@ -21,6 +21,7 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { useConversationApiConfiguration } from "@/components/conversation-api-onboarding-guard";
 import { ConversationApiSetup } from "@/components/conversation-api-setup";
 import { getTextFromMessage } from "@/lib/utils";
+import { resolveAgentChatRuntimePresentation } from "@/lib/ai/chat/runtime-presentation";
 
 interface AgentChatPanelProps {
   chatId?: string | null; // External chatId; if null, creates a new chat
@@ -30,6 +31,10 @@ interface AgentChatPanelProps {
   prefillToken?: string;
   /** A message to send immediately after mount (e.g., from onboarding "Chat with openloomi" card), sent only once */
   initialMessageToSend?: string;
+  /** A server-owned recovery Query is running without a browser abort handle. */
+  serverRecoveryActive?: boolean;
+  /** Recovery ownership is still loading; do not race it with a new Query. */
+  serverRecoveryPending?: boolean;
 }
 
 /**
@@ -42,6 +47,8 @@ export function AgentChatPanel({
   initialInput,
   prefillToken,
   initialMessageToSend,
+  serverRecoveryActive = false,
+  serverRecoveryPending = false,
 }: AgentChatPanelProps = {}) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -93,6 +100,11 @@ export function AgentChatPanel({
   // Get isAgentRunning for THIS chat panel's chatId (not the activeChatId)
   // This ensures the side panel shows correct status even when activeChatId changes
   const isAgentRunningForChat = getIsAgentRunningByChatId(chatId);
+  const runtimePresentation = resolveAgentChatRuntimePresentation({
+    browserRunActive: isAgentRunningForChat,
+    serverRecoveryActive,
+    serverRecoveryPending,
+  });
 
   useEffect(() => {
     if (lastTtsChatIdRef.current !== chatId) {
@@ -394,14 +406,14 @@ export function AgentChatPanel({
       }
 
       // Check if AI is already responding to prevent duplicate submissions
-      if (isAgentRunningForChat) {
+      if (!runtimePresentation.canStartRun) {
         console.warn("[sendMessage] Agent is already running");
         return Promise.reject(new Error("Agent is already running"));
       }
 
       return sendMessage(message, requestOptions);
     },
-    [apiConfigurationState, sendMessage, isAgentRunningForChat],
+    [apiConfigurationState, runtimePresentation.canStartRun, sendMessage],
   );
 
   /** Auto-send initialMessageToSend after mount (e.g., from onboarding "Chat with openloomi" click): switches to new chat first, then sends, runs only once; if from URL send param, clears after sending */
@@ -410,6 +422,8 @@ export function AgentChatPanel({
     if (
       !initialMessageToSend?.trim() ||
       initialMessageSentRef.current ||
+      serverRecoveryActive ||
+      serverRecoveryPending ||
       apiConfigurationState !== "available" ||
       !sendMessagePresent
     )
@@ -444,6 +458,8 @@ export function AgentChatPanel({
     router,
     searchParams,
     sendMessagePresent,
+    serverRecoveryActive,
+    serverRecoveryPending,
     switchChatId,
   ]);
 
@@ -525,7 +541,7 @@ export function AgentChatPanel({
                       messages={messages}
                       sendMessage={sendMessagePresent}
                       setMessages={setMessages}
-                      isAgentRunning={isAgentRunningForChat}
+                      isAgentRunning={runtimePresentation.effectiveRunning}
                     />
                   </div>
                 )}
@@ -575,8 +591,11 @@ export function AgentChatPanel({
               <TaskComposer
                 value={input}
                 setValue={handleSetInput}
-                onStop={stop}
-                isAgentRunning={isAgentRunningForChat}
+                onStop={
+                  runtimePresentation.canStopFromBrowser ? stop : undefined
+                }
+                isAgentRunning={runtimePresentation.effectiveRunning}
+                isLocked={runtimePresentation.composerLocked}
                 attachments={attachments}
                 setAttachments={setAttachments}
                 onSubmit={async ({ text, attachments: submitAttachments }) => {

--- a/apps/web/components/agent/goal-side-panel.tsx
+++ b/apps/web/components/agent/goal-side-panel.tsx
@@ -34,6 +34,7 @@ import type {
 import { AgentGoalApiError } from "@/lib/ai/runtime-instructions/api/client";
 import {
   blankGoalDraft,
+  canResumeGoal,
   formatDuration,
   goalDraft,
   goalInputFromDraft,
@@ -204,6 +205,11 @@ export function AgentGoalSidePanel({
           setEditingRevision(currentDetail.goal.revision);
           setEditing(true);
         }}
+        onResume={() =>
+          runCommand(() =>
+            commands.resume(currentDetail.goal.id, currentDetail.goal.revision),
+          ).then(() => undefined)
+        }
         onUpsertContext={(contextRef, expectedRevision) =>
           runCommand(() =>
             commands.upsertContext(
@@ -442,12 +448,14 @@ function GoalDetail({
   detail,
   busy,
   onEdit,
+  onResume,
   onUpsertContext,
   onRemoveContext,
 }: {
   detail: AgentGoalDetailResponse;
   busy: boolean;
   onEdit: () => void;
+  onResume: () => Promise<void>;
   onUpsertContext: (
     context: ContextInput,
     expectedRevision: number,
@@ -464,6 +472,7 @@ function GoalDetail({
     return ids;
   }, [evidence, latestRun?.lastEvaluation?.satisfiedCriteria]);
   const editable = goal.status === "active";
+  const resumable = canResumeGoal(goal.status);
 
   return (
     <div className="space-y-5">
@@ -476,12 +485,17 @@ function GoalDetail({
             </div>
             <h3 className="break-words text-base font-semibold">{goal.objective}</h3>
           </div>
-          {editable && (
+          {editable ? (
             <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={onEdit}>
               <RemixIcon name="edit" size="size-4" />
               <span className="sr-only">{t("agentGoals.edit")}</span>
             </Button>
-          )}
+          ) : resumable ? (
+            <Button variant="outline" size="sm" disabled={busy} onClick={() => void onResume().catch(() => undefined)}>
+              {busy && <RemixIcon name="loader_icon" size="size-4" className="animate-spin" />}
+              {goal.status === "blocked" ? t("agentGoals.retry") : t("agentGoals.resume")}
+            </Button>
+          ) : null}
         </div>
         <Progress value={goalProgressPercent(detail)} className="h-2" />
         <div className="flex justify-between text-xs text-muted-foreground">

--- a/apps/web/components/chat-context.tsx
+++ b/apps/web/components/chat-context.tsx
@@ -306,6 +306,8 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
 
   // Sending lock - prevents chat switching while message is being sent
   const [isSending, setIsSending] = useState(false);
+  const isSendingRef = useRef(isSending);
+  isSendingRef.current = isSending;
 
   // Get messages for a specific chat
   const getMessages = useCallback(
@@ -369,6 +371,9 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     messagesMapRef.current = messagesMap;
   }, [messagesMap]);
+  // A recovery-active chat is refreshed in the background. Fence overlapping
+  // reads so a slower, older response cannot replace a newer/final snapshot.
+  const chatLoadSequenceRef = useRef(new Map<string, number>());
 
   // Stream error retry management
   const [streamRetryCount, setStreamRetryCount] = useState(0);
@@ -2423,7 +2428,7 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
   const switchChatId = useCallback(
     async (newChatId: string | null, forceRefresh?: boolean) => {
       // Prevent chat switching while sending a message
-      if (isSending) {
+      if (isSendingRef.current) {
         return;
       }
 
@@ -2444,6 +2449,10 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
         return;
       }
 
+      const loadSequence =
+        (chatLoadSequenceRef.current.get(newChatId) ?? 0) + 1;
+      chatLoadSequenceRef.current.set(newChatId, loadSequence);
+
       // Load messages asynchronously without blocking UI
       (async () => {
         try {
@@ -2461,6 +2470,11 @@ export function ChatContextProvider({ children }: { children: ReactNode }) {
             return;
           }
           const data = await response.json();
+          if (
+            chatLoadSequenceRef.current.get(newChatId) !== loadSequence
+          ) {
+            return;
+          }
           const uiMessages = data.messages || [];
           // Store fetched messages in map
           setMessagesMap((prev) => {

--- a/apps/web/hooks/use-agent-goals.ts
+++ b/apps/web/hooks/use-agent-goals.ts
@@ -8,6 +8,7 @@ import type {
   AgentGoalCommandResponse,
   AgentGoalDetailResponse,
   AgentGoalSessionResponse,
+  ResumeGoalRequest,
   UpdateGoalRequest,
   UpsertGoalContextRequest,
 } from "@/lib/ai/runtime-instructions/api";
@@ -18,6 +19,7 @@ import {
   fetchAgentGoalDetail,
   fetchAgentGoalSession,
   removeAgentGoalContext,
+  resumeAgentGoal,
   updateAgentGoal,
   upsertAgentGoalContext,
 } from "@/lib/ai/runtime-instructions/api/client";
@@ -120,6 +122,24 @@ export function useAgentGoalCommands(runtimeSessionId: string) {
         "update",
         { goalId, ...request },
         (idempotencyKey) => updateAgentGoal(goalId, request, idempotencyKey),
+      );
+      await refresh(goalId);
+      return response;
+    },
+    resume: async (
+      goalId: string,
+      expectedRevision: number,
+      reason?: ResumeGoalRequest["reason"],
+    ) => {
+      const request = {
+        runtimeSessionId,
+        expectedRevision,
+        ...(reason === undefined ? {} : { reason }),
+      };
+      const response = await execute(
+        "resume",
+        { goalId, ...request },
+        (idempotencyKey) => resumeAgentGoal(goalId, request, idempotencyKey),
       );
       await refresh(goalId);
       return response;

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -52,6 +52,8 @@ const en = {
     invalidDeadline: "Enter a valid deadline.",
     waiting: "Waiting for Claude",
     edit: "Edit Goal",
+    resume: "Continue Goal",
+    retry: "Retry Goal",
     criteriaProgress: "{{done}} of {{total}} criteria",
     execution: "Execution",
     runStatus: "Run",

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -48,6 +48,8 @@ const zh = {
     invalidDeadline: "请输入有效的截止时间。",
     waiting: "等待 Claude",
     edit: "编辑目标",
+    resume: "继续目标",
+    retry: "重试目标",
     criteriaProgress: "已完成 {{done}} / {{total}} 项标准",
     execution: "执行情况",
     runStatus: "运行状态",

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -92,6 +92,24 @@ export function register() {
         })
         .catch((e) => console.warn("[Loop] Scheduler import failed:", e));
 
+      import("./lib/ai/runtime-instructions/recovery/startup")
+        .then(({ startAgentGoalRuntimeRecovery }) =>
+          startAgentGoalRuntimeRecovery().then((report) => {
+            const resumed = report.outcomes.filter(
+              (entry) => entry.status === "resumed",
+            ).length;
+            const failed = report.outcomes.filter(
+              (entry) => entry.status === "failed",
+            ).length;
+            if (report.scanned > 0) {
+              console.log(
+                `[Agent Goal Recovery] scanned=${report.scanned} resumed=${resumed} failed=${failed}`,
+              );
+            }
+          }),
+        )
+        .catch((e) => console.warn("[Agent Goal Recovery] Startup failed:", e));
+
       // Legacy daemon cleanup (#288): sweep for any stale
       // `openloomi-loop.cjs schedule|watch` process left running from an
       // older debug build and SIGTERM it. Best-effort; soft-fails so the

--- a/apps/web/lib/ai/chat/runtime-presentation.ts
+++ b/apps/web/lib/ai/chat/runtime-presentation.ts
@@ -1,0 +1,31 @@
+export interface AgentChatRuntimePresentation {
+  effectiveRunning: boolean;
+  composerLocked: boolean;
+  canStartRun: boolean;
+  canStopFromBrowser: boolean;
+}
+
+/**
+ * A recovered run is live in the server process but has no abort handle in the
+ * reloaded browser. Keep it visibly busy and reject a second run, without
+ * rendering a stop control that cannot reach the owning Query.
+ */
+export function resolveAgentChatRuntimePresentation(input: {
+  browserRunActive: boolean;
+  serverRecoveryActive: boolean;
+  serverRecoveryPending?: boolean;
+}): AgentChatRuntimePresentation {
+  const recoveryOwnsOrMayOwnRun =
+    input.serverRecoveryActive || input.serverRecoveryPending === true;
+  return {
+    effectiveRunning: input.browserRunActive || input.serverRecoveryActive,
+    // A browser-owned run already has its normal submit guard and a real stop
+    // handle. Do not make its composer look like a server-owned recovery merely
+    // because the persistence read model observes the same live session.
+    composerLocked: !input.browserRunActive && recoveryOwnsOrMayOwnRun,
+    canStartRun: !input.browserRunActive && !recoveryOwnsOrMayOwnRun,
+    // If the browser has a real abort handle, keep its functional stop even
+    // while the server read model also observes the ordinary live lease.
+    canStopFromBrowser: input.browserRunActive,
+  };
+}

--- a/apps/web/lib/ai/chat/startup-selection.ts
+++ b/apps/web/lib/ai/chat/startup-selection.ts
@@ -1,0 +1,47 @@
+export type StartupChatSelectionSource =
+  | "url"
+  | "recovery"
+  | "restored"
+  | "new";
+
+export type StartupChatSelection =
+  | { pending: true; chatId: null; source: null }
+  | {
+      pending: false;
+      chatId: string;
+      source: StartupChatSelectionSource;
+    };
+
+export function selectStartupChat(input: {
+  pathname: string;
+  page: string | null;
+  urlChatId?: string;
+  recoveryLoaded: boolean;
+  recoveryChatId?: string;
+  restoredChatId: string | null;
+  newChatId: string;
+}): StartupChatSelection {
+  if (input.urlChatId) {
+    return { pending: false, chatId: input.urlChatId, source: "url" };
+  }
+
+  const isColdHomeStart = input.pathname === "/" && input.page === null;
+  if (isColdHomeStart && !input.recoveryLoaded) {
+    return { pending: true, chatId: null, source: null };
+  }
+  if (isColdHomeStart && input.recoveryChatId) {
+    return {
+      pending: false,
+      chatId: input.recoveryChatId,
+      source: "recovery",
+    };
+  }
+  if (input.restoredChatId) {
+    return {
+      pending: false,
+      chatId: input.restoredChatId,
+      source: "restored",
+    };
+  }
+  return { pending: false, chatId: input.newChatId, source: "new" };
+}

--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -76,7 +76,10 @@ import {
   getExtendedPath,
   isUsingCustomApi,
 } from "./env";
-import { convertClaudeSdkMessage } from "./message-converter";
+import {
+  CLAUDE_API_ERROR_SENTINEL,
+  convertClaudeSdkMessage,
+} from "./message-converter";
 import {
   attachClaudeMcpServers,
   createClaudeQueryOptions,
@@ -86,6 +89,8 @@ import {
   claudeAgentSdkTransport,
   ClaudeRuntimeSession,
   createClaudeRecoveryInitialPrompt,
+  createClaudeProviderFailureSessionStore,
+  isFatalClaudeProviderDiagnostic,
   resolveAuthenticatedGoalRuntimeOwnerId,
   startClaudeGoalRuntimeSession,
 } from "./runtime";
@@ -1809,13 +1814,6 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       skipWebFetchPreflight: true,
     });
     const runtimeOptions: AgentOptions = options ?? {};
-    // The SDK does not wire its stderr callback when a custom spawner is
-    // supplied, so the spawner captures and line-buffers stderr directly.
-    const captureStderr = (data: string) => {
-      logger.error(
-        `[Claude ${session.id}] STDERR: ${this.redactRuntimeDiagnostic(data)}`,
-      );
-    };
     const goalRuntimeSessionId =
       runtimeRecovery?.runtimeSessionId ||
       options?.sessionId?.trim() ||
@@ -1827,8 +1825,23 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       sdkTransport: claudeAgentSdkTransport,
       logger,
       createMessageId: () => this.generateMessageId(),
+      abortProvider: (reason) => {
+        if (!session.abortController.signal.aborted) {
+          session.abortController.abort(reason);
+        }
+      },
       supplementalInput: options?.supplementalInput,
     });
+    // The SDK does not wire its stderr callback when a custom spawner is
+    // supplied, so the spawner captures and line-buffers stderr directly.
+    const captureStderr = (data: string) => {
+      logger.error(
+        `[Claude ${session.id}] STDERR: ${this.redactRuntimeDiagnostic(data)}`,
+      );
+      if (isFatalClaudeProviderDiagnostic(data)) {
+        claudeRuntime.reportProviderFailure("stderr");
+      }
+    };
     const queryOptions = createClaudeQueryOptions({
       sessionId: session.id,
       cwd: sessionCwd,
@@ -1859,6 +1872,15 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       resumeProviderSessionId: runtimeRecovery?.providerSessionId,
       permissionLogMode: "run",
     });
+    if (runtimeRecovery?.providerSessionId) {
+      queryOptions.sessionStore = createClaudeProviderFailureSessionStore({
+        expectedSessionId: runtimeRecovery.providerSessionId,
+        onProviderFailure: () => {
+          claudeRuntime.reportProviderFailure("session_store");
+        },
+      });
+      queryOptions.sessionStoreFlush = "eager";
+    }
     // MCP servers can expand the allowed tool set, so attach them after the
     // base query options are created.
     attachClaudeMcpServers({
@@ -1908,13 +1930,17 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       });
 
       for await (const agentMessage of claudeRuntime.subscribe()) {
-        if (session.abortController.signal.aborted) {
+        const safeProviderFailure =
+          agentMessage.type === "error" &&
+          agentMessage.message === CLAUDE_API_ERROR_SENTINEL;
+        if (session.abortController.signal.aborted && !safeProviderFailure) {
           console.log(
             `[Claude ${session.id}] query() abort signal detected, breaking loop`,
           );
           break;
         }
         yield agentMessage;
+        if (session.abortController.signal.aborted) break;
       }
       console.log(
         `[Claude ${session.id}] query() for-await loop completed normally. Total SDK messages: ${claudeRuntime.sdkMessageCount}`,

--- a/apps/web/lib/ai/extensions/agent/claude/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/index.ts
@@ -9,7 +9,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { arch, homedir, platform } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import {
   createSdkMcpServer,
   query,
@@ -36,6 +36,7 @@ import type {
   AgentMessage,
   AgentOptions,
   AgentProvider,
+  AgentRuntimeRecovery,
   ConversationMessage,
   ExecuteOptions,
   ImageAttachment,
@@ -44,6 +45,7 @@ import type {
   PlanOptions,
 } from "@openloomi/ai/agent/types";
 import { MAX_CONVERSATION_HISTORY_TOKENS } from "@/lib/ai/runtime/shared";
+import type { RuntimeRecoveryDescriptor } from "@/lib/ai/runtime-instructions/runtime-session-persistence";
 import {
   APP_DIR_NAME,
   DEFAULT_API_HOST,
@@ -83,6 +85,7 @@ import {
 import {
   claudeAgentSdkTransport,
   ClaudeRuntimeSession,
+  createClaudeRecoveryInitialPrompt,
   resolveAuthenticatedGoalRuntimeOwnerId,
   startClaudeGoalRuntimeSession,
 } from "./runtime";
@@ -794,6 +797,104 @@ function resolveClaudeWorkDir({
   return getSessionWorkDir(workDir, prompt, taskId);
 }
 
+function validateClaudeRuntimeRecovery(
+  recovery: AgentRuntimeRecovery | undefined,
+): AgentRuntimeRecovery | undefined {
+  if (!recovery) return undefined;
+
+  for (const [field, value] of [
+    ["runtimeSessionId", recovery.runtimeSessionId],
+    ["providerSessionId", recovery.providerSessionId],
+  ] as const) {
+    if (
+      typeof value !== "string" ||
+      value.length === 0 ||
+      value.length > 256 ||
+      value !== value.trim()
+    ) {
+      throw new TypeError(`${field} must be a non-empty identifier`);
+    }
+  }
+  if (
+    typeof recovery.workingDirectory !== "string" ||
+    recovery.workingDirectory.length === 0 ||
+    recovery.workingDirectory !== recovery.workingDirectory.trim() ||
+    !isAbsolute(recovery.workingDirectory)
+  ) {
+    throw new TypeError("workingDirectory must be an absolute path");
+  }
+  if (!Number.isInteger(recovery.runEpoch) || recovery.runEpoch < 0) {
+    throw new TypeError("runEpoch must be a non-negative integer");
+  }
+  if (
+    recovery.recoveryLeaseToken !== undefined &&
+    (recovery.recoveryLeaseToken.length === 0 ||
+      recovery.recoveryLeaseToken.length > 512 ||
+      recovery.recoveryLeaseToken !== recovery.recoveryLeaseToken.trim())
+  ) {
+    throw new TypeError("recoveryLeaseToken must be a non-empty token");
+  }
+  return recovery;
+}
+
+function createClaudeRuntimeRecoveryDescriptor(
+  config: AgentConfig,
+  options: AgentOptions | undefined,
+): RuntimeRecoveryDescriptor {
+  const skillsConfig = options?.skillsConfig;
+  const mcpConfig = options?.mcpConfig;
+  return {
+    schemaVersion: 1,
+    ...(config.model === undefined ? {} : { model: config.model }),
+    ...(config.thinkingLevel === undefined
+      ? {}
+      : { thinkingLevel: config.thinkingLevel }),
+    ...(options?.permissionMode === undefined
+      ? {}
+      : { permissionMode: options.permissionMode }),
+    allowedTools: [...(options?.allowedTools || DEFAULT_ALLOWED_TOOLS)],
+    ...(options?.disallowedTools === undefined
+      ? {}
+      : { disallowedTools: [...options.disallowedTools] }),
+    ...(options?.excludeTools === undefined
+      ? {}
+      : { excludedTools: [...options.excludeTools] }),
+    ...(options?.sandbox === undefined
+      ? {}
+      : {
+          sandbox: options.sandbox.enabled
+            ? {
+                enabled: true,
+                ...(options.sandbox.provider === undefined
+                  ? {}
+                  : { provider: options.sandbox.provider }),
+                ...(options.sandbox.image === undefined
+                  ? {}
+                  : { image: options.sandbox.image }),
+              }
+            : { enabled: false },
+        }),
+    ...(skillsConfig === undefined
+      ? {}
+      : {
+          skillsConfig: {
+            enabled: skillsConfig.enabled,
+            userDirEnabled: skillsConfig.userDirEnabled,
+            appDirEnabled: skillsConfig.appDirEnabled,
+          },
+        }),
+    ...(mcpConfig === undefined
+      ? {}
+      : {
+          mcpConfig: {
+            enabled: mcpConfig.enabled,
+            userDirEnabled: mcpConfig.userDirEnabled,
+            appDirEnabled: mcpConfig.appDirEnabled,
+          },
+        }),
+  };
+}
+
 /**
  * Get or create session working directory
  * If workDir already contains a valid session path (from frontend), use it directly
@@ -1471,6 +1572,9 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     prompt: string,
     options?: AgentOptions,
   ): AsyncGenerator<AgentMessage> {
+    const runtimeRecovery = validateClaudeRuntimeRecovery(
+      options?.runtimeRecovery,
+    );
     // Pass external abortController to session so that when connection closes it can properly stop Agent
     const session = this.createSession("executing", {
       abortController: options?.abortController,
@@ -1481,12 +1585,14 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       messageId: this.generateMessageId(),
     };
 
-    const sessionCwd = resolveClaudeWorkDir({
-      workDir: options?.cwd || this.config.workDir,
-      prompt,
-      taskId: options?.taskId,
-      useProvidedWorkDir: options?.useProvidedWorkDir,
-    });
+    const sessionCwd =
+      runtimeRecovery?.workingDirectory ??
+      resolveClaudeWorkDir({
+        workDir: options?.cwd || this.config.workDir,
+        prompt,
+        taskId: options?.taskId,
+        useProvidedWorkDir: options?.useProvidedWorkDir,
+      });
     // Ensure the working directory exists before calling SDK
     await ensureDir(sessionCwd);
 
@@ -1512,7 +1618,7 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     // Handle image attachments - directly send to Claude API
     // When images are present, we use AsyncIterable<SDKUserMessage> format
     // to include images as content blocks instead of saving to disk
-    const images = options?.images || [];
+    const images = runtimeRecovery ? [] : options?.images || [];
     const hasImages = images.length > 0;
     if (hasImages) {
       console.log(
@@ -1533,7 +1639,7 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
 
     // Handle PDF attachments - directly send to Claude API as document blocks
     // Only use native PDF API if PREFER_NATIVE_PDF is enabled
-    const pdfs = options?.pdfs || [];
+    const pdfs = runtimeRecovery ? [] : options?.pdfs || [];
     const hasPDFs = pdfs.length > 0 && PREFER_NATIVE_PDF;
     if (hasPDFs) {
       console.log(
@@ -1573,7 +1679,9 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     }
 
     // Handle file attachments (PDF, documents, etc.) - save to disk for agent access
-    const fileAttachments = options?.fileAttachments || [];
+    const fileAttachments = runtimeRecovery
+      ? []
+      : options?.fileAttachments || [];
     if (fileAttachments.length > 0) {
       console.log(
         `[Claude ${session.id}] Processing ${fileAttachments.length} file attachment(s)`,
@@ -1592,9 +1700,9 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     }
 
     // Format conversation history to include context from previous messages
-    const conversationContext = this.formatConversationHistory(
-      options?.conversation,
-    );
+    const conversationContext = runtimeRecovery
+      ? ""
+      : this.formatConversationHistory(options?.conversation);
 
     // List available files in workspace and add to prompt
     // Note: Image files are excluded since they're sent as content blocks
@@ -1663,18 +1771,19 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     // Build the base prompt (without images)
     // IMPORTANT: aiSoulInstruction must come FIRST (after mediaPrefix) to override default identity
     // so user's custom instructions take precedence over system-defined identity
-    const basePrompt =
-      mediaPrefix +
-      languageInstruction +
-      aiSoulInstruction +
-      getWorkspaceInstruction(
-        sessionCwd,
-        sandboxOpts,
-        options?.timezone ?? undefined,
-      ) +
-      fileListInfo +
-      conversationContext +
-      prompt;
+    const basePrompt = runtimeRecovery
+      ? ""
+      : mediaPrefix +
+        languageInstruction +
+        aiSoulInstruction +
+        getWorkspaceInstruction(
+          sessionCwd,
+          sandboxOpts,
+          options?.timezone ?? undefined,
+        ) +
+        fileListInfo +
+        conversationContext +
+        prompt;
 
     // Ensure Claude Code is installed
     const claudeCodePath = await ensureClaudeCode();
@@ -1707,10 +1816,14 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
         `[Claude ${session.id}] STDERR: ${this.redactRuntimeDiagnostic(data)}`,
       );
     };
-    const goalRuntimeSessionId = options?.sessionId?.trim() || session.id;
+    const goalRuntimeSessionId =
+      runtimeRecovery?.runtimeSessionId ||
+      options?.sessionId?.trim() ||
+      session.id;
     const claudeRuntime = new ClaudeRuntimeSession({
       runtimeSessionId: goalRuntimeSessionId,
-      runEpoch: 0,
+      runEpoch: runtimeRecovery?.runEpoch ?? 0,
+      expectedProviderSessionId: runtimeRecovery?.providerSessionId,
       sdkTransport: claudeAgentSdkTransport,
       logger,
       createMessageId: () => this.generateMessageId(),
@@ -1743,6 +1856,7 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       systemPrompt: getBusinessToolsInstruction(options?.excludeTools),
       maxTurns: 1000,
       includePartialMessages: options?.stream ?? false,
+      resumeProviderSessionId: runtimeRecovery?.providerSessionId,
       permissionLogMode: "run",
     });
     // MCP servers can expand the allowed tool set, so attach them after the
@@ -1763,14 +1877,16 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
     try {
       // Determine whether to send images/PDFs directly or use text-only prompt
       const hasMedia = hasImages || hasPDFs;
-      const queryPrompt = hasMedia
-        ? this.createUserMessageWithMedia(
-            basePrompt,
-            images,
-            hasPDFs ? pdfs : undefined,
-            session.id,
-          )
-        : basePrompt;
+      const queryPrompt = runtimeRecovery
+        ? createClaudeRecoveryInitialPrompt()
+        : hasMedia
+          ? this.createUserMessageWithMedia(
+              basePrompt,
+              images,
+              hasPDFs ? pdfs : undefined,
+              session.id,
+            )
+          : basePrompt;
 
       goalRuntimeRegistration = await startClaudeGoalRuntimeSession({
         session: options?.session,
@@ -1779,6 +1895,16 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
           initialPrompt: queryPrompt,
           queryOptions,
         },
+        persistence: runtimeRecovery
+          ? { workingDirectory: sessionCwd }
+          : {
+              workingDirectory: sessionCwd,
+              recoveryDescriptor: createClaudeRuntimeRecoveryDescriptor(
+                this.config,
+                options,
+              ),
+            },
+        ...(runtimeRecovery ? { recovery: runtimeRecovery } : {}),
       });
 
       for await (const agentMessage of claudeRuntime.subscribe()) {
@@ -1934,7 +2060,14 @@ ${formattedMessages}${truncationNotice}\n\n---\n## Current Request\n`;
       } finally {
         // Keep a closing Query registered until it can no longer accept Goal
         // commands or emit old-epoch events.
-        goalRuntimeRegistration?.release();
+        try {
+          await goalRuntimeRegistration?.release();
+        } catch (error) {
+          logger.error(
+            `[Claude ${session.id}] Failed to release Goal Runtime ownership`,
+            error,
+          );
+        }
       }
       this.sessions.delete(session.id);
       // Windows cleanup prevents skill files generated for this session from

--- a/apps/web/lib/ai/extensions/agent/claude/message-converter.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/message-converter.ts
@@ -1,5 +1,12 @@
 import type { AgentMessage } from "@openloomi/ai/agent/types";
 
+/**
+ * Claude's SDK can surface provider stream failures as a synthetic assistant
+ * message instead of throwing or emitting a terminal result. Keep the raw
+ * provider text out of user-visible output and durable Goal evidence.
+ */
+export const CLAUDE_API_ERROR_SENTINEL = "__INTERNAL_ERROR__";
+
 export interface ClaudeSdkMessageConversionOptions {
   message: unknown;
   // Tracks finalized assistant text blocks so replayed SDK messages do not
@@ -58,6 +65,20 @@ export function sanitizeClaudeAgentText(text: string): string {
 }
 
 /**
+ * Identify the SDK's synthetic provider-error assistant message. This flag is
+ * present at runtime even though older Claude Agent SDK type declarations do
+ * not expose it.
+ */
+export function isClaudeSdkApiErrorMessage(message: unknown): boolean {
+  return (
+    message !== null &&
+    typeof message === "object" &&
+    (message as { type?: unknown }).type === "assistant" &&
+    (message as { isApiErrorMessage?: unknown }).isApiErrorMessage === true
+  );
+}
+
+/**
  * Convert raw Claude Code SDK messages into OpenLoomi's AgentMessage stream.
  */
 export function* convertClaudeSdkMessage({
@@ -67,6 +88,15 @@ export function* convertClaudeSdkMessage({
   hasStreamedText,
   createMessageId,
 }: ClaudeSdkMessageConversionOptions): Generator<AgentMessage> {
+  if (isClaudeSdkApiErrorMessage(message)) {
+    yield {
+      type: "error",
+      message: CLAUDE_API_ERROR_SENTINEL,
+      messageId: createMessageId(),
+    };
+    return;
+  }
+
   const msg = message as {
     type: string;
     message?: { content?: unknown[] };

--- a/apps/web/lib/ai/extensions/agent/claude/query-options.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/query-options.ts
@@ -93,6 +93,7 @@ export function createClaudeQueryOptions({
   tools,
   maxTurns,
   includePartialMessages,
+  resumeProviderSessionId,
 }: {
   sessionId: string;
   cwd: string;
@@ -120,6 +121,8 @@ export function createClaudeQueryOptions({
   tools?: Options["tools"];
   maxTurns?: number;
   includePartialMessages?: boolean;
+  /** Exact Claude provider session to resume without continuing/forking another session. */
+  resumeProviderSessionId?: string;
 }): Options {
   const effectivePermissionMode = permissionMode || "bypassPermissions";
   const supplementalHooks = createClaudeSupplementalInputHooks({
@@ -149,6 +152,7 @@ export function createClaudeQueryOptions({
     abortController,
     env,
     model: config.model,
+    ...(resumeProviderSessionId ? { resume: resumeProviderSessionId } : {}),
     pathToClaudeCodeExecutable: claudeCodePath,
     ...(maxTurns !== undefined ? { maxTurns } : {}),
     ...(includePartialMessages !== undefined ? { includePartialMessages } : {}),

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/event-observer.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/event-observer.ts
@@ -158,6 +158,7 @@ export class ClaudeRuntimeEventObserver implements ClaudeRuntimeEventObserverPor
             ownerId: this.ownerId,
             runtimeSessionId: this.runtimeSessionId,
             providerSessionId: identity.providerSessionId,
+            runEpoch,
           });
         }
         return;

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AgentRuntimeRecovery,
   AgentRuntimeRecoveryContinuationResult,
+  AgentRuntimeRecoveryGoalFinalizationResult,
 } from "@openloomi/ai/agent/types";
 import type {
   RuntimeObservationLeaseFencePort,
@@ -256,6 +257,8 @@ export async function startClaudeGoalRuntimeSession(
         ownerId,
       });
 
+      const recoveryAttemptId =
+        input.recovery.recoveryLeaseToken ?? crypto.randomUUID();
       await input.recovery.onProviderSessionInitialized?.({
         runtimeSessionId: input.runtime.runtimeSessionId,
         providerSessionId,
@@ -265,8 +268,14 @@ export async function startClaudeGoalRuntimeSession(
           ownerId,
           goalRuntime,
           goalStopController,
-          input.recovery.recoveryLeaseToken ?? crypto.randomUUID(),
+          recoveryAttemptId,
         ),
+        finalizeGoalWithoutContinuation:
+          createRecoveryFinalizationTrigger(
+            input.runtime,
+            recoveryAttemptId,
+            input.recovery.recoveryLeaseToken,
+          ),
       });
     } else {
       await replayPendingInstructions({
@@ -507,6 +516,32 @@ function createRecoveryContinuationTrigger(
     try {
       decision = await inFlight;
       return recoveryContinuationResult(decision);
+    } finally {
+      inFlight = null;
+    }
+  };
+}
+
+function createRecoveryFinalizationTrigger(
+  runtime: ClaudeRuntimeSession,
+  recoveryAttemptId: string,
+  runtimeLeaseToken?: string,
+): () => Promise<AgentRuntimeRecoveryGoalFinalizationResult> {
+  let result: AgentRuntimeRecoveryGoalFinalizationResult | null = null;
+  let inFlight: Promise<AgentRuntimeRecoveryGoalFinalizationResult> | null =
+    null;
+  return async () => {
+    if (result) return result;
+    if (inFlight) return inFlight;
+
+    inFlight = runtime.finalizeGoalWithoutContinuation(
+      `recovery-terminal:${runtime.runtimeSessionId}:${runtime.runEpoch}:${recoveryAttemptId}`,
+      runtimeLeaseToken,
+    );
+    try {
+      const finalized = await inFlight;
+      result = finalized;
+      return finalized;
     } finally {
       inFlight = null;
     }

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/goal-registration.ts
@@ -4,14 +4,41 @@ import {
   type RuntimeInstructionDispatch,
   type RuntimeSessionRegistration,
 } from "@/lib/ai/runtime-instructions";
+import type {
+  AgentRuntimeRecovery,
+  AgentRuntimeRecoveryContinuationResult,
+} from "@openloomi/ai/agent/types";
+import type {
+  RuntimeObservationLeaseFencePort,
+  RuntimeObservationLeaseRegistration,
+} from "@/lib/ai/runtime-instructions/runtime-observation";
+import type {
+  RuntimeLiveSessionLease,
+  RuntimeSessionEnsureOptions,
+  RuntimeSessionPersistencePort,
+  RuntimeSessionRecoveryPersistencePort,
+} from "@/lib/ai/runtime-instructions/runtime-session-persistence";
 import type { ClaudeRuntimeSession } from "./session";
 import { ClaudeRuntimeEventObserver } from "./event-observer";
+import type {
+  ClaudeRuntimeGoalStopController,
+  ClaudeRuntimeStopHookDecision,
+} from "./supplemental-hooks";
 
 export interface StartClaudeGoalRuntimeSessionInput {
   session?: unknown;
   runtime: ClaudeRuntimeSession;
   start: Parameters<ClaudeRuntimeSession["start"]>[0];
   goalRuntime?: AgentGoalRuntime;
+  /** Credential-free metadata needed to recreate this exact runtime. */
+  persistence?: Omit<RuntimeSessionEnsureOptions, "recoveryLeaseToken">;
+  /** Trusted restart path; never populated from a public request body. */
+  recovery?: Pick<
+    AgentRuntimeRecovery,
+    | "recoveryLeaseToken"
+    | "instructionSettlements"
+    | "onProviderSessionInitialized"
+  >;
 }
 
 export class ClaudeGoalRuntimeRegistrationError extends Error {
@@ -49,36 +76,115 @@ export class ClaudeGoalRuntimeRecoveryRequiredError extends Error {
     public readonly runEpoch: number,
   ) {
     super(
-      `Claude Runtime Session ${runtimeSessionId} requires runEpoch ${runEpoch} recovery, which is not available before durable restart recovery is implemented`,
+      `Claude Runtime Session ${runtimeSessionId} at runEpoch ${runEpoch} must be attached through the authenticated durable recovery path`,
     );
     this.name = "ClaudeGoalRuntimeRecoveryRequiredError";
   }
 }
 
+export interface ClaudeGoalRuntimeRegistration extends Omit<
+  RuntimeSessionRegistration,
+  "release"
+> {
+  release(): Promise<void>;
+}
+
+export class ClaudeGoalRuntimeRecoveryAuthenticationError extends Error {
+  readonly code = "runtime_recovery_authentication_required";
+
+  constructor(public readonly runtimeSessionId: string) {
+    super(
+      `Claude Runtime Session ${runtimeSessionId} recovery requires an authenticated owner`,
+    );
+    this.name = "ClaudeGoalRuntimeRecoveryAuthenticationError";
+  }
+}
+
+export class ClaudeGoalRuntimeLiveLeaseError extends Error {
+  readonly code = "runtime_live_lease_unavailable";
+
+  constructor(public readonly runtimeSessionId: string) {
+    super(
+      `Claude Runtime Session ${runtimeSessionId} is already owned by another live or recovering host`,
+    );
+    this.name = "ClaudeGoalRuntimeLiveLeaseError";
+  }
+}
+
 /**
  * Reserves the owner-scoped runtime identity, starts the Claude SDK Query, then
- * replays its pending instruction outbox. Registration is synchronous, so no
- * command can observe the transport between reservation and Query startup.
+ * replays its pending instruction outbox. The transport is not returned to the
+ * caller until Query startup and the initial outbox replay have both finished.
  * Startup, registration, and replay form one lifecycle boundary: any failure
  * releases the registry handle and closes the runtime. An unauthenticated
  * session is deliberately not registered in a shared anonymous namespace.
  */
 export async function startClaudeGoalRuntimeSession(
   input: StartClaudeGoalRuntimeSessionInput,
-): Promise<RuntimeSessionRegistration | undefined> {
+): Promise<ClaudeGoalRuntimeRegistration | undefined> {
   const ownerId = resolveAuthenticatedGoalRuntimeOwnerId(input.session);
   if (!ownerId) {
+    if (input.recovery) {
+      throw new ClaudeGoalRuntimeRecoveryAuthenticationError(
+        input.runtime.runtimeSessionId,
+      );
+    }
     input.runtime.start(input.start);
     return undefined;
   }
 
   const goalRuntime = input.goalRuntime ?? getAgentGoalRuntime();
-  let registration: RuntimeSessionRegistration | undefined;
+  let registration: ClaudeGoalRuntimeRegistration | undefined;
+  let persistenceCleanup: (() => Promise<void>) | undefined;
+  let observationLease: RuntimeObservationLeaseRegistration | undefined;
+  let runtimeStarted = false;
   try {
-    await goalRuntime.runtimeSessions.ensure(
-      ownerId,
-      input.runtime.runtimeSessionId,
-    );
+    const recoveryPersistence = isRecoveryPersistence(
+      goalRuntime.runtimeSessions,
+    )
+      ? goalRuntime.runtimeSessions
+      : undefined;
+    let liveLease: LiveRuntimeLease | undefined;
+    if (input.recovery || !recoveryPersistence) {
+      await goalRuntime.runtimeSessions.ensure(
+        ownerId,
+        input.runtime.runtimeSessionId,
+        {
+          ...input.persistence,
+          ...(input.recovery?.recoveryLeaseToken === undefined
+            ? {}
+            : { recoveryLeaseToken: input.recovery.recoveryLeaseToken }),
+        },
+      );
+    } else {
+      liveLease = await acquireLiveRuntimeLease({
+        persistence: recoveryPersistence,
+        ownerId,
+        runtime: input.runtime,
+        metadata: input.persistence,
+      });
+    }
+    const recoveryLeaseToken = input.recovery?.recoveryLeaseToken;
+    persistenceCleanup = memoizeAsync(async () => {
+      try {
+        if (liveLease) {
+          await liveLease.release(
+            runtimeStarted ? input.runtime.runEpoch : liveLease.initialRunEpoch,
+          );
+        }
+      } finally {
+        observationLease?.release();
+      }
+    });
+    const runtimeLeaseToken = recoveryLeaseToken ?? liveLease?.leaseToken;
+    if (runtimeLeaseToken) {
+      observationLease = attachRuntimeObservationLease(
+        goalRuntime.observations,
+        ownerId,
+        input.runtime.runtimeSessionId,
+        runtimeLeaseToken,
+      );
+    }
     const expectedRunEpoch = await goalRuntime.goals.getRuntimeSessionRunEpoch(
       ownerId,
       input.runtime.runtimeSessionId,
@@ -90,7 +196,7 @@ export async function startClaudeGoalRuntimeSession(
         input.runtime.runEpoch,
       );
     }
-    if (expectedRunEpoch > 0) {
+    if (expectedRunEpoch > 0 && !input.recovery) {
       throw new ClaudeGoalRuntimeRecoveryRequiredError(
         input.runtime.runtimeSessionId,
         expectedRunEpoch,
@@ -103,53 +209,316 @@ export async function startClaudeGoalRuntimeSession(
         goalRuntime.observations,
       ),
     );
-    input.runtime.attachGoalStopController(
-      goalRuntime.controller.forSession({
+    const goalStopController = goalRuntime.controller.forSession({
+      ownerId,
+      runtimeSessionId: input.runtime.runtimeSessionId,
+      transport: input.runtime,
+    });
+    input.runtime.attachGoalStopController(goalStopController);
+    const registerRuntime = () => {
+      const registryRegistration = goalRuntime.sessions.register({
+        ownerId,
+        transport: input.runtime,
+      });
+      let released = false;
+      registration = {
+        ...registryRegistration,
+        release: async () => {
+          if (released) return;
+          released = true;
+          registryRegistration.release();
+          await persistenceCleanup?.();
+        },
+      };
+    };
+    // A recovery claim already reserves the durable Runtime Session identity.
+    // Do not expose its transport to normal dispatch until Claude proves that
+    // it resumed the exact persisted provider session. Otherwise a concurrent
+    // Goal command could enter the SDK input stream before the identity fence.
+    if (!input.recovery) registerRuntime();
+    input.runtime.start(input.start);
+    runtimeStarted = true;
+    await liveLease?.persistRunning();
+    if (input.recovery) {
+      const providerSessionId =
+        await input.runtime.waitUntilProviderSessionInitialized();
+      registerRuntime();
+
+      await goalRuntime.dispatcher.initializeRecoveredProgress({
         ownerId,
         runtimeSessionId: input.runtime.runtimeSessionId,
         transport: input.runtime,
-      }),
-    );
-    const registryRegistration = goalRuntime.sessions.register({
-      ownerId,
-      transport: input.runtime,
-    });
-    let released = false;
-    registration = {
-      ...registryRegistration,
-      release: () => {
-        if (released) return;
-        released = true;
-        registryRegistration.release();
-        void goalRuntime.runtimeSessions
-          .releaseProviderSession(ownerId, input.runtime.runtimeSessionId)
-          .catch((error) => {
-            console.error(
-              "[Agent Goal Runtime] Failed to release Claude provider session",
-              error,
-            );
-          });
-      },
-    };
-    input.runtime.start(input.start);
-    const replay = await input.runtime.replayInitialInstructions(() =>
-      goalRuntime.goals.replayPendingInstructions(
+        settlements: input.recovery.instructionSettlements,
+      });
+      await replayPendingInstructions({
+        runtime: input.runtime,
+        goalRuntime,
         ownerId,
-        input.runtime.runtimeSessionId,
-      ),
-    );
-    if (replay !== null && replay.status !== "accepted") {
-      throw new ClaudeGoalRuntimeRegistrationError(replay);
+      });
+
+      await input.recovery.onProviderSessionInitialized?.({
+        runtimeSessionId: input.runtime.runtimeSessionId,
+        providerSessionId,
+        runEpoch: input.runtime.runEpoch,
+        continueGoal: createRecoveryContinuationTrigger(
+          input.runtime,
+          ownerId,
+          goalRuntime,
+          goalStopController,
+          input.recovery.recoveryLeaseToken ?? crypto.randomUUID(),
+        ),
+      });
+    } else {
+      await replayPendingInstructions({
+        runtime: input.runtime,
+        goalRuntime,
+        ownerId,
+      });
     }
     return registration;
   } catch (error) {
     try {
       await input.runtime.close();
     } finally {
-      registration?.release();
+      await registration?.release();
+      await persistenceCleanup?.();
     }
     throw error;
   }
+}
+
+interface LiveRuntimeLease {
+  readonly leaseToken: string;
+  readonly initialRunEpoch: number;
+  stop(): void;
+  persistRunning(): Promise<void>;
+  release(expectedRunEpoch: number): Promise<void>;
+}
+
+const LIVE_RUNTIME_LEASE_DURATION_MS = 60_000;
+const LIVE_RUNTIME_HEARTBEAT_INTERVAL_MS = 20_000;
+const LIVE_RUNTIME_EXPIRY_SAFETY_MS = 1_000;
+
+async function acquireLiveRuntimeLease(input: {
+  persistence: RuntimeSessionRecoveryPersistencePort;
+  ownerId: string;
+  runtime: ClaudeRuntimeSession;
+  metadata?: Omit<RuntimeSessionEnsureOptions, "recoveryLeaseToken">;
+}): Promise<LiveRuntimeLease | undefined> {
+  const leaseOwner = `openloomi-live:${process.pid}:${crypto.randomUUID()}`;
+  const claim = await input.persistence.claimLiveRuntime({
+    ownerId: input.ownerId,
+    runtimeSessionId: input.runtime.runtimeSessionId,
+    leaseOwner,
+    leaseDurationMs: LIVE_RUNTIME_LEASE_DURATION_MS,
+    ...input.metadata,
+  });
+  if (!claim) {
+    throw new ClaudeGoalRuntimeLiveLeaseError(input.runtime.runtimeSessionId);
+  }
+  return createLiveRuntimeLease(input.persistence, claim, input.runtime);
+}
+
+function createLiveRuntimeLease(
+  persistence: RuntimeSessionRecoveryPersistencePort,
+  claim: RuntimeLiveSessionLease,
+  runtime: ClaudeRuntimeSession,
+): LiveRuntimeLease {
+  let stopped = false;
+  let renewal: Promise<void> | undefined;
+  let expiresAt =
+    Date.now() + LIVE_RUNTIME_LEASE_DURATION_MS - LIVE_RUNTIME_EXPIRY_SAFETY_MS;
+  let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  const failClosed = (error: unknown) => {
+    stop();
+    console.error(
+      `[Agent Goal Runtime] Lost live lease for ${claim.runtimeSessionId}; closing Claude`,
+      error,
+    );
+    void runtime.close();
+  };
+  const scheduleExpiry = () => {
+    if (stopped) return;
+    if (expiryTimer) clearTimeout(expiryTimer);
+    const delay = Math.max(0, expiresAt - Date.now());
+    expiryTimer = setTimeout(() => {
+      failClosed(
+        new Error(
+          `Live lease for Runtime Session ${claim.runtimeSessionId} expired`,
+        ),
+      );
+    }, delay);
+    expiryTimer.unref?.();
+  };
+  const renew = () => {
+    if (stopped || renewal) return;
+    renewal = persistence
+      .renewRecoveryLease({
+        ownerId: claim.ownerId,
+        runtimeSessionId: claim.runtimeSessionId,
+        leaseOwner: claim.leaseOwner,
+        leaseToken: claim.leaseToken,
+        leaseDurationMs: LIVE_RUNTIME_LEASE_DURATION_MS,
+      })
+      .then(() => {
+        expiresAt =
+          Date.now() +
+          LIVE_RUNTIME_LEASE_DURATION_MS -
+          LIVE_RUNTIME_EXPIRY_SAFETY_MS;
+        scheduleExpiry();
+      })
+      .catch((error) => {
+        if (!stopped) failClosed(error);
+      })
+      .finally(() => {
+        renewal = undefined;
+      });
+  };
+  const timer = setInterval(renew, LIVE_RUNTIME_HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    if (expiryTimer) clearTimeout(expiryTimer);
+  };
+  scheduleExpiry();
+
+  return {
+    leaseToken: claim.leaseToken,
+    initialRunEpoch: claim.runEpoch,
+    stop,
+    persistRunning: async () => {
+      await persistence.persistState({
+        ownerId: claim.ownerId,
+        runtimeSessionId: claim.runtimeSessionId,
+        expectedState: claim.state,
+        expectedRunEpoch: claim.runEpoch,
+        state: "running",
+        recoveryLeaseToken: claim.leaseToken,
+      });
+    },
+    release: async (expectedRunEpoch) => {
+      stop();
+      await renewal;
+      await persistence.releaseLiveRuntime({
+        ownerId: claim.ownerId,
+        runtimeSessionId: claim.runtimeSessionId,
+        leaseOwner: claim.leaseOwner,
+        leaseToken: claim.leaseToken,
+        expectedRunEpoch,
+      });
+    },
+  };
+}
+
+function isRecoveryPersistence(
+  persistence: RuntimeSessionPersistencePort,
+): persistence is RuntimeSessionRecoveryPersistencePort {
+  const candidate =
+    persistence as Partial<RuntimeSessionRecoveryPersistencePort>;
+  return (
+    typeof candidate.claimLiveRuntime === "function" &&
+    typeof candidate.renewRecoveryLease === "function" &&
+    typeof candidate.releaseLiveRuntime === "function" &&
+    typeof candidate.persistState === "function"
+  );
+}
+
+function attachRuntimeObservationLease(
+  observations: AgentGoalRuntime["observations"],
+  ownerId: string,
+  runtimeSessionId: string,
+  leaseToken: string,
+): RuntimeObservationLeaseRegistration | undefined {
+  const candidate = observations as Partial<RuntimeObservationLeaseFencePort>;
+  return typeof candidate.attachRuntimeLease === "function"
+    ? candidate.attachRuntimeLease({
+        ownerId,
+        runtimeSessionId,
+        leaseToken,
+      })
+    : undefined;
+}
+
+function memoizeAsync(action: () => Promise<void>): () => Promise<void> {
+  let result: Promise<void> | undefined;
+  return () => {
+    result ??= action();
+    return result;
+  };
+}
+
+async function replayPendingInstructions(input: {
+  runtime: ClaudeRuntimeSession;
+  goalRuntime: AgentGoalRuntime;
+  ownerId: string;
+}): Promise<void> {
+  const replay = await input.runtime.replayInitialInstructions(() =>
+    input.goalRuntime.goals.replayPendingInstructions(
+      input.ownerId,
+      input.runtime.runtimeSessionId,
+    ),
+  );
+  if (replay !== null && replay.status !== "accepted") {
+    throw new ClaudeGoalRuntimeRegistrationError(replay);
+  }
+}
+
+function createRecoveryContinuationTrigger(
+  runtime: ClaudeRuntimeSession,
+  ownerId: string,
+  goalRuntime: AgentGoalRuntime,
+  goalStopController: ClaudeRuntimeGoalStopController,
+  recoveryAttemptId: string,
+): () => Promise<AgentRuntimeRecoveryContinuationResult> {
+  let decision: ClaudeRuntimeStopHookDecision | null = null;
+  let inFlight: Promise<ClaudeRuntimeStopHookDecision> | null = null;
+  return async () => {
+    if (decision) return recoveryContinuationResult(decision);
+    if (inFlight) return recoveryContinuationResult(await inFlight);
+
+    inFlight = (async () => {
+      const turnContext = await goalRuntime.observations.captureContext({
+        ownerId,
+        runtimeSessionId: runtime.runtimeSessionId,
+        runEpoch: runtime.runEpoch,
+      });
+      const evaluated = await goalStopController.evaluateStop({
+        runEpoch: runtime.runEpoch,
+        // A runEpoch can survive multiple host restarts. Treat each durable
+        // recovery claim as a new synthetic evaluation boundary so evidence
+        // gathered between restarts cannot collide with an earlier
+        // goal.continue command that used the same runEpoch.
+        assistantTurnId: `recovery:${runtime.runtimeSessionId}:${runtime.runEpoch}:${recoveryAttemptId}`,
+        turnContext,
+        stopHookActive: false,
+      });
+      if (evaluated.decision === "block") {
+        const receipt = await runtime.deliver(evaluated.instruction);
+        if (receipt.state !== "queued") {
+          throw new Error(
+            `Recovered Goal continuation ${evaluated.instruction.id} was not queued: ${receipt.state}`,
+          );
+        }
+      }
+      return evaluated;
+    })();
+    try {
+      decision = await inFlight;
+      return recoveryContinuationResult(decision);
+    } finally {
+      inFlight = null;
+    }
+  };
+}
+
+function recoveryContinuationResult(
+  decision: ClaudeRuntimeStopHookDecision,
+): AgentRuntimeRecoveryContinuationResult {
+  return decision.decision === "block"
+    ? { decision: "block" as const, outcome: "continue" as const }
+    : { decision: "allow" as const, outcome: decision.outcome };
 }
 
 export function resolveAuthenticatedGoalRuntimeOwnerId(

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/index.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/index.ts
@@ -1,6 +1,7 @@
 export * from "./goal-registration";
 export * from "./input-multiplexer";
 export * from "./output-multiplexer";
+export * from "./provider-failure-monitor";
 export * from "./sdk-transport";
 export * from "./session";
 export * from "./supplemental-hooks";

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/input-multiplexer.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/input-multiplexer.ts
@@ -32,6 +32,38 @@ export class ClaudeInputMultiplexer {
   }
 }
 
+/**
+ * Starts the resumed SDK process without querying the model. The SDK does not
+ * emit its system/init message until an AsyncIterable prompt yields at least
+ * one item, so an empty iterable deadlocks the recovery identity barrier. A
+ * synthetic, non-querying, empty message is sufficient to initialize the
+ * exact resumed session while leaving the first real turn to the durable Goal
+ * instruction outbox.
+ */
+export function createClaudeRecoveryInitialPrompt(): AsyncIterable<SDKUserMessage> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
+      let emitted = false;
+      return {
+        next: async () => {
+          if (emitted) return { value: undefined, done: true };
+          emitted = true;
+          return {
+            value: {
+              type: "user",
+              message: { role: "user", content: "" },
+              parent_tool_use_id: null,
+              isSynthetic: true,
+              shouldQuery: false,
+            },
+            done: false,
+          };
+        },
+      };
+    },
+  };
+}
+
 function toClaudeSupplementalMessage(
   input: AgentSupplementalInput,
   sessionId: string,

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/provider-failure-monitor.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/provider-failure-monitor.ts
@@ -1,0 +1,57 @@
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+} from "@anthropic-ai/claude-agent-sdk";
+
+export interface ClaudeProviderFailureSessionStoreOptions {
+  /** Exact provider session expected during durable recovery. */
+  expectedSessionId?: string;
+  onProviderFailure: () => void;
+}
+
+/**
+ * Mirror-only SessionStore that observes the CLI's authoritative transcript
+ * entry before compatibility layers strip `isApiErrorMessage`.
+ *
+ * Returning null from load leaves explicit SDK resume on the existing local
+ * transcript. The store never retains prompt or response content.
+ */
+export function createClaudeProviderFailureSessionStore(
+  options: ClaudeProviderFailureSessionStoreOptions,
+): SessionStore {
+  return {
+    async append(key, entries) {
+      if (!isExpectedMainTranscript(key, options.expectedSessionId)) return;
+      if (entries.some(isProviderFailureEntry)) options.onProviderFailure();
+    },
+    async load() {
+      return null;
+    },
+  };
+}
+
+/**
+ * Match the Claude CLI's terminal request diagnostic, while excluding its
+ * retry diagnostics (`API error (attempt n/m)`). The text is used only as a
+ * boolean signal and must not cross the runtime boundary.
+ */
+export function isFatalClaudeProviderDiagnostic(line: string): boolean {
+  return /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+\[ERROR\]\s+)?Error in API request:\s*\S/i.test(
+    line.trim(),
+  );
+}
+
+function isExpectedMainTranscript(
+  key: SessionKey,
+  expectedSessionId?: string,
+): boolean {
+  return (
+    key.subpath === undefined &&
+    (expectedSessionId === undefined || key.sessionId === expectedSessionId)
+  );
+}
+
+function isProviderFailureEntry(entry: SessionStoreEntry): boolean {
+  return entry.type === "assistant" && entry.isApiErrorMessage === true;
+}

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
@@ -31,6 +31,7 @@ import type {
 } from "@openloomi/ai/agent/types";
 
 import type { ClaudeRuntimeLogger } from "../skills";
+import { isClaudeSdkApiErrorMessage } from "../message-converter";
 import type {
   ClaudeRuntimeEventObserverPort,
   ClaudeInstructionTurnHandoff,
@@ -50,6 +51,8 @@ import type {
 export interface ClaudeRuntimeSessionOptions {
   runtimeSessionId: string;
   runEpoch: number;
+  /** Provider identity loaded from durable state for an exact SDK resume. */
+  expectedProviderSessionId?: string;
   sdkTransport: ClaudeSdkTransport;
   logger: ClaudeRuntimeLogger;
   createMessageId: () => string;
@@ -60,6 +63,13 @@ interface TerminalWaiter {
   expectedRunEpoch: number;
   afterTerminalSequence: number;
   resolve: (terminal: RuntimeTurnTerminal) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+interface ProviderSessionInitializationWaiter {
+  resolve: (providerSessionId: string) => void;
   reject: (error: Error) => void;
   signal?: AbortSignal;
   onAbort?: () => void;
@@ -81,6 +91,7 @@ export class ClaudeRuntimeSession
   private readonly inputQueue: AgentSupplementalInputQueue;
   private readonly instructionTransport: SupplementalInputRuntimeInstructionTransport;
   private readonly externalInput?: AgentSupplementalInputSource;
+  private readonly expectedProviderSessionId?: string;
 
   private query: Query | null = null;
   private outputPump: Promise<void> | null = null;
@@ -99,12 +110,18 @@ export class ClaudeRuntimeSession
   private expectedProviderInterruptResults = 0;
   private latestAssistantTurnId?: string;
   private assistantTurnSequence = 0;
+  private providerSessionInitializationError?: ClaudeRuntimeSessionError;
+  private readonly providerSessionInitializationWaiters =
+    new Set<ProviderSessionInitializationWaiter>();
 
   claudeSessionId?: string;
 
   constructor(options: ClaudeRuntimeSessionOptions) {
     assertRunEpoch(options.runEpoch);
     this.runtimeSessionId = options.runtimeSessionId;
+    this.expectedProviderSessionId = options.expectedProviderSessionId
+      ? providerSessionIdentifier(options.expectedProviderSessionId)
+      : undefined;
     this.providerOutputEpoch = options.runEpoch;
     this.sdkTransport = options.sdkTransport;
     this.logger = options.logger;
@@ -146,6 +163,45 @@ export class ClaudeRuntimeSession
     return this.processedSdkMessages;
   }
 
+  /**
+   * Resolves only after the SDK emits system/init for the expected provider
+   * session. Recovery coordination uses this barrier before replaying any
+   * instruction into the resumed process.
+   */
+  waitUntilProviderSessionInitialized(
+    input: { signal?: AbortSignal } = {},
+  ): Promise<string> {
+    if (this.claudeSessionId) return Promise.resolve(this.claudeSessionId);
+    if (this.providerSessionInitializationError) {
+      return Promise.reject(this.providerSessionInitializationError);
+    }
+    if (input.signal?.aborted) {
+      return Promise.reject(this.providerSessionInitializationAborted());
+    }
+    if (this.currentState === "closed" || this.currentState === "failed") {
+      return Promise.reject(
+        this.providerSessionInitializationUnavailable(this.currentState),
+      );
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const waiter: ProviderSessionInitializationWaiter = {
+        resolve,
+        reject,
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
+      };
+      if (input.signal) {
+        waiter.onAbort = () => {
+          if (!this.providerSessionInitializationWaiters.delete(waiter)) return;
+          this.removeProviderSessionWaiterAbortListener(waiter);
+          reject(this.providerSessionInitializationAborted());
+        };
+        input.signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      this.providerSessionInitializationWaiters.add(waiter);
+    });
+  }
+
   attachEventObserver(observer: ClaudeRuntimeEventObserverPort): void {
     if (this.query || this.currentState !== "starting") {
       throw new ClaudeRuntimeSessionError(
@@ -181,14 +237,16 @@ export class ClaudeRuntimeSession
   async evaluateStop(
     input: ClaudeRuntimeStopHookInput,
   ): Promise<ClaudeRuntimeStopHookDecision> {
+    const boundProviderSessionId =
+      this.claudeSessionId ?? this.expectedProviderSessionId;
     if (
       input.providerSessionId !== undefined &&
-      this.claudeSessionId !== undefined &&
-      input.providerSessionId !== this.claudeSessionId
+      boundProviderSessionId !== undefined &&
+      input.providerSessionId !== boundProviderSessionId
     ) {
       throw new ClaudeRuntimeSessionError(
         "provider_session_mismatch",
-        `Stop hook belongs to Claude session ${input.providerSessionId}, not ${this.claudeSessionId}`,
+        `Stop hook belongs to Claude session ${input.providerSessionId}, not ${boundProviderSessionId}`,
       );
     }
     const controller = this.stopController;
@@ -315,6 +373,9 @@ export class ClaudeRuntimeSession
       this.inputQueue.close();
       this.output.abort(error);
       this.transition("failed");
+      this.rejectProviderSessionInitialization(
+        this.providerSessionInitializationUnavailable("failed"),
+      );
       throw error;
     }
   }
@@ -323,9 +384,7 @@ export class ClaudeRuntimeSession
     return this.output.subscribe();
   }
 
-  async replayInitialInstructions<T>(
-    replay: () => Promise<T>,
-  ): Promise<T> {
+  async replayInitialInstructions<T>(replay: () => Promise<T>): Promise<T> {
     if (this.replayingInitialInstructions) {
       throw new ClaudeRuntimeSessionError(
         "initial_replay_in_progress",
@@ -575,6 +634,9 @@ export class ClaudeRuntimeSession
     }
     this.output.close();
     this.rejectTerminalWaiters(this.terminalUnavailable("closed"));
+    this.rejectProviderSessionInitialization(
+      this.providerSessionInitializationUnavailable("closed"),
+    );
     if (this.currentState !== "closed" && this.currentState !== "failed") {
       this.transition("closed");
     }
@@ -597,11 +659,30 @@ export class ClaudeRuntimeSession
     try {
       for await (const message of query) {
         const observedRunEpoch = this.providerOutputEpoch;
+        const terminalApiError = isClaudeSdkApiErrorMessage(message);
         const expectedInterruptResult =
           this.consumeExpectedProviderInterruptResult(message);
         this.processedSdkMessages++;
-        this.updateSessionFromSdkMessage(message, observedRunEpoch);
-        await this.recordProviderObservation(message, observedRunEpoch);
+        if (!terminalApiError) {
+          this.updateSessionFromSdkMessage(message, observedRunEpoch);
+          await this.recordProviderObservation(message, observedRunEpoch);
+        }
+        if (terminalApiError) {
+          failed = true;
+          this.logger.error(
+            `[Claude ${this.runtimeSessionId}] SDK emitted a terminal provider API error`,
+          );
+          try {
+            query.close();
+          } catch (error) {
+            this.logger.warn(
+              `[Claude ${this.runtimeSessionId}] Failed to close SDK Query after provider API error`,
+              error,
+            );
+          } finally {
+            if (this.query === query) this.query = null;
+          }
+        }
         if (!expectedInterruptResult) {
           for (const agentMessage of this.outputMultiplexer.convert(message)) {
             await this.output.publish({
@@ -610,6 +691,7 @@ export class ClaudeRuntimeSession
             });
           }
         }
+        if (terminalApiError) break;
         if (message.type === "result") {
           if (observedRunEpoch === this.runEpoch) {
             this.inputQueue.releasePendingInform();
@@ -632,6 +714,11 @@ export class ClaudeRuntimeSession
       }
     } finally {
       this.inputQueue.close();
+      this.rejectProviderSessionInitialization(
+        this.providerSessionInitializationUnavailable(
+          failed ? "failed" : "closed",
+        ),
+      );
       this.rejectTerminalWaiters(
         this.terminalUnavailable(failed ? "failed" : "closed"),
       );
@@ -670,7 +757,22 @@ export class ClaudeRuntimeSession
     observedRunEpoch: number,
   ): void {
     if (message.type === "system" && message.subtype === "init") {
-      this.claudeSessionId = message.session_id;
+      const providerSessionId = providerSessionIdentifier(message.session_id);
+      const expected = this.expectedProviderSessionId;
+      const existing = this.claudeSessionId;
+      if (
+        (expected !== undefined && providerSessionId !== expected) ||
+        (existing !== undefined && providerSessionId !== existing)
+      ) {
+        const mismatch = new ClaudeRuntimeSessionError(
+          "provider_session_mismatch",
+          `Claude initialized provider session ${providerSessionId}, expected ${expected ?? existing}`,
+        );
+        this.rejectProviderSessionInitialization(mismatch);
+        throw mismatch;
+      }
+      this.claudeSessionId = providerSessionId;
+      this.resolveProviderSessionInitialization(providerSessionId);
     }
     if (message.type === "assistant" && observedRunEpoch === this.runEpoch) {
       this.latestAssistantTurnId =
@@ -852,6 +954,52 @@ export class ClaudeRuntimeSession
     this.terminalWaiters.clear();
   }
 
+  private resolveProviderSessionInitialization(
+    providerSessionId: string,
+  ): void {
+    for (const waiter of this.providerSessionInitializationWaiters) {
+      this.removeProviderSessionWaiterAbortListener(waiter);
+      waiter.resolve(providerSessionId);
+    }
+    this.providerSessionInitializationWaiters.clear();
+  }
+
+  private rejectProviderSessionInitialization(
+    error: ClaudeRuntimeSessionError,
+  ): void {
+    if (this.claudeSessionId) return;
+    this.providerSessionInitializationError ??= error;
+    for (const waiter of this.providerSessionInitializationWaiters) {
+      this.removeProviderSessionWaiterAbortListener(waiter);
+      waiter.reject(this.providerSessionInitializationError);
+    }
+    this.providerSessionInitializationWaiters.clear();
+  }
+
+  private removeProviderSessionWaiterAbortListener(
+    waiter: ProviderSessionInitializationWaiter,
+  ): void {
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+    }
+  }
+
+  private providerSessionInitializationAborted(): ClaudeRuntimeSessionError {
+    return new ClaudeRuntimeSessionError(
+      "provider_session_initialization_aborted",
+      "Waiting for the Claude provider session initialization was aborted",
+    );
+  }
+
+  private providerSessionInitializationUnavailable(
+    state: "closed" | "failed",
+  ): ClaudeRuntimeSessionError {
+    return new ClaudeRuntimeSessionError(
+      "provider_session_initialization_unavailable",
+      `Claude Runtime Session became ${state} before provider initialization was confirmed`,
+    );
+  }
+
   private removeWaiterAbortListener(waiter: TerminalWaiter): void {
     if (waiter.signal && waiter.onAbort) {
       waiter.signal.removeEventListener("abort", waiter.onAbort);
@@ -904,6 +1052,8 @@ export type ClaudeRuntimeSessionErrorCode =
   | "not_started"
   | "observer_already_attached"
   | "provider_session_mismatch"
+  | "provider_session_initialization_aborted"
+  | "provider_session_initialization_unavailable"
   | "stop_controller_already_attached"
   | "stop_controller_missing"
   | "terminal_unavailable"
@@ -956,4 +1106,19 @@ function assertRunEpoch(runEpoch: number): void {
       "runEpoch must be a non-negative integer",
     );
   }
+}
+
+function providerSessionIdentifier(value: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value !== value.trim()
+  ) {
+    throw new ClaudeRuntimeSessionError(
+      "provider_session_mismatch",
+      "Claude provider session ID must be a non-empty identifier",
+    );
+  }
+  return value;
 }

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/session.ts
@@ -31,7 +31,10 @@ import type {
 } from "@openloomi/ai/agent/types";
 
 import type { ClaudeRuntimeLogger } from "../skills";
-import { isClaudeSdkApiErrorMessage } from "../message-converter";
+import {
+  CLAUDE_API_ERROR_SENTINEL,
+  isClaudeSdkApiErrorMessage,
+} from "../message-converter";
 import type {
   ClaudeRuntimeEventObserverPort,
   ClaudeInstructionTurnHandoff,
@@ -42,10 +45,11 @@ import { ClaudeInputMultiplexer } from "./input-multiplexer";
 import { ClaudeOutputMultiplexer } from "./output-multiplexer";
 import type { ClaudeSdkTransport } from "./sdk-transport";
 import type {
+  ClaudeRuntimeGoalFinalizationDecision,
+  ClaudeRuntimeGoalStopController,
   ClaudeRuntimeStopHookDecision,
   ClaudeRuntimeStopHookInput,
   ClaudeRuntimeStopHookObserver,
-  ClaudeRuntimeGoalStopController,
 } from "./supplemental-hooks";
 
 export interface ClaudeRuntimeSessionOptions {
@@ -56,8 +60,15 @@ export interface ClaudeRuntimeSessionOptions {
   sdkTransport: ClaudeSdkTransport;
   logger: ClaudeRuntimeLogger;
   createMessageId: () => string;
+  /** Immediately terminates the provider process after a trusted fatal signal. */
+  abortProvider?: (reason: Error) => void;
   supplementalInput?: AgentSupplementalInputSource;
 }
+
+export type ClaudeProviderFailureSource =
+  | "sdk_message"
+  | "session_store"
+  | "stderr";
 
 interface TerminalWaiter {
   expectedRunEpoch: number;
@@ -86,6 +97,8 @@ export class ClaudeRuntimeSession
 
   private readonly sdkTransport: ClaudeSdkTransport;
   private readonly logger: ClaudeRuntimeLogger;
+  private readonly createMessageId: () => string;
+  private readonly abortProvider?: (reason: Error) => void;
   private readonly output: AgentOutputEventBus<AgentMessage>;
   private readonly outputMultiplexer: ClaudeOutputMultiplexer;
   private readonly inputQueue: AgentSupplementalInputQueue;
@@ -95,6 +108,8 @@ export class ClaudeRuntimeSession
 
   private query: Query | null = null;
   private outputPump: Promise<void> | null = null;
+  private providerFailureSource?: ClaudeProviderFailureSource;
+  private providerFailurePublication: Promise<void> | null = null;
   private currentState: RuntimeSessionState = "starting";
   private processedSdkMessages = 0;
   private closing = false;
@@ -125,6 +140,8 @@ export class ClaudeRuntimeSession
     this.providerOutputEpoch = options.runEpoch;
     this.sdkTransport = options.sdkTransport;
     this.logger = options.logger;
+    this.createMessageId = options.createMessageId;
+    this.abortProvider = options.abortProvider;
     this.output = new AgentOutputEventBus<AgentMessage>();
     this.outputMultiplexer = new ClaudeOutputMultiplexer(
       options.createMessageId,
@@ -161,6 +178,78 @@ export class ClaudeRuntimeSession
 
   get sdkMessageCount(): number {
     return this.processedSdkMessages;
+  }
+
+  /**
+   * Fail the OpenLoomi runtime immediately after an authoritative provider
+   * failure. Provider diagnostics are deliberately not accepted here: callers
+   * classify the signal and this boundary emits only the stable safe sentinel.
+   *
+   * Returns true only for the first accepted failure signal.
+   */
+  reportProviderFailure(source: ClaudeProviderFailureSource): boolean {
+    if (
+      this.providerFailureSource !== undefined ||
+      this.closing ||
+      this.currentState === "closed" ||
+      this.currentState === "failed"
+    ) {
+      return false;
+    }
+
+    this.providerFailureSource = source;
+    const failure = new ClaudeRuntimeSessionError(
+      "provider_failed",
+      "Claude provider failed",
+    );
+    this.logger.error(
+      `[Claude ${this.runtimeSessionId}] Terminal provider failure (${source})`,
+    );
+    this.transition("failed");
+    this.inputQueue.setInterruptHandler(null);
+    this.inputQueue.setHandoffHandler(null);
+    this.inputQueue.close();
+    this.rejectTerminalWaiters(this.terminalUnavailable("failed"));
+    this.rejectProviderSessionInitialization(
+      this.providerSessionInitializationUnavailable("failed"),
+    );
+
+    // Abort first so the custom Windows spawner terminates the whole process
+    // tree. Query.close() remains best-effort and is never awaited.
+    try {
+      this.abortProvider?.(failure);
+    } catch (error) {
+      this.logger.warn(
+        `[Claude ${this.runtimeSessionId}] Failed to abort provider process`,
+        error,
+      );
+    }
+    const query = this.query;
+    this.query = null;
+    try {
+      query?.close();
+    } catch (error) {
+      this.logger.warn(
+        `[Claude ${this.runtimeSessionId}] Failed to close SDK Query after provider failure`,
+        error,
+      );
+    }
+
+    this.providerFailurePublication = this.output
+      .publish({
+        type: "error",
+        message: CLAUDE_API_ERROR_SENTINEL,
+        messageId: this.createMessageId(),
+        runEpoch: this.providerOutputEpoch,
+      })
+      .catch((error) => {
+        this.logger.warn(
+          `[Claude ${this.runtimeSessionId}] Failed to publish provider failure`,
+          error,
+        );
+      })
+      .finally(() => this.output.close());
+    return true;
   }
 
   /**
@@ -232,6 +321,29 @@ export class ClaudeRuntimeSession
       );
     }
     this.stopController = controller;
+  }
+
+  async finalizeGoalWithoutContinuation(
+    evaluationId: string,
+    runtimeLeaseToken?: string,
+  ): Promise<ClaudeRuntimeGoalFinalizationDecision> {
+    const controller = this.stopController;
+    if (!controller) {
+      throw new ClaudeRuntimeSessionError(
+        "stop_controller_missing",
+        "Claude runtime session has no Goal Stop controller",
+      );
+    }
+
+    await this.eventObserver?.flush();
+    const turnContexts =
+      (await this.eventObserver?.captureTurnContexts(this.runEpoch)) ?? [];
+    return controller.finalizeWithoutContinuation({
+      runEpoch: this.runEpoch,
+      evaluationId,
+      turnContext: turnContexts.at(-1) ?? null,
+      ...(runtimeLeaseToken === undefined ? {} : { runtimeLeaseToken }),
+    });
   }
 
   async evaluateStop(
@@ -632,7 +744,7 @@ export class ClaudeRuntimeSession
         error,
       );
     }
-    this.output.close();
+    if (!this.providerFailurePublication) this.output.close();
     this.rejectTerminalWaiters(this.terminalUnavailable("closed"));
     this.rejectProviderSessionInitialization(
       this.providerSessionInitializationUnavailable("closed"),
@@ -641,7 +753,14 @@ export class ClaudeRuntimeSession
       this.transition("closed");
     }
 
-    if (this.outputPump) await this.outputPump;
+    // SDK iterator cleanup is provider-owned and can remain pending after a
+    // broken response stream. Runtime shutdown must not wait indefinitely for
+    // Query.return()/next() before releasing durable recovery ownership.
+    if (this.providerFailurePublication) {
+      await this.providerFailurePublication;
+    } else if (this.outputPump) {
+      await this.outputPump;
+    }
     if (this.eventObserver) {
       try {
         await this.eventObserver.flush();
@@ -656,8 +775,12 @@ export class ClaudeRuntimeSession
 
   private async pumpQuery(query: Query): Promise<void> {
     let failed = false;
+    const iterator = query[Symbol.asyncIterator]();
     try {
-      for await (const message of query) {
+      while (true) {
+        const result = await iterator.next();
+        if (result.done) break;
+        const message = result.value;
         const observedRunEpoch = this.providerOutputEpoch;
         const terminalApiError = isClaudeSdkApiErrorMessage(message);
         const expectedInterruptResult =
@@ -669,19 +792,11 @@ export class ClaudeRuntimeSession
         }
         if (terminalApiError) {
           failed = true;
-          this.logger.error(
-            `[Claude ${this.runtimeSessionId}] SDK emitted a terminal provider API error`,
-          );
-          try {
-            query.close();
-          } catch (error) {
-            this.logger.warn(
-              `[Claude ${this.runtimeSessionId}] Failed to close SDK Query after provider API error`,
-              error,
-            );
-          } finally {
-            if (this.query === query) this.query = null;
-          }
+          this.reportProviderFailure("sdk_message");
+          // Do not break out of a for-await loop here. AsyncIteratorClose would
+          // await Query.return(), which some failed provider streams never
+          // settle. The explicit iterator can be abandoned after process abort.
+          return;
         }
         if (!expectedInterruptResult) {
           for (const agentMessage of this.outputMultiplexer.convert(message)) {
@@ -691,7 +806,6 @@ export class ClaudeRuntimeSession
             });
           }
         }
-        if (terminalApiError) break;
         if (message.type === "result") {
           if (observedRunEpoch === this.runEpoch) {
             this.inputQueue.releasePendingInform();
@@ -706,9 +820,14 @@ export class ClaudeRuntimeSession
           this.recordTerminal(observedRunEpoch);
         }
       }
-      this.output.close();
+      if (!this.providerFailureSource) this.output.close();
     } catch (error) {
-      if (!this.closing) {
+      // Session-initialization failures reject their registration barrier
+      // before reaching this catch. Give that owner one microtask to close the
+      // runtime, preserving the established closed-vs-failed lifecycle race
+      // without invoking (or awaiting) the provider iterator's return().
+      await Promise.resolve();
+      if (!this.closing && !this.providerFailureSource) {
         failed = true;
         this.output.abort(error);
       }
@@ -1052,6 +1171,7 @@ export type ClaudeRuntimeSessionErrorCode =
   | "not_started"
   | "observer_already_attached"
   | "provider_session_mismatch"
+  | "provider_failed"
   | "provider_session_initialization_aborted"
   | "provider_session_initialization_unavailable"
   | "stop_controller_already_attached"

--- a/apps/web/lib/ai/extensions/agent/claude/runtime/supplemental-hooks.ts
+++ b/apps/web/lib/ai/extensions/agent/claude/runtime/supplemental-hooks.ts
@@ -36,6 +36,7 @@ export type ClaudeRuntimeStopHookDecision =
         | "no_active_goal"
         | "stale"
         | "completed"
+        | "paused"
         | "blocked"
         | "budget_limited"
         | "expired";
@@ -47,6 +48,20 @@ export type ClaudeRuntimeStopHookDecision =
       instruction: RuntimeInstruction;
     };
 
+export interface ClaudeRuntimeGoalFinalizationInput {
+  runEpoch: number;
+  evaluationId: string;
+  turnContext: RuntimeObservationContext | null;
+  runtimeLeaseToken?: string;
+}
+
+export interface ClaudeRuntimeGoalFinalizationDecision {
+  decision: "allow";
+  outcome: "no_active_goal" | "stale" | "completed" | "paused";
+  goalId?: string;
+  goalRevision?: number;
+}
+
 export interface ClaudeRuntimeGoalStopController {
   evaluateStop(input: {
     runEpoch: number;
@@ -55,6 +70,9 @@ export interface ClaudeRuntimeGoalStopController {
     lastAssistantMessage?: string;
     stopHookActive: boolean;
   }): Promise<ClaudeRuntimeStopHookDecision>;
+  finalizeWithoutContinuation(
+    input: ClaudeRuntimeGoalFinalizationInput,
+  ): Promise<ClaudeRuntimeGoalFinalizationDecision>;
 }
 
 export interface ClaudeRuntimeStopHookObserver {

--- a/apps/web/lib/ai/runtime-instructions/api/client.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/client.ts
@@ -4,6 +4,7 @@ import type {
   AgentGoalDetailResponse,
   AgentGoalSessionResponse,
   RemoveGoalContextRequest,
+  ResumeGoalRequest,
   UpdateGoalRequest,
   UpsertGoalContextRequest,
 } from ".";
@@ -58,6 +59,17 @@ export async function updateAgentGoal(
   return requestJson(
     `/api/agent-goals/${encodeURIComponent(goalId)}`,
     commandRequest("PATCH", request, idempotencyKey),
+  );
+}
+
+export async function resumeAgentGoal(
+  goalId: string,
+  request: ResumeGoalRequest,
+  idempotencyKey = crypto.randomUUID(),
+): Promise<AgentGoalCommandResponse> {
+  return requestJson(
+    `/api/agent-goals/${encodeURIComponent(goalId)}/resume`,
+    commandRequest("POST", request, idempotencyKey),
   );
 }
 

--- a/apps/web/lib/ai/runtime-instructions/api/contracts.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/contracts.ts
@@ -5,6 +5,7 @@ import type {
   GoalEvaluationResult,
   GoalEvidence,
   RuntimeInstructionKind,
+  RuntimeSessionState,
 } from "@openloomi/ai/agent/runtime-instructions";
 
 export type PublicAgentGoal = AgentGoal & {
@@ -58,6 +59,21 @@ export interface AgentGoalSessionResponse {
   live: boolean;
   activeGoalId: string | null;
   goals: PublicGoalSummary[];
+}
+
+export interface AgentGoalRecoverySession {
+  runtimeSessionId: string;
+  state: RuntimeSessionState;
+  live: boolean;
+  chat: {
+    id: string;
+    title: string;
+    createdAt: string;
+  };
+}
+
+export interface AgentGoalRecoverySessionsResponse {
+  sessions: AgentGoalRecoverySession[];
 }
 
 export interface AgentGoalDetailResponse extends PublicGoalSummary {

--- a/apps/web/lib/ai/runtime-instructions/api/schemas.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/schemas.ts
@@ -116,6 +116,14 @@ export const UpdateGoalRequestSchema = z
   })
   .strict();
 
+export const ResumeGoalRequestSchema = z
+  .object({
+    runtimeSessionId: identifierSchema,
+    expectedRevision: z.int().positive(),
+    reason: z.string().trim().min(1).max(4_000).optional(),
+  })
+  .strict();
+
 export const UpsertGoalContextRequestSchema = z
   .object({
     runtimeSessionId: identifierSchema,
@@ -139,6 +147,7 @@ export const GoalIdSchema = z.uuid();
 
 export type ActivateGoalRequest = z.output<typeof ActivateGoalRequestSchema>;
 export type UpdateGoalRequest = z.output<typeof UpdateGoalRequestSchema>;
+export type ResumeGoalRequest = z.output<typeof ResumeGoalRequestSchema>;
 export type UpsertGoalContextRequest = z.output<
   typeof UpsertGoalContextRequestSchema
 >;

--- a/apps/web/lib/ai/runtime-instructions/api/service.ts
+++ b/apps/web/lib/ai/runtime-instructions/api/service.ts
@@ -14,6 +14,7 @@ import type { RuntimeSessionPersistencePort } from "../runtime-session-persisten
 import type {
   ActivateGoalRequest,
   RemoveGoalContextRequest,
+  ResumeGoalRequest,
   UpdateGoalRequest,
   UpsertGoalContextRequest,
 } from "./schemas";
@@ -21,7 +22,7 @@ import type {
 export interface AgentGoalApiDependencies {
   goals: Pick<
     GoalService,
-    "activate" | "update" | "upsertContext" | "removeContext"
+    "activate" | "update" | "resume" | "upsertContext" | "removeContext"
   >;
   queries: Pick<AgentGoalQueryService, "listBySession" | "getById">;
   liveSessions: Pick<RuntimeSessionRegistry, "resolve">;
@@ -141,6 +142,24 @@ export class AgentGoalApiService {
       idempotencyKey,
       source: userCommandSource(),
       update: userGoalUpdate(request.update),
+    });
+  }
+
+  async resume(
+    ownerId: string,
+    goalId: string,
+    request: ResumeGoalRequest,
+    idempotencyKey: string,
+  ): Promise<GoalCommandResult> {
+    await this.requireSession(ownerId, request.runtimeSessionId);
+    return this.dependencies.goals.resume({
+      ownerId,
+      runtimeSessionId: request.runtimeSessionId,
+      goalId,
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      source: userCommandSource(),
+      ...(request.reason === undefined ? {} : { reason: request.reason }),
     });
   }
 

--- a/apps/web/lib/ai/runtime-instructions/goal-controller.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-controller.ts
@@ -18,7 +18,7 @@ import {
 } from "@openloomi/ai/agent/runtime-instructions";
 
 import { createGoalCommandFingerprint } from "./command-fingerprint";
-import type { GoalEvaluator } from "./goal-evaluator";
+import { GoalEvaluatorError, type GoalEvaluator } from "./goal-evaluator";
 import type { RuntimeInstructionDispatcher } from "./instruction-dispatcher";
 import { KeyedSerialExecutor } from "./keyed-serial-executor";
 import type {
@@ -39,6 +39,13 @@ export interface GoalStopEvaluationInput {
   stopHookActive: boolean;
 }
 
+export interface GoalFinalEvaluationInput {
+  runEpoch: number;
+  evaluationId: string;
+  turnContext: RuntimeObservationContext | null;
+  runtimeLeaseToken?: string;
+}
+
 export type GoalStopDecision =
   | {
       decision: "allow";
@@ -46,7 +53,7 @@ export type GoalStopDecision =
         | "no_active_goal"
         | "stale"
         | "completed"
-        | "blocked"
+        | "paused"
         | "budget_limited"
         | "expired";
       goalId?: string;
@@ -61,8 +68,18 @@ export type GoalStopDecision =
       reason: string;
     };
 
+export interface GoalFinalEvaluationDecision {
+  decision: "allow";
+  outcome: "no_active_goal" | "stale" | "completed" | "paused";
+  goalId?: string;
+  goalRevision?: number;
+}
+
 export interface RuntimeGoalStopControllerPort {
   evaluateStop(input: GoalStopEvaluationInput): Promise<GoalStopDecision>;
+  finalizeWithoutContinuation(
+    input: GoalFinalEvaluationInput,
+  ): Promise<GoalFinalEvaluationDecision>;
 }
 
 export interface GoalControllerSessionInput {
@@ -128,7 +145,128 @@ export class GoalController {
             stop,
           ),
         ),
+      finalizeWithoutContinuation: (evaluation) =>
+        this.evaluations.run(sessionScope(ownerId, runtimeSessionId), () =>
+          this.finalizeWithoutContinuationSerialized(
+            ownerId,
+            runtimeSessionId,
+            evaluation,
+          ),
+        ),
     };
+  }
+
+  private async finalizeWithoutContinuationSerialized(
+    ownerId: string,
+    runtimeSessionId: string,
+    input: GoalFinalEvaluationInput,
+  ): Promise<GoalFinalEvaluationDecision> {
+    const runEpoch = nonNegativeInteger(input.runEpoch, "runEpoch");
+    const evaluationId = requiredIdentifier(
+      input.evaluationId,
+      "evaluationId",
+    );
+    const runtimeLeaseToken =
+      input.runtimeLeaseToken === undefined
+        ? undefined
+        : requiredIdentifier(input.runtimeLeaseToken, "runtimeLeaseToken");
+    const active = await this.state.getActivePrimaryGoal(
+      ownerId,
+      runtimeSessionId,
+    );
+    if (!active) return { decision: "allow", outcome: "no_active_goal" };
+
+    const authoritativeEpoch = await this.state.getRuntimeSessionRunEpoch(
+      ownerId,
+      runtimeSessionId,
+    );
+    if (authoritativeEpoch !== runEpoch) {
+      return staleDecision(active.goal);
+    }
+    const turnContext = validateTurnContext(
+      input.turnContext,
+      ownerId,
+      runtimeSessionId,
+      runEpoch,
+    );
+    if (
+      !turnContext ||
+      turnContext.goalId !== active.goal.id ||
+      turnContext.goalRevision !== active.goal.revision
+    ) {
+      return turnContext
+        ? staleContextDecision(turnContext)
+        : staleDecision(active.goal);
+    }
+
+    const evaluationKey = createGoalCommandFingerprint({
+      runtimeSessionId,
+      runEpoch,
+      evaluationId,
+      goalId: active.goal.id,
+      goalRevision: active.goal.revision,
+    });
+    const cached = this.decisions.get(evaluationKey);
+    if (isGoalFinalEvaluationDecision(cached)) {
+      return structuredClone(cached);
+    }
+
+    const now = this.clock.now();
+    const snapshot = await this.observations.beginGoalEvaluation({
+      ownerId,
+      runtimeSessionId,
+      goalId: active.goal.id,
+      goalRevision: active.goal.revision,
+      runEpoch,
+      evaluationKey,
+      recordedAt: now.toISOString(),
+    });
+    if (!snapshot) return staleDecision(active.goal);
+
+    let evaluation: GoalEvaluationResult;
+    try {
+      evaluation = await this.evaluator.evaluate({
+        goal: active.goal,
+        run: snapshot.run,
+        evidence: snapshot.evidence,
+        ...(snapshot.evidenceRevisionFloor === undefined
+          ? {}
+          : { evidenceRevisionFloor: snapshot.evidenceRevisionFloor }),
+      });
+    } catch (error) {
+      evaluation = evaluatorFailureEvaluation(
+        active.goal,
+        `Goal evaluation failed: ${errorMessage(error)}`,
+        error,
+      );
+    }
+
+    const terminalEvaluation = GoalEvaluationResultSchema.parse({
+      ...evaluation,
+      nextInstruction: undefined,
+    });
+    const decision = await this.commitEvaluationOutcome({
+      ownerId,
+      runtimeSessionId,
+      runEpoch,
+      evaluationKey,
+      goal: active.goal,
+      evaluation: terminalEvaluation,
+      status: terminalEvaluation.completed ? "completed" : "paused",
+      outcome: terminalEvaluation.completed ? "completed" : "paused",
+      now,
+      ...(runtimeLeaseToken === undefined ? {} : { runtimeLeaseToken }),
+    });
+    if (decision.decision !== "allow") {
+      throw new Error("A terminal Goal evaluation cannot request continuation");
+    }
+    if (!isGoalFinalEvaluationDecision(decision)) {
+      throw new Error(
+        `A terminal Goal evaluation returned unsupported outcome ${decision.outcome}`,
+      );
+    }
+    this.cacheDecision(evaluationKey, decision);
+    return decision;
   }
 
   private async evaluateStopSerialized(
@@ -181,7 +319,7 @@ export class GoalController {
     const cached = this.decisions.get(evaluationKey);
     if (cached) {
       if (cached.decision === "block" && input.stopHookActive) {
-        return this.blockRecursiveStop({
+        return this.pauseRecursiveStop({
           ownerId,
           runtimeSessionId,
           runEpoch,
@@ -210,6 +348,9 @@ export class GoalController {
         goal: active.goal,
         run: snapshot.run,
         evidence: snapshot.evidence,
+        ...(snapshot.evidenceRevisionFloor === undefined
+          ? {}
+          : { evidenceRevisionFloor: snapshot.evidenceRevisionFloor }),
         ...(input.lastAssistantMessage === undefined
           ? {}
           : {
@@ -217,26 +358,27 @@ export class GoalController {
             }),
       });
     } catch (error) {
-      evaluation = failedEvaluation(
+      evaluation = evaluatorFailureEvaluation(
         active.goal,
         `Goal evaluation failed: ${errorMessage(error)}`,
+        error,
       );
-      const decision = await this.commitTerminalOutcome({
+      const decision = await this.commitEvaluationOutcome({
         ownerId,
         runtimeSessionId,
         runEpoch,
         evaluationKey,
         goal: active.goal,
         evaluation,
-        status: "blocked",
-        outcome: "blocked",
+        status: "paused",
+        outcome: "paused",
       });
       return this.cacheDecision(evaluationKey, decision);
     }
 
     const now = this.clock.now();
     if (evaluation.completed) {
-      const decision = await this.commitTerminalOutcome({
+      const decision = await this.commitEvaluationOutcome({
         ownerId,
         runtimeSessionId,
         runEpoch,
@@ -259,7 +401,7 @@ export class GoalController {
         ),
         nextInstruction: undefined,
       });
-      const decision = await this.commitTerminalOutcome({
+      const decision = await this.commitEvaluationOutcome({
         ownerId,
         runtimeSessionId,
         runEpoch,
@@ -278,15 +420,15 @@ export class GoalController {
       evaluation.missingCriteria.length === 0 ||
       hasMissingManualCriterion(active.goal, evaluation)
     ) {
-      const decision = await this.commitTerminalOutcome({
+      const decision = await this.commitEvaluationOutcome({
         ownerId,
         runtimeSessionId,
         runEpoch,
         evaluationKey,
         goal: active.goal,
         evaluation,
-        status: "blocked",
-        outcome: "blocked",
+        status: "paused",
+        outcome: "paused",
         now,
       });
       return this.cacheDecision(evaluationKey, decision);
@@ -299,15 +441,15 @@ export class GoalController {
           `${evaluation.reason}\nAutomatic continuation stopped after ${MAX_IDENTICAL_CONTINUATIONS} evaluations without new evidence or satisfied criteria.`,
         ),
       });
-      const decision = await this.commitTerminalOutcome({
+      const decision = await this.commitEvaluationOutcome({
         ownerId,
         runtimeSessionId,
         runEpoch,
         evaluationKey,
         goal: active.goal,
         evaluation: guarded,
-        status: "blocked",
-        outcome: "blocked",
+        status: "paused",
+        outcome: "paused",
         now,
       });
       return this.cacheDecision(evaluationKey, decision);
@@ -443,7 +585,7 @@ export class GoalController {
     return committed.instruction;
   }
 
-  private async commitTerminalOutcome(input: {
+  private async commitEvaluationOutcome(input: {
     ownerId: string;
     runtimeSessionId: string;
     runEpoch: number;
@@ -452,10 +594,11 @@ export class GoalController {
     evaluation: GoalEvaluationResult;
     status: Extract<
       GoalStatus,
-      "blocked" | "completed" | "budget_limited" | "expired"
+      "paused" | "completed" | "budget_limited" | "expired"
     >;
     outcome: Extract<GoalStopDecision, { decision: "allow" }>["outcome"];
     now?: Date;
+    runtimeLeaseToken?: string;
   }): Promise<GoalStopDecision> {
     const now = input.now ?? this.clock.now();
     const goal = AgentGoalSchema.parse({
@@ -471,12 +614,16 @@ export class GoalController {
         expectedRevision: input.goal.revision,
         expectedRunEpoch: input.runEpoch,
         goal,
+        evaluation: input.evaluation,
+        ...(input.runtimeLeaseToken === undefined
+          ? {}
+          : { runtimeLeaseToken: input.runtimeLeaseToken }),
       });
     } catch {
       await this.abandonEvaluation(input);
       return staleDecision(input.goal);
     }
-    await this.observations.finishGoalEvaluation({
+    const finished = await this.observations.finishGoalEvaluation({
       ownerId: input.ownerId,
       runtimeSessionId: input.runtimeSessionId,
       goalId: input.goal.id,
@@ -487,11 +634,16 @@ export class GoalController {
       outcome:
         input.status === "completed"
           ? "completed"
-          : input.status === "blocked"
-            ? "blocked"
+          : input.status === "paused"
+            ? "paused"
             : "budget_limited",
       recordedAt: now.toISOString(),
     });
+    if (!finished) {
+      throw new Error(
+        `Goal evaluation ${input.evaluationKey} lost its observation lease before finalization`,
+      );
+    }
     this.continuationProgress.delete(progressKey(input.goal));
     return {
       decision: "allow",
@@ -501,7 +653,7 @@ export class GoalController {
     };
   }
 
-  private async blockRecursiveStop(input: {
+  private async pauseRecursiveStop(input: {
     ownerId: string;
     runtimeSessionId: string;
     runEpoch: number;
@@ -519,14 +671,14 @@ export class GoalController {
       recordedAt: now,
     });
     if (!snapshot) return staleDecision(input.goal);
-    return this.commitTerminalOutcome({
+    return this.commitEvaluationOutcome({
       ...input,
       evaluation: failedEvaluation(
         input.goal,
-        "Claude invoked the Stop hook again without producing a new assistant turn; automatic continuation was blocked to prevent recursion.",
+        "Claude invoked the Stop hook again without producing a new assistant turn; automatic continuation was paused to prevent recursion.",
       ),
-      status: "blocked",
-      outcome: "blocked",
+      status: "paused",
+      outcome: "paused",
     });
   }
 
@@ -704,7 +856,39 @@ function failedEvaluation(
   });
 }
 
-function staleDecision(goal: AgentGoal): GoalStopDecision {
+function evaluatorFailureEvaluation(
+  goal: AgentGoal,
+  reason: string,
+  error: unknown,
+): GoalEvaluationResult {
+  const partial =
+    error instanceof GoalEvaluatorError ? error.partialEvaluation : undefined;
+  if (!partial) return failedEvaluation(goal, reason);
+
+  const criterionIds = new Set(
+    goal.successCriteria.map((criterion) => criterion.id),
+  );
+  const satisfiedCriteria = partial.satisfiedCriteria.filter((criterionId) =>
+    criterionIds.has(criterionId),
+  );
+  const satisfied = new Set(satisfiedCriteria);
+  return GoalEvaluationResultSchema.parse({
+    completed: false,
+    confidence: 0,
+    satisfiedCriteria,
+    missingCriteria: goal.successCriteria
+      .filter(
+        (criterion) => criterion.required && !satisfied.has(criterion.id),
+      )
+      .map((criterion) => criterion.id),
+    evidence: partial.evidence.filter(({ criterionId }) =>
+      satisfied.has(criterionId),
+    ),
+    reason: boundedReason(reason),
+  });
+}
+
+function staleDecision(goal: AgentGoal): GoalFinalEvaluationDecision {
   return {
     decision: "allow",
     outcome: "stale",
@@ -715,13 +899,25 @@ function staleDecision(goal: AgentGoal): GoalStopDecision {
 
 function staleContextDecision(
   context: RuntimeObservationContext,
-): GoalStopDecision {
+): GoalFinalEvaluationDecision {
   return {
     decision: "allow",
     outcome: "stale",
     goalId: context.goalId,
     goalRevision: context.goalRevision,
   };
+}
+
+function isGoalFinalEvaluationDecision(
+  decision: GoalStopDecision | undefined,
+): decision is GoalFinalEvaluationDecision {
+  return (
+    decision?.decision === "allow" &&
+    (decision.outcome === "no_active_goal" ||
+      decision.outcome === "stale" ||
+      decision.outcome === "completed" ||
+      decision.outcome === "paused")
+  );
 }
 
 function validateTurnContext(

--- a/apps/web/lib/ai/runtime-instructions/goal-evaluator.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-evaluator.ts
@@ -400,29 +400,81 @@ function validateSemanticEvaluation(
   const availableEvidence = new Set(evidence.map(({ id }) => id));
   const semanticallySatisfied = new Set(result.satisfiedCriteria);
   const evidenceByCriterion = new Map<string, string[]>();
+  const criteriaWithInvalidEvidence = new Set<string>();
+  let ignoredEvidenceAssociation = false;
   for (const association of result.evidence) {
     if (
       !requested.has(association.criterionId) ||
-      !semanticallySatisfied.has(association.criterionId) ||
-      evidenceByCriterion.has(association.criterionId) ||
+      !semanticallySatisfied.has(association.criterionId)
+    ) {
+      ignoredEvidenceAssociation = true;
+      continue;
+    }
+    if (evidenceByCriterion.has(association.criterionId)) {
+      ignoredEvidenceAssociation = true;
+      criteriaWithInvalidEvidence.add(association.criterionId);
+      continue;
+    }
+
+    // Evidence references come from a model and must never widen the
+    // controller's authoritative snapshot. Treat a bad citation as an
+    // unsatisfied criterion instead of terminating the Goal: the cited data is
+    // ignored and a later turn can provide valid, scoped evidence.
+    if (
       new Set(association.evidenceIds).size !==
         association.evidenceIds.length ||
       association.evidenceIds.some((id) => !availableEvidence.has(id))
     ) {
-      throw invalidSemanticEvaluation(
-        "The semantic evaluator referenced evidence outside its delegated snapshot",
-      );
+      ignoredEvidenceAssociation = true;
+      criteriaWithInvalidEvidence.add(association.criterionId);
+      continue;
     }
     evidenceByCriterion.set(association.criterionId, association.evidenceIds);
   }
   for (const criterionId of result.satisfiedCriteria) {
     if ((evidenceByCriterion.get(criterionId)?.length ?? 0) === 0) {
-      throw invalidSemanticEvaluation(
-        `Satisfied semantic criterion ${criterionId} must cite scoped evidence`,
-      );
+      criteriaWithInvalidEvidence.add(criterionId);
     }
   }
-  return result;
+
+  if (
+    criteriaWithInvalidEvidence.size === 0 &&
+    !ignoredEvidenceAssociation
+  ) {
+    return result;
+  }
+
+  const satisfiedCriteria = result.satisfiedCriteria.filter(
+    (criterionId) => !criteriaWithInvalidEvidence.has(criterionId),
+  );
+  const satisfied = new Set(satisfiedCriteria);
+  const missingCriteria = criteria
+    .map(({ id }) => id)
+    .filter((criterionId) => !satisfied.has(criterionId));
+  const downgraded = criteria
+    .map(({ id }) => id)
+    .filter((criterionId) => criteriaWithInvalidEvidence.has(criterionId));
+  const associationReason =
+    downgraded.length > 0
+      ? `Semantic evidence associations were invalid or outside the delegated snapshot; affected criteria remain unsatisfied: ${downgraded.join(", ")}.`
+      : "Invalid semantic evidence associations outside the delegated criteria were ignored.";
+  const reason = [result.reason, associationReason]
+    .join(" ")
+    .slice(0, MAX_REASON_CHARACTERS)
+    .trim();
+
+  return GoalEvaluationResultSchema.parse({
+    ...result,
+    completed: missingCriteria.length === 0,
+    satisfiedCriteria,
+    missingCriteria,
+    evidence: result.evidence.filter(
+      ({ criterionId }) =>
+        satisfied.has(criterionId) &&
+        evidenceByCriterion.has(criterionId),
+    ),
+    reason,
+  });
 }
 
 function buildResult(input: {

--- a/apps/web/lib/ai/runtime-instructions/goal-evaluator.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-evaluator.ts
@@ -40,6 +40,12 @@ export class GoalEvaluatorError extends Error {
     public readonly code: GoalEvaluatorErrorCode,
     message: string,
     public readonly cause?: unknown,
+    /**
+     * Progress that was already proven by the fenced durable snapshot before
+     * semantic evaluation failed. Callers may persist this as an incomplete
+     * result without inventing or widening evidence associations.
+     */
+    public readonly partialEvaluation?: GoalEvaluationResult,
   ) {
     super(message);
     this.name = "GoalEvaluatorError";
@@ -49,7 +55,7 @@ export class GoalEvaluatorError extends Error {
 export interface GoalSemanticEvaluationInput {
   goal: AgentGoal;
   run: AgentGoalRun;
-  /** Evidence is already fenced to this Goal, Run, and Goal revision. */
+  /** Evidence is already fenced to this Goal, Run, and semantic revision. */
   evidence: GoalEvidence[];
   /** Only unresolved, required model-evidence criteria are delegated. */
   criteria: GoalSuccessCriterion[];
@@ -65,6 +71,7 @@ export interface GoalEvaluatorInput {
   goal: AgentGoal;
   run: AgentGoalRun;
   evidence: GoalEvidence[];
+  evidenceRevisionFloor?: number;
   lastAssistantMessage?: string;
 }
 
@@ -88,11 +95,24 @@ export class GoalEvaluator {
   async evaluate(input: GoalEvaluatorInput): Promise<GoalEvaluationResult> {
     assertSnapshot(input);
 
+    const evidenceRevisionFloor =
+      input.evidenceRevisionFloor ?? input.goal.revision;
+    if (
+      !Number.isInteger(evidenceRevisionFloor) ||
+      evidenceRevisionFloor < 1 ||
+      evidenceRevisionFloor > input.goal.revision
+    ) {
+      throw new GoalEvaluatorError(
+        "invalid_evaluation_snapshot",
+        `Goal evidence revision floor ${evidenceRevisionFloor} is invalid for Goal ${input.goal.id} revision ${input.goal.revision}`,
+      );
+    }
     const evidence = input.evidence.filter(
       (item) =>
         item.goalId === input.goal.id &&
         item.goalRunId === input.run.id &&
-        item.goalRevision === input.goal.revision,
+        item.goalRevision >= evidenceRevisionFloor &&
+        item.goalRevision <= input.goal.revision,
     );
     const availableEvidenceIds = new Set(evidence.map(({ id }) => id));
     const evaluations = input.goal.successCriteria.map((criterion) =>
@@ -156,10 +176,18 @@ export class GoalEvaluator {
       });
     }
 
+    const partialEvaluation = buildResult({
+      goal: input.goal,
+      evaluations,
+      confidence: 0,
+    });
+
     if (!this.semanticEvaluator) {
       throw new GoalEvaluatorError(
         "semantic_evaluator_unavailable",
         "Required model-evidence criteria cannot be evaluated because no semantic evaluator is configured",
+        undefined,
+        partialEvaluation,
       );
     }
 
@@ -182,14 +210,28 @@ export class GoalEvaluator {
         "semantic_evaluator_failed",
         "The semantic Goal evaluator failed",
         cause,
+        partialEvaluation,
       );
     }
 
-    const semantic = validateSemanticEvaluation(
-      candidate,
-      semanticCriteria,
-      evidence,
-    );
+    let semantic: GoalEvaluationResult;
+    try {
+      semantic = validateSemanticEvaluation(
+        candidate,
+        semanticCriteria,
+        evidence,
+      );
+    } catch (error) {
+      if (error instanceof GoalEvaluatorError) {
+        throw new GoalEvaluatorError(
+          error.code,
+          error.message,
+          error.cause,
+          partialEvaluation,
+        );
+      }
+      throw error;
+    }
     const semanticSatisfied = new Set(
       semantic.confidence >= MIN_SEMANTIC_COMPLETION_CONFIDENCE
         ? semantic.satisfiedCriteria

--- a/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-lifecycle-service.ts
@@ -49,6 +49,10 @@ export type PauseGoalCommand = GoalLifecycleCommand;
 export type ResumeGoalCommand = GoalLifecycleCommand;
 export type CancelGoalCommand = GoalLifecycleCommand;
 
+export interface RuntimeSessionRecoveryWakePort {
+  wake(input: { ownerId: string; runtimeSessionId: string }): Promise<boolean>;
+}
+
 interface ParsedLifecycleCommand {
   ownerId: string;
   runtimeSessionId: string;
@@ -85,6 +89,7 @@ export class GoalLifecycleService {
     private readonly ids: RuntimeIdGeneratorPort,
     private readonly terminalTimeoutMs = 30_000,
     private readonly observations?: RuntimeLifecycleObservationPort,
+    private readonly recoveryWake?: RuntimeSessionRecoveryWakePort,
   ) {
     if (
       !Number.isInteger(terminalTimeoutMs) ||
@@ -343,13 +348,14 @@ export class GoalLifecycleService {
       command: command.command,
     });
     if (replay) {
+      const dispatch = await this.dispatchResumeInstruction(
+        command.ownerId,
+        command.runtimeSessionId,
+        replay.instruction.id,
+      );
       return {
         ...replay,
-        dispatch: await this.dispatcher.drain({
-          ownerId: command.ownerId,
-          runtimeSessionId: command.runtimeSessionId,
-          targetInstructionId: replay.instruction.id,
-        }),
+        dispatch,
       };
     }
 
@@ -383,14 +389,46 @@ export class GoalLifecycleService {
       instruction,
       command: command.command,
     });
+    const dispatch = await this.dispatchResumeInstruction(
+      command.ownerId,
+      command.runtimeSessionId,
+      commit.instruction.id,
+    );
     return {
       ...commit,
-      dispatch: await this.dispatcher.drain({
-        ownerId: command.ownerId,
-        runtimeSessionId: command.runtimeSessionId,
-        targetInstructionId: commit.instruction.id,
-      }),
+      dispatch,
     };
+  }
+
+  private async dispatchResumeInstruction(
+    ownerId: string,
+    runtimeSessionId: string,
+    instructionId: string,
+  ): Promise<RuntimeInstructionDispatch> {
+    let dispatch = await this.dispatcher.drain({
+      ownerId,
+      runtimeSessionId,
+      targetInstructionId: instructionId,
+    });
+    if (dispatch.status !== "unavailable" || !this.recoveryWake) {
+      return dispatch;
+    }
+
+    const awakened = await this.recoveryWake.wake({
+      ownerId,
+      runtimeSessionId,
+    });
+    if (!awakened) return dispatch;
+
+    // Recovery initialization hydrates durable progress and drains the same
+    // outbox before reporting ready. Re-reading through the dispatcher is
+    // idempotent and gives the caller the actual receipt for this command.
+    dispatch = await this.dispatcher.drain({
+      ownerId,
+      runtimeSessionId,
+      targetInstructionId: instructionId,
+    });
+    return dispatch;
   }
 
   private async requireGoal(

--- a/apps/web/lib/ai/runtime-instructions/goal-query-service.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-query-service.ts
@@ -9,6 +9,8 @@ import type {
   RuntimeInstructionKind,
 } from "@openloomi/ai/agent/runtime-instructions";
 
+import { resolveGoalEvidenceRevisionFloor } from "./runtime-observation";
+
 const MAX_VISIBLE_EVIDENCE = 100;
 
 export interface AgentGoalProgressView {
@@ -98,6 +100,8 @@ export class AgentGoalQueryService {
         deliveryIndex.get(goal.goal.id) ?? null,
         [],
         now,
+        instructions,
+        false,
       ),
     );
   }
@@ -129,16 +133,29 @@ export class AgentGoalQueryService {
           MAX_VISIBLE_EVIDENCE,
         )
       : [];
+    const evidenceRevisionFloor = resolveGoalEvidenceRevisionFloor(
+      goal.goal.id,
+      goal.goal.revision,
+      instructions,
+    );
+    const scopedEvidence = evidence.filter(
+      (item) =>
+        item.goalId === goal.goal.id &&
+        item.goalRevision >= evidenceRevisionFloor &&
+        item.goalRevision <= goal.goal.revision,
+    );
     return {
       ...summaryFor(
         goal,
         latestRun,
         indexLatestDeliveries(instructions, deliveries).get(goal.goal.id) ??
           null,
-        evidence,
+        scopedEvidence,
         this.clock.now(),
+        instructions,
+        true,
       ),
-      evidence: evidence.map((item) => structuredClone(item)),
+      evidence: scopedEvidence.map((item) => structuredClone(item)),
     };
   }
 }
@@ -212,9 +229,39 @@ function summaryFor(
   latestDelivery: AgentGoalDeliveryView | null,
   evidence: readonly GoalEvidence[],
   now: Date,
+  instructions: readonly RuntimeInstruction[],
+  validateEvaluationEvidence: boolean,
 ): AgentGoalSummaryView {
   const goal = structuredClone(persistedGoal);
   const run = latestRun ? structuredClone(latestRun) : null;
+  const evidenceRevisionFloor = resolveGoalEvidenceRevisionFloor(
+    goal.goal.id,
+    goal.goal.revision,
+    instructions,
+  );
+  const evaluationIsCurrent =
+    run !== null && run.goalRevision >= evidenceRevisionFloor;
+  const scopedEvidenceIds = new Set(evidence.map((item) => item.id));
+  const evaluationEvidenceByCriterion = new Map(
+    run?.lastEvaluation?.evidence.map((association) => [
+      association.criterionId,
+      association.evidenceIds,
+    ]) ?? [],
+  );
+  const evaluationEvidenceIsCurrent =
+    !validateEvaluationEvidence ||
+    run?.lastEvaluation === undefined ||
+    run.lastEvaluation.satisfiedCriteria.every((criterionId) => {
+      const evidenceIds = evaluationEvidenceByCriterion.get(criterionId);
+      return (
+        evidenceIds !== undefined &&
+        evidenceIds.length > 0 &&
+        evidenceIds.every((evidenceId) => scopedEvidenceIds.has(evidenceId))
+      );
+    });
+  if (run && (!evaluationIsCurrent || !evaluationEvidenceIsCurrent)) {
+    run.lastEvaluation = undefined;
+  }
   const satisfied = new Set(run?.lastEvaluation?.satisfiedCriteria ?? []);
   const completedCriteria = goal.goal.successCriteria.filter((criterion) =>
     satisfied.has(criterion.id),

--- a/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
@@ -229,7 +229,7 @@ export function assertGoalResumeCommit(
   expectedRevision: number,
 ): void {
   if (
-    previousGoal.status !== "paused" ||
+    (previousGoal.status !== "paused" && previousGoal.status !== "blocked") ||
     goal.status !== "active" ||
     goal.revision !== expectedRevision + 1 ||
     instruction.kind !== "goal.resume" ||
@@ -240,7 +240,7 @@ export function assertGoalResumeCommit(
   ) {
     throw new DurableAgentGoalStateError(
       "invalid_commit",
-      "An ordinary Goal transition may only resume a paused Goal with its matching steer instruction",
+      "An ordinary Goal transition may only resume a paused or blocked Goal with its matching steer instruction",
     );
   }
 

--- a/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-state-validation.ts
@@ -324,6 +324,7 @@ export function assertGoalEvaluationTransition(
   expectedRevision: number,
 ): void {
   const allowedStatus =
+    goal.status === "paused" ||
     goal.status === "blocked" ||
     goal.status === "completed" ||
     goal.status === "expired" ||

--- a/apps/web/lib/ai/runtime-instructions/goal-ui-model.ts
+++ b/apps/web/lib/ai/runtime-instructions/goal-ui-model.ts
@@ -171,6 +171,10 @@ export function shouldPollGoal(summary?: PublicGoalSummary): boolean {
   return summary?.goal.status === "active";
 }
 
+export function canResumeGoal(status: PublicAgentGoal["status"]): boolean {
+  return status === "paused" || status === "blocked";
+}
+
 export function formatDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);

--- a/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-goal-state.ts
@@ -1,3 +1,4 @@
+import { GoalEvaluationResultSchema } from "@openloomi/ai/agent/runtime-instructions";
 import type {
   AgentGoal,
   AgentGoalEvaluationStatePort,
@@ -5,6 +6,7 @@ import type {
   AgentGoalReplacement,
   AgentGoalStatePort,
   GoalCommandIdentity,
+  GoalEvaluationResult,
   GoalEvaluationTransitionCommit,
   GoalInstructionCommit,
   GoalLifecycleTransitionAction,
@@ -554,6 +556,8 @@ export class InMemoryAgentGoalState
     expectedRevision: number;
     expectedRunEpoch: number;
     goal: AgentGoal;
+    evaluation?: GoalEvaluationResult;
+    runtimeLeaseToken?: string;
   }): Promise<GoalEvaluationTransitionCommit> {
     const scope = validatedScope(input.ownerId, input.runtimeSessionId);
     const expectedRevision = positiveInteger(
@@ -565,6 +569,9 @@ export class InMemoryAgentGoalState
       "expectedRunEpoch",
     );
     const goal = parseGoal(input.goal);
+    if (input.evaluation !== undefined) {
+      GoalEvaluationResultSchema.parse(input.evaluation);
+    }
 
     return this.mutations.run(ownerScope(scope.ownerId), () => {
       const current = this.sessions.get(scope.key);

--- a/apps/web/lib/ai/runtime-instructions/in-memory-runtime-observation-journal.ts
+++ b/apps/web/lib/ai/runtime-instructions/in-memory-runtime-observation-journal.ts
@@ -28,6 +28,10 @@ import type {
   RuntimeGoalEvaluationSnapshot,
   RuntimeUsageDelta,
 } from "./runtime-observation";
+import {
+  isGoalEvidenceRevisionBoundary,
+  resolveGoalEvidenceRevisionFloor,
+} from "./runtime-observation";
 
 interface PreparedInstruction {
   instruction: RuntimeInstruction;
@@ -441,6 +445,11 @@ export class InMemoryRuntimeObservationJournal implements RuntimeObservationJour
       ) {
         return null;
       }
+      const evidenceRevisionFloor = resolveGoalEvidenceRevisionFloor(
+        goalId,
+        goalRevision,
+        await this.goals.listInstructions(ownerId, runtimeSessionId),
+      );
       if (run.status === "queued") this.transitionRun(run, "running");
       if (run.status === "evaluating") return null;
       this.transitionRun(run, "evaluating");
@@ -455,12 +464,14 @@ export class InMemoryRuntimeObservationJournal implements RuntimeObservationJour
 
       return {
         run: structuredClone(run),
+        evidenceRevisionFloor,
         evidence: [...session.evidence.values()]
           .filter(
             (item) =>
               item.goalRunId === run.id &&
               item.goalId === goalId &&
-              item.goalRevision === goalRevision,
+              item.goalRevision >= evidenceRevisionFloor &&
+              item.goalRevision <= goalRevision,
           )
           .sort((left, right) =>
             left.observedAt.localeCompare(right.observedAt),
@@ -918,6 +929,9 @@ export class InMemoryRuntimeObservationJournal implements RuntimeObservationJour
       run.goalRevision,
       stored.instruction.goalRevision ?? run.goalRevision,
     );
+    if (isGoalEvidenceRevisionBoundary(stored.instruction.kind)) {
+      run.lastEvaluation = undefined;
+    }
     if (
       run.status === "queued" ||
       run.status === "continuing" ||
@@ -1285,6 +1299,7 @@ function parseEvaluationOutcome(
 ): RuntimeGoalEvaluationOutcome {
   if (
     outcome !== "continuing" &&
+    outcome !== "paused" &&
     outcome !== "blocked" &&
     outcome !== "completed" &&
     outcome !== "budget_limited" &&

--- a/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
+++ b/apps/web/lib/ai/runtime-instructions/instruction-dispatcher.ts
@@ -30,6 +30,21 @@ export interface RuntimeInstructionInlineAcceptanceInput extends RuntimeInstruct
   receipt: RuntimeDeliveryReceipt;
 }
 
+export interface RuntimeInstructionRecoverySettlement {
+  instructionId: string;
+  disposition: "accepted" | "superseded";
+  recordedAt: string;
+  providerEventId?: string;
+  reason?: string;
+}
+
+export interface RuntimeInstructionRecoveryProgressInput {
+  ownerId: string;
+  runtimeSessionId: string;
+  transport: RuntimeInstructionTransportPort;
+  settlements: readonly RuntimeInstructionRecoverySettlement[];
+}
+
 export type RuntimeInstructionControlBarrierPolicy =
   | "preserve_predecessors"
   | "supersede_predecessors";
@@ -147,6 +162,135 @@ export class RuntimeInstructionDispatcher {
     private readonly outbox: RuntimeInstructionOutboxReader,
     private readonly deliveryJournal?: RuntimeDeliveryJournalPort,
   ) {}
+
+  /**
+   * Rebuild process-local transport progress from the durable Delivery journal.
+   *
+   * A recovered transport is a new object, so its WeakMap progress starts at
+   * sequence zero. Without this hydration, replaying the outbox would write
+   * provider-visible instructions to Claude a second time. Callers must only
+   * classify durable provider-visible attempts as `accepted`; undelivered
+   * attempts are deliberately omitted so the normal drain can retry them.
+   */
+  initializeRecoveredProgress(
+    input: RuntimeInstructionRecoveryProgressInput,
+  ): Promise<void> {
+    const ownerId = requiredIdentifier(input.ownerId, "ownerId");
+    const runtimeSessionId = requiredIdentifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    assertTransportTargetsSession(input.transport, runtimeSessionId);
+    const scope = sessionScope(ownerId, runtimeSessionId);
+    return this.deliveries.run(scope, async () => {
+      const resolved = await this.sessions.resolve(ownerId, runtimeSessionId);
+      if (resolved !== input.transport) {
+        throw new RuntimeInstructionDispatcherError(
+          "outbox_progress_conflict",
+          `Runtime Session ${runtimeSessionId} changed before recovery progress was initialized`,
+        );
+      }
+
+      let rawInstructions: RuntimeInstruction[];
+      try {
+        rawInstructions = await this.outbox.listInstructions(
+          ownerId,
+          runtimeSessionId,
+        );
+      } catch (cause) {
+        throw new RuntimeInstructionDispatcherError(
+          "outbox_read_failed",
+          `Failed to read the authoritative outbox for Runtime Session ${runtimeSessionId}`,
+          cause,
+        );
+      }
+      const instructions = parseCompleteOutbox(
+        runtimeSessionId,
+        rawInstructions,
+      );
+      const byId = new Map(
+        instructions.map((instruction) => [instruction.id, instruction]),
+      );
+      const progress = this.getProgress(input.transport, scope, instructions);
+      const seen = new Set<string>();
+
+      for (const settlement of input.settlements) {
+        const instructionId = requiredIdentifier(
+          settlement.instructionId,
+          "settlement.instructionId",
+        );
+        if (seen.has(instructionId)) {
+          throw new RuntimeInstructionDispatcherError(
+            "outbox_progress_conflict",
+            `Recovery progress contains duplicate instruction ${instructionId}`,
+          );
+        }
+        seen.add(instructionId);
+        const instruction = byId.get(instructionId);
+        if (!instruction) {
+          throw new RuntimeInstructionDispatcherError(
+            "outbox_progress_conflict",
+            `Recovery progress references unknown instruction ${instructionId}`,
+          );
+        }
+        const recordedAt = requiredTimestamp(
+          settlement.recordedAt,
+          "settlement.recordedAt",
+        );
+        if (settlement.disposition === "accepted") {
+          const acceptedInstruction: AcceptedInstruction = {
+            instructionId,
+            instruction: structuredClone(instruction),
+            receipt: {
+              instructionId,
+              runtimeSessionId,
+              state: "written_to_sdk",
+              recordedAt,
+              ...(settlement.providerEventId === undefined
+                ? {}
+                : {
+                    providerEventId: requiredIdentifier(
+                      settlement.providerEventId,
+                      "settlement.providerEventId",
+                    ),
+                  }),
+            },
+          };
+          const existing = progress.acceptedBySequence.get(
+            instruction.sequence,
+          );
+          if (existing) assertSameProgressInstruction(existing, instruction);
+          else
+            progress.acceptedBySequence.set(
+              instruction.sequence,
+              acceptedInstruction,
+            );
+          continue;
+        }
+        if (settlement.disposition !== "superseded") {
+          throw new RuntimeInstructionDispatcherError(
+            "outbox_progress_conflict",
+            `Unsupported recovery disposition for instruction ${instructionId}`,
+          );
+        }
+        const reason = requiredText(
+          settlement.reason ?? "Instruction was settled before recovery",
+          "settlement.reason",
+        );
+        const existing = progress.supersededBySequence.get(
+          instruction.sequence,
+        );
+        if (existing) assertSameProgressInstruction(existing, instruction);
+        else
+          progress.supersededBySequence.set(instruction.sequence, {
+            instructionId,
+            instruction: structuredClone(instruction),
+            reason,
+          });
+      }
+      advanceSettledPrefix(progress, instructions);
+    });
+  }
 
   drain(
     input: RuntimeInstructionDrainInput,
@@ -654,16 +798,47 @@ function parseOutbox(input: {
   targetInstructionId: string;
   instructions: readonly RuntimeInstruction[];
 }): ParsedDrain {
-  if (!Array.isArray(input.instructions) || input.instructions.length === 0) {
+  const instructions = parseCompleteOutbox(
+    input.runtimeSessionId,
+    input.instructions,
+  );
+  if (instructions.length === 0) {
     throw new RuntimeInstructionDispatcherError(
       "invalid_drain",
       "Runtime Instruction outbox must contain at least one instruction",
     );
   }
 
+  const target = instructions.find(
+    (instruction) => instruction.id === input.targetInstructionId,
+  );
+  if (!target) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      `Target instruction ${input.targetInstructionId} is not present in the outbox`,
+    );
+  }
+  return {
+    ownerId: input.ownerId,
+    runtimeSessionId: input.runtimeSessionId,
+    instructions,
+    target,
+  };
+}
+
+function parseCompleteOutbox(
+  runtimeSessionId: string,
+  input: readonly RuntimeInstruction[],
+): RuntimeInstruction[] {
+  if (!Array.isArray(input)) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      "Runtime Instruction outbox must be an array",
+    );
+  }
   let instructions: RuntimeInstruction[];
   try {
-    instructions = input.instructions.map((instruction) =>
+    instructions = input.map((instruction) =>
       RuntimeInstructionSchema.parse(instruction),
     );
   } catch (cause) {
@@ -683,7 +858,7 @@ function parseOutbox(input: {
         `Complete outbox must contain contiguous sequences starting at 1; expected ${expectedSequence}, received ${instruction.sequence}`,
       );
     }
-    if (instruction.targetSessionId !== input.runtimeSessionId) {
+    if (instruction.targetSessionId !== runtimeSessionId) {
       throw new RuntimeInstructionDispatcherError(
         "invalid_drain",
         "Every instruction in one outbox drain must target the same Runtime Session",
@@ -697,22 +872,7 @@ function parseOutbox(input: {
     }
     instructionIds.add(instruction.id);
   }
-
-  const target = instructions.find(
-    (instruction) => instruction.id === input.targetInstructionId,
-  );
-  if (!target) {
-    throw new RuntimeInstructionDispatcherError(
-      "invalid_drain",
-      `Target instruction ${input.targetInstructionId} is not present in the outbox`,
-    );
-  }
-  return {
-    ownerId: input.ownerId,
-    runtimeSessionId: input.runtimeSessionId,
-    instructions,
-    target,
-  };
+  return instructions;
 }
 
 function assertCompatibleProgress(
@@ -961,6 +1121,16 @@ function requiredText(value: unknown, field: string): string {
     );
   }
   return normalized;
+}
+
+function requiredTimestamp(value: unknown, field: string): string {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    throw new RuntimeInstructionDispatcherError(
+      "invalid_drain",
+      `${field} must be an ISO timestamp`,
+    );
+  }
+  return value;
 }
 
 function sessionScope(ownerId: string, runtimeSessionId: string): string {

--- a/apps/web/lib/ai/runtime-instructions/persistence/goal-run-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/goal-run-state.ts
@@ -27,6 +27,8 @@ export function goalRunStatusForEvaluation(
   status: AgentGoal["status"],
 ): GoalRunStatus {
   switch (status) {
+    case "paused":
+      return "paused";
     case "blocked":
       return "blocked";
     case "completed":

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/agent-goal-state.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/agent-goal-state.ts
@@ -7,6 +7,7 @@ import {
   type AgentGoalReplacement,
   type AgentGoalRun,
   type AgentGoalStatePort,
+  type GoalEvaluationResult,
   type GoalRunStatus,
   type GoalCommandIdentity,
   type GoalEvaluationTransitionCommit,
@@ -17,6 +18,7 @@ import {
   type PersistedAgentGoal,
   type RuntimeInstruction,
   type RuntimeInstructionDraft,
+  GoalEvaluationResultSchema,
   canonicalJson,
 } from "@openloomi/ai/agent/runtime-instructions";
 
@@ -356,7 +358,11 @@ export class SqliteAgentGoalState
         throw revisionConflict(expectedRevision, current.goal.revision);
       }
       const run = this.requireRun(session, goal.id);
-      this.updateRun(run, { goalRevision: goal.revision }, recordedAt);
+      this.updateRun(
+        run,
+        { goalRevision: goal.revision, lastEvaluation: null },
+        recordedAt,
+      );
       this.commitInstruction({
         session,
         instruction,
@@ -442,7 +448,10 @@ export class SqliteAgentGoalState
       const run = this.requireRun(session, goal.id);
       this.updateRun(
         run,
-        { goalRevision: goal.revision, status: "running" },
+        {
+          goalRevision: goal.revision,
+          status: "running",
+        },
         recordedAt,
       );
       this.commitInstruction({
@@ -550,6 +559,8 @@ export class SqliteAgentGoalState
     expectedRevision: number;
     expectedRunEpoch: number;
     goal: AgentGoal;
+    evaluation?: GoalEvaluationResult;
+    runtimeLeaseToken?: string;
   }): Promise<GoalEvaluationTransitionCommit> {
     const scope = validateGoalStateScope(input.ownerId, input.runtimeSessionId);
     const expectedRevision = requirePositiveGoalStateInteger(
@@ -561,12 +572,36 @@ export class SqliteAgentGoalState
       "expectedRunEpoch",
     );
     const goal = parseGoalState(input.goal);
+    const evaluation =
+      input.evaluation === undefined
+        ? undefined
+        : GoalEvaluationResultSchema.parse(input.evaluation);
+    const runtimeLeaseToken =
+      input.runtimeLeaseToken === undefined
+        ? undefined
+        : requireGoalStateIdentifier(
+            input.runtimeLeaseToken,
+            "runtimeLeaseToken",
+          );
 
     return this.mutate(() => {
+      const recordedAt = this.recordedAt();
       const session = this.requireSession(
         scope.ownerId,
         scope.runtimeSessionId,
       );
+      if (
+        runtimeLeaseToken !== undefined &&
+        (session.recoveryLeaseToken !== runtimeLeaseToken ||
+          session.recoveryLeaseExpiresAtSeconds === undefined ||
+          session.recoveryLeaseExpiresAtSeconds <=
+            Math.floor(Date.parse(recordedAt) / 1_000))
+      ) {
+        throw new DurableAgentGoalStateError(
+          "invalid_commit",
+          `Runtime Session ${scope.runtimeSessionId} recovery lease is no longer current`,
+        );
+      }
       assertNoPendingOperation(session);
       assertRunEpoch(session, expectedRunEpoch);
       const current = this.requireGoal(scope, goal.id);
@@ -598,8 +633,9 @@ export class SqliteAgentGoalState
           goalRevision: goal.revision,
           status: nextRunStatus,
           terminal: isTerminalRunStatus(nextRunStatus),
+          ...(evaluation === undefined ? {} : { lastEvaluation: evaluation }),
         },
-        this.recordedAt(),
+        recordedAt,
       );
       return { goal: clone(transitioned) };
     });
@@ -1258,6 +1294,7 @@ export class SqliteAgentGoalState
       goalRevision?: number;
       status?: GoalRunStatus;
       terminal?: boolean;
+      lastEvaluation?: GoalEvaluationResult | null;
     },
     recordedAt: string,
   ): AgentGoalRun {
@@ -1273,6 +1310,14 @@ export class SqliteAgentGoalState
       status,
       lastActivityAt,
       ...(input.terminal ? { completedAt: lastActivityAt } : {}),
+      ...(input.lastEvaluation === undefined
+        ? {}
+        : {
+            lastEvaluation:
+              input.lastEvaluation === null
+                ? undefined
+                : input.lastEvaluation,
+          }),
     };
     if (!this.storage.updateRun(run, next, recordedAt)) {
       throw new DurableAgentGoalStateError(

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/runtime-observation-journal.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/runtime-observation-journal.ts
@@ -26,6 +26,7 @@ import type {
   RuntimeObservationLeaseRegistration,
   RuntimeProviderEventObservation,
 } from "../../runtime-observation";
+import { resolveGoalEvidenceRevisionFloor } from "../../runtime-observation";
 import type { RuntimeSessionPersistencePort } from "../../runtime-session-persistence";
 import { persistenceConflict } from "../errors";
 import type { PersistedRuntimeInstructionDelivery } from "../runtime-observation-mappers";
@@ -709,6 +710,11 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
             isTerminalRun(run.status)
           )
             return null;
+          const evidenceRevisionFloor = resolveGoalEvidenceRevisionFloor(
+            input.goalId,
+            input.goalRevision,
+            store.listInstructions(input.ownerId, input.runtimeSessionId),
+          );
           assertGoalRunStatusTransition(run.status, "evaluating");
           const next = {
             ...run,
@@ -718,9 +724,14 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
           if (!store.updateRun(run, next, input.recordedAt)) return null;
           return {
             run: next,
+            evidenceRevisionFloor,
             evidence: store
               .listEvidenceByRun(input.ownerId, input.runtimeSessionId, run.id)
-              .filter((item) => item.goalRevision === input.goalRevision),
+              .filter(
+                (item) =>
+                  item.goalRevision >= evidenceRevisionFloor &&
+                  item.goalRevision <= input.goalRevision,
+              ),
           };
         },
       );

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/runtime-observation-journal.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/runtime-observation-journal.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   GoalEvaluationResultSchema,
@@ -23,6 +23,7 @@ import type {
   RuntimeGoalEvaluationSnapshot,
   RuntimeObservationContext,
   RuntimeObservationJournalPort,
+  RuntimeObservationLeaseRegistration,
   RuntimeProviderEventObservation,
 } from "../../runtime-observation";
 import type { RuntimeSessionPersistencePort } from "../../runtime-session-persistence";
@@ -43,11 +44,16 @@ interface EvaluationLease {
   phase: "evaluating" | "finished" | "abandoned";
 }
 
+interface AttachedRuntimeLease {
+  readonly leaseToken: string;
+  readonly registrations: Set<symbol>;
+}
+
 export class SqliteRuntimeObservationJournal implements RuntimeObservationJournalPort {
   private readonly database: SqliteGoalRuntimeDatabase;
   private readonly serial = new KeyedSerialExecutor();
-  private readonly providerEvents = new Set<string>();
   private readonly evaluations = new Map<string, EvaluationLease>();
+  private readonly runtimeLeases = new Map<string, AttachedRuntimeLease>();
 
   constructor(
     source: SqliteGoalRuntimeDatabaseSource,
@@ -58,6 +64,47 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     this.database = resolveSqliteGoalRuntimeDatabase(source);
   }
 
+  attachRuntimeLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseToken: string;
+  }): RuntimeObservationLeaseRegistration {
+    const ownerId = identifier(input.ownerId, "ownerId");
+    const runtimeSessionId = identifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const leaseToken = identifier(input.leaseToken, "leaseToken");
+    const key = scope(ownerId, runtimeSessionId);
+    const existing = this.runtimeLeases.get(key);
+    if (existing && existing.leaseToken !== leaseToken) {
+      throw persistenceConflict(
+        `Runtime Session ${runtimeSessionId} already has a different local ownership fence`,
+      );
+    }
+    const registration = Symbol(runtimeSessionId);
+    const attached =
+      existing ??
+      ({
+        leaseToken,
+        registrations: new Set<symbol>(),
+      } satisfies AttachedRuntimeLease);
+    attached.registrations.add(registration);
+    this.runtimeLeases.set(key, attached);
+
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        const current = this.runtimeLeases.get(key);
+        if (current !== attached) return;
+        current.registrations.delete(registration);
+        if (current.registrations.size === 0) this.runtimeLeases.delete(key);
+      },
+    };
+  }
+
   async prepareDelivery(input: {
     ownerId: string;
     instruction: RuntimeInstruction;
@@ -65,7 +112,7 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     const instruction = RuntimeInstructionSchema.parse(input.instruction);
     const ownerId = identifier(input.ownerId, "ownerId");
     await this.serial.run(scope(ownerId, instruction.targetSessionId), () => {
-      this.database.immediate((store) => {
+      this.withRuntimeLease(ownerId, instruction.targetSessionId, (store) => {
         const stored = requireCanonicalInstruction(store, ownerId, instruction);
         requireCurrentEpoch(
           store,
@@ -134,7 +181,7 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     const ownerId = identifier(input.ownerId, "ownerId");
     const receipt = parseReceipt(input.receipt, instruction);
     await this.serial.run(scope(ownerId, instruction.targetSessionId), () => {
-      this.database.immediate((store) => {
+      this.withRuntimeLease(ownerId, instruction.targetSessionId, (store) => {
         const canonical = requireCanonicalInstruction(
           store,
           ownerId,
@@ -227,7 +274,7 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     );
     const instructionId = identifier(input.instructionId, "instructionId");
     return this.serial.run(scope(ownerId, runtimeSessionId), () =>
-      this.database.immediate((store) => {
+      this.withRuntimeLease(ownerId, runtimeSessionId, (store) => {
         const session = store.getSession(ownerId, runtimeSessionId);
         if (!session || session.runEpoch !== input.runEpoch) return false;
         const stored = store.getInstruction(
@@ -275,62 +322,81 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     ownerId: string;
     runtimeSessionId: string;
     providerSessionId: string;
+    runEpoch?: number;
   }): Promise<void> {
     await this.serial.run(
       scope(input.ownerId, input.runtimeSessionId),
       async () => {
-        const activeRunId = this.database.immediate((store) => {
-          const session = store.getSession(
+        // Persist the resume handle at SDK initialization, even when this is
+        // still an ordinary chat. A Goal can be injected later, and a crash
+        // between its first handoff and the next Claude event must not leave
+        // that durable Goal without the provider session it belongs to.
+        await this.runtimeSessions.bindProviderSession({
+          ownerId: input.ownerId,
+          runtimeSessionId: input.runtimeSessionId,
+          providerSessionId: input.providerSessionId,
+          ...this.runtimeLeaseFence(
             input.ownerId,
             input.runtimeSessionId,
-          );
-          const active = store.getAssignedPrimaryGoal(
-            input.ownerId,
-            input.runtimeSessionId,
-          );
-          if (!session || active?.persistedGoal.goal.status !== "active")
-            return null;
-          return (
-            store.findRun(
+            input.runEpoch,
+          ),
+        });
+        const activeRunId = this.withRuntimeLease(
+          input.ownerId,
+          input.runtimeSessionId,
+          (store) => {
+            const session = store.getSession(
               input.ownerId,
               input.runtimeSessionId,
-              active.persistedGoal.goal.id,
-              session.runEpoch,
-            )?.id ?? null
-          );
-        });
+            );
+            const active = store.getAssignedPrimaryGoal(
+              input.ownerId,
+              input.runtimeSessionId,
+            );
+            if (!session || active?.persistedGoal.goal.status !== "active")
+              return null;
+            return (
+              store.findRun(
+                input.ownerId,
+                input.runtimeSessionId,
+                active.persistedGoal.goal.id,
+                session.runEpoch,
+              )?.id ?? null
+            );
+          },
+        );
         if (!activeRunId) return;
-        await this.runtimeSessions.bindProviderSession(input);
         const at = this.now();
-        const stillActive = this.database.immediate((store) => {
-          const run = store.getRun(
-            input.ownerId,
-            input.runtimeSessionId,
-            activeRunId,
-          );
-          const active = store.getAssignedPrimaryGoal(
-            input.ownerId,
-            input.runtimeSessionId,
-          );
-          if (
-            !run ||
-            isTerminalRun(run.status) ||
-            active?.persistedGoal.goal.id !== run.goalId
-          ) {
-            return false;
-          }
-          return store.updateRun(
-            run,
-            { ...run, providerSessionId: input.providerSessionId },
-            at,
-          );
-        });
-        if (!stillActive) {
-          await this.runtimeSessions.releaseProviderSession(
-            input.ownerId,
-            input.runtimeSessionId,
-          );
-        }
+        this.withRuntimeLease(
+          input.ownerId,
+          input.runtimeSessionId,
+          (store) => {
+            const run = store.getRun(
+              input.ownerId,
+              input.runtimeSessionId,
+              activeRunId,
+            );
+            const active = store.getAssignedPrimaryGoal(
+              input.ownerId,
+              input.runtimeSessionId,
+            );
+            if (
+              !run ||
+              isTerminalRun(run.status) ||
+              active?.persistedGoal.goal.id !== run.goalId
+            ) {
+              return false;
+            }
+            return store.updateRun(
+              run,
+              { ...run, providerSessionId: input.providerSessionId },
+              at,
+            );
+          },
+        );
+        // Session ownership is released by ClaudeGoalRuntimeRegistration when
+        // the Query ends. A concurrent Goal transition here is not proof that
+        // the live provider handle should be cleared.
       },
     );
   }
@@ -359,174 +425,239 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     input: RuntimeProviderEventObservation,
   ): Promise<boolean> {
     const parsed = parseObservation(input);
-    const eventScope = `${scope(parsed.ownerId, parsed.runtimeSessionId)}:${parsed.eventKey}`;
+    const eventFingerprint = providerEventFingerprint(parsed);
     return this.serial.run(
       scope(parsed.ownerId, parsed.runtimeSessionId),
       async () => {
-        if (this.providerEvents.has(eventScope)) return false;
-        const preflightContext = this.database.immediate((store) => {
-          const session = store.getSession(
-            parsed.ownerId,
-            parsed.runtimeSessionId,
-          );
-          if (!session || session.runEpoch !== parsed.runEpoch) return null;
-          return parsed.context
-            ? validateContext(
-                store,
-                parsed.context,
-                parsed.runEpoch,
-                parsed.terminal === true,
-              )
-            : latestContext(
-                store,
-                parsed.ownerId,
-                parsed.runtimeSessionId,
-                parsed.runEpoch,
-              );
-        });
+        const preflightContext = this.withRuntimeLease(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+          (store) => {
+            const existing = store.getProviderEventReceipt(
+              parsed.ownerId,
+              parsed.runtimeSessionId,
+              parsed.runEpoch,
+              parsed.eventKey,
+            );
+            if (existing) {
+              assertSameProviderEvent(existing, parsed, eventFingerprint);
+              return "duplicate" as const;
+            }
+            const session = store.getSession(
+              parsed.ownerId,
+              parsed.runtimeSessionId,
+            );
+            if (!session || session.runEpoch !== parsed.runEpoch) return null;
+            return parsed.context
+              ? validateContext(
+                  store,
+                  parsed.context,
+                  parsed.runEpoch,
+                  parsed.terminal === true,
+                )
+              : latestContext(
+                  store,
+                  parsed.ownerId,
+                  parsed.runtimeSessionId,
+                  parsed.runEpoch,
+                );
+          },
+        );
+        if (preflightContext === "duplicate") return false;
         if (!preflightContext) return false;
         if (parsed.providerSessionId) {
           await this.runtimeSessions.bindProviderSession({
             ownerId: parsed.ownerId,
             runtimeSessionId: parsed.runtimeSessionId,
             providerSessionId: parsed.providerSessionId,
+            ...this.runtimeLeaseFence(
+              parsed.ownerId,
+              parsed.runtimeSessionId,
+              parsed.runEpoch,
+            ),
           });
         }
-        const accepted = this.database.immediate((store) => {
-          const session = store.getSession(
-            parsed.ownerId,
-            parsed.runtimeSessionId,
-          );
-          if (!session || session.runEpoch !== parsed.runEpoch) return false;
-          const context = parsed.context
-            ? validateContext(
-                store,
-                parsed.context,
-                parsed.runEpoch,
-                parsed.terminal === true,
-              )
-            : latestContext(
-                store,
-                parsed.ownerId,
-                parsed.runtimeSessionId,
-                parsed.runEpoch,
-              );
-          if (!context) return false;
-          const deliveryContexts = acknowledgedContexts(
-            store,
-            context,
-            parsed.acknowledgedContexts,
-            parsed.runEpoch,
-            parsed.terminal === true,
-          );
-          for (const acknowledged of deliveryContexts) {
-            const instruction = store.getInstruction(
+        const accepted = this.withRuntimeLease(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+          (store) => {
+            const existing = store.getProviderEventReceipt(
               parsed.ownerId,
               parsed.runtimeSessionId,
-              acknowledged.instructionId,
-            )?.instruction;
-            let delivery = store.getActiveDeliveryForInstruction(
+              parsed.runEpoch,
+              parsed.eventKey,
+            );
+            if (existing) {
+              assertSameProviderEvent(existing, parsed, eventFingerprint);
+              return false;
+            }
+            const session = store.getSession(
               parsed.ownerId,
               parsed.runtimeSessionId,
-              acknowledged.instructionId,
             );
-            if (!delivery || !instruction || isControl(instruction)) continue;
-            if (delivery.state === "written_to_sdk") {
-              delivery = transitionDelivery(
-                store,
-                delivery,
-                "observed",
-                parsed.observedAt,
-                {
-                  providerEventId: parsed.providerEventId,
-                },
-              );
-            }
-            if (parsed.terminal && delivery.state === "observed") {
-              transitionDelivery(
-                store,
-                delivery,
-                "applied",
-                parsed.observedAt,
-                {
-                  providerEventId: parsed.providerEventId,
-                },
-              );
-            }
-          }
-          const run = store.getRun(
-            parsed.ownerId,
-            parsed.runtimeSessionId,
-            context.goalRunId,
-          );
-          if (!run || isTerminalRun(run.status)) return true;
-          const nextStatus =
-            run.status === "queued" || run.status === "continuing"
-              ? "running"
-              : run.status;
-          const turnsUsed = run.turnsUsed + (parsed.usage?.turnsUsed ?? 0);
-          const tokensUsed = run.tokensUsed + (parsed.usage?.tokensUsed ?? 0);
-          if (
-            !Number.isSafeInteger(turnsUsed) ||
-            !Number.isSafeInteger(tokensUsed)
-          ) {
-            throw persistenceConflict(
-              "Provider usage exceeds the supported counter range",
-            );
-          }
-          const nextRun: AgentGoalRun = {
-            ...run,
-            status: nextStatus,
-            turnsUsed,
-            tokensUsed,
-            lastActivityAt: latest(run.lastActivityAt, parsed.observedAt),
-            ...(parsed.providerSessionId === undefined
-              ? {}
-              : { providerSessionId: parsed.providerSessionId }),
-          };
-          if (nextStatus !== run.status)
-            assertGoalRunStatusTransition(run.status, nextStatus);
-          if (!store.updateRun(run, nextRun, parsed.observedAt)) {
-            throw persistenceConflict(
-              `Goal Run ${run.id} changed while recording a provider event`,
-            );
-          }
-          for (const draft of parsed.evidence ?? []) {
+            if (!session || session.runEpoch !== parsed.runEpoch) return false;
+            const context = parsed.context
+              ? validateContext(
+                  store,
+                  parsed.context,
+                  parsed.runEpoch,
+                  parsed.terminal === true,
+                )
+              : latestContext(
+                  store,
+                  parsed.ownerId,
+                  parsed.runtimeSessionId,
+                  parsed.runEpoch,
+                );
+            if (!context) return false;
             if (
-              store.findEvidenceBySourceEvent(
+              !store.insertProviderEventReceipt({
+                ownerId: parsed.ownerId,
+                runtimeSessionId: parsed.runtimeSessionId,
+                runEpoch: parsed.runEpoch,
+                eventKey: parsed.eventKey,
+                providerEventId: parsed.providerEventId,
+                ...(parsed.providerSessionId === undefined
+                  ? {}
+                  : { providerSessionId: parsed.providerSessionId }),
+                eventFingerprint,
+                observedAtSeconds: Math.floor(
+                  Date.parse(parsed.observedAt) / 1_000,
+                ),
+                createdAtSeconds: Math.floor(
+                  this.clock.now().getTime() / 1_000,
+                ),
+              })
+            ) {
+              const raced = store.getProviderEventReceipt(
                 parsed.ownerId,
                 parsed.runtimeSessionId,
-                run.id,
-                draft.sourceEventId,
-              )
-            )
-              continue;
-            const evidence = GoalEvidenceSchema.parse({
-              id: this.ids.generate(),
-              goalId: context.goalId,
-              goalRunId: run.id,
-              goalRevision: context.goalRevision,
-              instructionId: context.instructionId,
-              type: draft.type,
-              sourceEventId: draft.sourceEventId,
-              summary: draft.summary,
-              ...(draft.success === undefined
+                parsed.runEpoch,
+                parsed.eventKey,
+              );
+              if (!raced) {
+                throw persistenceConflict(
+                  `Provider event ${parsed.eventKey} could not be recorded`,
+                );
+              }
+              assertSameProviderEvent(raced, parsed, eventFingerprint);
+              return false;
+            }
+            const deliveryContexts = acknowledgedContexts(
+              store,
+              context,
+              parsed.acknowledgedContexts,
+              parsed.runEpoch,
+              parsed.terminal === true,
+            );
+            for (const acknowledged of deliveryContexts) {
+              const instruction = store.getInstruction(
+                parsed.ownerId,
+                parsed.runtimeSessionId,
+                acknowledged.instructionId,
+              )?.instruction;
+              let delivery = store.getActiveDeliveryForInstruction(
+                parsed.ownerId,
+                parsed.runtimeSessionId,
+                acknowledged.instructionId,
+              );
+              if (!delivery || !instruction || isControl(instruction)) continue;
+              if (delivery.state === "written_to_sdk") {
+                delivery = transitionDelivery(
+                  store,
+                  delivery,
+                  "observed",
+                  parsed.observedAt,
+                  {
+                    providerEventId: parsed.providerEventId,
+                  },
+                );
+              }
+              if (parsed.terminal && delivery.state === "observed") {
+                transitionDelivery(
+                  store,
+                  delivery,
+                  "applied",
+                  parsed.observedAt,
+                  {
+                    providerEventId: parsed.providerEventId,
+                  },
+                );
+              }
+            }
+            const run = store.getRun(
+              parsed.ownerId,
+              parsed.runtimeSessionId,
+              context.goalRunId,
+            );
+            if (!run || isTerminalRun(run.status)) return true;
+            const nextStatus =
+              run.status === "queued" || run.status === "continuing"
+                ? "running"
+                : run.status;
+            const turnsUsed = run.turnsUsed + (parsed.usage?.turnsUsed ?? 0);
+            const tokensUsed = run.tokensUsed + (parsed.usage?.tokensUsed ?? 0);
+            if (
+              !Number.isSafeInteger(turnsUsed) ||
+              !Number.isSafeInteger(tokensUsed)
+            ) {
+              throw persistenceConflict(
+                "Provider usage exceeds the supported counter range",
+              );
+            }
+            const nextRun: AgentGoalRun = {
+              ...run,
+              status: nextStatus,
+              turnsUsed,
+              tokensUsed,
+              lastActivityAt: latest(run.lastActivityAt, parsed.observedAt),
+              ...(parsed.providerSessionId === undefined
                 ? {}
-                : { success: draft.success }),
-              payload: draft.payload,
-              observedAt: draft.observedAt,
-            });
-            store.insertEvidence({
-              ownerId: parsed.ownerId,
-              runtimeSessionId: parsed.runtimeSessionId,
-              runEpoch: parsed.runEpoch,
-              evidence,
-              recordedAt: parsed.observedAt,
-            });
-          }
-          return true;
-        });
-        if (accepted) this.providerEvents.add(eventScope);
+                : { providerSessionId: parsed.providerSessionId }),
+            };
+            if (nextStatus !== run.status)
+              assertGoalRunStatusTransition(run.status, nextStatus);
+            if (!store.updateRun(run, nextRun, parsed.observedAt)) {
+              throw persistenceConflict(
+                `Goal Run ${run.id} changed while recording a provider event`,
+              );
+            }
+            for (const draft of parsed.evidence ?? []) {
+              if (
+                store.findEvidenceBySourceEvent(
+                  parsed.ownerId,
+                  parsed.runtimeSessionId,
+                  run.id,
+                  draft.sourceEventId,
+                )
+              )
+                continue;
+              const evidence = GoalEvidenceSchema.parse({
+                id: this.ids.generate(),
+                goalId: context.goalId,
+                goalRunId: run.id,
+                goalRevision: context.goalRevision,
+                instructionId: context.instructionId,
+                type: draft.type,
+                sourceEventId: draft.sourceEventId,
+                summary: draft.summary,
+                ...(draft.success === undefined
+                  ? {}
+                  : { success: draft.success }),
+                payload: draft.payload,
+                observedAt: draft.observedAt,
+              });
+              store.insertEvidence({
+                ownerId: parsed.ownerId,
+                runtimeSessionId: parsed.runtimeSessionId,
+                runEpoch: parsed.runEpoch,
+                evidence,
+                recordedAt: parsed.observedAt,
+              });
+            }
+            return true;
+          },
+        );
         return accepted;
       },
     );
@@ -548,44 +679,51 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     );
     return this.serial.run(scope(input.ownerId, input.runtimeSessionId), () => {
       if (this.evaluations.has(key)) return null;
-      const snapshot = this.database.immediate((store) => {
-        const session = store.getSession(input.ownerId, input.runtimeSessionId);
-        const active = store.getAssignedPrimaryGoal(
-          input.ownerId,
-          input.runtimeSessionId,
-        );
-        const run = store.findRun(
-          input.ownerId,
-          input.runtimeSessionId,
-          input.goalId,
-          input.runEpoch,
-        );
-        if (
-          session?.runEpoch !== input.runEpoch ||
-          active?.persistedGoal.goal.id !== input.goalId ||
-          active.persistedGoal.goal.revision !== input.goalRevision ||
-          !run ||
-          run.goalRevision !== input.goalRevision ||
-          run.status === "evaluating" ||
-          run.status === "paused" ||
-          run.status === "blocked" ||
-          isTerminalRun(run.status)
-        )
-          return null;
-        assertGoalRunStatusTransition(run.status, "evaluating");
-        const next = {
-          ...run,
-          status: "evaluating" as const,
-          lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
-        };
-        if (!store.updateRun(run, next, input.recordedAt)) return null;
-        return {
-          run: next,
-          evidence: store
-            .listEvidenceByRun(input.ownerId, input.runtimeSessionId, run.id)
-            .filter((item) => item.goalRevision === input.goalRevision),
-        };
-      });
+      const snapshot = this.withRuntimeLease(
+        input.ownerId,
+        input.runtimeSessionId,
+        (store) => {
+          const session = store.getSession(
+            input.ownerId,
+            input.runtimeSessionId,
+          );
+          const active = store.getAssignedPrimaryGoal(
+            input.ownerId,
+            input.runtimeSessionId,
+          );
+          const run = store.findRun(
+            input.ownerId,
+            input.runtimeSessionId,
+            input.goalId,
+            input.runEpoch,
+          );
+          if (
+            session?.runEpoch !== input.runEpoch ||
+            active?.persistedGoal.goal.id !== input.goalId ||
+            active.persistedGoal.goal.revision !== input.goalRevision ||
+            !run ||
+            run.goalRevision !== input.goalRevision ||
+            run.status === "evaluating" ||
+            run.status === "paused" ||
+            run.status === "blocked" ||
+            isTerminalRun(run.status)
+          )
+            return null;
+          assertGoalRunStatusTransition(run.status, "evaluating");
+          const next = {
+            ...run,
+            status: "evaluating" as const,
+            lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
+          };
+          if (!store.updateRun(run, next, input.recordedAt)) return null;
+          return {
+            run: next,
+            evidence: store
+              .listEvidenceByRun(input.ownerId, input.runtimeSessionId, run.id)
+              .filter((item) => item.goalRevision === input.goalRevision),
+          };
+        },
+      );
       if (snapshot) {
         this.evaluations.set(key, {
           goalId: input.goalId,
@@ -629,38 +767,42 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
       const lease = this.evaluations.get(key);
       if (!matchesEvaluation(lease, input) || lease.phase !== "evaluating")
         return false;
-      const finished = this.database.immediate((store) => {
-        const run = store.getRun(
-          input.ownerId,
-          input.runtimeSessionId,
-          lease.runId,
-        );
-        if (!run || run.runEpoch !== input.runEpoch) return false;
-        let status: GoalRunStatus = run.status;
-        if (input.outcome === "continuing") {
-          if (run.status !== "evaluating") return false;
-          assertGoalRunStatusTransition(run.status, "continuing");
-          status = "continuing";
-        } else if (run.status !== input.outcome) {
-          // AgentGoalState commits the terminal state before evaluation details.
-          return false;
-        }
-        const next = {
-          ...run,
-          status,
-          lastEvaluation: evaluation,
-          lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
-          ...(isTerminalRun(status)
-            ? {
-                completedAt: latest(
-                  run.completedAt ?? run.lastActivityAt,
-                  input.recordedAt,
-                ),
-              }
-            : {}),
-        };
-        return store.updateRun(run, next, input.recordedAt);
-      });
+      const finished = this.withRuntimeLease(
+        input.ownerId,
+        input.runtimeSessionId,
+        (store) => {
+          const run = store.getRun(
+            input.ownerId,
+            input.runtimeSessionId,
+            lease.runId,
+          );
+          if (!run || run.runEpoch !== input.runEpoch) return false;
+          let status: GoalRunStatus = run.status;
+          if (input.outcome === "continuing") {
+            if (run.status !== "evaluating") return false;
+            assertGoalRunStatusTransition(run.status, "continuing");
+            status = "continuing";
+          } else if (run.status !== input.outcome) {
+            // AgentGoalState commits the terminal state before evaluation details.
+            return false;
+          }
+          const next = {
+            ...run,
+            status,
+            lastEvaluation: evaluation,
+            lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
+            ...(isTerminalRun(status)
+              ? {
+                  completedAt: latest(
+                    run.completedAt ?? run.lastActivityAt,
+                    input.recordedAt,
+                  ),
+                }
+              : {}),
+          };
+          return store.updateRun(run, next, input.recordedAt);
+        },
+      );
       if (finished) lease.phase = "finished";
       return finished;
     });
@@ -684,24 +826,28 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
       const lease = this.evaluations.get(key);
       if (!matchesEvaluation(lease, input) || lease.phase !== "evaluating")
         return false;
-      const abandoned = this.database.immediate((store) => {
-        const run = store.getRun(
-          input.ownerId,
-          input.runtimeSessionId,
-          lease.runId,
-        );
-        if (!run || run.status !== "evaluating") return false;
-        assertGoalRunStatusTransition(run.status, "running");
-        return store.updateRun(
-          run,
-          {
-            ...run,
-            status: "running",
-            lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
-          },
-          input.recordedAt,
-        );
-      });
+      const abandoned = this.withRuntimeLease(
+        input.ownerId,
+        input.runtimeSessionId,
+        (store) => {
+          const run = store.getRun(
+            input.ownerId,
+            input.runtimeSessionId,
+            lease.runId,
+          );
+          if (!run || run.status !== "evaluating") return false;
+          assertGoalRunStatusTransition(run.status, "running");
+          return store.updateRun(
+            run,
+            {
+              ...run,
+              status: "running",
+              lastActivityAt: latest(run.lastActivityAt, input.recordedAt),
+            },
+            input.recordedAt,
+          );
+        },
+      );
       if (abandoned) lease.phase = "abandoned";
       return abandoned;
     });
@@ -716,7 +862,7 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     recordedAt?: string;
   }): Promise<void> {
     await this.serial.run(scope(input.ownerId, input.runtimeSessionId), () => {
-      this.database.immediate((store) => {
+      this.withRuntimeLease(input.ownerId, input.runtimeSessionId, (store) => {
         const instruction = store.getInstruction(
           input.ownerId,
           input.runtimeSessionId,
@@ -760,7 +906,7 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
     reason: string;
   }): Promise<void> {
     await this.serial.run(scope(input.ownerId, input.runtimeSessionId), () => {
-      this.database.immediate((store) => {
+      this.withRuntimeLease(input.ownerId, input.runtimeSessionId, (store) => {
         const deliveries = [...new Set(input.instructionIds)].flatMap(
           (instructionId) => {
             const delivery = store.getActiveDeliveryForInstruction(
@@ -794,6 +940,45 @@ export class SqliteRuntimeObservationJournal implements RuntimeObservationJourna
         }
       });
     });
+  }
+
+  private withRuntimeLease<T>(
+    ownerId: string,
+    runtimeSessionId: string,
+    operation: (store: SqliteGoalRuntimeStore) => T,
+  ): T {
+    const lease = this.runtimeLeases.get(scope(ownerId, runtimeSessionId));
+    return this.database.immediate((store) => {
+      if (lease) {
+        const session = store.getSession(ownerId, runtimeSessionId);
+        if (
+          !session ||
+          session.recoveryLeaseToken !== lease.leaseToken ||
+          session.recoveryLeaseExpiresAtSeconds === undefined ||
+          session.recoveryLeaseExpiresAtSeconds <=
+            Math.floor(this.clock.now().getTime() / 1_000)
+        ) {
+          throw persistenceConflict(
+            `Runtime Session ${runtimeSessionId} no longer owns its durable execution lease`,
+          );
+        }
+      }
+      return operation(store);
+    });
+  }
+
+  private runtimeLeaseFence(
+    ownerId: string,
+    runtimeSessionId: string,
+    expectedRunEpoch?: number,
+  ): { runtimeLeaseToken?: string; expectedRunEpoch?: number } {
+    const leaseToken = this.runtimeLeases.get(
+      scope(ownerId, runtimeSessionId),
+    )?.leaseToken;
+    return {
+      ...(leaseToken === undefined ? {} : { runtimeLeaseToken: leaseToken }),
+      ...(expectedRunEpoch === undefined ? {} : { expectedRunEpoch }),
+    };
   }
 
   private now(): string {
@@ -1058,6 +1243,50 @@ function parseObservation(
     }
   }
   return structuredClone(input);
+}
+
+function assertSameProviderEvent(
+  existing: {
+    providerEventId: string;
+    providerSessionId?: string;
+    eventFingerprint: string;
+  },
+  observed: RuntimeProviderEventObservation,
+  eventFingerprint: string,
+): void {
+  if (
+    existing.providerEventId !== observed.providerEventId ||
+    existing.providerSessionId !== observed.providerSessionId ||
+    existing.eventFingerprint !== eventFingerprint
+  ) {
+    throw persistenceConflict(
+      `Provider event key ${observed.eventKey} was reused with different event data`,
+    );
+  }
+}
+
+function providerEventFingerprint(
+  observed: RuntimeProviderEventObservation,
+): string {
+  // `observedAt` is assigned by the local observer. A provider can replay the
+  // same durable event after restart with a new observation timestamp, so it
+  // must not participate in identity. Evidence timestamps are observer-local
+  // for the same reason; all semantic payload fields remain fenced.
+  const { observedAt: _observedAt, evidence, ...stable } = observed;
+  return createHash("sha256")
+    .update(
+      canonicalJson({
+        ...stable,
+        ...(evidence === undefined
+          ? {}
+          : {
+              evidence: evidence.map(
+                ({ observedAt: _evidenceObservedAt, ...item }) => item,
+              ),
+            }),
+      }),
+    )
+    .digest("hex");
 }
 
 function isSettledForReceipt(

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
@@ -38,6 +38,218 @@ import {
 } from "../runtime-observation-mappers";
 import type { BetterSqlite3Client } from "./transaction";
 
+const UNFINISHED_GOAL_PREDICATE = `EXISTS (
+    SELECT 1 FROM agent_goals AS goal
+     WHERE goal.owner_id = session.owner_id
+       AND goal.runtime_session_id = session.id
+       AND goal.slot_state IN ('assigned', 'reserved')
+       AND goal.status IN ('active', 'paused', 'blocked')
+)`;
+
+const UNFINISHED_RUN_PREDICATE = `EXISTS (
+    SELECT 1 FROM agent_goal_runs AS run
+     WHERE run.owner_id = session.owner_id
+       AND run.runtime_session_id = session.id
+       AND run.status IN (
+         'queued', 'running', 'evaluating', 'continuing', 'paused', 'blocked'
+       )
+)`;
+
+const UNFINISHED_DELIVERY_PREDICATE = `EXISTS (
+    SELECT 1 FROM agent_runtime_deliveries AS delivery
+     WHERE delivery.owner_id = session.owner_id
+       AND delivery.runtime_session_id = session.id
+       AND delivery.state IN (
+         'pending', 'leased', 'queued', 'written_to_sdk', 'observed'
+       )
+)`;
+
+const UNFINISHED_RUNTIME_PREDICATE = `(
+  session.pending_operation IS NOT NULL
+  OR ${UNFINISHED_GOAL_PREDICATE}
+  OR ${UNFINISHED_RUN_PREDICATE}
+  OR ${UNFINISHED_DELIVERY_PREDICATE}
+)`;
+
+/**
+ * A provider host can disappear after Goal/Run finalization but before its
+ * last Delivery reaches a terminal state. Nothing remains to resume in that
+ * case, but the Delivery still fences an ordinary live claim. Recovery must
+ * therefore reconcile this terminal execution boundary instead of leaving
+ * the Session permanently interrupted.
+ */
+const DELIVERY_ONLY_RECOVERY_PREDICATE = `(
+  session.pending_operation IS NULL
+  AND NOT ${UNFINISHED_GOAL_PREDICATE}
+  AND NOT ${UNFINISHED_RUN_PREDICATE}
+  AND ${UNFINISHED_DELIVERY_PREDICATE}
+)`;
+
+/**
+ * A Goal created while no Claude transport is attached has not crashed: it is
+ * waiting for the next ordinary Runtime to claim the Session and replay its
+ * pristine outbox. Keep this stricter than "no provider session" so an
+ * abandoned lease, provider-visible delivery, or any execution evidence still
+ * goes through durable recovery and fails closed when its resume handle is
+ * unavailable.
+ */
+const WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE = `(
+  session.run_epoch = 0
+  AND session.state = 'idle'
+  AND session.provider_session_id IS NULL
+  AND session.pending_operation IS NULL
+  AND session.recovery_failed_at IS NULL
+  AND session.recovery_lease_owner IS NULL
+  AND session.recovery_lease_token IS NULL
+  AND session.recovery_lease_expires_at IS NULL
+  AND EXISTS (
+    SELECT 1
+      FROM agent_goals AS waiting_goal
+      JOIN agent_goal_runs AS waiting_run
+        ON waiting_run.owner_id = waiting_goal.owner_id
+       AND waiting_run.runtime_session_id = waiting_goal.runtime_session_id
+       AND waiting_run.goal_id = waiting_goal.id
+       AND waiting_run.goal_revision = waiting_goal.revision
+       AND waiting_run.run_epoch = session.run_epoch
+     WHERE waiting_goal.owner_id = session.owner_id
+       AND waiting_goal.runtime_session_id = session.id
+       AND waiting_goal.slot = 'primary'
+       AND waiting_goal.slot_state = 'assigned'
+       AND waiting_goal.status = 'active'
+       AND waiting_run.status = 'queued'
+       AND waiting_run.provider_session_id IS NULL
+       AND waiting_run.turns_used = 0
+       AND waiting_run.tokens_used = 0
+       AND waiting_run.completed_at IS NULL
+       AND waiting_run.last_evaluation IS NULL
+       AND EXISTS (
+         SELECT 1
+           FROM agent_runtime_instructions AS activation
+           JOIN agent_runtime_deliveries AS activation_delivery
+             ON activation_delivery.owner_id = activation.owner_id
+            AND activation_delivery.runtime_session_id = activation.runtime_session_id
+            AND activation_delivery.instruction_id = activation.id
+            AND activation_delivery.run_epoch = activation.run_epoch
+          WHERE activation.owner_id = waiting_goal.owner_id
+            AND activation.runtime_session_id = waiting_goal.runtime_session_id
+            AND activation.goal_id = waiting_goal.id
+            AND activation.run_epoch = waiting_run.run_epoch
+            AND activation.kind = 'goal.activate'
+            AND activation.command_order = 0
+            AND activation.command_type = 'goal_instruction'
+            AND activation.command_phase = 'committed'
+            AND activation_delivery.goal_run_id = waiting_run.id
+            AND activation_delivery.state = 'pending'
+            AND activation_delivery.attempt = 1
+            AND activation_delivery.lease_token IS NULL
+            AND activation_delivery.lease_owner IS NULL
+            AND activation_delivery.lease_expires_at IS NULL
+            AND activation_delivery.provider_event_id IS NULL
+            AND activation_delivery.error_code IS NULL
+            AND activation_delivery.error_message IS NULL
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_runtime_deliveries AS attempted_delivery
+          WHERE attempted_delivery.owner_id = waiting_run.owner_id
+            AND attempted_delivery.runtime_session_id = waiting_run.runtime_session_id
+            AND attempted_delivery.goal_run_id = waiting_run.id
+            AND (
+              attempted_delivery.state <> 'pending'
+              OR attempted_delivery.attempt <> 1
+              OR attempted_delivery.lease_token IS NOT NULL
+              OR attempted_delivery.lease_owner IS NOT NULL
+              OR attempted_delivery.lease_expires_at IS NOT NULL
+              OR attempted_delivery.provider_event_id IS NOT NULL
+              OR attempted_delivery.error_code IS NOT NULL
+              OR attempted_delivery.error_message IS NOT NULL
+            )
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_runtime_instructions AS undeliverable_instruction
+          WHERE undeliverable_instruction.owner_id = waiting_goal.owner_id
+            AND undeliverable_instruction.runtime_session_id = waiting_goal.runtime_session_id
+            AND undeliverable_instruction.goal_id = waiting_goal.id
+            AND undeliverable_instruction.run_epoch = waiting_run.run_epoch
+            AND NOT EXISTS (
+              SELECT 1 FROM agent_runtime_deliveries AS instruction_delivery
+               WHERE instruction_delivery.owner_id = undeliverable_instruction.owner_id
+                 AND instruction_delivery.runtime_session_id = undeliverable_instruction.runtime_session_id
+                 AND instruction_delivery.instruction_id = undeliverable_instruction.id
+                 AND instruction_delivery.goal_run_id = waiting_run.id
+                 AND instruction_delivery.run_epoch = undeliverable_instruction.run_epoch
+            )
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_goal_evidence AS waiting_evidence
+          WHERE waiting_evidence.owner_id = waiting_run.owner_id
+            AND waiting_evidence.runtime_session_id = waiting_run.runtime_session_id
+            AND waiting_evidence.goal_run_id = waiting_run.id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_goal_runs AS other_run
+          WHERE other_run.owner_id = waiting_run.owner_id
+            AND other_run.runtime_session_id = waiting_run.runtime_session_id
+            AND other_run.id <> waiting_run.id
+            AND other_run.status IN (
+              'queued', 'running', 'evaluating', 'continuing', 'paused', 'blocked'
+            )
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_runtime_deliveries AS other_delivery
+          WHERE other_delivery.owner_id = waiting_run.owner_id
+            AND other_delivery.runtime_session_id = waiting_run.runtime_session_id
+            AND (
+              other_delivery.goal_run_id IS NULL
+              OR other_delivery.goal_run_id <> waiting_run.id
+            )
+            AND other_delivery.state IN (
+              'pending', 'leased', 'queued', 'written_to_sdk', 'observed'
+            )
+       )
+  )
+)`;
+
+const RECOVERABLE_SESSION_PREDICATE = `(
+  session.state <> 'failed'
+  AND (
+    session.state <> 'closed'
+    OR session.pending_operation IS NOT NULL
+    OR EXISTS (
+      SELECT 1 FROM agent_goals AS goal
+       WHERE goal.owner_id = session.owner_id
+         AND goal.runtime_session_id = session.id
+         AND goal.slot_state IN ('assigned', 'reserved')
+         AND goal.status IN ('active', 'paused', 'blocked')
+    )
+    OR EXISTS (
+      SELECT 1 FROM agent_goal_runs AS run
+       WHERE run.owner_id = session.owner_id
+         AND run.runtime_session_id = session.id
+         AND run.status IN (
+           'queued', 'running', 'evaluating', 'continuing', 'paused', 'blocked'
+         )
+    )
+  )
+)`;
+
+const IMMEDIATE_RECOVERY_PREDICATE = `(
+  session.pending_operation IS NOT NULL
+  OR EXISTS (
+    SELECT 1 FROM agent_goals AS goal
+     WHERE goal.owner_id = session.owner_id
+       AND goal.runtime_session_id = session.id
+       AND goal.slot_state = 'assigned'
+       AND goal.status = 'active'
+  )
+  OR EXISTS (
+    SELECT 1 FROM agent_goal_runs AS run
+     WHERE run.owner_id = session.owner_id
+       AND run.runtime_session_id = session.id
+       AND run.status IN ('queued', 'running', 'evaluating', 'continuing')
+  )
+  OR ${DELIVERY_ONLY_RECOVERY_PREDICATE}
+)`;
+
 export interface SqliteGoalSessionRecord {
   readonly ownerId: string;
   readonly runtimeSessionId: string;
@@ -46,6 +258,14 @@ export interface SqliteGoalSessionRecord {
   readonly runEpoch: number;
   readonly lastInstructionSequence: number;
   readonly providerSessionId?: string;
+  readonly workingDirectory?: string;
+  readonly recoveryDescriptor?: Readonly<Record<string, unknown>>;
+  readonly recoveryLeaseOwner?: string;
+  readonly recoveryLeaseToken?: string;
+  readonly recoveryLeaseExpiresAtSeconds?: number;
+  readonly recoveryErrorCode?: string;
+  readonly recoveryErrorMessage?: string;
+  readonly recoveryFailedAtSeconds?: number;
   readonly pendingOperation?: AgentRuntimePendingOperation;
   readonly createdAtSeconds: number;
   readonly updatedAtSeconds: number;
@@ -93,6 +313,20 @@ export interface UpdateSqliteDeliveryInput {
   readonly next: PersistedRuntimeInstructionDelivery;
 }
 
+export interface SqliteProviderEventReceiptInput {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly runEpoch: number;
+  readonly eventKey: string;
+  readonly providerEventId: string;
+  readonly providerSessionId?: string;
+  readonly eventFingerprint: string;
+  readonly observedAtSeconds: number;
+  readonly createdAtSeconds: number;
+}
+
+export interface SqliteProviderEventReceiptRecord extends SqliteProviderEventReceiptInput {}
+
 /**
  * Synchronous SQLite row store shared by the Goal state unit of work and the
  * standalone repositories. Callers that perform writes must hold the native
@@ -108,7 +342,11 @@ export class SqliteGoalRuntimeStore {
     const row = this.client
       .prepare(
         `SELECT owner_id, id, provider, state, run_epoch, last_instruction_sequence,
-                provider_session_id, pending_operation, created_at, updated_at
+                provider_session_id, working_directory, recovery_descriptor,
+                recovery_lease_owner, recovery_lease_token,
+                recovery_lease_expires_at, recovery_error_code,
+                recovery_error_message, recovery_failed_at, pending_operation,
+                created_at, updated_at
            FROM agent_runtime_sessions
           WHERE owner_id = ? AND id = ?`,
       )
@@ -117,7 +355,11 @@ export class SqliteGoalRuntimeStore {
     return {
       ownerId: requiredString(row.owner_id, "runtime session owner_id"),
       runtimeSessionId: requiredString(row.id, "runtime session id"),
-      provider: requiredLiteral(row.provider, "claude", "runtime session provider"),
+      provider: requiredLiteral(
+        row.provider,
+        "claude",
+        "runtime session provider",
+      ),
       state: requiredSessionState(row.state),
       runEpoch: requiredInteger(row.run_epoch, "runtime session run_epoch", 0),
       lastInstructionSequence: requiredInteger(
@@ -128,6 +370,43 @@ export class SqliteGoalRuntimeStore {
       ...(optionalString(row.provider_session_id) === undefined
         ? {}
         : { providerSessionId: optionalString(row.provider_session_id) }),
+      ...(optionalString(row.working_directory) === undefined
+        ? {}
+        : { workingDirectory: optionalString(row.working_directory) }),
+      ...(row.recovery_descriptor === null ||
+      row.recovery_descriptor === undefined
+        ? {}
+        : {
+            recoveryDescriptor: parseJsonObject(
+              row.recovery_descriptor,
+              "runtime session recovery_descriptor",
+            ),
+          }),
+      ...(optionalString(row.recovery_lease_owner) === undefined
+        ? {}
+        : { recoveryLeaseOwner: optionalString(row.recovery_lease_owner) }),
+      ...(optionalString(row.recovery_lease_token) === undefined
+        ? {}
+        : { recoveryLeaseToken: optionalString(row.recovery_lease_token) }),
+      ...(optionalInteger(row.recovery_lease_expires_at, 0) === undefined
+        ? {}
+        : {
+            recoveryLeaseExpiresAtSeconds: optionalInteger(
+              row.recovery_lease_expires_at,
+              0,
+            ),
+          }),
+      ...(optionalString(row.recovery_error_code) === undefined
+        ? {}
+        : { recoveryErrorCode: optionalString(row.recovery_error_code) }),
+      ...(optionalString(row.recovery_error_message) === undefined
+        ? {}
+        : { recoveryErrorMessage: optionalString(row.recovery_error_message) }),
+      ...(optionalInteger(row.recovery_failed_at, 0) === undefined
+        ? {}
+        : {
+            recoveryFailedAtSeconds: optionalInteger(row.recovery_failed_at, 0),
+          }),
       ...(row.pending_operation === null || row.pending_operation === undefined
         ? {}
         : {
@@ -185,17 +464,22 @@ export class SqliteGoalRuntimeStore {
   insertSession(input: {
     ownerId: string;
     runtimeSessionId: string;
+    workingDirectory?: string;
+    recoveryDescriptor?: object;
     recordedAtSeconds: number;
   }): void {
     this.client
       .prepare(
         `INSERT INTO agent_runtime_sessions
-           (id, owner_id, provider, state, created_at, updated_at)
-         VALUES (?, ?, 'claude', 'starting', ?, ?)`,
+           (id, owner_id, provider, state, working_directory,
+            recovery_descriptor, created_at, updated_at)
+         VALUES (?, ?, 'claude', 'starting', ?, ?, ?, ?)`,
       )
       .run(
         input.runtimeSessionId,
         input.ownerId,
+        input.workingDirectory ?? null,
+        serializeJson(input.recoveryDescriptor),
         input.recordedAtSeconds,
         input.recordedAtSeconds,
       );
@@ -206,6 +490,9 @@ export class SqliteGoalRuntimeStore {
     runtimeSessionId: string;
     expectedProviderSessionId?: string;
     providerSessionId: string;
+    runtimeLeaseToken: string;
+    expectedRunEpoch: number;
+    availableAtSeconds: number;
     updatedAtSeconds: number;
   }): boolean {
     const predicate =
@@ -226,9 +513,17 @@ export class SqliteGoalRuntimeStore {
         .prepare(
           `UPDATE agent_runtime_sessions
               SET provider_session_id = ?, updated_at = MAX(updated_at, ?)
-            WHERE owner_id = ? AND id = ? AND ${predicate}`,
+            WHERE owner_id = ? AND id = ? AND ${predicate}
+              AND recovery_lease_token = ?
+              AND recovery_lease_expires_at > ?
+              AND run_epoch = ?`,
         )
-        .run(...parameters).changes === 1
+        .run(
+          ...parameters,
+          input.runtimeLeaseToken,
+          input.availableAtSeconds,
+          input.expectedRunEpoch,
+        ).changes === 1
     );
   }
 
@@ -250,6 +545,379 @@ export class SqliteGoalRuntimeStore {
           input.ownerId,
           input.runtimeSessionId,
           input.expectedProviderSessionId,
+        ).changes === 1
+    );
+  }
+
+  updateSessionRecoveryMetadata(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    workingDirectory?: string;
+    recoveryDescriptor?: object;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET working_directory = ?, recovery_descriptor = ?,
+                  updated_at = MAX(updated_at, ?)
+            WHERE owner_id = ? AND id = ?`,
+        )
+        .run(
+          input.workingDirectory ?? null,
+          serializeJson(input.recoveryDescriptor),
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+        ).changes === 1
+    );
+  }
+
+  listRecoverableSessionIds(
+    availableAtSeconds: number,
+    limit: number,
+  ): Array<{ ownerId: string; runtimeSessionId: string }> {
+    return this.client
+      .prepare(
+        `SELECT session.owner_id, session.id
+           FROM agent_runtime_sessions AS session
+          WHERE session.recovery_failed_at IS NULL
+            AND (
+              session.recovery_lease_token IS NULL
+              OR session.recovery_lease_expires_at <= ?
+            )
+            AND ${RECOVERABLE_SESSION_PREDICATE}
+            AND ${IMMEDIATE_RECOVERY_PREDICATE}
+            AND NOT ${WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE}
+          ORDER BY session.updated_at ASC, session.id ASC
+          LIMIT ?`,
+      )
+      .all(availableAtSeconds, limit)
+      .map((row) => {
+        const candidate = row as RawRow;
+        return {
+          ownerId: requiredString(candidate.owner_id, "recovery owner_id"),
+          runtimeSessionId: requiredString(candidate.id, "recovery session id"),
+        };
+      });
+  }
+
+  /**
+   * Owner-scoped read model for the desktop recovery UI. Unlike
+   * `listRecoverableSessionIds`, this intentionally includes a session whose
+   * recovery lease is currently held: that is the session the restarted UI
+   * must keep displaying while the coordinator is consuming Claude output.
+   */
+  listRecoveryPresentationSessionIds(ownerId: string, limit: number): string[] {
+    return this.client
+      .prepare(
+        `SELECT session.id
+           FROM agent_runtime_sessions AS session
+          WHERE session.owner_id = ?
+            AND session.recovery_failed_at IS NULL
+            AND ${RECOVERABLE_SESSION_PREDICATE}
+            AND ${IMMEDIATE_RECOVERY_PREDICATE}
+            AND NOT ${WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE}
+          ORDER BY session.updated_at DESC, session.id ASC
+          LIMIT ?`,
+      )
+      .all(ownerId, limit)
+      .map((row) => requiredString((row as RawRow).id, "recovery session id"));
+  }
+
+  hasUnfinishedRuntimeState(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): boolean {
+    const row = this.client
+      .prepare(
+        `SELECT ${UNFINISHED_RUNTIME_PREDICATE} AS unfinished
+           FROM agent_runtime_sessions AS session
+          WHERE session.owner_id = ? AND session.id = ?`,
+      )
+      .get(ownerId, runtimeSessionId) as RawRow | undefined;
+    return row?.unfinished === 1;
+  }
+
+  hasDeliveryOnlyRecoveryState(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): boolean {
+    const row = this.client
+      .prepare(
+        `SELECT ${DELIVERY_ONLY_RECOVERY_PREDICATE} AS delivery_only
+           FROM agent_runtime_sessions AS session
+          WHERE session.owner_id = ? AND session.id = ?`,
+      )
+      .get(ownerId, runtimeSessionId) as RawRow | undefined;
+    return row?.delivery_only === 1;
+  }
+
+  isWaitingForFirstProviderRuntime(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): boolean {
+    const row = this.client
+      .prepare(
+        `SELECT ${WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE} AS waiting
+           FROM agent_runtime_sessions AS session
+          WHERE session.owner_id = ? AND session.id = ?`,
+      )
+      .get(ownerId, runtimeSessionId) as RawRow | undefined;
+    return row?.waiting === 1;
+  }
+
+  claimLiveRuntimeLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    availableAtSeconds: number;
+    leaseExpiresAtSeconds: number;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions AS session
+              SET recovery_lease_owner = ?, recovery_lease_token = ?,
+                  recovery_lease_expires_at = ?, updated_at = MAX(updated_at, ?)
+            WHERE session.owner_id = ? AND session.id = ?
+              AND session.state NOT IN ('closed', 'failed')
+              AND session.recovery_failed_at IS NULL
+              AND (
+                session.recovery_lease_token IS NULL
+                OR session.recovery_lease_expires_at <= ?
+              )
+              AND (
+                NOT ${UNFINISHED_RUNTIME_PREDICATE}
+                OR ${WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE}
+              )`,
+        )
+        .run(
+          input.leaseOwner,
+          input.leaseToken,
+          input.leaseExpiresAtSeconds,
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.availableAtSeconds,
+        ).changes === 1
+    );
+  }
+
+  claimRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    availableAtSeconds: number;
+    leaseExpiresAtSeconds: number;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions AS session
+              SET recovery_lease_owner = ?, recovery_lease_token = ?,
+                  recovery_lease_expires_at = ?, updated_at = MAX(updated_at, ?)
+            WHERE session.owner_id = ? AND session.id = ?
+              AND session.recovery_failed_at IS NULL
+              AND (
+                session.recovery_lease_token IS NULL
+                OR session.recovery_lease_expires_at <= ?
+              )
+              AND ${RECOVERABLE_SESSION_PREDICATE}
+              AND ${UNFINISHED_RUNTIME_PREDICATE}
+              AND NOT ${WAITING_FOR_FIRST_PROVIDER_RUNTIME_PREDICATE}`,
+        )
+        .run(
+          input.leaseOwner,
+          input.leaseToken,
+          input.leaseExpiresAtSeconds,
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.availableAtSeconds,
+        ).changes === 1
+    );
+  }
+
+  renewRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    availableAtSeconds: number;
+    leaseExpiresAtSeconds: number;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET recovery_lease_expires_at = ?, updated_at = MAX(updated_at, ?)
+            WHERE owner_id = ? AND id = ?
+              AND recovery_lease_owner = ? AND recovery_lease_token = ?
+              AND recovery_lease_expires_at > ?`,
+        )
+        .run(
+          input.leaseExpiresAtSeconds,
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.leaseOwner,
+          input.leaseToken,
+          input.availableAtSeconds,
+        ).changes === 1
+    );
+  }
+
+  releaseRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    availableAtSeconds: number;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET recovery_lease_owner = NULL, recovery_lease_token = NULL,
+                  recovery_lease_expires_at = NULL,
+                  updated_at = MAX(updated_at, ?)
+            WHERE owner_id = ? AND id = ?
+              AND recovery_lease_owner = ? AND recovery_lease_token = ?
+              AND recovery_lease_expires_at > ?`,
+        )
+        .run(
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.leaseOwner,
+          input.leaseToken,
+          input.availableAtSeconds,
+        ).changes === 1
+    );
+  }
+
+  releaseLiveRuntimeLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+    availableAtSeconds: number;
+    updatedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions AS session
+              SET state = CASE
+                    WHEN ${UNFINISHED_RUNTIME_PREDICATE} THEN 'interrupted'
+                    ELSE 'idle'
+                  END,
+                  provider_session_id = CASE
+                    WHEN ${UNFINISHED_RUNTIME_PREDICATE}
+                      THEN provider_session_id
+                    ELSE NULL
+                  END,
+                  recovery_lease_owner = NULL,
+                  recovery_lease_token = NULL,
+                  recovery_lease_expires_at = NULL,
+                  updated_at = MAX(updated_at, ?)
+            WHERE session.owner_id = ? AND session.id = ?
+              AND session.state NOT IN ('closed', 'failed')
+              AND session.recovery_lease_owner = ?
+              AND session.recovery_lease_token = ?
+              AND session.run_epoch = ?
+              AND session.recovery_lease_expires_at > ?`,
+        )
+        .run(
+          input.updatedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.leaseOwner,
+          input.leaseToken,
+          input.expectedRunEpoch,
+          input.availableAtSeconds,
+        ).changes === 1
+    );
+  }
+
+  updateSessionState(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedState: RuntimeSessionState;
+    expectedRunEpoch: number;
+    state: RuntimeSessionState;
+    recoveryLeaseToken?: string;
+    updatedAtSeconds: number;
+  }): boolean {
+    const leasePredicate = input.recoveryLeaseToken
+      ? "recovery_lease_token = ? AND recovery_lease_expires_at > ?"
+      : "recovery_lease_token IS NULL";
+    const parameters: unknown[] = [
+      input.state,
+      input.updatedAtSeconds,
+      input.ownerId,
+      input.runtimeSessionId,
+      input.expectedState,
+      input.expectedRunEpoch,
+    ];
+    if (input.recoveryLeaseToken) {
+      parameters.push(input.recoveryLeaseToken, input.updatedAtSeconds);
+    }
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET state = ?, updated_at = MAX(updated_at, ?)
+            WHERE owner_id = ? AND id = ? AND state = ? AND run_epoch = ?
+              AND ${leasePredicate}`,
+        )
+        .run(...parameters).changes === 1
+    );
+  }
+
+  markRecoveryFailed(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+    errorCode: string;
+    errorMessage: string;
+    failedAtSeconds: number;
+  }): boolean {
+    return (
+      this.client
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET state = 'failed', recovery_error_code = ?,
+                  recovery_error_message = ?, recovery_failed_at = ?,
+                  recovery_lease_owner = NULL, recovery_lease_token = NULL,
+                  recovery_lease_expires_at = NULL,
+                  updated_at = MAX(updated_at, ?)
+            WHERE owner_id = ? AND id = ?
+              AND recovery_lease_owner = ? AND recovery_lease_token = ?
+              AND run_epoch = ? AND recovery_lease_expires_at > ?`,
+        )
+        .run(
+          input.errorCode,
+          input.errorMessage,
+          input.failedAtSeconds,
+          input.failedAtSeconds,
+          input.ownerId,
+          input.runtimeSessionId,
+          input.leaseOwner,
+          input.leaseToken,
+          input.expectedRunEpoch,
+          input.failedAtSeconds,
         ).changes === 1
     );
   }
@@ -490,6 +1158,20 @@ export class SqliteGoalRuntimeStore {
       )
       .all(ownerId, runtimeSessionId, afterSequence)
       .map((row) => mapInstructionRow(row as RawRow).instruction);
+  }
+
+  listStoredInstructions(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): StoredRuntimeInstruction[] {
+    return this.client
+      .prepare(
+        `SELECT * FROM agent_runtime_instructions
+          WHERE owner_id = ? AND runtime_session_id = ?
+          ORDER BY sequence ASC`,
+      )
+      .all(ownerId, runtimeSessionId)
+      .map((row) => mapInstructionRow(row as RawRow));
   }
 
   insertInstruction(input: InsertSqliteInstructionInput): void {
@@ -879,6 +1561,79 @@ export class SqliteGoalRuntimeStore {
     );
   }
 
+  getProviderEventReceipt(
+    ownerId: string,
+    runtimeSessionId: string,
+    runEpoch: number,
+    eventKey: string,
+  ): SqliteProviderEventReceiptRecord | null {
+    const row = this.client
+      .prepare(
+        `SELECT owner_id, runtime_session_id, run_epoch, event_key,
+                provider_event_id, provider_session_id, event_fingerprint,
+                observed_at, created_at
+           FROM agent_runtime_provider_events
+          WHERE owner_id = ? AND runtime_session_id = ?
+            AND run_epoch = ? AND event_key = ?`,
+      )
+      .get(ownerId, runtimeSessionId, runEpoch, eventKey) as RawRow | undefined;
+    if (!row) return null;
+    return {
+      ownerId: requiredString(row.owner_id, "provider event owner_id"),
+      runtimeSessionId: requiredString(
+        row.runtime_session_id,
+        "provider event runtime_session_id",
+      ),
+      runEpoch: requiredInteger(row.run_epoch, "provider event run_epoch", 0),
+      eventKey: requiredString(row.event_key, "provider event event_key"),
+      providerEventId: requiredString(
+        row.provider_event_id,
+        "provider event provider_event_id",
+      ),
+      ...(optionalString(row.provider_session_id) === undefined
+        ? {}
+        : { providerSessionId: optionalString(row.provider_session_id) }),
+      eventFingerprint: requiredString(
+        row.event_fingerprint,
+        "provider event event_fingerprint",
+      ),
+      observedAtSeconds: requiredInteger(
+        row.observed_at,
+        "provider event observed_at",
+        0,
+      ),
+      createdAtSeconds: requiredInteger(
+        row.created_at,
+        "provider event created_at",
+        0,
+      ),
+    };
+  }
+
+  insertProviderEventReceipt(input: SqliteProviderEventReceiptInput): boolean {
+    return (
+      this.client
+        .prepare(
+          `INSERT OR IGNORE INTO agent_runtime_provider_events (
+             owner_id, runtime_session_id, run_epoch, event_key,
+             provider_event_id, provider_session_id, event_fingerprint,
+             observed_at, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          input.ownerId,
+          input.runtimeSessionId,
+          input.runEpoch,
+          input.eventKey,
+          input.providerEventId,
+          input.providerSessionId ?? null,
+          input.eventFingerprint,
+          input.observedAtSeconds,
+          input.createdAtSeconds,
+        ).changes === 1
+    );
+  }
+
   getEvidence(
     ownerId: string,
     runtimeSessionId: string,
@@ -1154,6 +1909,12 @@ function requiredInteger(
     throw new Error(`Invalid persisted ${field}`);
   }
   return value as number;
+}
+
+function optionalInteger(value: unknown, minimum: number): number | undefined {
+  return value === null || value === undefined
+    ? undefined
+    : requiredInteger(value, "optional integer", minimum);
 }
 
 function parseJsonObject(

--- a/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
+++ b/apps/web/lib/ai/runtime-instructions/persistence/sqlite/store.ts
@@ -884,22 +884,20 @@ export class SqliteGoalRuntimeStore {
     );
   }
 
-  markRecoveryFailed(input: {
+  pauseAfterRecoveryFailure(input: {
     ownerId: string;
     runtimeSessionId: string;
     leaseOwner: string;
     leaseToken: string;
     expectedRunEpoch: number;
-    errorCode: string;
-    errorMessage: string;
-    failedAtSeconds: number;
+    updatedAtSeconds: number;
   }): boolean {
     return (
       this.client
         .prepare(
           `UPDATE agent_runtime_sessions
-              SET state = 'failed', recovery_error_code = ?,
-                  recovery_error_message = ?, recovery_failed_at = ?,
+              SET state = 'idle', recovery_error_code = NULL,
+                  recovery_error_message = NULL, recovery_failed_at = NULL,
                   recovery_lease_owner = NULL, recovery_lease_token = NULL,
                   recovery_lease_expires_at = NULL,
                   updated_at = MAX(updated_at, ?)
@@ -908,16 +906,13 @@ export class SqliteGoalRuntimeStore {
               AND run_epoch = ? AND recovery_lease_expires_at > ?`,
         )
         .run(
-          input.errorCode,
-          input.errorMessage,
-          input.failedAtSeconds,
-          input.failedAtSeconds,
+          input.updatedAtSeconds,
           input.ownerId,
           input.runtimeSessionId,
           input.leaseOwner,
           input.leaseToken,
           input.expectedRunEpoch,
-          input.failedAtSeconds,
+          input.updatedAtSeconds,
         ).changes === 1
     );
   }

--- a/apps/web/lib/ai/runtime-instructions/recovery/chat-message-recorder.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/chat-message-recorder.ts
@@ -1,0 +1,448 @@
+import { createHash } from "node:crypto";
+
+import type { AgentMessage } from "@openloomi/ai/agent/types";
+
+import {
+  MESSAGE_ID_SCOPE_CONFLICT,
+  getChatById,
+  getMessageById,
+  saveMessages,
+} from "@/lib/db/queries";
+
+const DEFAULT_FLUSH_DELAY_MS = 250;
+const MAX_CAS_REBASE_ATTEMPTS = 3;
+
+type RecoveryMessagePart = Record<string, unknown> & { type: string };
+
+type RecoveryMessageMutation =
+  | {
+      kind: "append-text";
+      partType: "text" | "reasoning";
+      text: string;
+    }
+  | {
+      kind: "tool-use";
+      toolUseId: string;
+      toolName: string;
+      toolInput: unknown;
+    }
+  | {
+      kind: "tool-result";
+      toolUseId: string;
+      toolOutput: unknown;
+      isError: boolean;
+    }
+  | { kind: "provider-error" }
+  | { kind: "fail-executing-tools" };
+
+interface StoredMessageLike {
+  id: string;
+  chatId: string;
+  role: string;
+  parts: unknown;
+  attachments?: unknown;
+  createdAt: Date | string | number;
+  metadata?: unknown;
+}
+
+export interface RuntimeRecoveryChatRecorder {
+  record(message: AgentMessage): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface RuntimeRecoveryChatRecorderInput {
+  ownerId: string;
+  runtimeSessionId: string;
+  providerSessionId: string;
+  runEpoch: number;
+}
+
+interface RuntimeRecoveryChatRecorderDependencies {
+  getChatById: typeof getChatById;
+  getMessageById: typeof getMessageById;
+  saveMessages: typeof saveMessages;
+  now(): Date;
+  flushDelayMs: number;
+  logger: Pick<Console, "warn">;
+}
+
+export function recoveryAssistantMessageId(
+  input: RuntimeRecoveryChatRecorderInput,
+): string {
+  const hex = createHash("sha256")
+    .update("openloomi:goal-recovery-message:v1\0")
+    .update(input.ownerId)
+    .update("\0")
+    .update(input.runtimeSessionId)
+    .update("\0")
+    .update(input.providerSessionId)
+    .update("\0")
+    .update(String(input.runEpoch))
+    .digest("hex")
+    .slice(0, 32);
+  // UUID-shaped deterministic ID keeps the existing Message_v2 conventions.
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20)}`;
+}
+
+export async function createRuntimeRecoveryChatRecorder(
+  input: RuntimeRecoveryChatRecorderInput,
+  overrides: Partial<RuntimeRecoveryChatRecorderDependencies> = {},
+): Promise<RuntimeRecoveryChatRecorder> {
+  const deps: RuntimeRecoveryChatRecorderDependencies = {
+    getChatById,
+    getMessageById,
+    saveMessages,
+    now: () => new Date(),
+    flushDelayMs: DEFAULT_FLUSH_DELAY_MS,
+    logger: console,
+    ...overrides,
+  };
+  const chat = await deps.getChatById({ id: input.runtimeSessionId });
+  if (!chat || chat.userId !== input.ownerId) {
+    throw new Error(
+      `Recovery chat ${input.runtimeSessionId} is not owned by ${input.ownerId}`,
+    );
+  }
+
+  const messageId = recoveryAssistantMessageId(input);
+  const existing = (await deps.getMessageById({ id: messageId }))[0] as
+    | StoredMessageLike
+    | undefined;
+  if (
+    existing &&
+    (existing.chatId !== input.runtimeSessionId ||
+      existing.role !== "assistant")
+  ) {
+    throw new Error(`Recovery message ${messageId} has an invalid scope`);
+  }
+
+  return new BufferedRuntimeRecoveryChatRecorder(
+    input,
+    messageId,
+    existing,
+    deps,
+  );
+}
+
+class BufferedRuntimeRecoveryChatRecorder implements RuntimeRecoveryChatRecorder {
+  private parts: RecoveryMessagePart[];
+  private attachments: unknown;
+  private metadata: unknown;
+  private createdAt: Date;
+  private readonly seenMessageIds = new Set<string>();
+  private readonly pendingMutations: RecoveryMessageMutation[] = [];
+  private persistedParts: RecoveryMessagePart[] | null;
+  private dirty = false;
+  private revision = 0;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private saveInFlight: Promise<void> | undefined;
+
+  constructor(
+    private readonly input: RuntimeRecoveryChatRecorderInput,
+    private readonly messageId: string,
+    existing: StoredMessageLike | undefined,
+    private readonly deps: RuntimeRecoveryChatRecorderDependencies,
+  ) {
+    const existingParts = Array.isArray(existing?.parts)
+      ? (structuredClone(existing.parts) as RecoveryMessagePart[])
+      : [];
+    this.parts = existingParts;
+    this.persistedParts = existing ? structuredClone(existingParts) : null;
+    this.attachments = existing?.attachments ?? [];
+    this.metadata = existing?.metadata;
+    this.createdAt = existing ? new Date(existing.createdAt) : this.deps.now();
+  }
+
+  async record(message: AgentMessage): Promise<void> {
+    if (message.messageId) {
+      if (this.seenMessageIds.has(message.messageId)) return;
+      this.seenMessageIds.add(message.messageId);
+    }
+
+    if (message.type === "text" || message.type === "direct_answer") {
+      this.recordMutation({
+        kind: "append-text",
+        partType: "text",
+        text: message.content ?? "",
+      });
+      this.scheduleFlush();
+      return;
+    }
+    if (message.type === "reasoning") {
+      this.recordMutation({
+        kind: "append-text",
+        partType: "reasoning",
+        text: message.content ?? "",
+      });
+      this.scheduleFlush();
+      return;
+    }
+    if (message.type === "tool_use") {
+      const toolUseId = message.id ?? message.toolUseId;
+      if (!toolUseId) return;
+      this.recordMutation({
+        kind: "tool-use",
+        toolUseId,
+        toolName: message.name ?? "unknown",
+        toolInput: message.input,
+      });
+      await this.flush();
+      return;
+    }
+    if (message.type === "tool_result" && message.toolUseId) {
+      this.recordMutation({
+        kind: "tool-result",
+        toolUseId: message.toolUseId,
+        toolOutput: message.output,
+        isError: message.isError === true,
+      });
+      await this.flush();
+      return;
+    }
+    if (message.type === "error") {
+      this.recordMutation({ kind: "provider-error" });
+      await this.flush();
+      return;
+    }
+    if (message.type === "done") {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    this.clearTimer();
+    if (this.saveInFlight) {
+      await this.saveInFlight;
+      if (this.dirty) await this.flush();
+      return;
+    }
+    if (!this.dirty || this.parts.length === 0) return;
+
+    const save = this.persistWithCasRebase()
+      .finally(() => {
+        this.saveInFlight = undefined;
+      });
+    this.saveInFlight = save;
+    await save;
+  }
+
+  async close(): Promise<void> {
+    this.clearTimer();
+    if (this.parts.some(isExecutingToolPart)) {
+      this.recordMutation({ kind: "fail-executing-tools" });
+    }
+    await this.flush();
+  }
+
+  private recordMutation(mutation: RecoveryMessageMutation): void {
+    if (
+      mutation.kind === "append-text" &&
+      mutation.text.length === 0
+    ) {
+      return;
+    }
+    this.pendingMutations.push(mutation);
+    this.applyMutation(mutation);
+    this.dirty = true;
+    this.revision += 1;
+  }
+
+  private applyMutation(mutation: RecoveryMessageMutation): void {
+    if (mutation.kind === "append-text") {
+      const last = this.parts.at(-1);
+      if (last?.type === mutation.partType) {
+        last.text = `${typeof last.text === "string" ? last.text : ""}${mutation.text}`;
+      } else {
+        this.parts.push({ type: mutation.partType, text: mutation.text });
+      }
+      return;
+    }
+    if (mutation.kind === "tool-use") {
+      const index = this.parts.findIndex(
+        (part) =>
+          part.type === "tool-native" &&
+          part.toolUseId === mutation.toolUseId,
+      );
+      const next = {
+        type: "tool-native",
+        toolName: mutation.toolName,
+        toolUseId: mutation.toolUseId,
+        toolInput: mutation.toolInput,
+        status: "executing",
+      } satisfies RecoveryMessagePart;
+      if (index >= 0) {
+        this.parts[index] = { ...this.parts[index], ...next };
+      } else {
+        this.parts.push(next);
+      }
+      return;
+    }
+    if (mutation.kind === "tool-result") {
+      const index = this.parts.findIndex(
+        (part) =>
+          part.type === "tool-native" &&
+          part.toolUseId === mutation.toolUseId,
+      );
+      const result = {
+        status: mutation.isError ? "error" : "completed",
+        toolOutput: mutation.toolOutput,
+        isError: mutation.isError,
+      };
+      if (index >= 0) {
+        this.parts[index] = { ...this.parts[index], ...result };
+      } else {
+        this.parts.push({
+          type: "tool-native",
+          toolName: "unknown",
+          toolUseId: mutation.toolUseId,
+          toolInput: undefined,
+          ...result,
+        });
+      }
+      return;
+    }
+    if (mutation.kind === "provider-error") {
+      this.failExecutingTools();
+      this.appendTextPart(
+        "text",
+        "\n\n**Error:** The recovered assistant run stopped unexpectedly. Check the Goal status for details.",
+      );
+      return;
+    }
+    this.failExecutingTools();
+  }
+
+  private appendTextPart(type: "text" | "reasoning", text: string): void {
+    const last = this.parts.at(-1);
+    if (last?.type === type) {
+      last.text = `${typeof last.text === "string" ? last.text : ""}${text}`;
+    } else {
+      this.parts.push({ type, text });
+    }
+  }
+
+  private failExecutingTools(): void {
+    for (let index = 0; index < this.parts.length; index += 1) {
+      const part = this.parts[index];
+      if (!isExecutingToolPart(part)) continue;
+      this.parts[index] = {
+        ...part,
+        status: "error",
+        toolOutput: "The recovered assistant run ended before this tool completed.",
+        isError: true,
+      };
+    }
+  }
+
+  private async persistWithCasRebase(): Promise<void> {
+    for (let attempt = 0; ; attempt += 1) {
+      const revision = this.revision;
+      const includedMutationCount = this.pendingMutations.length;
+      const parts = structuredClone(this.parts);
+      const expectedParts = this.persistedParts
+        ? structuredClone(this.persistedParts)
+        : null;
+      try {
+        await this.deps.saveMessages({
+          messages: [
+            {
+              id: this.messageId,
+              chatId: this.input.runtimeSessionId,
+              role: "assistant",
+              parts,
+              attachments: this.attachments,
+              createdAt: this.createdAt,
+              metadata: this.metadata,
+            },
+          ],
+          expectedUserId: this.input.ownerId,
+          expectedMessages: expectedParts
+            ? [
+                {
+                  id: this.messageId,
+                  chatId: this.input.runtimeSessionId,
+                  parts: expectedParts,
+                },
+              ]
+            : [],
+        });
+        this.persistedParts = parts;
+        this.pendingMutations.splice(0, includedMutationCount);
+        this.dirty = this.pendingMutations.length > 0 || this.revision !== revision;
+        return;
+      } catch (error) {
+        if (
+          !isMessageCasConflict(error) ||
+          attempt >= MAX_CAS_REBASE_ATTEMPTS
+        ) {
+          throw error;
+        }
+        await this.rebaseOntoLatestPersistedMessage();
+      }
+    }
+  }
+
+  private async rebaseOntoLatestPersistedMessage(): Promise<void> {
+    const chat = await this.deps.getChatById({
+      id: this.input.runtimeSessionId,
+    });
+    if (!chat || chat.userId !== this.input.ownerId) {
+      throw new Error(
+        `Recovery chat ${this.input.runtimeSessionId} is not owned by ${this.input.ownerId}`,
+      );
+    }
+    const latest = (await this.deps.getMessageById({ id: this.messageId }))[0] as
+      | StoredMessageLike
+      | undefined;
+    if (!latest) {
+      throw new Error(`Recovery message ${this.messageId} disappeared during rebase`);
+    }
+    if (
+      latest.chatId !== this.input.runtimeSessionId ||
+      latest.role !== "assistant"
+    ) {
+      throw new Error(`Recovery message ${this.messageId} has an invalid scope`);
+    }
+
+    const latestParts = Array.isArray(latest.parts)
+      ? (structuredClone(latest.parts) as RecoveryMessagePart[])
+      : [];
+    this.parts = structuredClone(latestParts);
+    this.persistedParts = latestParts;
+    this.attachments = latest.attachments ?? [];
+    this.metadata = latest.metadata;
+    this.createdAt = new Date(latest.createdAt);
+    for (const mutation of this.pendingMutations) this.applyMutation(mutation);
+  }
+
+  private scheduleFlush(): void {
+    if (!this.dirty || this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.flush().catch((error) => {
+        this.deps.logger.warn(
+          `[Agent Goal Recovery] Failed to persist chat output for ${this.input.runtimeSessionId}`,
+          error,
+        );
+      });
+    }, this.deps.flushDelayMs);
+    this.timer.unref?.();
+  }
+
+  private clearTimer(): void {
+    if (!this.timer) return;
+    clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+}
+
+function isExecutingToolPart(part: RecoveryMessagePart): boolean {
+  return part.type === "tool-native" && part.status === "executing";
+}
+
+function isMessageCasConflict(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === MESSAGE_ID_SCOPE_CONFLICT
+  );
+}

--- a/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
@@ -357,7 +357,7 @@ export class GoalRuntimeRecoveryCoordinator {
     } catch (error) {
       heartbeat?.stop();
       if (claim) {
-        await this.markRecoveryFailed(claim, expectedRunEpoch, error);
+        await this.pauseAfterRecoveryFailure(claim, expectedRunEpoch, error);
       }
       this.logger.error(
         `[Agent Goal Recovery] Failed to resume ${candidate.runtimeSessionId}`,
@@ -415,14 +415,18 @@ export class GoalRuntimeRecoveryCoordinator {
           releaseRunEpoch = failureRunEpoch;
         } catch (refreshError) {
           // A reclaimed/expired lease must not mutate the new owner's state.
-          // For other failures, markRecoveryFailed still has its own token and
+          // For other failures, pauseAfterRecoveryFailure still has its own token and
           // epoch fence and will safely reject a stale snapshot.
           this.logger.warn(
             `[Agent Goal Recovery] Could not refresh failure epoch for ${input.claim.runtimeSessionId}`,
             refreshError,
           );
         }
-        await this.markRecoveryFailed(input.claim, failureRunEpoch, error);
+        await this.pauseAfterRecoveryFailure(
+          input.claim,
+          failureRunEpoch,
+          error,
+        );
       })();
       await failureFinalization;
     };
@@ -574,7 +578,7 @@ export class GoalRuntimeRecoveryCoordinator {
     })();
 
     // Own the rejection in the background. Startup only waits for the init
-    // barrier; later provider failures are durably converted to blocked state.
+    // barrier; later provider failures durably pause the Goal for an explicit retry.
     const observedCompletion = completion
       .catch((error) => {
         this.logger.error(
@@ -644,14 +648,14 @@ export class GoalRuntimeRecoveryCoordinator {
     return persisted.state;
   }
 
-  private async markRecoveryFailed(
+  private async pauseAfterRecoveryFailure(
     claim: RuntimeRecoveryClaim,
     expectedRunEpoch: number,
     error: unknown,
   ): Promise<void> {
     const failure = recoveryFailure(error);
     try {
-      await this.deps.persistence.markRecoveryFailed({
+      await this.deps.persistence.pauseAfterRecoveryFailure({
         ...claimIdentity(claim),
         expectedRunEpoch,
         errorCode: failure.code,

--- a/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
@@ -1,0 +1,998 @@
+import { isAbsolute } from "node:path";
+
+import type { RuntimeSessionState } from "@openloomi/ai/agent/runtime-instructions";
+import type {
+  AgentRuntimeRecovery,
+  AgentRuntimeRecoveryContinuationResult,
+} from "@openloomi/ai/agent/types";
+import type {
+  NativeAgentRequest,
+  NativeAgentRun,
+  NativeAgentSession,
+} from "@openloomi/ai/agent/native-runner";
+import type { AgentRuntimePermissionHandler } from "@openloomi/ai/agent/runtime";
+
+import type {
+  RuntimeRecoveryCandidate,
+  RuntimeRecoveryClaim,
+  RuntimeRecoveryDescriptor,
+  RuntimeRecoverySnapshot,
+  RuntimeSessionRecoveryPersistencePort,
+} from "../runtime-session-persistence";
+import type { RuntimeObservationLeaseRegistration } from "../runtime-observation";
+import type {
+  PendingOperationRecoveryResult,
+  RuntimeRecoveryPendingOperation,
+} from "./pending-operation-reconciler";
+import type {
+  RuntimeRecoveryChatRecorder,
+  RuntimeRecoveryChatRecorderInput,
+} from "./chat-message-recorder";
+
+const DEFAULT_SCAN_LIMIT = 500;
+const DEFAULT_LEASE_DURATION_MS = 60_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 20_000;
+const DEFAULT_RESCAN_INTERVAL_MS = 15_000;
+const DEFAULT_INITIALIZATION_TIMEOUT_MS = 60_000;
+const RECOVERY_BOOTSTRAP_PROMPT =
+  "Resume the authenticated OpenLoomi Goal Runtime from its durable state.";
+
+export interface RuntimeRecoveryOwnerSession extends NativeAgentSession {
+  user: NonNullable<NativeAgentSession["user"]> & { id: string };
+  expires: string;
+}
+
+export interface RuntimeProviderSessionPreflightPort {
+  verify(input: {
+    providerSessionId: string;
+    workingDirectory: string;
+  }): Promise<void>;
+}
+
+export interface RuntimeRecoveryNativeRunnerPort {
+  run(
+    request: NativeAgentRequest,
+    context: {
+      session: RuntimeRecoveryOwnerSession;
+      userId: string;
+      abortController: AbortController;
+      permissionHandler: AgentRuntimePermissionHandler;
+      emitPermissionRequestEvents: false;
+      runtimeRecovery: AgentRuntimeRecovery;
+    },
+  ): Promise<NativeAgentRun>;
+}
+
+export interface RuntimeRecoveryCoordinatorDependencies {
+  persistence: RuntimeSessionRecoveryPersistencePort;
+  providerPreflight: RuntimeProviderSessionPreflightPort;
+  nativeRunner: RuntimeRecoveryNativeRunnerPort;
+  loadOwnerSession(
+    ownerId: string,
+  ): Promise<RuntimeRecoveryOwnerSession | null>;
+  reconcilePendingOperation(
+    operation: RuntimeRecoveryPendingOperation,
+  ): Promise<PendingOperationRecoveryResult>;
+  /**
+   * Extends the durable recovery fence to journal writes that occur before the
+   * provider runtime attaches its own observation registration.
+   */
+  attachObservationLease?(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseToken: string;
+  }): RuntimeObservationLeaseRegistration;
+  createChatRecorder?(
+    input: RuntimeRecoveryChatRecorderInput,
+  ): Promise<RuntimeRecoveryChatRecorder>;
+  logger?: Pick<Console, "log" | "warn" | "error">;
+  leaseOwner?: string;
+  scanLimit?: number;
+  leaseDurationMs?: number;
+  heartbeatIntervalMs?: number;
+  rescanIntervalMs?: number;
+  initializationTimeoutMs?: number;
+}
+
+export type RuntimeRecoveryStartupStatus =
+  | "resumed"
+  | "dormant"
+  | "unclaimed"
+  | "already_running"
+  | "failed";
+
+export interface RuntimeRecoveryStartupOutcome {
+  ownerId: string;
+  runtimeSessionId: string;
+  status: RuntimeRecoveryStartupStatus;
+  reason?: string;
+}
+
+export interface RuntimeRecoveryStartupReport {
+  scanned: number;
+  outcomes: RuntimeRecoveryStartupOutcome[];
+}
+
+/**
+ * Reattaches unfinished, owner-scoped Goal runtimes to their exact provider
+ * sessions. The durable recovery lease fences every reconciliation and remains
+ * alive until the recovered provider query ends, so another process cannot
+ * concurrently resume the same transcript.
+ */
+export class GoalRuntimeRecoveryCoordinator {
+  private readonly logger: Pick<Console, "log" | "warn" | "error">;
+  private readonly leaseOwner: string;
+  private readonly scanLimit: number;
+  private readonly leaseDurationMs: number;
+  private readonly heartbeatIntervalMs: number;
+  private readonly rescanIntervalMs: number;
+  private readonly initializationTimeoutMs: number;
+  private readonly activeRuns = new Map<string, Promise<void>>();
+  private readonly launches = new Map<
+    string,
+    Promise<RuntimeRecoveryStartupOutcome>
+  >();
+  private scan?: Promise<RuntimeRecoveryStartupReport>;
+  private rescanTimer?: ReturnType<typeof setInterval>;
+  private rescanInFlight = false;
+
+  constructor(private readonly deps: RuntimeRecoveryCoordinatorDependencies) {
+    this.logger = deps.logger ?? console;
+    this.leaseOwner =
+      normalizeIdentifier(deps.leaseOwner ?? `openloomi:${process.pid}`) ??
+      `openloomi:${process.pid}`;
+    this.scanLimit = positiveInteger(
+      deps.scanLimit ?? DEFAULT_SCAN_LIMIT,
+      "scanLimit",
+    );
+    this.leaseDurationMs = positiveInteger(
+      deps.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS,
+      "leaseDurationMs",
+    );
+    this.heartbeatIntervalMs = positiveInteger(
+      deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
+      "heartbeatIntervalMs",
+    );
+    this.rescanIntervalMs = positiveInteger(
+      deps.rescanIntervalMs ?? DEFAULT_RESCAN_INTERVAL_MS,
+      "rescanIntervalMs",
+    );
+    this.initializationTimeoutMs = positiveInteger(
+      deps.initializationTimeoutMs ?? DEFAULT_INITIALIZATION_TIMEOUT_MS,
+      "initializationTimeoutMs",
+    );
+    if (this.heartbeatIntervalMs >= this.leaseDurationMs) {
+      throw new TypeError(
+        "heartbeatIntervalMs must be shorter than leaseDurationMs",
+      );
+    }
+  }
+
+  start(): Promise<RuntimeRecoveryStartupReport> {
+    if (this.scan) return this.scan;
+    const scan = this.scanRecoverable().finally(() => {
+      if (this.scan === scan) this.scan = undefined;
+    });
+    this.scan = scan;
+    return scan;
+  }
+
+  /**
+   * Keeps looking for sessions whose previous host lease was still valid at
+   * boot. The timer is process-local and unref'd; each pass remains bounded by
+   * scanLimit and concurrent passes collapse onto the same scan promise.
+   */
+  startMonitoring(): void {
+    if (this.rescanTimer) return;
+    this.rescanTimer = setInterval(() => {
+      if (this.rescanInFlight) return;
+      this.rescanInFlight = true;
+      void this.start()
+        .then((report) => {
+          if (report.scanned === 0) return;
+          const resumed = report.outcomes.filter(
+            (entry) => entry.status === "resumed",
+          ).length;
+          const failed = report.outcomes.filter(
+            (entry) => entry.status === "failed",
+          ).length;
+          this.logger.log(
+            `[Agent Goal Recovery] rescan scanned=${report.scanned} resumed=${resumed} failed=${failed}`,
+          );
+        })
+        .catch((error) => {
+          this.logger.warn("[Agent Goal Recovery] Rescan failed", error);
+        })
+        .finally(() => {
+          this.rescanInFlight = false;
+        });
+    }, this.rescanIntervalMs);
+    this.rescanTimer.unref?.();
+  }
+
+  stopMonitoring(): void {
+    if (!this.rescanTimer) return;
+    clearInterval(this.rescanTimer);
+    this.rescanTimer = undefined;
+  }
+
+  private async scanRecoverable(): Promise<RuntimeRecoveryStartupReport> {
+    const candidates = await this.deps.persistence.listRecoverable(
+      this.scanLimit,
+    );
+    const outcomes: RuntimeRecoveryStartupOutcome[] = [];
+    // Start sequentially so desktop boot does not spawn several Claude CLI
+    // processes and database-heavy memory lookups at the same instant.
+    for (const candidate of candidates) {
+      outcomes.push(await this.startCandidate(candidate));
+    }
+    return { scanned: candidates.length, outcomes };
+  }
+
+  /**
+   * Reattaches one dormant persisted Runtime Session after a user resumes its
+   * Goal. This uses the same durable claim and initialization barrier as boot
+   * recovery; it never creates a fresh provider conversation.
+   */
+  async wake(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+  }): Promise<RuntimeRecoveryStartupOutcome> {
+    const ownerId = normalizeIdentifier(input.ownerId);
+    const runtimeSessionId = normalizeIdentifier(input.runtimeSessionId);
+    if (!ownerId || !runtimeSessionId) {
+      throw new TypeError(
+        "Recovery wake requires ownerId and runtimeSessionId",
+      );
+    }
+    const candidate: RuntimeRecoveryCandidate = {
+      ownerId,
+      runtimeSessionId,
+      runEpoch: 0,
+      updatedAt: new Date().toISOString(),
+    };
+    const first = await this.startCandidate(candidate);
+    // A startup scan can already be finalizing this session as dormant while
+    // the resume transaction commits. Retry once after that launch releases
+    // its claim so the now-active Goal is not stranded until another restart.
+    return first.status === "dormant"
+      ? this.startCandidate({
+          ...candidate,
+          updatedAt: new Date().toISOString(),
+        })
+      : first;
+  }
+
+  private startCandidate(
+    candidate: RuntimeRecoveryCandidate,
+  ): Promise<RuntimeRecoveryStartupOutcome> {
+    const key = recoveryScope(candidate.ownerId, candidate.runtimeSessionId);
+    if (this.activeRuns.has(key)) {
+      return Promise.resolve(outcome(candidate, "already_running"));
+    }
+    const launching = this.launches.get(key);
+    if (launching) return launching;
+
+    const launch = this.claimAndStart(candidate).finally(() => {
+      this.launches.delete(key);
+    });
+    this.launches.set(key, launch);
+    return launch;
+  }
+
+  private async claimAndStart(
+    candidate: RuntimeRecoveryCandidate,
+  ): Promise<RuntimeRecoveryStartupOutcome> {
+    let claim: RuntimeRecoveryClaim | null = null;
+    let heartbeat: RecoveryLeaseHeartbeat | null = null;
+    let observationLease: RuntimeObservationLeaseRegistration | undefined;
+    let expectedRunEpoch = candidate.runEpoch;
+    try {
+      claim = await this.deps.persistence.claimRecovery({
+        ownerId: candidate.ownerId,
+        runtimeSessionId: candidate.runtimeSessionId,
+        leaseOwner: this.leaseOwner,
+        leaseDurationMs: this.leaseDurationMs,
+      });
+      if (!claim) return outcome(candidate, "unclaimed");
+      observationLease = this.deps.attachObservationLease?.({
+        ownerId: claim.ownerId,
+        runtimeSessionId: claim.runtimeSessionId,
+        leaseToken: claim.leaseToken,
+      });
+
+      heartbeat = new RecoveryLeaseHeartbeat({
+        persistence: this.deps.persistence,
+        claim,
+        leaseDurationMs: this.leaseDurationMs,
+        intervalMs: this.heartbeatIntervalMs,
+        logger: this.logger,
+      });
+      heartbeat.start();
+
+      let snapshot = claim.snapshot;
+      expectedRunEpoch = snapshot.session.runEpoch;
+      if (snapshot.pendingOperation) {
+        await this.deps.reconcilePendingOperation(snapshot.pendingOperation);
+        // Pending lifecycle/replacement recovery can change runEpoch, Goal
+        // assignment, and the canonical outbox. Never start from the claim's
+        // now-stale snapshot.
+        snapshot = await this.deps.persistence.refreshRecovery(
+          claimIdentity(claim),
+        );
+        expectedRunEpoch = snapshot.session.runEpoch;
+      }
+
+      if (!shouldResume(snapshot)) {
+        await this.persistDormantState(claim, snapshot);
+        heartbeat.stop();
+        await this.deps.persistence.releaseRecoveryLease(claimIdentity(claim));
+        return outcome(candidate, "dormant", dormantReason(snapshot));
+      }
+
+      const config = validateResumeConfiguration(snapshot);
+      const ownerSession = await this.deps.loadOwnerSession(claim.ownerId);
+      if (!ownerSession || ownerSession.user.id !== claim.ownerId) {
+        throw new RuntimeRecoveryError(
+          "runtime_recovery_owner_not_found",
+          `Owner ${claim.ownerId} is unavailable for Runtime Session ${claim.runtimeSessionId}`,
+        );
+      }
+      await this.deps.providerPreflight.verify({
+        providerSessionId: config.providerSessionId,
+        workingDirectory: config.workingDirectory,
+      });
+      heartbeat.assertHealthy();
+
+      return await this.launchRecoveredRun({
+        candidate,
+        claim,
+        snapshot,
+        descriptor: config.descriptor,
+        providerSessionId: config.providerSessionId,
+        workingDirectory: config.workingDirectory,
+        ownerSession,
+        heartbeat,
+      });
+    } catch (error) {
+      heartbeat?.stop();
+      if (claim) {
+        await this.markRecoveryFailed(claim, expectedRunEpoch, error);
+      }
+      this.logger.error(
+        `[Agent Goal Recovery] Failed to resume ${candidate.runtimeSessionId}`,
+        error,
+      );
+      return outcome(candidate, "failed", errorMessage(error));
+    } finally {
+      observationLease?.release();
+    }
+  }
+
+  private async launchRecoveredRun(input: {
+    candidate: RuntimeRecoveryCandidate;
+    claim: RuntimeRecoveryClaim;
+    snapshot: RuntimeRecoverySnapshot;
+    descriptor: RuntimeRecoveryDescriptor;
+    providerSessionId: string;
+    workingDirectory: string;
+    ownerSession: RuntimeRecoveryOwnerSession;
+    heartbeat: RecoveryLeaseHeartbeat;
+  }): Promise<RuntimeRecoveryStartupOutcome> {
+    const key = recoveryScope(
+      input.claim.ownerId,
+      input.claim.runtimeSessionId,
+    );
+    const abortController = new AbortController();
+    const initialized = deferred<AgentRuntimeRecoveryContinuationResult>();
+    let durableState = input.snapshot.session.state;
+    let continuationResult: AgentRuntimeRecoveryContinuationResult | undefined;
+    let intentionalStop = false;
+    let failureFinalization: Promise<void> | undefined;
+    let releasePromise: Promise<void> | undefined;
+    let releaseRunEpoch = input.snapshot.session.runEpoch;
+
+    const releaseRuntime = async (expectedRunEpoch: number) => {
+      releasePromise ??= (async () => {
+        input.heartbeat.stop();
+        await this.deps.persistence.releaseLiveRuntime({
+          ...claimIdentity(input.claim),
+          expectedRunEpoch,
+        });
+      })();
+      await releasePromise;
+    };
+
+    const finalizeFailure = async (error: unknown) => {
+      failureFinalization ??= (async () => {
+        input.heartbeat.stop();
+        let failureRunEpoch = releaseRunEpoch;
+        try {
+          const latest = await this.deps.persistence.refreshRecovery(
+            claimIdentity(input.claim),
+          );
+          failureRunEpoch = latest.session.runEpoch;
+          releaseRunEpoch = failureRunEpoch;
+        } catch (refreshError) {
+          // A reclaimed/expired lease must not mutate the new owner's state.
+          // For other failures, markRecoveryFailed still has its own token and
+          // epoch fence and will safely reject a stale snapshot.
+          this.logger.warn(
+            `[Agent Goal Recovery] Could not refresh failure epoch for ${input.claim.runtimeSessionId}`,
+            refreshError,
+          );
+        }
+        await this.markRecoveryFailed(input.claim, failureRunEpoch, error);
+      })();
+      await failureFinalization;
+    };
+    input.heartbeat.onLost((error) => {
+      initialized.reject(error);
+      if (!abortController.signal.aborted) abortController.abort(error);
+      void finalizeFailure(error);
+    });
+
+    const runtimeRecovery: AgentRuntimeRecovery = {
+      runtimeSessionId: input.claim.runtimeSessionId,
+      providerSessionId: input.providerSessionId,
+      workingDirectory: input.workingDirectory,
+      runEpoch: input.snapshot.session.runEpoch,
+      recoveryLeaseToken: input.claim.leaseToken,
+      instructionSettlements: input.snapshot.instructionSettlements.map(
+        (settlement) => ({ ...settlement }),
+      ),
+      onProviderSessionInitialized: async (provider) => {
+        try {
+          assertProviderInitialization(input.claim, input.snapshot, provider);
+          durableState = await this.persistRuntimeState({
+            claim: input.claim,
+            expectedState: durableState,
+            runEpoch: input.snapshot.session.runEpoch,
+            state: "running",
+          });
+          continuationResult =
+            input.snapshot.replayableInstructionIds.length > 0
+              ? { decision: "block", outcome: "continue" }
+              : await provider.continueGoal();
+          if (continuationResult.decision === "allow") {
+            // Mark the provider shutdown durably while retaining its lease.
+            // The lease is released only after the generator terminates, so a
+            // second process cannot resume the same transcript mid-shutdown.
+            durableState = await this.persistRuntimeState({
+              claim: input.claim,
+              expectedState: durableState,
+              runEpoch: input.snapshot.session.runEpoch,
+              state: "interrupted",
+            });
+            intentionalStop = true;
+            abortController.abort(
+              new Error(`Recovered Goal is ${continuationResult.outcome}`),
+            );
+          }
+          initialized.resolve(continuationResult);
+        } catch (error) {
+          initialized.reject(error);
+          throw error;
+        }
+      },
+    };
+
+    const request = recoveryRequest(
+      input.claim.runtimeSessionId,
+      input.workingDirectory,
+      input.descriptor,
+    );
+    const run = await this.deps.nativeRunner.run(request, {
+      session: input.ownerSession,
+      userId: input.claim.ownerId,
+      abortController,
+      permissionHandler: denyBackgroundPermission,
+      emitPermissionRequestEvents: false,
+      runtimeRecovery,
+    });
+    let chatRecorder: RuntimeRecoveryChatRecorder | undefined;
+    try {
+      chatRecorder = await this.deps.createChatRecorder?.({
+        ownerId: input.claim.ownerId,
+        runtimeSessionId: input.claim.runtimeSessionId,
+        providerSessionId: input.providerSessionId,
+        runEpoch: input.snapshot.session.runEpoch,
+      });
+    } catch (error) {
+      // Chat presentation is best-effort and must never alter durable Goal
+      // recovery semantics or release its lease early.
+      this.logger.warn(
+        `[Agent Goal Recovery] Could not attach chat output for ${input.claim.runtimeSessionId}`,
+        error,
+      );
+    }
+
+    const completion = (async () => {
+      let providerError: string | undefined;
+      try {
+        try {
+          for await (const message of run.generator) {
+            if (message.type === "error") {
+              providerError =
+                message.message ?? "Recovered provider run failed";
+            }
+            try {
+              await chatRecorder?.record(message);
+            } catch (error) {
+              this.logger.warn(
+                `[Agent Goal Recovery] Could not persist recovered output for ${input.claim.runtimeSessionId}`,
+                error,
+              );
+            }
+          }
+        } finally {
+          try {
+            await chatRecorder?.close();
+          } catch (error) {
+            this.logger.warn(
+              `[Agent Goal Recovery] Could not flush recovered output for ${input.claim.runtimeSessionId}`,
+              error,
+            );
+          }
+        }
+        if (providerError && !intentionalStop) {
+          throw new RuntimeRecoveryError(
+            "provider_resume_failed",
+            providerError,
+          );
+        }
+        if (!continuationResult) {
+          throw new RuntimeRecoveryError(
+            "provider_resume_ended_before_initialization",
+            "Claude recovery ended before the provider session was initialized",
+          );
+        }
+        if (continuationResult.decision === "block") {
+          const latest = await this.deps.persistence.refreshRecovery(
+            claimIdentity(input.claim),
+          );
+          releaseRunEpoch = latest.session.runEpoch;
+          if (latest.activeGoal?.goal.status === "active") {
+            throw new RuntimeRecoveryError(
+              "provider_resume_ended_with_active_goal",
+              "Claude recovery ended while the Goal was still active",
+            );
+          }
+        }
+        await releaseRuntime(releaseRunEpoch);
+      } catch (error) {
+        if (intentionalStop) {
+          await releaseRuntime(releaseRunEpoch);
+          return;
+        }
+        initialized.reject(error);
+        await finalizeFailure(error);
+        throw error;
+      } finally {
+        input.heartbeat.stop();
+      }
+    })();
+
+    // Own the rejection in the background. Startup only waits for the init
+    // barrier; later provider failures are durably converted to blocked state.
+    const observedCompletion = completion
+      .catch((error) => {
+        this.logger.error(
+          `[Agent Goal Recovery] Recovered runtime ${input.claim.runtimeSessionId} stopped`,
+          error,
+        );
+      })
+      .finally(() => {
+        this.activeRuns.delete(key);
+      });
+    this.activeRuns.set(key, observedCompletion);
+
+    try {
+      await withTimeout(
+        initialized.promise,
+        this.initializationTimeoutMs,
+        `Claude session ${input.providerSessionId} did not initialize in time`,
+      );
+      return outcome(input.candidate, "resumed");
+    } catch (error) {
+      if (!abortController.signal.aborted) abortController.abort(error);
+      await finalizeFailure(error);
+      this.logger.error(
+        `[Agent Goal Recovery] Failed to initialize ${input.claim.runtimeSessionId}`,
+        error,
+      );
+      return outcome(input.candidate, "failed", errorMessage(error));
+    }
+  }
+
+  private async persistDormantState(
+    claim: RuntimeRecoveryClaim,
+    snapshot: RuntimeRecoverySnapshot,
+  ): Promise<void> {
+    if (snapshot.session.state === "idle") return;
+    if (
+      snapshot.session.state === "closed" ||
+      snapshot.session.state === "failed"
+    ) {
+      return;
+    }
+    await this.deps.persistence.persistState({
+      ownerId: claim.ownerId,
+      runtimeSessionId: claim.runtimeSessionId,
+      expectedState: snapshot.session.state,
+      expectedRunEpoch: snapshot.session.runEpoch,
+      state: "idle",
+      recoveryLeaseToken: claim.leaseToken,
+    });
+  }
+
+  private async persistRuntimeState(input: {
+    claim: RuntimeRecoveryClaim;
+    expectedState: RuntimeSessionState;
+    runEpoch: number;
+    state: RuntimeSessionState;
+  }): Promise<RuntimeSessionState> {
+    if (input.expectedState === input.state) return input.state;
+    const persisted = await this.deps.persistence.persistState({
+      ownerId: input.claim.ownerId,
+      runtimeSessionId: input.claim.runtimeSessionId,
+      expectedState: input.expectedState,
+      expectedRunEpoch: input.runEpoch,
+      state: input.state,
+      recoveryLeaseToken: input.claim.leaseToken,
+    });
+    return persisted.state;
+  }
+
+  private async markRecoveryFailed(
+    claim: RuntimeRecoveryClaim,
+    expectedRunEpoch: number,
+    error: unknown,
+  ): Promise<void> {
+    const failure = recoveryFailure(error);
+    try {
+      await this.deps.persistence.markRecoveryFailed({
+        ...claimIdentity(claim),
+        expectedRunEpoch,
+        errorCode: failure.code,
+        errorMessage: failure.message,
+      });
+    } catch (markError) {
+      this.logger.error(
+        `[Agent Goal Recovery] Could not persist failure for ${claim.runtimeSessionId}`,
+        markError,
+      );
+    }
+  }
+}
+
+class RuntimeRecoveryError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "RuntimeRecoveryError";
+  }
+}
+
+class RecoveryLeaseHeartbeat {
+  private timer?: ReturnType<typeof setInterval>;
+  private renewal: Promise<void> | null = null;
+  private failure?: unknown;
+  private expiresAt = 0;
+  private readonly failureListeners = new Set<(error: unknown) => void>();
+
+  constructor(
+    private readonly input: {
+      persistence: RuntimeSessionRecoveryPersistencePort;
+      claim: RuntimeRecoveryClaim;
+      leaseDurationMs: number;
+      intervalMs: number;
+      logger: Pick<Console, "warn">;
+    },
+  ) {
+    this.expiresAt = Date.parse(input.claim.leaseExpiresAt);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      if (this.renewal) return;
+      this.renewal = this.input.persistence
+        .renewRecoveryLease({
+          ...claimIdentity(this.input.claim),
+          leaseDurationMs: this.input.leaseDurationMs,
+        })
+        .then((expiresAt) => {
+          this.expiresAt = Date.parse(expiresAt);
+        })
+        .catch((error) => {
+          if (
+            recoveryErrorCode(error) === "runtime_recovery_claim_conflict" ||
+            !Number.isFinite(this.expiresAt) ||
+            Date.now() + this.input.intervalMs >= this.expiresAt
+          ) {
+            this.fail(error);
+          }
+          this.input.logger.warn(
+            `[Agent Goal Recovery] Lease heartbeat failed for ${this.input.claim.runtimeSessionId}`,
+            error,
+          );
+        })
+        .finally(() => {
+          this.renewal = null;
+        });
+    }, this.input.intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  assertHealthy(): void {
+    if (this.failure !== undefined) throw this.failure;
+  }
+
+  onLost(listener: (error: unknown) => void): void {
+    this.failureListeners.add(listener);
+    if (this.failure !== undefined) listener(this.failure);
+  }
+
+  private fail(error: unknown): void {
+    if (this.failure !== undefined) return;
+    this.failure = error;
+    for (const listener of this.failureListeners) {
+      try {
+        listener(error);
+      } catch (listenerError) {
+        this.input.logger.warn(
+          `[Agent Goal Recovery] Lease-loss handler failed for ${this.input.claim.runtimeSessionId}`,
+          listenerError,
+        );
+      }
+    }
+  }
+}
+
+function shouldResume(snapshot: RuntimeRecoverySnapshot): boolean {
+  return snapshot.activeGoal?.goal.status === "active";
+}
+
+function dormantReason(snapshot: RuntimeRecoverySnapshot): string {
+  const status = snapshot.activeGoal?.goal.status;
+  return status ? `goal_${status}` : "no_active_goal";
+}
+
+function validateResumeConfiguration(snapshot: RuntimeRecoverySnapshot): {
+  providerSessionId: string;
+  workingDirectory: string;
+  descriptor: RuntimeRecoveryDescriptor;
+} {
+  if (snapshot.session.provider !== "claude") {
+    throw new RuntimeRecoveryError(
+      "runtime_recovery_provider_unsupported",
+      `Runtime provider ${snapshot.session.provider} cannot be recovered by the Claude host`,
+    );
+  }
+  const providerSessionId = normalizeIdentifier(
+    snapshot.session.providerSessionId,
+  );
+  if (!providerSessionId) {
+    throw new RuntimeRecoveryError(
+      "provider_session_missing",
+      "The unfinished Goal has no persisted Claude provider session",
+    );
+  }
+  const workingDirectory = snapshot.session.workingDirectory;
+  if (
+    typeof workingDirectory !== "string" ||
+    workingDirectory.length === 0 ||
+    workingDirectory !== workingDirectory.trim() ||
+    !isAbsolute(workingDirectory)
+  ) {
+    throw new RuntimeRecoveryError(
+      "working_directory_missing",
+      "The unfinished Goal has no valid persisted provider working directory",
+    );
+  }
+  if (!snapshot.recoveryDescriptor) {
+    throw new RuntimeRecoveryError(
+      "recovery_descriptor_missing",
+      "The unfinished Goal has no trusted runtime recovery descriptor",
+    );
+  }
+  return {
+    providerSessionId,
+    workingDirectory,
+    descriptor: snapshot.recoveryDescriptor,
+  };
+}
+
+function recoveryRequest(
+  runtimeSessionId: string,
+  workingDirectory: string,
+  descriptor: RuntimeRecoveryDescriptor,
+): NativeAgentRequest {
+  return {
+    prompt: RECOVERY_BOOTSTRAP_PROMPT,
+    provider: "claude",
+    platform: "desktop-recovery",
+    sessionId: runtimeSessionId,
+    workDir: workingDirectory,
+    useProvidedWorkDir: true,
+    ...(descriptor.model === undefined && descriptor.thinkingLevel === undefined
+      ? {}
+      : {
+          modelConfig: {
+            ...(descriptor.model === undefined
+              ? {}
+              : { model: descriptor.model }),
+            ...(descriptor.thinkingLevel === undefined
+              ? {}
+              : { thinkingLevel: descriptor.thinkingLevel }),
+          },
+        }),
+    ...(descriptor.allowedTools === undefined
+      ? {}
+      : { allowedTools: [...descriptor.allowedTools] }),
+    ...(descriptor.disallowedTools === undefined
+      ? {}
+      : { disallowedTools: [...descriptor.disallowedTools] }),
+    ...(descriptor.excludedTools === undefined
+      ? {}
+      : { excludeTools: [...descriptor.excludedTools] }),
+    ...(descriptor.permissionMode === undefined
+      ? {}
+      : { permissionMode: descriptor.permissionMode }),
+    ...(descriptor.sandbox === undefined
+      ? {}
+      : { sandboxConfig: { ...descriptor.sandbox } }),
+    ...(descriptor.skillsConfig === undefined
+      ? {}
+      : { skillsConfig: { ...descriptor.skillsConfig } }),
+    ...(descriptor.mcpConfig === undefined
+      ? {}
+      : { mcpConfig: { ...descriptor.mcpConfig } }),
+  };
+}
+
+function assertProviderInitialization(
+  claim: RuntimeRecoveryClaim,
+  snapshot: RuntimeRecoverySnapshot,
+  provider: {
+    runtimeSessionId: string;
+    providerSessionId: string;
+    runEpoch: number;
+  },
+): void {
+  if (
+    provider.runtimeSessionId !== claim.runtimeSessionId ||
+    provider.providerSessionId !== snapshot.session.providerSessionId ||
+    provider.runEpoch !== snapshot.session.runEpoch
+  ) {
+    throw new RuntimeRecoveryError(
+      "provider_session_mismatch",
+      "Claude initialized a different provider session or runtime fence",
+    );
+  }
+}
+
+const denyBackgroundPermission: AgentRuntimePermissionHandler = async () => ({
+  behavior: "deny",
+});
+
+function claimIdentity(claim: RuntimeRecoveryClaim) {
+  return {
+    ownerId: claim.ownerId,
+    runtimeSessionId: claim.runtimeSessionId,
+    leaseOwner: claim.leaseOwner,
+    leaseToken: claim.leaseToken,
+  };
+}
+
+function recoveryScope(ownerId: string, runtimeSessionId: string): string {
+  return JSON.stringify([ownerId, runtimeSessionId]);
+}
+
+function outcome(
+  candidate: RuntimeRecoveryCandidate,
+  status: RuntimeRecoveryStartupStatus,
+  reason?: string,
+): RuntimeRecoveryStartupOutcome {
+  return {
+    ownerId: candidate.ownerId,
+    runtimeSessionId: candidate.runtimeSessionId,
+    status,
+    ...(reason === undefined ? {} : { reason }),
+  };
+}
+
+function normalizeIdentifier(value: unknown): string | undefined {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value !== value.trim()
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function positiveInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function recoveryFailure(error: unknown): { code: string; message: string } {
+  const candidateCode = recoveryErrorCode(error);
+  const code =
+    typeof candidateCode === "string" &&
+    /^[a-z][a-z0-9_]{0,127}$/.test(candidateCode)
+      ? candidateCode
+      : "runtime_recovery_failed";
+  const message =
+    errorMessage(error).slice(0, 8_000) || "Runtime recovery failed";
+  return { code, message };
+}
+
+function recoveryErrorCode(error: unknown): string | undefined {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  return typeof code === "string" ? code : undefined;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(
+              new RuntimeRecoveryError(
+                "provider_initialization_timeout",
+                message,
+              ),
+            ),
+          timeoutMs,
+        );
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/coordinator.ts
@@ -4,6 +4,7 @@ import type { RuntimeSessionState } from "@openloomi/ai/agent/runtime-instructio
 import type {
   AgentRuntimeRecovery,
   AgentRuntimeRecoveryContinuationResult,
+  AgentRuntimeRecoveryGoalFinalizationResult,
 } from "@openloomi/ai/agent/types";
 import type {
   NativeAgentRequest,
@@ -287,6 +288,9 @@ export class GoalRuntimeRecoveryCoordinator {
     let heartbeat: RecoveryLeaseHeartbeat | null = null;
     let observationLease: RuntimeObservationLeaseRegistration | undefined;
     let expectedRunEpoch = candidate.runEpoch;
+    let expectedGoal:
+      | { readonly id: string; readonly revision: number }
+      | undefined;
     try {
       claim = await this.deps.persistence.claimRecovery({
         ownerId: candidate.ownerId,
@@ -312,6 +316,7 @@ export class GoalRuntimeRecoveryCoordinator {
 
       let snapshot = claim.snapshot;
       expectedRunEpoch = snapshot.session.runEpoch;
+      expectedGoal = snapshot.activeGoal?.goal;
       if (snapshot.pendingOperation) {
         await this.deps.reconcilePendingOperation(snapshot.pendingOperation);
         // Pending lifecycle/replacement recovery can change runEpoch, Goal
@@ -321,6 +326,7 @@ export class GoalRuntimeRecoveryCoordinator {
           claimIdentity(claim),
         );
         expectedRunEpoch = snapshot.session.runEpoch;
+        expectedGoal = snapshot.activeGoal?.goal;
       }
 
       if (!shouldResume(snapshot)) {
@@ -357,7 +363,12 @@ export class GoalRuntimeRecoveryCoordinator {
     } catch (error) {
       heartbeat?.stop();
       if (claim) {
-        await this.pauseAfterRecoveryFailure(claim, expectedRunEpoch, error);
+        await this.pauseAfterRecoveryFailure(
+          claim,
+          expectedRunEpoch,
+          error,
+          expectedGoal,
+        );
       }
       this.logger.error(
         `[Agent Goal Recovery] Failed to resume ${candidate.runtimeSessionId}`,
@@ -391,10 +402,13 @@ export class GoalRuntimeRecoveryCoordinator {
     let failureFinalization: Promise<void> | undefined;
     let releasePromise: Promise<void> | undefined;
     let releaseRunEpoch = input.snapshot.session.runEpoch;
+    let finalizeGoalWithoutContinuation:
+      | (() => Promise<AgentRuntimeRecoveryGoalFinalizationResult>)
+      | undefined;
 
     const releaseRuntime = async (expectedRunEpoch: number) => {
       releasePromise ??= (async () => {
-        input.heartbeat.stop();
+        await input.heartbeat.stopAndDrain();
         await this.deps.persistence.releaseLiveRuntime({
           ...claimIdentity(input.claim),
           expectedRunEpoch,
@@ -403,16 +417,20 @@ export class GoalRuntimeRecoveryCoordinator {
       await releasePromise;
     };
 
-    const finalizeFailure = async (error: unknown) => {
+    const finalizeFailure = async (
+      error: unknown,
+      options: { evaluateDurableEvidence?: boolean } = {},
+    ) => {
       failureFinalization ??= (async () => {
-        input.heartbeat.stop();
         let failureRunEpoch = releaseRunEpoch;
+        let expectedGoal = input.snapshot.activeGoal?.goal;
         try {
           const latest = await this.deps.persistence.refreshRecovery(
             claimIdentity(input.claim),
           );
           failureRunEpoch = latest.session.runEpoch;
           releaseRunEpoch = failureRunEpoch;
+          expectedGoal = latest.activeGoal?.goal;
         } catch (refreshError) {
           // A reclaimed/expired lease must not mutate the new owner's state.
           // For other failures, pauseAfterRecoveryFailure still has its own token and
@@ -422,10 +440,36 @@ export class GoalRuntimeRecoveryCoordinator {
             refreshError,
           );
         }
+        if (
+          options.evaluateDurableEvidence &&
+          finalizeGoalWithoutContinuation
+        ) {
+          try {
+            const finalized = await finalizeGoalWithoutContinuation();
+            if (finalized.outcome !== "stale") {
+              await releaseRuntime(failureRunEpoch);
+              return;
+            }
+            throw new RuntimeRecoveryError(
+              "goal_finalization_stale",
+              `Durable Goal evidence could not be finalized for revision ${finalized.goalRevision ?? "unknown"}`,
+            );
+          } catch (evaluationError) {
+            // Evaluation is best-effort at a provider-failure boundary. If its
+            // own infrastructure is unavailable, the fenced recovery pause
+            // below still prevents a stuck running lease.
+            this.logger.warn(
+              `[Agent Goal Recovery] Could not evaluate durable evidence before pausing ${input.claim.runtimeSessionId}`,
+              evaluationError,
+            );
+          }
+        }
+        input.heartbeat.stop();
         await this.pauseAfterRecoveryFailure(
           input.claim,
           failureRunEpoch,
           error,
+          expectedGoal,
         );
       })();
       await failureFinalization;
@@ -448,6 +492,8 @@ export class GoalRuntimeRecoveryCoordinator {
       onProviderSessionInitialized: async (provider) => {
         try {
           assertProviderInitialization(input.claim, input.snapshot, provider);
+          finalizeGoalWithoutContinuation =
+            provider.finalizeGoalWithoutContinuation;
           durableState = await this.persistRuntimeState({
             claim: input.claim,
             expectedState: durableState,
@@ -512,13 +558,22 @@ export class GoalRuntimeRecoveryCoordinator {
     }
 
     const completion = (async () => {
-      let providerError: string | undefined;
+      let providerFailure: RuntimeRecoveryError | undefined;
+      const providerIterator = run.generator[Symbol.asyncIterator]();
       try {
         try {
-          for await (const message of run.generator) {
+          while (true) {
+            const next = await providerIterator.next();
+            if (next.done) break;
+            const message = next.value;
             if (message.type === "error") {
-              providerError =
-                message.message ?? "Recovered provider run failed";
+              providerFailure = new RuntimeRecoveryError(
+                "provider_resume_failed",
+                message.message ?? "Recovered provider run failed",
+              );
+              if (!abortController.signal.aborted) {
+                abortController.abort(providerFailure);
+              }
             }
             try {
               await chatRecorder?.record(message);
@@ -527,6 +582,9 @@ export class GoalRuntimeRecoveryCoordinator {
                 `[Agent Goal Recovery] Could not persist recovered output for ${input.claim.runtimeSessionId}`,
                 error,
               );
+            }
+            if (providerFailure) {
+              break;
             }
           }
         } finally {
@@ -539,11 +597,8 @@ export class GoalRuntimeRecoveryCoordinator {
             );
           }
         }
-        if (providerError && !intentionalStop) {
-          throw new RuntimeRecoveryError(
-            "provider_resume_failed",
-            providerError,
-          );
+        if (providerFailure && !intentionalStop) {
+          throw providerFailure;
         }
         if (!continuationResult) {
           throw new RuntimeRecoveryError(
@@ -570,7 +625,22 @@ export class GoalRuntimeRecoveryCoordinator {
           return;
         }
         initialized.reject(error);
-        await finalizeFailure(error);
+        try {
+          await finalizeFailure(error, {
+            evaluateDurableEvidence: error === providerFailure,
+          });
+        } finally {
+          if (error === providerFailure) {
+            // Keep the Goal observer attached until durable evidence has been
+            // evaluated. Provider cleanup remains best-effort and must never
+            // retain the recovery lease after that boundary.
+            closeIteratorInBackground(
+              providerIterator,
+              input.claim.runtimeSessionId,
+              this.logger,
+            );
+          }
+        }
         throw error;
       } finally {
         input.heartbeat.stop();
@@ -652,12 +722,19 @@ export class GoalRuntimeRecoveryCoordinator {
     claim: RuntimeRecoveryClaim,
     expectedRunEpoch: number,
     error: unknown,
+    expectedGoal?: { readonly id: string; readonly revision: number },
   ): Promise<void> {
     const failure = recoveryFailure(error);
     try {
       await this.deps.persistence.pauseAfterRecoveryFailure({
         ...claimIdentity(claim),
         expectedRunEpoch,
+        ...(expectedGoal === undefined
+          ? {}
+          : {
+              expectedGoalId: expectedGoal.id,
+              expectedGoalRevision: expectedGoal.revision,
+            }),
         errorCode: failure.code,
         errorMessage: failure.message,
       });
@@ -667,6 +744,28 @@ export class GoalRuntimeRecoveryCoordinator {
         markError,
       );
     }
+  }
+}
+
+function closeIteratorInBackground(
+  iterator: AsyncIterator<unknown>,
+  runtimeSessionId: string,
+  logger: Pick<Console, "warn">,
+): void {
+  try {
+    const cleanup = iterator.return?.();
+    if (!cleanup) return;
+    void cleanup.catch((error) => {
+      logger.warn(
+        `[Agent Goal Recovery] Provider cleanup failed for ${runtimeSessionId}`,
+        error,
+      );
+    });
+  } catch (error) {
+    logger.warn(
+      `[Agent Goal Recovery] Provider cleanup failed for ${runtimeSessionId}`,
+      error,
+    );
   }
 }
 
@@ -736,6 +835,12 @@ class RecoveryLeaseHeartbeat {
     if (!this.timer) return;
     clearInterval(this.timer);
     this.timer = undefined;
+  }
+
+  async stopAndDrain(): Promise<void> {
+    this.stop();
+    await this.renewal;
+    this.assertHealthy();
   }
 
   assertHealthy(): void {

--- a/apps/web/lib/ai/runtime-instructions/recovery/pending-operation-reconciler.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/pending-operation-reconciler.ts
@@ -1,0 +1,261 @@
+import {
+  RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+  type AgentGoalLifecycleTransition,
+  type AgentGoalReplacement,
+  type AgentGoalStatePort,
+  type GoalCommandIdentity,
+  type RuntimeClockPort,
+  type RuntimeIdGeneratorPort,
+  type RuntimeInstructionDraft,
+} from "@openloomi/ai/agent/runtime-instructions";
+
+import type { StoredRuntimeInstruction } from "../persistence/goal-instruction-mappers";
+import type { PersistedRuntimeInstructionDelivery } from "../persistence/runtime-observation-mappers";
+import type { RuntimeLifecycleObservationPort } from "../runtime-observation";
+
+export type RuntimeRecoveryPendingOperation =
+  | AgentGoalLifecycleTransition
+  | AgentGoalReplacement;
+
+export interface RuntimeRecoveryCommandReader {
+  getStoredById(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+  }): Promise<StoredRuntimeInstruction | null>;
+}
+
+export interface RuntimeRecoveryDeliveryReader {
+  getActiveByInstruction(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+  }): Promise<PersistedRuntimeInstructionDelivery | null>;
+}
+
+export interface PendingOperationRecoveryResult {
+  disposition: "dormant" | "resume";
+  runEpoch: number;
+  activationInstructionId?: string;
+}
+
+/**
+ * Finishes a lifecycle checkpoint after the provider process has disappeared.
+ *
+ * The crashed process itself is the terminal boundary: there can be no more
+ * output from its old turn. We still advance the existing durable phases one
+ * at a time so a second crash during recovery resumes idempotently from the
+ * last committed checkpoint.
+ */
+export class PendingGoalOperationRecovery {
+  constructor(
+    private readonly state: AgentGoalStatePort,
+    private readonly instructions: RuntimeRecoveryCommandReader,
+    private readonly deliveries: RuntimeRecoveryDeliveryReader,
+    private readonly observations: RuntimeLifecycleObservationPort,
+    private readonly clock: RuntimeClockPort = { now: () => new Date() },
+    private readonly ids: RuntimeIdGeneratorPort = {
+      generate: () => crypto.randomUUID(),
+    },
+  ) {}
+
+  async reconcile(
+    operation: RuntimeRecoveryPendingOperation,
+  ): Promise<PendingOperationRecoveryResult> {
+    validateOperationIdentity(operation);
+    return "action" in operation
+      ? this.reconcileLifecycle(operation)
+      : this.reconcileReplacement(operation);
+  }
+
+  private async reconcileLifecycle(
+    initial: AgentGoalLifecycleTransition,
+  ): Promise<PendingOperationRecoveryResult> {
+    let transition = initial;
+    const command = await this.commandFor(
+      transition.ownerId,
+      transition.runtimeSessionId,
+      transition.instruction.id,
+    );
+    const nextRunEpoch =
+      transition.action === "cancel"
+        ? transition.expectedRunEpoch + 1
+        : transition.expectedRunEpoch;
+
+    if (transition.action === "cancel" && transition.phase === "prepared") {
+      transition = (
+        await this.state.markLifecycleTransitionBoundary({
+          ownerId: transition.ownerId,
+          runtimeSessionId: transition.runtimeSessionId,
+          goalId: transition.transitionedGoal.goal.id,
+          expectedRunEpoch: transition.expectedRunEpoch,
+          nextRunEpoch,
+          command,
+        })
+      ).transition;
+    }
+    if (transition.phase !== "finalized") {
+      transition = (
+        await this.state.finalizeLifecycleTransition({
+          ownerId: transition.ownerId,
+          runtimeSessionId: transition.runtimeSessionId,
+          goalId: transition.transitionedGoal.goal.id,
+          expectedRunEpoch: transition.expectedRunEpoch,
+          nextRunEpoch,
+          command,
+        })
+      ).transition;
+    }
+    await this.settleControlInstruction({
+      ownerId: transition.ownerId,
+      runtimeSessionId: transition.runtimeSessionId,
+      instructionId: transition.instruction.id,
+      runEpoch: transition.expectedRunEpoch,
+      status: transition.action === "pause" ? "paused" : "cancelled",
+    });
+    return { disposition: "dormant", runEpoch: transition.runEpoch };
+  }
+
+  private async reconcileReplacement(
+    initial: AgentGoalReplacement,
+  ): Promise<PendingOperationRecoveryResult> {
+    let replacement = initial;
+    const command = await this.commandFor(
+      replacement.ownerId,
+      replacement.runtimeSessionId,
+      replacement.controlInstruction.id,
+    );
+    if (replacement.phase === "prepared") {
+      replacement = (
+        await this.state.markReplacementBoundary({
+          ownerId: replacement.ownerId,
+          runtimeSessionId: replacement.runtimeSessionId,
+          replacementGoalId: replacement.replacementGoal.goal.id,
+          expectedRunEpoch: replacement.expectedRunEpoch,
+          nextRunEpoch: replacement.expectedRunEpoch + 1,
+          command,
+        })
+      ).replacement;
+    }
+    if (replacement.phase !== "activated") {
+      replacement = (
+        await this.state.finalizeReplacement({
+          ownerId: replacement.ownerId,
+          runtimeSessionId: replacement.runtimeSessionId,
+          replacementGoalId: replacement.replacementGoal.goal.id,
+          activationInstruction: this.activationInstruction(replacement),
+          command,
+        })
+      ).replacement;
+    }
+    await this.settleControlInstruction({
+      ownerId: replacement.ownerId,
+      runtimeSessionId: replacement.runtimeSessionId,
+      instructionId: replacement.controlInstruction.id,
+      runEpoch: replacement.expectedRunEpoch,
+      status: "cancelled",
+    });
+    const activationInstructionId = replacement.activationInstruction?.id;
+    if (!activationInstructionId) {
+      throw new Error(
+        `Recovered Goal replacement ${replacement.replacementGoal.goal.id} has no activation instruction`,
+      );
+    }
+    return {
+      disposition: "resume",
+      runEpoch: replacement.runEpoch,
+      activationInstructionId,
+    };
+  }
+
+  private activationInstruction(
+    replacement: AgentGoalReplacement,
+  ): RuntimeInstructionDraft {
+    return {
+      schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+      id: this.ids.generate(),
+      goalId: replacement.replacementGoal.goal.id,
+      goalRevision: replacement.replacementGoal.goal.revision,
+      kind: "goal.activate",
+      deliveryMode: "steer",
+      targetSessionId: replacement.runtimeSessionId,
+      payload: { goal: replacement.replacementGoal.goal },
+      source: replacement.controlInstruction.source,
+      idempotencyKey: replacement.controlInstruction.idempotencyKey,
+      issuedAt: this.clock.now().toISOString(),
+    };
+  }
+
+  private async settleControlInstruction(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    instructionId: string;
+    runEpoch: number;
+    status: "paused" | "cancelled";
+  }): Promise<void> {
+    const delivery = await this.deliveries.getActiveByInstruction(input);
+    if (!delivery) return;
+
+    if (
+      delivery.state === "pending" ||
+      delivery.state === "leased" ||
+      delivery.state === "queued"
+    ) {
+      // The provider process is gone, so the lifecycle boundary is real even
+      // though this control message was never provider-visible. Retire the
+      // stale outbox item instead of fabricating a Claude receipt or allowing
+      // it to replay when the Goal is later resumed.
+      await this.observations.supersedeDeliveries({
+        ownerId: input.ownerId,
+        runtimeSessionId: input.runtimeSessionId,
+        instructionIds: [input.instructionId],
+        reason: `Settled ${input.status} during Runtime recovery before provider delivery`,
+      });
+      return;
+    }
+
+    await this.observations.finalizeControlInstruction({
+      ...input,
+      recordedAt: this.clock.now().toISOString(),
+    });
+  }
+
+  private async commandFor(
+    ownerId: string,
+    runtimeSessionId: string,
+    instructionId: string,
+  ): Promise<GoalCommandIdentity> {
+    const stored = await this.instructions.getStoredById({
+      ownerId,
+      runtimeSessionId,
+      instructionId,
+    });
+    if (!stored || stored.instruction.id !== instructionId) {
+      throw new Error(
+        `Cannot recover command metadata for Runtime Instruction ${instructionId}`,
+      );
+    }
+    return {
+      idempotencyKey: stored.instruction.idempotencyKey,
+      requestFingerprint: stored.requestFingerprint,
+    };
+  }
+}
+
+function validateOperationIdentity(
+  operation: RuntimeRecoveryPendingOperation,
+): void {
+  for (const [field, value] of [
+    ["ownerId", operation.ownerId],
+    ["runtimeSessionId", operation.runtimeSessionId],
+  ] as const) {
+    if (
+      typeof value !== "string" ||
+      value.length === 0 ||
+      value.length > 256 ||
+      value !== value.trim()
+    ) {
+      throw new TypeError(`${field} must be a non-empty identifier`);
+    }
+  }
+}

--- a/apps/web/lib/ai/runtime-instructions/recovery/startup.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/startup.ts
@@ -198,7 +198,7 @@ function asRecoveryPersistence(
     "releaseRecoveryLease",
     "releaseLiveRuntime",
     "persistState",
-    "markRecoveryFailed",
+    "pauseAfterRecoveryFailure",
   ] as const) {
     if (typeof candidate[method] !== "function") {
       throw new Error(

--- a/apps/web/lib/ai/runtime-instructions/recovery/startup.ts
+++ b/apps/web/lib/ai/runtime-instructions/recovery/startup.ts
@@ -1,0 +1,219 @@
+import { stat } from "node:fs/promises";
+
+import { getDbInstance } from "@/lib/db";
+import { getUserById } from "@/lib/db/queries";
+import {
+  runNativeAgentRequest,
+  type NativeAgentRunnerContext,
+} from "@/lib/ai/native-agent/runner";
+import { getAgentGoalRuntime, type SqliteAgentGoalRuntime } from "../runtime";
+import type {
+  RuntimeSessionPersistencePort,
+  RuntimeSessionRecoveryPersistencePort,
+} from "../runtime-session-persistence";
+import {
+  SqliteDeliveryRepository,
+  SqliteInstructionRepository,
+  type SqliteGoalRuntimeDatabaseSource,
+} from "../persistence/sqlite";
+import { PendingGoalOperationRecovery } from "./pending-operation-reconciler";
+import { createRuntimeRecoveryChatRecorder } from "./chat-message-recorder";
+import {
+  GoalRuntimeRecoveryCoordinator,
+  type RuntimeProviderSessionPreflightPort,
+  type RuntimeRecoveryOwnerSession,
+  type RuntimeRecoveryStartupReport,
+} from "./coordinator";
+
+type RecoveryProcessGlobal = typeof globalThis & {
+  __openLoomiGoalRuntimeRecoveryCoordinator?: GoalRuntimeRecoveryCoordinator;
+  __openLoomiGoalRuntimeRecoveryBootstrap?: Promise<RuntimeRecoveryStartupReport>;
+};
+
+/**
+ * Tauri/Node boot entrypoint. The process-global coordinator survives Next.js
+ * development reloads and keeps active recovery tasks from being started a
+ * second time by another instrumentation registration in the same process.
+ */
+export function startAgentGoalRuntimeRecovery(): Promise<RuntimeRecoveryStartupReport> {
+  const processGlobal = globalThis as RecoveryProcessGlobal;
+  const coordinator = getOrCreateRecoveryCoordinator(processGlobal);
+  coordinator.startMonitoring();
+  if (processGlobal.__openLoomiGoalRuntimeRecoveryBootstrap) {
+    return processGlobal.__openLoomiGoalRuntimeRecoveryBootstrap;
+  }
+
+  const bootstrap = coordinator.start().finally(() => {
+    if (processGlobal.__openLoomiGoalRuntimeRecoveryBootstrap === bootstrap) {
+      processGlobal.__openLoomiGoalRuntimeRecoveryBootstrap = undefined;
+    }
+  });
+  processGlobal.__openLoomiGoalRuntimeRecoveryBootstrap = bootstrap;
+  return bootstrap;
+}
+
+export async function wakeAgentGoalRuntimeRecovery(input: {
+  ownerId: string;
+  runtimeSessionId: string;
+}): Promise<boolean> {
+  const coordinator = getOrCreateRecoveryCoordinator(
+    globalThis as RecoveryProcessGlobal,
+  );
+  const result = await coordinator.wake(input);
+  return result.status === "resumed" || result.status === "already_running";
+}
+
+function getOrCreateRecoveryCoordinator(
+  processGlobal: RecoveryProcessGlobal,
+): GoalRuntimeRecoveryCoordinator {
+  processGlobal.__openLoomiGoalRuntimeRecoveryCoordinator ??=
+    createAgentGoalRuntimeRecoveryCoordinator();
+  return processGlobal.__openLoomiGoalRuntimeRecoveryCoordinator;
+}
+
+export function createAgentGoalRuntimeRecoveryCoordinator(): GoalRuntimeRecoveryCoordinator {
+  const runtime = getAgentGoalRuntime();
+  const sqliteRuntime = asSqliteRuntime(runtime);
+  const persistence = asRecoveryPersistence(runtime.runtimeSessions);
+  const databaseSource =
+    getDbInstance() as unknown as SqliteGoalRuntimeDatabaseSource;
+  const pendingOperations = new PendingGoalOperationRecovery(
+    sqliteRuntime.state,
+    new SqliteInstructionRepository(databaseSource),
+    new SqliteDeliveryRepository(databaseSource),
+    sqliteRuntime.observations,
+  );
+
+  return new GoalRuntimeRecoveryCoordinator({
+    persistence,
+    providerPreflight: new ClaudeSdkSessionPreflight(),
+    nativeRunner: {
+      run: (request, context) =>
+        runNativeAgentRequest(
+          request,
+          context as unknown as NativeAgentRunnerContext,
+        ),
+    },
+    loadOwnerSession: loadRecoveryOwnerSession,
+    reconcilePendingOperation: (operation) =>
+      pendingOperations.reconcile(operation),
+    attachObservationLease: (input) =>
+      sqliteRuntime.observations.attachRuntimeLease(input),
+    createChatRecorder: createRuntimeRecoveryChatRecorder,
+    logger: console,
+  });
+}
+
+class ClaudeSdkSessionPreflight implements RuntimeProviderSessionPreflightPort {
+  async verify(input: {
+    providerSessionId: string;
+    workingDirectory: string;
+  }): Promise<void> {
+    let directory: Awaited<ReturnType<typeof stat>>;
+    try {
+      directory = await stat(input.workingDirectory);
+    } catch (cause) {
+      throw new ProviderSessionPreflightError(
+        "working_directory_unavailable",
+        `Persisted working directory is unavailable: ${input.workingDirectory}`,
+        { cause },
+      );
+    }
+    if (!directory.isDirectory()) {
+      throw new ProviderSessionPreflightError(
+        "working_directory_unavailable",
+        `Persisted working directory is not a directory: ${input.workingDirectory}`,
+      );
+    }
+
+    try {
+      const { getSessionInfo, getSessionMessages } =
+        await import("@anthropic-ai/claude-agent-sdk");
+      const options = { dir: input.workingDirectory };
+      const info = await getSessionInfo(input.providerSessionId, options);
+      if (info) return;
+
+      // getSessionInfo intentionally returns undefined when a valid transcript
+      // has no extractable summary. Inspect one historical message before
+      // declaring the exact resume handle missing.
+      const messages = await getSessionMessages(input.providerSessionId, {
+        ...options,
+        limit: 1,
+        includeSystemMessages: true,
+      });
+      if (messages.length > 0) return;
+    } catch (cause) {
+      if (cause instanceof ProviderSessionPreflightError) throw cause;
+      throw new ProviderSessionPreflightError(
+        "provider_session_unreadable",
+        `Claude session ${input.providerSessionId} could not be read from its persisted working directory`,
+        { cause },
+      );
+    }
+    throw new ProviderSessionPreflightError(
+      "provider_session_unavailable",
+      `Claude session ${input.providerSessionId} no longer exists in its persisted working directory`,
+    );
+  }
+}
+
+class ProviderSessionPreflightError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ProviderSessionPreflightError";
+  }
+}
+
+async function loadRecoveryOwnerSession(
+  ownerId: string,
+): Promise<RuntimeRecoveryOwnerSession | null> {
+  const user = await getUserById(ownerId);
+  if (!user) return null;
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name ?? undefined,
+      type: "regular",
+    },
+    platform: "desktop-recovery",
+    expires: new Date(Date.now() + 24 * 60 * 60 * 1_000).toISOString(),
+  };
+}
+
+function asRecoveryPersistence(
+  persistence: RuntimeSessionPersistencePort,
+): RuntimeSessionRecoveryPersistencePort {
+  const candidate =
+    persistence as Partial<RuntimeSessionRecoveryPersistencePort>;
+  for (const method of [
+    "listRecoverable",
+    "claimRecovery",
+    "refreshRecovery",
+    "renewRecoveryLease",
+    "releaseRecoveryLease",
+    "releaseLiveRuntime",
+    "persistState",
+    "markRecoveryFailed",
+  ] as const) {
+    if (typeof candidate[method] !== "function") {
+      throw new Error(
+        "Goal Runtime restart recovery requires the durable SQLite runtime-session adapter",
+      );
+    }
+  }
+  return persistence as RuntimeSessionRecoveryPersistencePort;
+}
+
+function asSqliteRuntime(runtime: ReturnType<typeof getAgentGoalRuntime>) {
+  if (!("state" in runtime)) {
+    throw new Error(
+      "Goal Runtime restart recovery is only available for the desktop SQLite runtime",
+    );
+  }
+  return runtime as SqliteAgentGoalRuntime;
+}

--- a/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
@@ -50,11 +50,66 @@ export interface RuntimeProviderEventObservation {
 export interface RuntimeGoalEvaluationSnapshot {
   run: AgentGoalRun;
   evidence: GoalEvidence[];
+  /**
+   * Oldest Goal revision whose evidence is still valid for the current Goal
+   * definition. Lifecycle-only revisions (pause/resume/evaluation) preserve
+   * evidence; goal/context mutations move this boundary forward.
+   */
+  evidenceRevisionFloor?: number;
+}
+
+const EVIDENCE_SCOPE_BOUNDARY_KINDS = new Set<RuntimeInstruction["kind"]>([
+  "goal.activate",
+  "goal.update",
+  "context.upsert",
+  "context.remove",
+  "constraint.upsert",
+  "constraint.remove",
+]);
+
+export function isGoalEvidenceRevisionBoundary(
+  kind: RuntimeInstruction["kind"],
+): boolean {
+  return EVIDENCE_SCOPE_BOUNDARY_KINDS.has(kind);
+}
+
+/**
+ * Resolve the semantic evidence boundary for a Goal revision.
+ *
+ * Goal revisions also fence lifecycle transitions, so exact-revision
+ * filtering would discard valid evidence every time a Goal is paused and
+ * resumed. Evidence remains valid until an instruction changes the Goal or
+ * its evaluation context. Missing instruction history fails closed to the
+ * current revision.
+ */
+export function resolveGoalEvidenceRevisionFloor(
+  goalId: string,
+  currentRevision: number,
+  instructions: readonly RuntimeInstruction[],
+): number {
+  let floor: number | undefined;
+  for (const instruction of instructions) {
+    if (
+      instruction.goalId !== goalId ||
+      instruction.goalRevision === undefined ||
+      instruction.goalRevision > currentRevision ||
+      !isGoalEvidenceRevisionBoundary(instruction.kind)
+    ) {
+      continue;
+    }
+    floor = Math.max(floor ?? 0, instruction.goalRevision);
+  }
+  return floor ?? currentRevision;
 }
 
 export type RuntimeGoalEvaluationOutcome = Extract<
   GoalRunStatus,
-  "continuing" | "blocked" | "completed" | "budget_limited" | "failed"
+  | "continuing"
+  | "paused"
+  | "blocked"
+  | "completed"
+  | "budget_limited"
+  | "failed"
 >;
 
 export interface RuntimeGoalEvaluationJournalPort {

--- a/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-observation.ts
@@ -139,6 +139,7 @@ export interface RuntimeProviderObservationPort {
     ownerId: string;
     runtimeSessionId: string;
     providerSessionId: string;
+    runEpoch?: number;
   }): Promise<void>;
 
   captureContext(input: {
@@ -150,6 +151,23 @@ export interface RuntimeProviderObservationPort {
   observeProviderEvent(
     input: RuntimeProviderEventObservation,
   ): Promise<boolean>;
+}
+
+export interface RuntimeObservationLeaseRegistration {
+  release(): void;
+}
+
+/**
+ * Optional durable ownership fence implemented by persistent journals.
+ * Runtime adapters attach the lease that owns their provider process before
+ * any provider event or Delivery mutation is recorded.
+ */
+export interface RuntimeObservationLeaseFencePort {
+  attachRuntimeLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseToken: string;
+  }): RuntimeObservationLeaseRegistration;
 }
 
 /** Complete boundary implemented by process-local and future durable journals. */

--- a/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
@@ -1,7 +1,20 @@
-import type {
-  AgentRuntimeSession,
-  RuntimeClockPort,
+import { isAbsolute } from "node:path";
+
+import {
+  assertDeliveryStateTransition,
+  assertGoalStatusTransition,
+  assertGoalRunStatusTransition,
+  assertRuntimeSessionStateTransition,
+  type AgentGoalRun,
+  type AgentRuntimeSession,
+  type GoalEvidence,
+  type PersistedAgentGoal,
+  type RuntimeClockPort,
+  type RuntimeInstruction,
+  type RuntimeSessionState,
 } from "@openloomi/ai/agent/runtime-instructions";
+
+import type { AgentRuntimePendingOperation } from "@/lib/db/agent-goal-runtime-schema-types";
 
 import {
   resolveSqliteGoalRuntimeDatabase,
@@ -12,10 +25,13 @@ import type {
   SqliteGoalRuntimeStore,
   SqliteGoalSessionRecord,
 } from "./persistence/sqlite/store";
+import type { PersistedRuntimeInstructionDelivery } from "./persistence/runtime-observation-mappers";
 
 export type RuntimeSessionPersistenceErrorCode =
   | "runtime_session_not_found"
   | "runtime_session_recovery_required"
+  | "runtime_recovery_claim_conflict"
+  | "runtime_recovery_configuration_invalid"
   | "provider_session_conflict"
   | "storage_failure";
 
@@ -30,20 +46,208 @@ export class RuntimeSessionPersistenceError extends Error {
   }
 }
 
+/**
+ * Provider-neutral, credential-free options required to recreate a runtime.
+ * API keys, base URLs, auth tokens, and provider-specific configuration are
+ * intentionally absent; the recovery host resolves those from current trusted
+ * application configuration.
+ */
+export interface RuntimeRecoveryDescriptor {
+  readonly schemaVersion: 1;
+  readonly model?: string;
+  readonly thinkingLevel?: "disabled" | "low" | "adaptive";
+  readonly permissionMode?:
+    | "default"
+    | "acceptEdits"
+    | "bypassPermissions"
+    | "plan"
+    | "dontAsk";
+  readonly allowedTools?: readonly string[];
+  readonly disallowedTools?: readonly string[];
+  readonly excludedTools?: readonly string[];
+  readonly sandbox?: {
+    readonly enabled: boolean;
+    readonly provider?: string;
+    readonly image?: string;
+  };
+  readonly skillsConfig?: RuntimeRecoveryFeatureSources;
+  readonly mcpConfig?: RuntimeRecoveryFeatureSources;
+}
+
+export interface RuntimeRecoveryFeatureSources {
+  readonly enabled: boolean;
+  readonly userDirEnabled: boolean;
+  readonly appDirEnabled: boolean;
+}
+
+export interface RuntimeSessionEnsureOptions {
+  readonly workingDirectory?: string;
+  readonly recoveryDescriptor?: RuntimeRecoveryDescriptor;
+  /** Trusted token returned by `claimRecovery`; never accepted from HTTP. */
+  readonly recoveryLeaseToken?: string;
+}
+
+export interface RuntimeRecoveryCandidate {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly providerSessionId?: string;
+  readonly workingDirectory?: string;
+  readonly runEpoch: number;
+  readonly updatedAt: string;
+}
+
+/** Internal read model used only to reconnect the desktop UI to live recovery. */
+export interface RuntimeRecoveryPresentationSession {
+  readonly runtimeSessionId: string;
+  readonly state: RuntimeSessionState;
+  readonly runEpoch: number;
+  readonly updatedAt: string;
+}
+
+export interface RuntimeRecoveryInstructionSettlement {
+  readonly instructionId: string;
+  readonly disposition: "accepted" | "superseded";
+  readonly recordedAt: string;
+  readonly providerEventId?: string;
+  readonly reason?: string;
+}
+
+export interface RuntimeRecoverySnapshot {
+  readonly session: AgentRuntimeSession;
+  readonly recoveryDescriptor?: RuntimeRecoveryDescriptor;
+  readonly activeGoal?: PersistedAgentGoal;
+  readonly pendingOperation?: AgentRuntimePendingOperation;
+  readonly runs: readonly AgentGoalRun[];
+  readonly instructions: readonly RuntimeInstruction[];
+  readonly deliveries: readonly PersistedRuntimeInstructionDelivery[];
+  readonly evidence: readonly GoalEvidence[];
+  readonly replayableInstructionIds: readonly string[];
+  readonly instructionSettlements: readonly RuntimeRecoveryInstructionSettlement[];
+  readonly reconciliation: {
+    readonly evaluationsReset: number;
+    readonly leasesReclaimed: number;
+    readonly queuedAttemptsRetried: number;
+    readonly writtenAttemptsRetried: number;
+    readonly expired: number;
+    readonly superseded: number;
+  };
+}
+
+export interface RuntimeRecoveryClaim {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly leaseOwner: string;
+  readonly leaseToken: string;
+  readonly leaseExpiresAt: string;
+  readonly snapshot: RuntimeRecoverySnapshot;
+}
+
+/**
+ * Durable ownership of an ordinary, already-running provider session.
+ * Unlike a recovery claim, acquiring this lease never reconciles persisted
+ * Goal state or Delivery attempts.
+ */
+export interface RuntimeLiveSessionLease {
+  readonly ownerId: string;
+  readonly runtimeSessionId: string;
+  readonly leaseOwner: string;
+  readonly leaseToken: string;
+  readonly leaseExpiresAt: string;
+  readonly state: RuntimeSessionState;
+  readonly runEpoch: number;
+}
+
+export interface RuntimeSessionLeaseFence {
+  readonly runtimeLeaseToken: string;
+  readonly expectedRunEpoch: number;
+}
+
+export interface RuntimeSessionRecoveryPersistencePort extends RuntimeSessionPersistencePort {
+  claimLiveRuntime(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseDurationMs?: number;
+    workingDirectory?: string;
+    recoveryDescriptor?: RuntimeRecoveryDescriptor;
+  }): Promise<RuntimeLiveSessionLease | null>;
+  releaseLiveRuntime(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+  }): Promise<AgentRuntimeSession>;
+  listRecoverable(limit?: number): Promise<RuntimeRecoveryCandidate[]>;
+  claimRecovery(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseDurationMs?: number;
+  }): Promise<RuntimeRecoveryClaim | null>;
+  refreshRecovery(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+  }): Promise<RuntimeRecoverySnapshot>;
+  renewRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    leaseDurationMs?: number;
+  }): Promise<string>;
+  releaseRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+  }): Promise<void>;
+  persistState(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedState: RuntimeSessionState;
+    expectedRunEpoch: number;
+    state: RuntimeSessionState;
+    recoveryLeaseToken?: string;
+  }): Promise<AgentRuntimeSession>;
+  markRecoveryFailed(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+    errorCode: string;
+    errorMessage: string;
+  }): Promise<void>;
+}
+
 export interface RuntimeSessionPersistencePort {
-  get(ownerId: string, runtimeSessionId: string): Promise<AgentRuntimeSession | null>;
-  ensure(ownerId: string, runtimeSessionId: string): Promise<AgentRuntimeSession>;
+  get(
+    ownerId: string,
+    runtimeSessionId: string,
+  ): Promise<AgentRuntimeSession | null>;
+  ensure(
+    ownerId: string,
+    runtimeSessionId: string,
+    options?: RuntimeSessionEnsureOptions,
+  ): Promise<AgentRuntimeSession>;
   bindProviderSession(input: {
     ownerId: string;
     runtimeSessionId: string;
     providerSessionId: string;
+    runtimeLeaseToken?: string;
+    expectedRunEpoch?: number;
   }): Promise<void>;
-  releaseProviderSession(ownerId: string, runtimeSessionId: string): Promise<void>;
+  releaseProviderSession(
+    ownerId: string,
+    runtimeSessionId: string,
+    fence?: RuntimeSessionLeaseFence,
+  ): Promise<void>;
 }
 
-export class InMemoryRuntimeSessionPersistence
-  implements RuntimeSessionPersistencePort
-{
+export class InMemoryRuntimeSessionPersistence implements RuntimeSessionPersistencePort {
   private readonly sessions = new Map<string, AgentRuntimeSession>();
 
   constructor(
@@ -54,7 +258,9 @@ export class InMemoryRuntimeSessionPersistence
     ownerId: string,
     runtimeSessionId: string,
   ): Promise<AgentRuntimeSession | null> {
-    const session = this.sessions.get(identifier(runtimeSessionId, "runtimeSessionId"));
+    const session = this.sessions.get(
+      identifier(runtimeSessionId, "runtimeSessionId"),
+    );
     return session?.ownerId === identifier(ownerId, "ownerId")
       ? structuredClone(session)
       : null;
@@ -63,19 +269,35 @@ export class InMemoryRuntimeSessionPersistence
   async ensure(
     ownerId: string,
     runtimeSessionId: string,
+    options: RuntimeSessionEnsureOptions = {},
   ): Promise<AgentRuntimeSession> {
     const owner = identifier(ownerId, "ownerId");
     const sessionId = identifier(runtimeSessionId, "runtimeSessionId");
     const existing = this.sessions.get(sessionId);
     if (existing) {
       if (existing.ownerId !== owner) throw sessionNotFound(sessionId);
-      return structuredClone(existing);
+      const workingDirectory = options.workingDirectory
+        ? workingDirectoryPath(options.workingDirectory)
+        : existing.workingDirectory;
+      if (workingDirectory === existing.workingDirectory) {
+        return structuredClone(existing);
+      }
+      const updated = {
+        ...existing,
+        workingDirectory,
+        updatedAt: this.clock.now().toISOString(),
+      };
+      this.sessions.set(sessionId, updated);
+      return structuredClone(updated);
     }
     const now = this.clock.now().toISOString();
     const session: AgentRuntimeSession = {
       id: sessionId,
       ownerId: owner,
       provider: "claude",
+      ...(options.workingDirectory === undefined
+        ? {}
+        : { workingDirectory: workingDirectoryPath(options.workingDirectory) }),
       state: "starting",
       runEpoch: 0,
       createdAt: now,
@@ -89,6 +311,8 @@ export class InMemoryRuntimeSessionPersistence
     ownerId: string;
     runtimeSessionId: string;
     providerSessionId: string;
+    runtimeLeaseToken?: string;
+    expectedRunEpoch?: number;
   }): Promise<void> {
     const session = await this.ensure(input.ownerId, input.runtimeSessionId);
     const providerSessionId = identifier(
@@ -109,6 +333,7 @@ export class InMemoryRuntimeSessionPersistence
   async releaseProviderSession(
     ownerId: string,
     runtimeSessionId: string,
+    _fence?: RuntimeSessionLeaseFence,
   ): Promise<void> {
     const session = await this.get(ownerId, runtimeSessionId);
     if (!session?.providerSessionId) return;
@@ -118,13 +343,13 @@ export class InMemoryRuntimeSessionPersistence
   }
 }
 
-/** Refuses to claim unfinished rows until durable restart recovery exists. */
-export class SqliteRuntimeSessionPersistence
-  implements RuntimeSessionPersistencePort
-{
+export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPersistencePort {
   private readonly database: SqliteGoalRuntimeDatabase;
-  private readonly claimed = new Set<string>();
-  private readonly providerLeases = new Map<string, string>();
+  /** Process-local capabilities backed by durable, expiring SQLite leases. */
+  private readonly claimed = new Map<
+    string,
+    { leaseOwner: string; leaseToken: string; runEpoch: number }
+  >();
 
   constructor(
     source: SqliteGoalRuntimeDatabaseSource,
@@ -146,16 +371,42 @@ export class SqliteRuntimeSessionPersistence
   async ensure(
     ownerId: string,
     runtimeSessionId: string,
+    options: RuntimeSessionEnsureOptions = {},
   ): Promise<AgentRuntimeSession> {
     const owner = identifier(ownerId, "ownerId");
     const sessionId = identifier(runtimeSessionId, "runtimeSessionId");
     const claim = scope(owner, sessionId);
+    const metadata = parseEnsureOptions(options);
     try {
       const record = this.database.immediate((store) => {
         const byId = store.getSessionById(sessionId);
         if (byId) {
           if (byId.ownerId !== owner) throw sessionNotFound(sessionId);
-          if (!this.claimed.has(claim)) {
+          const localClaim = this.claimed.get(claim);
+          const recoveryToken = metadata.recoveryLeaseToken;
+          const leaseIsCurrent =
+            byId.recoveryLeaseExpiresAtSeconds !== undefined &&
+            byId.recoveryLeaseExpiresAtSeconds > nowSeconds(this.clock);
+          const tokenAuthorizesRecovery =
+            recoveryToken !== undefined &&
+            byId.recoveryLeaseToken === recoveryToken &&
+            leaseIsCurrent;
+          const localClaimIsCurrent =
+            localClaim !== undefined &&
+            byId.recoveryLeaseToken === localClaim.leaseToken &&
+            byId.recoveryLeaseOwner === localClaim.leaseOwner &&
+            leaseIsCurrent;
+          if (recoveryToken !== undefined && !tokenAuthorizesRecovery) {
+            throw recoveryClaimConflict(sessionId);
+          }
+          if (
+            leaseIsCurrent &&
+            !localClaimIsCurrent &&
+            !tokenAuthorizesRecovery
+          ) {
+            throw recoveryClaimConflict(sessionId);
+          }
+          if (!localClaimIsCurrent && !tokenAuthorizesRecovery) {
             if (requiresRecovery(store, byId)) {
               throw new RuntimeSessionPersistenceError(
                 "runtime_session_recovery_required",
@@ -167,21 +418,68 @@ export class SqliteRuntimeSessionPersistence
                 ownerId: owner,
                 runtimeSessionId: sessionId,
                 expectedProviderSessionId: byId.providerSessionId,
-                updatedAtSeconds: Math.floor(this.clock.now().getTime() / 1_000),
+                updatedAtSeconds: Math.floor(
+                  this.clock.now().getTime() / 1_000,
+                ),
               });
               return store.getSession(owner, sessionId) ?? byId;
             }
           }
-          return byId;
+          const workingDirectory =
+            metadata.workingDirectory ?? byId.workingDirectory;
+          const recoveryDescriptor =
+            metadata.recoveryDescriptor ?? parseStoredDescriptor(byId);
+          if (
+            workingDirectory !== byId.workingDirectory ||
+            canonicalJson(recoveryDescriptor) !==
+              canonicalJson(parseStoredDescriptor(byId))
+          ) {
+            if (
+              !store.updateSessionRecoveryMetadata({
+                ownerId: owner,
+                runtimeSessionId: sessionId,
+                workingDirectory,
+                recoveryDescriptor,
+                updatedAtSeconds: nowSeconds(this.clock),
+              })
+            ) {
+              throw storageFailure(
+                "Could not persist Runtime recovery metadata",
+              );
+            }
+          }
+          return store.getSession(owner, sessionId) ?? byId;
         }
         if (!store.hasUser(owner)) throw sessionNotFound(sessionId);
-        const now = Math.floor(this.clock.now().getTime() / 1_000);
-        store.insertSession({ ownerId: owner, runtimeSessionId: sessionId, recordedAtSeconds: now });
+        if (metadata.recoveryLeaseToken !== undefined) {
+          throw recoveryClaimConflict(sessionId);
+        }
+        const now = nowSeconds(this.clock);
+        store.insertSession({
+          ownerId: owner,
+          runtimeSessionId: sessionId,
+          ...(metadata.workingDirectory === undefined
+            ? {}
+            : { workingDirectory: metadata.workingDirectory }),
+          ...(metadata.recoveryDescriptor === undefined
+            ? {}
+            : { recoveryDescriptor: metadata.recoveryDescriptor }),
+          recordedAtSeconds: now,
+        });
         const inserted = store.getSession(owner, sessionId);
-        if (!inserted) throw storageFailure("Could not read the created Runtime Session");
+        if (!inserted)
+          throw storageFailure("Could not read the created Runtime Session");
         return inserted;
       });
-      this.claimed.add(claim);
+      if (metadata.recoveryLeaseToken !== undefined) {
+        const leaseOwner = record.recoveryLeaseOwner;
+        if (!leaseOwner) throw recoveryClaimConflict(sessionId);
+        this.claimed.set(claim, {
+          leaseOwner,
+          leaseToken: metadata.recoveryLeaseToken,
+          runEpoch: record.runEpoch,
+        });
+      }
       return mapSession(record);
     } catch (cause) {
       if (cause instanceof RuntimeSessionPersistenceError) throw cause;
@@ -193,15 +491,46 @@ export class SqliteRuntimeSessionPersistence
     ownerId: string;
     runtimeSessionId: string;
     providerSessionId: string;
+    runtimeLeaseToken?: string;
+    expectedRunEpoch?: number;
   }): Promise<void> {
     const ownerId = identifier(input.ownerId, "ownerId");
-    const runtimeSessionId = identifier(input.runtimeSessionId, "runtimeSessionId");
-    const providerSessionId = identifier(input.providerSessionId, "providerSessionId");
-    await this.ensure(ownerId, runtimeSessionId);
+    const runtimeSessionId = identifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const providerSessionId = identifier(
+      input.providerSessionId,
+      "providerSessionId",
+    );
+    const localClaim = this.claimed.get(scope(ownerId, runtimeSessionId));
+    const suppliedLeaseToken =
+      input.runtimeLeaseToken ?? localClaim?.leaseToken;
+    const suppliedRunEpoch = input.expectedRunEpoch ?? localClaim?.runEpoch;
+    if (suppliedLeaseToken === undefined || suppliedRunEpoch === undefined) {
+      throw recoveryClaimConflict(runtimeSessionId);
+    }
+    const runtimeLeaseToken = identifier(
+      suppliedLeaseToken,
+      "runtimeLeaseToken",
+    );
+    const expectedRunEpoch = nonNegativeInteger(
+      suppliedRunEpoch,
+      "expectedRunEpoch",
+    );
     try {
       this.database.immediate((store) => {
         const current = store.getSession(ownerId, runtimeSessionId);
         if (!current) throw sessionNotFound(runtimeSessionId);
+        const now = nowSeconds(this.clock);
+        if (
+          current.recoveryLeaseToken !== runtimeLeaseToken ||
+          current.recoveryLeaseExpiresAtSeconds === undefined ||
+          current.recoveryLeaseExpiresAtSeconds <= now ||
+          current.runEpoch !== expectedRunEpoch
+        ) {
+          throw recoveryClaimConflict(runtimeSessionId);
+        }
         if (current.providerSessionId === providerSessionId) return;
         if (current.providerSessionId !== undefined) {
           throw providerConflict(runtimeSessionId);
@@ -214,11 +543,13 @@ export class SqliteRuntimeSessionPersistence
           ownerId,
           runtimeSessionId,
           providerSessionId,
-          updatedAtSeconds: Math.floor(this.clock.now().getTime() / 1_000),
+          runtimeLeaseToken,
+          expectedRunEpoch,
+          availableAtSeconds: now,
+          updatedAtSeconds: now,
         });
         if (!changed) throw providerConflict(runtimeSessionId);
       });
-      this.providerLeases.set(scope(ownerId, runtimeSessionId), providerSessionId);
     } catch (cause) {
       if (cause instanceof RuntimeSessionPersistenceError) throw cause;
       throw storageFailure("Could not bind the Claude provider session", cause);
@@ -228,26 +559,959 @@ export class SqliteRuntimeSessionPersistence
   async releaseProviderSession(
     ownerId: string,
     runtimeSessionId: string,
+    fence?: RuntimeSessionLeaseFence,
   ): Promise<void> {
     const owner = identifier(ownerId, "ownerId");
     const sessionId = identifier(runtimeSessionId, "runtimeSessionId");
     const claim = scope(owner, sessionId);
-    const providerSessionId = this.providerLeases.get(claim);
-    if (!providerSessionId) return;
+    const localClaim = this.claimed.get(claim);
+    const suppliedLeaseToken =
+      fence?.runtimeLeaseToken ?? localClaim?.leaseToken;
+    const suppliedRunEpoch = fence?.expectedRunEpoch ?? localClaim?.runEpoch;
+    if (suppliedLeaseToken === undefined || suppliedRunEpoch === undefined) {
+      throw recoveryClaimConflict(sessionId);
+    }
+    const runtimeLeaseToken = identifier(
+      suppliedLeaseToken,
+      "runtimeLeaseToken",
+    );
+    const expectedRunEpoch = nonNegativeInteger(
+      suppliedRunEpoch,
+      "expectedRunEpoch",
+    );
     try {
       this.database.immediate((store) => {
-        store.clearProviderSession({
-          ownerId: owner,
-          runtimeSessionId: sessionId,
-          expectedProviderSessionId: providerSessionId,
-          updatedAtSeconds: Math.floor(this.clock.now().getTime() / 1_000),
-        });
+        const session = store.getSession(owner, sessionId);
+        const now = nowSeconds(this.clock);
+        if (
+          !session ||
+          session.recoveryLeaseToken !== runtimeLeaseToken ||
+          session.recoveryLeaseExpiresAtSeconds === undefined ||
+          session.recoveryLeaseExpiresAtSeconds <= now ||
+          session.runEpoch !== expectedRunEpoch
+        ) {
+          throw recoveryClaimConflict(sessionId);
+        }
+        // The provider session identity is the only resume handle. Keep it
+        // while durable Goal/Run state is unfinished; a process-local lease is
+        // not proof that the provider session itself should be forgotten.
+        if (
+          session.providerSessionId &&
+          !store.hasUnfinishedRuntimeState(owner, sessionId)
+        ) {
+          if (
+            !store.clearProviderSession({
+              ownerId: owner,
+              runtimeSessionId: sessionId,
+              expectedProviderSessionId: session.providerSessionId,
+              updatedAtSeconds: now,
+            })
+          ) {
+            throw providerConflict(sessionId);
+          }
+        }
       });
-      this.providerLeases.delete(claim);
     } catch (cause) {
-      throw storageFailure("Could not release the Claude provider session", cause);
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure(
+        "Could not release the Claude provider session",
+        cause,
+      );
     }
   }
+
+  async listRecoverable(limit = 100): Promise<RuntimeRecoveryCandidate[]> {
+    const parsedLimit = positiveInteger(limit, "limit", 500);
+    try {
+      const store = this.database.store;
+      return store
+        .listRecoverableSessionIds(nowSeconds(this.clock), parsedLimit)
+        .flatMap(({ ownerId, runtimeSessionId }) => {
+          const session = store.getSession(ownerId, runtimeSessionId);
+          return session
+            ? [
+                {
+                  ownerId,
+                  runtimeSessionId,
+                  ...(session.providerSessionId === undefined
+                    ? {}
+                    : { providerSessionId: session.providerSessionId }),
+                  ...(session.workingDirectory === undefined
+                    ? {}
+                    : { workingDirectory: session.workingDirectory }),
+                  runEpoch: session.runEpoch,
+                  updatedAt: secondsIso(session.updatedAtSeconds),
+                },
+              ]
+            : [];
+        });
+    } catch (cause) {
+      throw storageFailure(
+        "Could not list recoverable Runtime Sessions",
+        cause,
+      );
+    }
+  }
+
+  async listRecoveryPresentationSessions(
+    ownerId: string,
+    limit = 20,
+  ): Promise<RuntimeRecoveryPresentationSession[]> {
+    const owner = identifier(ownerId, "ownerId");
+    const parsedLimit = positiveInteger(limit, "limit", 100);
+    try {
+      const store = this.database.store;
+      return store
+        .listRecoveryPresentationSessionIds(owner, parsedLimit)
+        .flatMap((runtimeSessionId) => {
+          const session = store.getSession(owner, runtimeSessionId);
+          return session
+            ? [
+                {
+                  runtimeSessionId,
+                  state: session.state,
+                  runEpoch: session.runEpoch,
+                  updatedAt: secondsIso(session.updatedAtSeconds),
+                },
+              ]
+            : [];
+        });
+    } catch (cause) {
+      throw storageFailure(
+        "Could not list Runtime Sessions for recovery presentation",
+        cause,
+      );
+    }
+  }
+
+  async claimLiveRuntime(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseDurationMs?: number;
+    workingDirectory?: string;
+    recoveryDescriptor?: RuntimeRecoveryDescriptor;
+  }): Promise<RuntimeLiveSessionLease | null> {
+    const ownerId = identifier(input.ownerId, "ownerId");
+    const runtimeSessionId = identifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const leaseOwner = identifier(input.leaseOwner, "leaseOwner");
+    const leaseDurationMs = recoveryLeaseDuration(input.leaseDurationMs);
+    const metadata = parseEnsureOptions({
+      ...(input.workingDirectory === undefined
+        ? {}
+        : { workingDirectory: input.workingDirectory }),
+      ...(input.recoveryDescriptor === undefined
+        ? {}
+        : { recoveryDescriptor: input.recoveryDescriptor }),
+    });
+    const leaseToken = crypto.randomUUID();
+    const now = nowSeconds(this.clock);
+    const leaseExpiresAtSeconds = now + Math.ceil(leaseDurationMs / 1_000);
+    try {
+      const session = this.database.immediate((store) => {
+        let current = store.getSessionById(runtimeSessionId);
+        let inserted = false;
+        if (current) {
+          if (current.ownerId !== ownerId)
+            throw sessionNotFound(runtimeSessionId);
+        } else {
+          if (!store.hasUser(ownerId)) throw sessionNotFound(runtimeSessionId);
+          store.insertSession({
+            ownerId,
+            runtimeSessionId,
+            ...(metadata.workingDirectory === undefined
+              ? {}
+              : { workingDirectory: metadata.workingDirectory }),
+            ...(metadata.recoveryDescriptor === undefined
+              ? {}
+              : { recoveryDescriptor: metadata.recoveryDescriptor }),
+            recordedAtSeconds: now,
+          });
+          current = store.getSession(ownerId, runtimeSessionId);
+          if (!current) {
+            throw storageFailure("Could not read the created Runtime Session");
+          }
+          inserted = true;
+        }
+        if (
+          !store.claimLiveRuntimeLease({
+            ownerId,
+            runtimeSessionId,
+            leaseOwner,
+            leaseToken,
+            availableAtSeconds: now,
+            leaseExpiresAtSeconds,
+            updatedAtSeconds: now,
+          })
+        ) {
+          if (inserted) {
+            throw storageFailure(
+              "Could not claim the newly created Runtime Session",
+            );
+          }
+          return null;
+        }
+        if (current.providerSessionId) {
+          if (
+            !store.clearProviderSession({
+              ownerId,
+              runtimeSessionId,
+              expectedProviderSessionId: current.providerSessionId,
+              updatedAtSeconds: now,
+            })
+          ) {
+            throw providerConflict(runtimeSessionId);
+          }
+        }
+        const workingDirectory =
+          metadata.workingDirectory ?? current.workingDirectory;
+        const descriptor =
+          metadata.recoveryDescriptor ?? parseStoredDescriptor(current);
+        if (
+          workingDirectory !== current.workingDirectory ||
+          canonicalJson(descriptor) !==
+            canonicalJson(parseStoredDescriptor(current))
+        ) {
+          if (
+            !store.updateSessionRecoveryMetadata({
+              ownerId,
+              runtimeSessionId,
+              workingDirectory,
+              recoveryDescriptor: descriptor,
+              updatedAtSeconds: now,
+            })
+          ) {
+            throw storageFailure("Could not persist Runtime recovery metadata");
+          }
+        }
+        return store.getSession(ownerId, runtimeSessionId) ?? current;
+      });
+      if (!session) return null;
+      this.claimed.set(scope(ownerId, runtimeSessionId), {
+        leaseOwner,
+        leaseToken,
+        runEpoch: session.runEpoch,
+      });
+      return {
+        ownerId,
+        runtimeSessionId,
+        leaseOwner,
+        leaseToken,
+        leaseExpiresAt: secondsIso(leaseExpiresAtSeconds),
+        state: session.state,
+        runEpoch: session.runEpoch,
+      };
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure(
+        "Could not claim live Runtime Session ownership",
+        cause,
+      );
+    }
+  }
+
+  async releaseLiveRuntime(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+  }): Promise<AgentRuntimeSession> {
+    const parsed = recoveryLeaseInput(input);
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const now = nowSeconds(this.clock);
+    try {
+      const session = this.database.immediate((store) => {
+        if (
+          !store.releaseLiveRuntimeLease({
+            ...parsed,
+            expectedRunEpoch,
+            availableAtSeconds: now,
+            updatedAtSeconds: now,
+          })
+        ) {
+          throw recoveryClaimConflict(parsed.runtimeSessionId);
+        }
+        const released = store.getSession(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+        );
+        if (!released) throw sessionNotFound(parsed.runtimeSessionId);
+        return released;
+      });
+      const claim = scope(parsed.ownerId, parsed.runtimeSessionId);
+      if (this.claimed.get(claim)?.leaseToken === parsed.leaseToken) {
+        this.claimed.delete(claim);
+      }
+      return mapSession(session);
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure(
+        "Could not release live Runtime Session ownership",
+        cause,
+      );
+    }
+  }
+
+  async claimRecovery(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseDurationMs?: number;
+  }): Promise<RuntimeRecoveryClaim | null> {
+    const ownerId = identifier(input.ownerId, "ownerId");
+    const runtimeSessionId = identifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    const leaseOwner = identifier(input.leaseOwner, "leaseOwner");
+    const leaseDurationMs = recoveryLeaseDuration(input.leaseDurationMs);
+    const leaseToken = crypto.randomUUID();
+    const now = nowSeconds(this.clock);
+    const leaseExpiresAtSeconds = now + Math.ceil(leaseDurationMs / 1_000);
+    try {
+      const snapshot = this.database.immediate((store) => {
+        const session = store.getSession(ownerId, runtimeSessionId);
+        if (!session) throw sessionNotFound(runtimeSessionId);
+        if (
+          !store.claimRecoveryLease({
+            ownerId,
+            runtimeSessionId,
+            leaseOwner,
+            leaseToken,
+            availableAtSeconds: now,
+            leaseExpiresAtSeconds,
+            updatedAtSeconds: now,
+          })
+        ) {
+          return null;
+        }
+        return reconcileAndSnapshot(
+          store,
+          store.getSession(ownerId, runtimeSessionId) ?? session,
+          this.clock.now(),
+        );
+      });
+      if (!snapshot) return null;
+      this.claimed.set(scope(ownerId, runtimeSessionId), {
+        leaseOwner,
+        leaseToken,
+        runEpoch: snapshot.session.runEpoch,
+      });
+      return {
+        ownerId,
+        runtimeSessionId,
+        leaseOwner,
+        leaseToken,
+        leaseExpiresAt: secondsIso(leaseExpiresAtSeconds),
+        snapshot,
+      };
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure("Could not claim Runtime Session recovery", cause);
+    }
+  }
+
+  async refreshRecovery(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+  }): Promise<RuntimeRecoverySnapshot> {
+    const parsed = recoveryLeaseInput(input);
+    try {
+      return this.database.immediate((store) => {
+        const session = store.getSession(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+        );
+        if (
+          !session ||
+          session.recoveryLeaseOwner !== parsed.leaseOwner ||
+          session.recoveryLeaseToken !== parsed.leaseToken ||
+          session.recoveryLeaseExpiresAtSeconds === undefined ||
+          session.recoveryLeaseExpiresAtSeconds <= nowSeconds(this.clock)
+        ) {
+          throw recoveryClaimConflict(parsed.runtimeSessionId);
+        }
+        return reconcileAndSnapshot(store, session, this.clock.now());
+      });
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure(
+        "Could not refresh Runtime recovery snapshot",
+        cause,
+      );
+    }
+  }
+
+  async renewRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    leaseDurationMs?: number;
+  }): Promise<string> {
+    const parsed = recoveryLeaseInput(input);
+    const now = nowSeconds(this.clock);
+    const expiresAt =
+      now + Math.ceil(recoveryLeaseDuration(input.leaseDurationMs) / 1_000);
+    try {
+      const renewed = this.database.immediate((store) =>
+        store.renewRecoveryLease({
+          ...parsed,
+          availableAtSeconds: now,
+          leaseExpiresAtSeconds: expiresAt,
+          updatedAtSeconds: now,
+        }),
+      );
+      if (!renewed) throw recoveryClaimConflict(parsed.runtimeSessionId);
+      return secondsIso(expiresAt);
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure("Could not renew Runtime recovery lease", cause);
+    }
+  }
+
+  async releaseRecoveryLease(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+  }): Promise<void> {
+    const parsed = recoveryLeaseInput(input);
+    const now = nowSeconds(this.clock);
+    try {
+      const released = this.database.immediate((store) =>
+        store.releaseRecoveryLease({
+          ...parsed,
+          availableAtSeconds: now,
+          updatedAtSeconds: now,
+        }),
+      );
+      if (!released) throw recoveryClaimConflict(parsed.runtimeSessionId);
+      const localClaim = this.claimed.get(
+        scope(parsed.ownerId, parsed.runtimeSessionId),
+      );
+      if (localClaim?.leaseToken === parsed.leaseToken) {
+        this.claimed.delete(scope(parsed.ownerId, parsed.runtimeSessionId));
+      }
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure("Could not release Runtime recovery lease", cause);
+    }
+  }
+
+  async persistState(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    expectedState: RuntimeSessionState;
+    expectedRunEpoch: number;
+    state: RuntimeSessionState;
+    recoveryLeaseToken?: string;
+  }): Promise<AgentRuntimeSession> {
+    const ownerId = identifier(input.ownerId, "ownerId");
+    const runtimeSessionId = identifier(
+      input.runtimeSessionId,
+      "runtimeSessionId",
+    );
+    if (input.expectedState !== input.state) {
+      assertRuntimeSessionStateTransition(input.expectedState, input.state);
+    }
+    try {
+      return this.database.immediate((store) => {
+        const current = store.getSession(ownerId, runtimeSessionId);
+        if (!current) throw sessionNotFound(runtimeSessionId);
+        const recoveryLeaseToken =
+          input.recoveryLeaseToken === undefined
+            ? undefined
+            : identifier(input.recoveryLeaseToken, "recoveryLeaseToken");
+        if (
+          current.state !== input.expectedState ||
+          current.runEpoch !== input.expectedRunEpoch ||
+          (recoveryLeaseToken === undefined
+            ? current.recoveryLeaseToken !== undefined
+            : current.recoveryLeaseToken !== recoveryLeaseToken ||
+              current.recoveryLeaseExpiresAtSeconds === undefined ||
+              current.recoveryLeaseExpiresAtSeconds <= nowSeconds(this.clock))
+        ) {
+          throw recoveryClaimConflict(runtimeSessionId);
+        }
+        if (current.state !== input.state) {
+          const changed = store.updateSessionState({
+            ownerId,
+            runtimeSessionId,
+            expectedState: input.expectedState,
+            expectedRunEpoch: input.expectedRunEpoch,
+            state: input.state,
+            ...(recoveryLeaseToken === undefined ? {} : { recoveryLeaseToken }),
+            updatedAtSeconds: nowSeconds(this.clock),
+          });
+          if (!changed) throw recoveryClaimConflict(runtimeSessionId);
+        }
+        const updated = store.getSession(ownerId, runtimeSessionId);
+        if (!updated) throw sessionNotFound(runtimeSessionId);
+        return mapSession(updated);
+      });
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure("Could not persist Runtime Session state", cause);
+    }
+  }
+
+  async markRecoveryFailed(input: {
+    ownerId: string;
+    runtimeSessionId: string;
+    leaseOwner: string;
+    leaseToken: string;
+    expectedRunEpoch: number;
+    errorCode: string;
+    errorMessage: string;
+  }): Promise<void> {
+    const parsed = recoveryLeaseInput(input);
+    const expectedRunEpoch = nonNegativeInteger(
+      input.expectedRunEpoch,
+      "expectedRunEpoch",
+    );
+    const errorCode = boundedText(input.errorCode, "errorCode", 128);
+    const errorMessage = boundedText(input.errorMessage, "errorMessage", 8_000);
+    try {
+      const failed = this.database.immediate((store) => {
+        const session = store.getSession(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+        );
+        if (
+          !session ||
+          session.recoveryLeaseOwner !== parsed.leaseOwner ||
+          session.recoveryLeaseToken !== parsed.leaseToken ||
+          session.runEpoch !== expectedRunEpoch ||
+          session.recoveryLeaseExpiresAtSeconds === undefined ||
+          session.recoveryLeaseExpiresAtSeconds <= nowSeconds(this.clock)
+        ) {
+          return false;
+        }
+        const at = this.clock.now().toISOString();
+        const assigned = store.getAssignedPrimaryGoal(
+          parsed.ownerId,
+          parsed.runtimeSessionId,
+        );
+        if (assigned?.persistedGoal.goal.status === "active") {
+          const currentGoal = assigned.persistedGoal;
+          assertGoalStatusTransition(currentGoal.goal.status, "blocked");
+          const blockedGoal: PersistedAgentGoal = {
+            ...currentGoal,
+            goal: {
+              ...currentGoal.goal,
+              revision: currentGoal.goal.revision + 1,
+              status: "blocked",
+              updatedAt: at,
+            },
+          };
+          const failureEvaluation = {
+            completed: false,
+            confidence: 0,
+            satisfiedCriteria: [],
+            missingCriteria: currentGoal.goal.successCriteria
+              .filter((criterion) => criterion.required)
+              .map((criterion) => criterion.id),
+            evidence: [],
+            reason: `Goal recovery failed: ${errorMessage}`.slice(0, 8_000),
+          };
+          if (
+            !store.updateGoal(
+              blockedGoal,
+              currentGoal.goal.revision,
+              "assigned",
+              "assigned",
+            )
+          ) {
+            throw storageFailure(
+              "Could not block the Goal after recovery failure",
+            );
+          }
+          const run = store.findRun(
+            parsed.ownerId,
+            parsed.runtimeSessionId,
+            currentGoal.goal.id,
+            session.runEpoch,
+          );
+          if (
+            run &&
+            ["running", "evaluating", "continuing"].includes(run.status)
+          ) {
+            assertGoalRunStatusTransition(run.status, "blocked");
+            if (
+              !store.updateRun(
+                run,
+                {
+                  ...run,
+                  goalRevision: blockedGoal.goal.revision,
+                  status: "blocked",
+                  lastActivityAt: at,
+                  lastEvaluation: failureEvaluation,
+                },
+                at,
+              )
+            ) {
+              throw storageFailure(
+                "Could not block the Goal Run after recovery failure",
+              );
+            }
+          } else if (run?.status === "queued") {
+            assertGoalRunStatusTransition(run.status, "failed");
+            if (
+              !store.updateRun(
+                run,
+                {
+                  ...run,
+                  goalRevision: blockedGoal.goal.revision,
+                  status: "failed",
+                  lastActivityAt: at,
+                  completedAt: at,
+                  lastEvaluation: failureEvaluation,
+                },
+                at,
+              )
+            ) {
+              throw storageFailure(
+                "Could not fail the queued Goal Run after recovery failure",
+              );
+            }
+          }
+        }
+        return store.markRecoveryFailed({
+          ...parsed,
+          expectedRunEpoch,
+          errorCode,
+          errorMessage,
+          failedAtSeconds: nowSeconds(this.clock),
+        });
+      });
+      if (!failed) throw recoveryClaimConflict(parsed.runtimeSessionId);
+      this.claimed.delete(scope(parsed.ownerId, parsed.runtimeSessionId));
+    } catch (cause) {
+      if (cause instanceof RuntimeSessionPersistenceError) throw cause;
+      throw storageFailure("Could not mark Runtime recovery as failed", cause);
+    }
+  }
+}
+
+function reconcileAndSnapshot(
+  store: SqliteGoalRuntimeStore,
+  session: SqliteGoalSessionRecord,
+  now: Date,
+): RuntimeRecoverySnapshot {
+  const recordedAt = now.toISOString();
+  const instructions = store.listStoredInstructions(
+    session.ownerId,
+    session.runtimeSessionId,
+  );
+  const instructionById = new Map(
+    instructions.map((stored) => [stored.instruction.id, stored]),
+  );
+  const activeGoal = store.getAssignedPrimaryGoal(
+    session.ownerId,
+    session.runtimeSessionId,
+  )?.persistedGoal;
+  const deliveryOnlyRecovery = store.hasDeliveryOnlyRecoveryState(
+    session.ownerId,
+    session.runtimeSessionId,
+  );
+  const reconciliation = {
+    evaluationsReset: 0,
+    leasesReclaimed: 0,
+    queuedAttemptsRetried: 0,
+    writtenAttemptsRetried: 0,
+    expired: 0,
+    superseded: 0,
+  };
+
+  for (const run of store.listRuns(session.ownerId, session.runtimeSessionId)) {
+    if (run.status !== "evaluating") continue;
+    assertGoalRunStatusTransition(run.status, "running");
+    if (
+      !store.updateRun(
+        run,
+        { ...run, status: "running", lastActivityAt: recordedAt },
+        recordedAt,
+      )
+    ) {
+      throw storageFailure(`Could not reset evaluating Goal Run ${run.id}`);
+    }
+    reconciliation.evaluationsReset += 1;
+  }
+
+  for (const delivery of store.listDeliveries(
+    session.ownerId,
+    session.runtimeSessionId,
+  )) {
+    if (!isRecoverableDelivery(delivery.state)) continue;
+    const stored = instructionById.get(delivery.instructionId);
+    const instruction = stored?.instruction;
+    const expired =
+      instruction?.expiresAt !== undefined &&
+      Date.parse(instruction.expiresAt) <= now.getTime();
+    const stale =
+      !stored ||
+      stored.runEpoch !== session.runEpoch ||
+      delivery.runEpoch !== session.runEpoch ||
+      (!deliveryOnlyRecovery &&
+        instruction?.goalId !== undefined &&
+        (activeGoal?.goal.id !== instruction.goalId ||
+          activeGoal.goal.revision !== instruction.goalRevision));
+
+    if (delivery.state === "observed") {
+      // An observed Delivery crossed the provider boundary before the host
+      // disappeared. Claiming the abandoned runtime establishes the missing
+      // terminal boundary, so a still-current attempt can be made durable as
+      // applied without replaying it to the provider. Never apply an observed
+      // attempt from an obsolete epoch or Goal revision.
+      transitionRecoveryDelivery(
+        store,
+        delivery,
+        stale ? "failed" : "applied",
+        recordedAt,
+        stale
+          ? {
+              errorCode: "stale_runtime_fence",
+              errorMessage:
+                "Observed instruction belongs to a stale Goal revision or run epoch",
+            }
+          : {},
+      );
+      if (stale) reconciliation.superseded += 1;
+      continue;
+    }
+
+    if (expired) {
+      transitionRecoveryDelivery(
+        store,
+        delivery,
+        delivery.state === "written_to_sdk" ? "failed" : "expired",
+        recordedAt,
+        {
+          errorCode: "instruction_expired",
+          errorMessage: "Instruction expired while the runtime was offline",
+        },
+      );
+      reconciliation.expired += 1;
+      continue;
+    }
+    if (stale) {
+      transitionRecoveryDelivery(
+        store,
+        delivery,
+        delivery.state === "written_to_sdk" ? "failed" : "superseded",
+        recordedAt,
+        {
+          errorCode: "stale_runtime_fence",
+          errorMessage:
+            "Instruction belongs to a stale Goal revision or run epoch",
+        },
+      );
+      reconciliation.superseded += 1;
+      continue;
+    }
+    if (deliveryOnlyRecovery) {
+      transitionRecoveryDelivery(
+        store,
+        delivery,
+        delivery.state === "written_to_sdk" ? "failed" : "superseded",
+        recordedAt,
+        {
+          errorCode: "runtime_execution_already_terminal",
+          errorMessage:
+            "Instruction remained unsettled after its Goal execution reached a terminal state",
+        },
+      );
+      reconciliation.superseded += 1;
+      continue;
+    }
+    if (delivery.state === "leased") {
+      transitionRecoveryDelivery(store, delivery, "pending", recordedAt);
+      reconciliation.leasesReclaimed += 1;
+      continue;
+    }
+    if (delivery.state === "queued") {
+      retryRecoveryDelivery(store, delivery, recordedAt, {
+        errorCode: "runtime_restarted_before_provider_write",
+        errorMessage:
+          "Queued delivery was not durably observed by the provider before restart",
+      });
+      reconciliation.queuedAttemptsRetried += 1;
+      continue;
+    }
+    if (delivery.state === "written_to_sdk") {
+      retryRecoveryDelivery(store, delivery, recordedAt, {
+        errorCode: "runtime_restarted_before_provider_observation",
+        errorMessage:
+          "Delivery reached the SDK input boundary but was not durably observed by the provider before restart",
+      });
+      reconciliation.writtenAttemptsRetried += 1;
+    }
+  }
+
+  const runs = store.listRuns(session.ownerId, session.runtimeSessionId);
+  const deliveries = store.listDeliveries(
+    session.ownerId,
+    session.runtimeSessionId,
+  );
+  const evidence = runs.flatMap((run) =>
+    store.listEvidenceByRun(session.ownerId, session.runtimeSessionId, run.id),
+  );
+  const progress = recoveryInstructionProgress(instructions, deliveries);
+  return {
+    session: mapSession(
+      store.getSession(session.ownerId, session.runtimeSessionId) ?? session,
+    ),
+    ...(parseStoredDescriptor(session) === undefined
+      ? {}
+      : { recoveryDescriptor: parseStoredDescriptor(session) }),
+    ...(activeGoal === undefined ? {} : { activeGoal }),
+    ...(session.pendingOperation === undefined
+      ? {}
+      : { pendingOperation: structuredClone(session.pendingOperation) }),
+    runs,
+    instructions: instructions.map((stored) => stored.instruction),
+    deliveries,
+    evidence,
+    replayableInstructionIds: progress.replayableInstructionIds,
+    instructionSettlements: progress.instructionSettlements,
+    reconciliation,
+  };
+}
+
+function recoveryInstructionProgress(
+  instructions: ReturnType<SqliteGoalRuntimeStore["listStoredInstructions"]>,
+  deliveries: readonly PersistedRuntimeInstructionDelivery[],
+): Pick<
+  RuntimeRecoverySnapshot,
+  "replayableInstructionIds" | "instructionSettlements"
+> {
+  const replayableInstructionIds: string[] = [];
+  const instructionSettlements: RuntimeRecoveryInstructionSettlement[] = [];
+  for (const stored of instructions) {
+    const attempts = deliveries.filter(
+      (delivery) => delivery.instructionId === stored.instruction.id,
+    );
+    const visible = attempts.find((delivery) =>
+      isProviderObservedDelivery(delivery.state),
+    );
+    if (visible) {
+      instructionSettlements.push({
+        instructionId: stored.instruction.id,
+        disposition: "accepted",
+        recordedAt: visible.updatedAt,
+        ...(visible.providerEventId === undefined
+          ? {}
+          : { providerEventId: visible.providerEventId }),
+      });
+      continue;
+    }
+    if (attempts.some((delivery) => delivery.state === "pending")) {
+      replayableInstructionIds.push(stored.instruction.id);
+      continue;
+    }
+    const terminal = attempts.at(-1);
+    if (terminal && isTerminalDelivery(terminal.state)) {
+      instructionSettlements.push({
+        instructionId: stored.instruction.id,
+        disposition: "superseded",
+        recordedAt: terminal.updatedAt,
+        reason:
+          terminal.errorMessage ??
+          `Instruction settled as ${terminal.state} before recovery`,
+      });
+    }
+  }
+  return { replayableInstructionIds, instructionSettlements };
+}
+
+function transitionRecoveryDelivery(
+  store: SqliteGoalRuntimeStore,
+  current: PersistedRuntimeInstructionDelivery,
+  state: PersistedRuntimeInstructionDelivery["state"],
+  recordedAt: string,
+  fields: Pick<
+    PersistedRuntimeInstructionDelivery,
+    "errorCode" | "errorMessage"
+  > = {},
+): void {
+  assertDeliveryStateTransition(current.state, state);
+  const next: PersistedRuntimeInstructionDelivery = {
+    ...current,
+    state,
+    updatedAt: recordedAt,
+    leaseToken: undefined,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+    ...fields,
+  };
+  if (!store.updateDelivery(current, next)) {
+    throw storageFailure(`Could not reconcile Delivery ${current.id}`);
+  }
+}
+
+function retryRecoveryDelivery(
+  store: SqliteGoalRuntimeStore,
+  delivery: PersistedRuntimeInstructionDelivery,
+  recordedAt: string,
+  fields: Pick<
+    PersistedRuntimeInstructionDelivery,
+    "errorCode" | "errorMessage"
+  >,
+): void {
+  transitionRecoveryDelivery(store, delivery, "failed", recordedAt, fields);
+  store.insertPendingDelivery({
+    id: crypto.randomUUID(),
+    ownerId: delivery.ownerId,
+    runtimeSessionId: delivery.runtimeSessionId,
+    instructionId: delivery.instructionId,
+    ...(delivery.goalRunId === undefined
+      ? {}
+      : { goalRunId: delivery.goalRunId }),
+    runEpoch: delivery.runEpoch,
+    attempt: delivery.attempt + 1,
+    availableAt: recordedAt,
+    recordedAt,
+  });
+}
+
+function isRecoverableDelivery(
+  state: PersistedRuntimeInstructionDelivery["state"],
+): boolean {
+  return (
+    state === "pending" ||
+    state === "leased" ||
+    state === "queued" ||
+    state === "written_to_sdk" ||
+    state === "observed"
+  );
+}
+
+function isProviderObservedDelivery(
+  state: PersistedRuntimeInstructionDelivery["state"],
+): boolean {
+  return state === "observed" || state === "applied" || state === "completed";
+}
+
+function isTerminalDelivery(
+  state: PersistedRuntimeInstructionDelivery["state"],
+): boolean {
+  return (
+    state === "rejected" ||
+    state === "expired" ||
+    state === "superseded" ||
+    state === "cancelled" ||
+    state === "failed"
+  );
 }
 
 function mapSession(record: SqliteGoalSessionRecord): AgentRuntimeSession {
@@ -255,6 +1519,9 @@ function mapSession(record: SqliteGoalSessionRecord): AgentRuntimeSession {
     id: record.runtimeSessionId,
     ownerId: record.ownerId,
     provider: record.provider,
+    ...(record.workingDirectory === undefined
+      ? {}
+      : { workingDirectory: record.workingDirectory }),
     state: record.state,
     runEpoch: record.runEpoch,
     ...(record.providerSessionId === undefined
@@ -269,6 +1536,14 @@ function requiresRecovery(
   store: SqliteGoalRuntimeStore,
   session: SqliteGoalSessionRecord,
 ): boolean {
+  if (
+    store.isWaitingForFirstProviderRuntime(
+      session.ownerId,
+      session.runtimeSessionId,
+    )
+  ) {
+    return false;
+  }
   if (session.pendingOperation !== undefined) return true;
   if (store.getAssignedPrimaryGoal(session.ownerId, session.runtimeSessionId)) {
     return true;
@@ -277,9 +1552,14 @@ function requiresRecovery(
     store
       .listRuns(session.ownerId, session.runtimeSessionId)
       .some((run) =>
-        ["queued", "running", "evaluating", "continuing", "paused", "blocked"].includes(
-          run.status,
-        ),
+        [
+          "queued",
+          "running",
+          "evaluating",
+          "continuing",
+          "paused",
+          "blocked",
+        ].includes(run.status),
       )
   ) {
     return true;
@@ -294,7 +1574,12 @@ function requiresRecovery(
 }
 
 function identifier(value: string, field: string): string {
-  if (typeof value !== "string" || value.length === 0 || value.length > 256 || value !== value.trim()) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value !== value.trim()
+  ) {
     throw new TypeError(`${field} must be a non-empty identifier`);
   }
   return value;
@@ -304,20 +1589,339 @@ function scope(ownerId: string, runtimeSessionId: string): string {
   return JSON.stringify([ownerId, runtimeSessionId]);
 }
 
-function sessionNotFound(runtimeSessionId: string): RuntimeSessionPersistenceError {
+function sessionNotFound(
+  runtimeSessionId: string,
+): RuntimeSessionPersistenceError {
   return new RuntimeSessionPersistenceError(
     "runtime_session_not_found",
     `Runtime Session ${runtimeSessionId} was not found for this user`,
   );
 }
 
-function providerConflict(runtimeSessionId: string): RuntimeSessionPersistenceError {
+function providerConflict(
+  runtimeSessionId: string,
+): RuntimeSessionPersistenceError {
   return new RuntimeSessionPersistenceError(
     "provider_session_conflict",
     `Runtime Session ${runtimeSessionId} is already bound to another Claude session`,
   );
 }
 
-function storageFailure(message: string, cause?: unknown): RuntimeSessionPersistenceError {
-  return new RuntimeSessionPersistenceError("storage_failure", message, { cause });
+function storageFailure(
+  message: string,
+  cause?: unknown,
+): RuntimeSessionPersistenceError {
+  return new RuntimeSessionPersistenceError("storage_failure", message, {
+    cause,
+  });
+}
+
+function recoveryClaimConflict(
+  runtimeSessionId: string,
+): RuntimeSessionPersistenceError {
+  return new RuntimeSessionPersistenceError(
+    "runtime_recovery_claim_conflict",
+    `Runtime Session ${runtimeSessionId} is not owned by this recovery claim`,
+  );
+}
+
+function parseEnsureOptions(
+  options: RuntimeSessionEnsureOptions,
+): RuntimeSessionEnsureOptions {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("Runtime Session options must be an object");
+  }
+  return {
+    ...(options.workingDirectory === undefined
+      ? {}
+      : { workingDirectory: workingDirectoryPath(options.workingDirectory) }),
+    ...(options.recoveryDescriptor === undefined
+      ? {}
+      : { recoveryDescriptor: recoveryDescriptor(options.recoveryDescriptor) }),
+    ...(options.recoveryLeaseToken === undefined
+      ? {}
+      : {
+          recoveryLeaseToken: identifier(
+            options.recoveryLeaseToken,
+            "recoveryLeaseToken",
+          ),
+        }),
+  };
+}
+
+function parseStoredDescriptor(
+  session: SqliteGoalSessionRecord,
+): RuntimeRecoveryDescriptor | undefined {
+  return session.recoveryDescriptor === undefined
+    ? undefined
+    : recoveryDescriptor(session.recoveryDescriptor);
+}
+
+function recoveryDescriptor(value: unknown): RuntimeRecoveryDescriptor {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw recoveryConfigurationInvalid("Recovery descriptor must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "schemaVersion",
+    "model",
+    "thinkingLevel",
+    "permissionMode",
+    "allowedTools",
+    "disallowedTools",
+    "excludedTools",
+    "sandbox",
+    "skillsConfig",
+    "mcpConfig",
+  ]);
+  const unknownKey = Object.keys(record).find((key) => !allowedKeys.has(key));
+  if (unknownKey) {
+    throw recoveryConfigurationInvalid(
+      `Recovery descriptor contains unsupported field ${unknownKey}`,
+    );
+  }
+  if (record.schemaVersion !== 1) {
+    throw recoveryConfigurationInvalid(
+      "Recovery descriptor schemaVersion must be 1",
+    );
+  }
+  const thinkingLevel = optionalLiteral(
+    record.thinkingLevel,
+    ["disabled", "low", "adaptive"] as const,
+    "thinkingLevel",
+  );
+  const permissionMode = optionalLiteral(
+    record.permissionMode,
+    ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const,
+    "permissionMode",
+  );
+  return {
+    schemaVersion: 1,
+    ...(record.model === undefined
+      ? {}
+      : { model: boundedText(record.model, "model", 256) }),
+    ...(thinkingLevel === undefined ? {} : { thinkingLevel }),
+    ...(permissionMode === undefined ? {} : { permissionMode }),
+    ...(record.allowedTools === undefined
+      ? {}
+      : { allowedTools: stringList(record.allowedTools, "allowedTools") }),
+    ...(record.disallowedTools === undefined
+      ? {}
+      : {
+          disallowedTools: stringList(
+            record.disallowedTools,
+            "disallowedTools",
+          ),
+        }),
+    ...(record.excludedTools === undefined
+      ? {}
+      : { excludedTools: stringList(record.excludedTools, "excludedTools") }),
+    ...(record.sandbox === undefined
+      ? {}
+      : { sandbox: sandboxDescriptor(record.sandbox) }),
+    ...(record.skillsConfig === undefined
+      ? {}
+      : { skillsConfig: featureSources(record.skillsConfig, "skillsConfig") }),
+    ...(record.mcpConfig === undefined
+      ? {}
+      : { mcpConfig: featureSources(record.mcpConfig, "mcpConfig") }),
+  };
+}
+
+function sandboxDescriptor(
+  value: unknown,
+): NonNullable<RuntimeRecoveryDescriptor["sandbox"]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw recoveryConfigurationInvalid("sandbox must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const enabled = booleanValue(record.enabled, "sandbox.enabled");
+
+  // Provider details have no effect while sandboxing is disabled. Older
+  // clients may still send their previously saved provider, image, endpoint,
+  // or network configuration, so discard it instead of persisting or
+  // validating data that recovery will never consume.
+  if (!enabled) return { enabled: false };
+
+  const unknown = Object.keys(record).find(
+    (key) => !["enabled", "provider", "image"].includes(key),
+  );
+  if (unknown) {
+    throw recoveryConfigurationInvalid(
+      `sandbox contains unsupported field ${unknown}`,
+    );
+  }
+  return {
+    enabled: true,
+    ...(record.provider === undefined
+      ? {}
+      : { provider: boundedText(record.provider, "sandbox.provider", 128) }),
+    ...(record.image === undefined
+      ? {}
+      : { image: credentialFreeSandboxImage(record.image) }),
+  };
+}
+
+function credentialFreeSandboxImage(value: unknown): string {
+  const image = boundedText(value, "sandbox.image", 512);
+  // Container image references are names (optionally with a tag or digest),
+  // not credential-bearing URLs. Query strings/fragments are likewise not
+  // part of an OCI image reference and are common places for bearer secrets.
+  if (image.includes("://") || image.includes("?") || image.includes("#")) {
+    throw recoveryConfigurationInvalid(
+      "sandbox.image must not contain a URL or embedded credentials",
+    );
+  }
+  const at = image.indexOf("@");
+  if (
+    at !== -1 &&
+    (image.indexOf("@", at + 1) !== -1 ||
+      !/^[A-Za-z][A-Za-z0-9+._-]*:[A-Za-z0-9=_-]+$/.test(image.slice(at + 1)))
+  ) {
+    throw recoveryConfigurationInvalid(
+      "sandbox.image must not contain embedded credentials",
+    );
+  }
+  return image;
+}
+
+function featureSources(
+  value: unknown,
+  field: string,
+): RuntimeRecoveryFeatureSources {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw recoveryConfigurationInvalid(`${field} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const unknown = Object.keys(record).find(
+    (key) => !["enabled", "userDirEnabled", "appDirEnabled"].includes(key),
+  );
+  if (unknown) {
+    throw recoveryConfigurationInvalid(
+      `${field} contains unsupported field ${unknown}`,
+    );
+  }
+  return {
+    enabled: booleanValue(record.enabled, `${field}.enabled`),
+    userDirEnabled: booleanValue(
+      record.userDirEnabled,
+      `${field}.userDirEnabled`,
+    ),
+    appDirEnabled: booleanValue(record.appDirEnabled, `${field}.appDirEnabled`),
+  };
+}
+
+function recoveryConfigurationInvalid(
+  message: string,
+): RuntimeSessionPersistenceError {
+  return new RuntimeSessionPersistenceError(
+    "runtime_recovery_configuration_invalid",
+    message,
+  );
+}
+
+function stringList(value: unknown, field: string): readonly string[] {
+  if (!Array.isArray(value) || value.length > 256) {
+    throw recoveryConfigurationInvalid(
+      `${field} must be a bounded string list`,
+    );
+  }
+  return value.map((item, index) =>
+    boundedText(item, `${field}[${index}]`, 256),
+  );
+}
+
+function optionalLiteral<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+  field: string,
+): T[number] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !values.includes(value)) {
+    throw recoveryConfigurationInvalid(`${field} is invalid`);
+  }
+  return value;
+}
+
+function booleanValue(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw recoveryConfigurationInvalid(`${field} must be boolean`);
+  }
+  return value;
+}
+
+function boundedText(value: unknown, field: string, maximum: number): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximum ||
+    value !== value.trim()
+  ) {
+    throw new TypeError(`${field} must be non-empty bounded text`);
+  }
+  return value;
+}
+
+function workingDirectoryPath(value: unknown): string {
+  const path = boundedText(value, "workingDirectory", 4_096);
+  if (!isAbsolute(path)) {
+    throw recoveryConfigurationInvalid("workingDirectory must be absolute");
+  }
+  return path;
+}
+
+function recoveryLeaseInput(input: {
+  ownerId: string;
+  runtimeSessionId: string;
+  leaseOwner: string;
+  leaseToken: string;
+}) {
+  return {
+    ownerId: identifier(input.ownerId, "ownerId"),
+    runtimeSessionId: identifier(input.runtimeSessionId, "runtimeSessionId"),
+    leaseOwner: identifier(input.leaseOwner, "leaseOwner"),
+    leaseToken: identifier(input.leaseToken, "leaseToken"),
+  };
+}
+
+function recoveryLeaseDuration(value: number | undefined): number {
+  const duration = value ?? 30_000;
+  if (
+    !Number.isSafeInteger(duration) ||
+    duration < 1_000 ||
+    duration > 300_000
+  ) {
+    throw new TypeError("leaseDurationMs must be between 1 and 300 seconds");
+  }
+  return duration;
+}
+
+function positiveInteger(
+  value: number,
+  field: string,
+  maximum: number,
+): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new TypeError(`${field} must be a positive bounded integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${field} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function nowSeconds(clock: RuntimeClockPort): number {
+  return Math.floor(clock.now().getTime() / 1_000);
+}
+
+function secondsIso(value: number): string {
+  return new Date(value * 1_000).toISOString();
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
 }

--- a/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
@@ -218,6 +218,8 @@ export interface RuntimeSessionRecoveryPersistencePort extends RuntimeSessionPer
     leaseOwner: string;
     leaseToken: string;
     expectedRunEpoch: number;
+    expectedGoalId?: string;
+    expectedGoalRevision?: number;
     errorCode: string;
     errorMessage: string;
   }): Promise<void>;
@@ -1071,6 +1073,8 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
     leaseOwner: string;
     leaseToken: string;
     expectedRunEpoch: number;
+    expectedGoalId?: string;
+    expectedGoalRevision?: number;
     errorCode: string;
     errorMessage: string;
   }): Promise<void> {
@@ -1081,6 +1085,26 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
     );
     const errorCode = boundedText(input.errorCode, "errorCode", 128);
     const errorMessage = boundedText(input.errorMessage, "errorMessage", 8_000);
+    if (
+      (input.expectedGoalId === undefined) !==
+      (input.expectedGoalRevision === undefined)
+    ) {
+      throw new TypeError(
+        "expectedGoalId and expectedGoalRevision must be provided together",
+      );
+    }
+    const expectedGoalId =
+      input.expectedGoalId === undefined
+        ? undefined
+        : identifier(input.expectedGoalId, "expectedGoalId");
+    const expectedGoalRevision =
+      input.expectedGoalRevision === undefined
+        ? undefined
+        : positiveInteger(
+            input.expectedGoalRevision,
+            "expectedGoalRevision",
+            Number.MAX_SAFE_INTEGER,
+          );
     try {
       const paused = this.database.immediate((store) => {
         const session = store.getSession(
@@ -1105,6 +1129,14 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
           parsed.ownerId,
           parsed.runtimeSessionId,
         );
+        if (
+          assigned?.persistedGoal.goal.status === "active" &&
+          expectedGoalId !== undefined &&
+          (assigned.persistedGoal.goal.id !== expectedGoalId ||
+            assigned.persistedGoal.goal.revision !== expectedGoalRevision)
+        ) {
+          return false;
+        }
         if (assigned?.persistedGoal.goal.status === "active") {
           const currentGoal = assigned.persistedGoal;
           assertGoalStatusTransition(currentGoal.goal.status, "paused");
@@ -1117,19 +1149,11 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
               updatedAt: at,
             },
           };
-          const failureEvaluation = {
-            completed: false,
-            confidence: 0,
-            satisfiedCriteria: [],
-            missingCriteria: currentGoal.goal.successCriteria
-              .filter((criterion) => criterion.required)
-              .map((criterion) => criterion.id),
-            evidence: [],
-            reason: `Goal recovery paused (${errorCode}): ${errorMessage}`.slice(
+          const failureReason =
+            `Goal recovery paused (${errorCode}): ${errorMessage}`.slice(
               0,
               8_000,
-            ),
-          };
+            );
           if (
             !store.updateGoal(
               pausedGoal,
@@ -1155,6 +1179,24 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
             )
           ) {
             assertGoalRunStatusTransition(run.status, "paused");
+            const failureEvaluation: NonNullable<
+              AgentGoalRun["lastEvaluation"]
+            > = run.lastEvaluation
+              ? {
+                  ...run.lastEvaluation,
+                  completed: false,
+                  reason: failureReason,
+                }
+              : {
+                  completed: false,
+                  confidence: 0,
+                  satisfiedCriteria: [],
+                  missingCriteria: currentGoal.goal.successCriteria
+                    .filter((criterion) => criterion.required)
+                    .map((criterion) => criterion.id),
+                  evidence: [],
+                  reason: failureReason,
+                };
             if (
               !store.updateRun(
                 run,

--- a/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-session-persistence.ts
@@ -212,7 +212,7 @@ export interface RuntimeSessionRecoveryPersistencePort extends RuntimeSessionPer
     state: RuntimeSessionState;
     recoveryLeaseToken?: string;
   }): Promise<AgentRuntimeSession>;
-  markRecoveryFailed(input: {
+  pauseAfterRecoveryFailure(input: {
     ownerId: string;
     runtimeSessionId: string;
     leaseOwner: string;
@@ -1065,7 +1065,7 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
     }
   }
 
-  async markRecoveryFailed(input: {
+  async pauseAfterRecoveryFailure(input: {
     ownerId: string;
     runtimeSessionId: string;
     leaseOwner: string;
@@ -1082,7 +1082,7 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
     const errorCode = boundedText(input.errorCode, "errorCode", 128);
     const errorMessage = boundedText(input.errorMessage, "errorMessage", 8_000);
     try {
-      const failed = this.database.immediate((store) => {
+      const paused = this.database.immediate((store) => {
         const session = store.getSession(
           parsed.ownerId,
           parsed.runtimeSessionId,
@@ -1097,6 +1097,9 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
         ) {
           return false;
         }
+        if (session.state !== "idle") {
+          assertRuntimeSessionStateTransition(session.state, "idle");
+        }
         const at = this.clock.now().toISOString();
         const assigned = store.getAssignedPrimaryGoal(
           parsed.ownerId,
@@ -1104,13 +1107,13 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
         );
         if (assigned?.persistedGoal.goal.status === "active") {
           const currentGoal = assigned.persistedGoal;
-          assertGoalStatusTransition(currentGoal.goal.status, "blocked");
-          const blockedGoal: PersistedAgentGoal = {
+          assertGoalStatusTransition(currentGoal.goal.status, "paused");
+          const pausedGoal: PersistedAgentGoal = {
             ...currentGoal,
             goal: {
               ...currentGoal.goal,
               revision: currentGoal.goal.revision + 1,
-              status: "blocked",
+              status: "paused",
               updatedAt: at,
             },
           };
@@ -1122,18 +1125,21 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
               .filter((criterion) => criterion.required)
               .map((criterion) => criterion.id),
             evidence: [],
-            reason: `Goal recovery failed: ${errorMessage}`.slice(0, 8_000),
+            reason: `Goal recovery paused (${errorCode}): ${errorMessage}`.slice(
+              0,
+              8_000,
+            ),
           };
           if (
             !store.updateGoal(
-              blockedGoal,
+              pausedGoal,
               currentGoal.goal.revision,
               "assigned",
               "assigned",
             )
           ) {
             throw storageFailure(
-              "Could not block the Goal after recovery failure",
+              "Could not pause the Goal after recovery failure",
             );
           }
           const run = store.findRun(
@@ -1144,61 +1150,42 @@ export class SqliteRuntimeSessionPersistence implements RuntimeSessionRecoveryPe
           );
           if (
             run &&
-            ["running", "evaluating", "continuing"].includes(run.status)
+            ["queued", "running", "evaluating", "continuing"].includes(
+              run.status,
+            )
           ) {
-            assertGoalRunStatusTransition(run.status, "blocked");
+            assertGoalRunStatusTransition(run.status, "paused");
             if (
               !store.updateRun(
                 run,
                 {
                   ...run,
-                  goalRevision: blockedGoal.goal.revision,
-                  status: "blocked",
+                  goalRevision: pausedGoal.goal.revision,
+                  status: "paused",
                   lastActivityAt: at,
+                  completedAt: undefined,
                   lastEvaluation: failureEvaluation,
                 },
                 at,
               )
             ) {
               throw storageFailure(
-                "Could not block the Goal Run after recovery failure",
-              );
-            }
-          } else if (run?.status === "queued") {
-            assertGoalRunStatusTransition(run.status, "failed");
-            if (
-              !store.updateRun(
-                run,
-                {
-                  ...run,
-                  goalRevision: blockedGoal.goal.revision,
-                  status: "failed",
-                  lastActivityAt: at,
-                  completedAt: at,
-                  lastEvaluation: failureEvaluation,
-                },
-                at,
-              )
-            ) {
-              throw storageFailure(
-                "Could not fail the queued Goal Run after recovery failure",
+                "Could not pause the Goal Run after recovery failure",
               );
             }
           }
         }
-        return store.markRecoveryFailed({
+        return store.pauseAfterRecoveryFailure({
           ...parsed,
           expectedRunEpoch,
-          errorCode,
-          errorMessage,
-          failedAtSeconds: nowSeconds(this.clock),
+          updatedAtSeconds: nowSeconds(this.clock),
         });
       });
-      if (!failed) throw recoveryClaimConflict(parsed.runtimeSessionId);
+      if (!paused) throw recoveryClaimConflict(parsed.runtimeSessionId);
       this.claimed.delete(scope(parsed.ownerId, parsed.runtimeSessionId));
     } catch (cause) {
       if (cause instanceof RuntimeSessionPersistenceError) throw cause;
-      throw storageFailure("Could not mark Runtime recovery as failed", cause);
+      throw storageFailure("Could not pause Runtime recovery", cause);
     }
   }
 }

--- a/apps/web/lib/ai/runtime-instructions/runtime-session-registry.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime-session-registry.ts
@@ -131,6 +131,12 @@ export class RuntimeSessionRegistry implements RuntimeSessionResolverPort {
     return session?.ownerId === ownerId && session.transport === transport;
   }
 
+  /** Owner-scoped liveness probe for the recovery presentation API. */
+  has(ownerId: string, runtimeSessionId: string): boolean {
+    const session = this.sessions.get(runtimeSessionId);
+    return session?.ownerId === ownerId;
+  }
+
   get size(): number {
     return this.sessions.size;
   }

--- a/apps/web/lib/ai/runtime-instructions/runtime.ts
+++ b/apps/web/lib/ai/runtime-instructions/runtime.ts
@@ -15,7 +15,10 @@ import {
   AgentGoalQueryService,
   type AgentGoalReadSource,
 } from "./goal-query-service";
-import { GoalLifecycleService } from "./goal-lifecycle-service";
+import {
+  GoalLifecycleService,
+  type RuntimeSessionRecoveryWakePort,
+} from "./goal-lifecycle-service";
 import { GoalReplacementCoordinator } from "./goal-replacement-coordinator";
 import { InMemoryAgentGoalState } from "./in-memory-goal-state";
 import { InMemoryRuntimeObservationJournal } from "./in-memory-runtime-observation-journal";
@@ -66,6 +69,7 @@ export interface AgentGoalRuntime {
 export interface SqliteAgentGoalRuntime extends AgentGoalRuntime {
   readonly state: SqliteAgentGoalState;
   readonly observations: SqliteRuntimeObservationJournal;
+  readonly runtimeSessions: SqliteRuntimeSessionPersistence;
 }
 
 export function createInMemoryAgentGoalRuntime(
@@ -74,6 +78,7 @@ export function createInMemoryAgentGoalRuntime(
     idGenerator?: RuntimeIdGeneratorPort;
     observationIdGenerator?: RuntimeIdGeneratorPort;
     semanticEvaluator?: GoalSemanticEvaluatorPort;
+    recoveryWake?: RuntimeSessionRecoveryWakePort;
   } = {},
 ): InMemoryAgentGoalRuntime {
   const state = new InMemoryAgentGoalState();
@@ -116,6 +121,7 @@ export function createInMemoryAgentGoalRuntime(
     idGenerator,
     30_000,
     observations,
+    options.recoveryWake,
   );
   const goals = new GoalService(
     state,
@@ -153,6 +159,7 @@ export function createSqliteAgentGoalRuntime(
     idGenerator?: RuntimeIdGeneratorPort;
     observationIdGenerator?: RuntimeIdGeneratorPort;
     semanticEvaluator?: GoalSemanticEvaluatorPort;
+    recoveryWake?: RuntimeSessionRecoveryWakePort;
   } = {},
 ): SqliteAgentGoalRuntime {
   const database =
@@ -186,6 +193,7 @@ export function createSqliteAgentGoalRuntime(
     clock,
     idGenerator,
     semanticEvaluator: options.semanticEvaluator,
+    recoveryWake: options.recoveryWake,
     queries: sqliteGoalReadSource(database),
   });
 }
@@ -194,10 +202,11 @@ function composeRuntime(input: {
   state: SqliteAgentGoalState;
   observations: SqliteRuntimeObservationJournal;
   sessions: RuntimeSessionRegistry;
-  runtimeSessions: RuntimeSessionPersistencePort;
+  runtimeSessions: SqliteRuntimeSessionPersistence;
   clock: RuntimeClockPort;
   idGenerator: RuntimeIdGeneratorPort;
   semanticEvaluator?: GoalSemanticEvaluatorPort;
+  recoveryWake?: RuntimeSessionRecoveryWakePort;
   queries: AgentGoalReadSource;
 }): SqliteAgentGoalRuntime {
   const queries = new AgentGoalQueryService(input.queries, input.clock);
@@ -222,6 +231,7 @@ function composeRuntime(input: {
     input.idGenerator,
     30_000,
     input.observations,
+    input.recoveryWake,
   );
   return {
     state: input.state,
@@ -321,7 +331,16 @@ export function getAgentGoalRuntime(): AgentGoalRuntime {
   processGlobal.__openLoomiAgentGoalRuntimeV2 ??= isTauriMode()
     ? createSqliteAgentGoalRuntime(
         getDbInstance() as unknown as SqliteGoalRuntimeDatabaseSource,
-        { semanticEvaluator: new OpenLoomiGoalSemanticEvaluator() },
+        {
+          semanticEvaluator: new OpenLoomiGoalSemanticEvaluator(),
+          recoveryWake: {
+            async wake(input) {
+              const { wakeAgentGoalRuntimeRecovery } =
+                await import("./recovery/startup");
+              return wakeAgentGoalRuntimeRecovery(input);
+            },
+          },
+        },
       )
     : createInMemoryAgentGoalRuntime({
         semanticEvaluator: new OpenLoomiGoalSemanticEvaluator(),

--- a/apps/web/lib/db/migrations-sqlite/0108_agent_goal_runtime_recovery.sql
+++ b/apps/web/lib/db/migrations-sqlite/0108_agent_goal_runtime_recovery.sql
@@ -1,0 +1,106 @@
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_descriptor` text;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_lease_owner` text;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_lease_token` text;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_lease_expires_at` integer;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_error_code` text;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_error_message` text;
+--> statement-breakpoint
+ALTER TABLE `agent_runtime_sessions` ADD COLUMN `recovery_failed_at` integer;
+--> statement-breakpoint
+
+CREATE TRIGGER `agent_runtime_sessions_recovery_insert_check`
+BEFORE INSERT ON `agent_runtime_sessions`
+WHEN NOT (
+  (NEW.`recovery_descriptor` IS NULL OR
+    (json_valid(NEW.`recovery_descriptor`) AND json_type(NEW.`recovery_descriptor`) = 'object'))
+  AND (
+    (NEW.`recovery_lease_owner` IS NULL AND NEW.`recovery_lease_token` IS NULL AND NEW.`recovery_lease_expires_at` IS NULL)
+    OR
+    (length(trim(NEW.`recovery_lease_owner`)) BETWEEN 1 AND 256
+      AND length(trim(NEW.`recovery_lease_token`)) BETWEEN 1 AND 256
+      AND NEW.`recovery_lease_expires_at` IS NOT NULL)
+  )
+  AND (
+    (NEW.`recovery_error_code` IS NULL AND NEW.`recovery_error_message` IS NULL AND NEW.`recovery_failed_at` IS NULL)
+    OR
+    (length(trim(NEW.`recovery_error_code`)) BETWEEN 1 AND 128
+      AND length(trim(NEW.`recovery_error_message`)) BETWEEN 1 AND 8000
+      AND NEW.`recovery_failed_at` IS NOT NULL)
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid agent runtime recovery state');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `agent_runtime_sessions_recovery_update_check`
+BEFORE UPDATE OF
+  `recovery_descriptor`, `recovery_lease_owner`, `recovery_lease_token`,
+  `recovery_lease_expires_at`, `recovery_error_code`,
+  `recovery_error_message`, `recovery_failed_at`
+ON `agent_runtime_sessions`
+WHEN NOT (
+  (NEW.`recovery_descriptor` IS NULL OR
+    (json_valid(NEW.`recovery_descriptor`) AND json_type(NEW.`recovery_descriptor`) = 'object'))
+  AND (
+    (NEW.`recovery_lease_owner` IS NULL AND NEW.`recovery_lease_token` IS NULL AND NEW.`recovery_lease_expires_at` IS NULL)
+    OR
+    (length(trim(NEW.`recovery_lease_owner`)) BETWEEN 1 AND 256
+      AND length(trim(NEW.`recovery_lease_token`)) BETWEEN 1 AND 256
+      AND NEW.`recovery_lease_expires_at` IS NOT NULL)
+  )
+  AND (
+    (NEW.`recovery_error_code` IS NULL AND NEW.`recovery_error_message` IS NULL AND NEW.`recovery_failed_at` IS NULL)
+    OR
+    (length(trim(NEW.`recovery_error_code`)) BETWEEN 1 AND 128
+      AND length(trim(NEW.`recovery_error_message`)) BETWEEN 1 AND 8000
+      AND NEW.`recovery_failed_at` IS NOT NULL)
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid agent runtime recovery state');
+END;
+--> statement-breakpoint
+
+DROP INDEX IF EXISTS `agent_runtime_sessions_recovery_idx`;
+--> statement-breakpoint
+CREATE INDEX `agent_runtime_sessions_recovery_idx`
+  ON `agent_runtime_sessions` (`recovery_failed_at`, `recovery_lease_expires_at`, `updated_at`)
+  WHERE `recovery_failed_at` IS NULL;
+--> statement-breakpoint
+
+CREATE TABLE `agent_runtime_provider_events` (
+  `owner_id` text NOT NULL,
+  `runtime_session_id` text NOT NULL,
+  `run_epoch` integer NOT NULL,
+  `event_key` text NOT NULL,
+  `provider_event_id` text NOT NULL,
+  `provider_session_id` text,
+  `event_fingerprint` text NOT NULL,
+  `observed_at` integer NOT NULL,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  CONSTRAINT `agent_runtime_provider_events_pkey`
+    PRIMARY KEY (`owner_id`, `runtime_session_id`, `run_epoch`, `event_key`),
+  CONSTRAINT `agent_runtime_provider_events_owner_session_fkey`
+    FOREIGN KEY (`owner_id`, `runtime_session_id`)
+    REFERENCES `agent_runtime_sessions`(`owner_id`, `id`) ON DELETE CASCADE,
+  CONSTRAINT `agent_runtime_provider_events_epoch_check`
+    CHECK (`run_epoch` >= 0),
+  CONSTRAINT `agent_runtime_provider_events_identity_check`
+    CHECK (
+      length(trim(`event_key`)) BETWEEN 1 AND 256
+      AND length(trim(`provider_event_id`)) BETWEEN 1 AND 256
+      AND length(`event_fingerprint`) = 64
+      AND (`provider_session_id` IS NULL OR length(trim(`provider_session_id`)) BETWEEN 1 AND 256)
+    ),
+  CONSTRAINT `agent_runtime_provider_events_timestamps_check`
+    CHECK (`created_at` >= 0 AND `observed_at` >= 0)
+);
+--> statement-breakpoint
+CREATE INDEX `agent_runtime_provider_events_provider_event_idx`
+  ON `agent_runtime_provider_events` (`owner_id`, `runtime_session_id`, `provider_event_id`);

--- a/apps/web/lib/db/migrations-sqlite/0109_agent_goal_recovery_pause.sql
+++ b/apps/web/lib/db/migrations-sqlite/0109_agent_goal_recovery_pause.sql
@@ -1,0 +1,98 @@
+-- Convert only legacy rows written by the old restart-recovery failure path.
+-- Ordinary evaluator-blocked Goals have no recovery_failed_at marker and are
+-- intentionally left unchanged.
+UPDATE `agent_goals` AS `goal`
+SET
+  `status` = 'paused',
+  `goal_snapshot` = json_set(
+    `goal_snapshot`,
+    '$.status',
+    'paused',
+    '$.updatedAt',
+    strftime(
+      '%Y-%m-%dT%H:%M:%fZ',
+      MAX(`updated_at`, unixepoch()),
+      'unixepoch'
+    )
+  ),
+  `updated_at` = MAX(`updated_at`, unixepoch())
+WHERE `goal`.`slot` = 'primary'
+  AND `goal`.`slot_state` = 'assigned'
+  AND `goal`.`status` = 'blocked'
+  AND EXISTS (
+    SELECT 1
+    FROM `agent_runtime_sessions` AS `session`
+    WHERE `session`.`owner_id` = `goal`.`owner_id`
+      AND `session`.`id` = `goal`.`runtime_session_id`
+      AND `session`.`state` = 'failed'
+      AND `session`.`recovery_failed_at` IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM `agent_goal_runs` AS `run`
+        WHERE `run`.`owner_id` = `session`.`owner_id`
+          AND `run`.`runtime_session_id` = `session`.`id`
+          AND `run`.`goal_id` = `goal`.`id`
+          AND `run`.`run_epoch` = `session`.`run_epoch`
+          AND `run`.`status` IN ('blocked', 'failed')
+      )
+  );
+--> statement-breakpoint
+
+UPDATE `agent_goal_runs` AS `run`
+SET
+  `status` = 'paused',
+  `completed_at` = NULL,
+  `last_activity_at` = MAX(`last_activity_at`, unixepoch()),
+  `updated_at` = MAX(`updated_at`, unixepoch())
+WHERE `run`.`status` IN ('blocked', 'failed')
+  AND EXISTS (
+    SELECT 1
+    FROM `agent_runtime_sessions` AS `session`
+    WHERE `session`.`owner_id` = `run`.`owner_id`
+      AND `session`.`id` = `run`.`runtime_session_id`
+      AND `session`.`run_epoch` = `run`.`run_epoch`
+      AND `session`.`state` = 'failed'
+      AND `session`.`recovery_failed_at` IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM `agent_goals` AS `goal`
+        WHERE `goal`.`owner_id` = `run`.`owner_id`
+          AND `goal`.`runtime_session_id` = `run`.`runtime_session_id`
+          AND `goal`.`id` = `run`.`goal_id`
+          AND `goal`.`slot` = 'primary'
+          AND `goal`.`slot_state` = 'assigned'
+          AND `goal`.`status` = 'paused'
+      )
+  );
+--> statement-breakpoint
+
+UPDATE `agent_runtime_sessions` AS `session`
+SET
+  `state` = 'idle',
+  `recovery_error_code` = NULL,
+  `recovery_error_message` = NULL,
+  `recovery_failed_at` = NULL,
+  `recovery_lease_owner` = NULL,
+  `recovery_lease_token` = NULL,
+  `recovery_lease_expires_at` = NULL,
+  `updated_at` = MAX(`updated_at`, unixepoch())
+WHERE `session`.`state` = 'failed'
+  AND `session`.`recovery_failed_at` IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `agent_goals` AS `goal`
+    WHERE `goal`.`owner_id` = `session`.`owner_id`
+      AND `goal`.`runtime_session_id` = `session`.`id`
+      AND `goal`.`slot` = 'primary'
+      AND `goal`.`slot_state` = 'assigned'
+      AND `goal`.`status` = 'paused'
+      AND EXISTS (
+        SELECT 1
+        FROM `agent_goal_runs` AS `run`
+        WHERE `run`.`owner_id` = `session`.`owner_id`
+          AND `run`.`runtime_session_id` = `session`.`id`
+          AND `run`.`goal_id` = `goal`.`id`
+          AND `run`.`run_epoch` = `session`.`run_epoch`
+          AND `run`.`status` = 'paused'
+      )
+  );

--- a/apps/web/lib/db/migrations-sqlite/0110_agent_goal_evaluation_pause.sql
+++ b/apps/web/lib/db/migrations-sqlite/0110_agent_goal_evaluation_pause.sql
@@ -1,0 +1,57 @@
+-- GoalController historically used `blocked` for recoverable evaluation
+-- boundaries (evaluator errors, manual review, and no-progress guards).
+-- Normalize only the currently assigned primary Goal and its current Run;
+-- terminal and historical Goal Runs remain untouched.
+UPDATE `agent_goals` AS `goal`
+SET
+  `status` = 'paused',
+  `goal_snapshot` = json_set(
+    `goal_snapshot`,
+    '$.status',
+    'paused',
+    '$.updatedAt',
+    strftime(
+      '%Y-%m-%dT%H:%M:%fZ',
+      MAX(`updated_at`, unixepoch()),
+      'unixepoch'
+    )
+  ),
+  `updated_at` = MAX(`updated_at`, unixepoch())
+WHERE `goal`.`slot` = 'primary'
+  AND `goal`.`slot_state` = 'assigned'
+  AND `goal`.`status` = 'blocked'
+  AND EXISTS (
+    SELECT 1
+    FROM `agent_runtime_sessions` AS `session`
+    JOIN `agent_goal_runs` AS `run`
+      ON `run`.`owner_id` = `session`.`owner_id`
+     AND `run`.`runtime_session_id` = `session`.`id`
+     AND `run`.`run_epoch` = `session`.`run_epoch`
+    WHERE `session`.`owner_id` = `goal`.`owner_id`
+      AND `session`.`id` = `goal`.`runtime_session_id`
+      AND `run`.`goal_id` = `goal`.`id`
+      AND `run`.`status` = 'blocked'
+  );
+--> statement-breakpoint
+
+UPDATE `agent_goal_runs` AS `run`
+SET
+  `status` = 'paused',
+  `completed_at` = NULL,
+  `last_activity_at` = MAX(`last_activity_at`, unixepoch()),
+  `updated_at` = MAX(`updated_at`, unixepoch())
+WHERE `run`.`status` = 'blocked'
+  AND EXISTS (
+    SELECT 1
+    FROM `agent_runtime_sessions` AS `session`
+    JOIN `agent_goals` AS `goal`
+      ON `goal`.`owner_id` = `session`.`owner_id`
+     AND `goal`.`runtime_session_id` = `session`.`id`
+     AND `goal`.`slot` = 'primary'
+     AND `goal`.`slot_state` = 'assigned'
+    WHERE `session`.`owner_id` = `run`.`owner_id`
+      AND `session`.`id` = `run`.`runtime_session_id`
+      AND `session`.`run_epoch` = `run`.`run_epoch`
+      AND `goal`.`id` = `run`.`goal_id`
+      AND `goal`.`status` = 'paused'
+  );

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -267,6 +267,13 @@
                         "when": 1786435200000,
                         "tag": "0109_agent_goal_recovery_pause",
                         "breakpoints": true
+                    },
+                    {
+                        "idx": 38,
+                        "version": "7",
+                        "when": 1786521600000,
+                        "tag": "0110_agent_goal_evaluation_pause",
+                        "breakpoints": true
                     }
                 ]
 }

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -260,6 +260,13 @@
                         "when": 1786360215209,
                         "tag": "0108_agent_goal_runtime_recovery",
                         "breakpoints": true
+                    },
+                    {
+                        "idx": 37,
+                        "version": "7",
+                        "when": 1786435200000,
+                        "tag": "0109_agent_goal_recovery_pause",
+                        "breakpoints": true
                     }
                 ]
 }

--- a/apps/web/lib/db/migrations-sqlite/meta/_journal.json
+++ b/apps/web/lib/db/migrations-sqlite/meta/_journal.json
@@ -253,6 +253,13 @@
                         "when": 1785917494363,
                         "tag": "0107_agent_goal_runtime",
                         "breakpoints": true
+                    },
+                    {
+                        "idx": 36,
+                        "version": "7",
+                        "when": 1786360215209,
+                        "tag": "0108_agent_goal_runtime_recovery",
+                        "breakpoints": true
                     }
                 ]
 }

--- a/apps/web/lib/db/schema-sqlite.ts
+++ b/apps/web/lib/db/schema-sqlite.ts
@@ -2896,6 +2896,17 @@ export const agentRuntimeSessions = sqliteTable(
       .default("claude"),
     providerSessionId: text("provider_session_id"),
     workingDirectory: text("working_directory"),
+    recoveryDescriptor: text("recovery_descriptor", {
+      mode: "json",
+    }).$type<Record<string, unknown> | null>(),
+    recoveryLeaseOwner: text("recovery_lease_owner"),
+    recoveryLeaseToken: text("recovery_lease_token"),
+    recoveryLeaseExpiresAt: integer("recovery_lease_expires_at", {
+      mode: "timestamp",
+    }),
+    recoveryErrorCode: text("recovery_error_code"),
+    recoveryErrorMessage: text("recovery_error_message"),
+    recoveryFailedAt: integer("recovery_failed_at", { mode: "timestamp" }),
     state: text("state")
       .$type<RuntimeSessionState>()
       .notNull()
@@ -2924,8 +2935,8 @@ export const agentRuntimeSessions = sqliteTable(
       .on(table.provider, table.providerSessionId)
       .where(sql`${table.providerSessionId} is not null`),
     recoveryIdx: index("agent_runtime_sessions_recovery_idx")
-      .on(table.ownerId, table.state, table.updatedAt)
-      .where(sql`${table.state} not in ('closed', 'failed')`),
+      .on(table.recoveryFailedAt, table.recoveryLeaseExpiresAt, table.updatedAt)
+      .where(sql`${table.recoveryFailedAt} is null`),
     providerCheck: check(
       "agent_runtime_sessions_provider_check",
       sql`${table.provider} in ('claude')`,
@@ -2946,6 +2957,34 @@ export const agentRuntimeSessions = sqliteTable(
       "agent_runtime_sessions_pending_operation_check",
       sql`${table.pendingOperation} is null or (json_valid(${table.pendingOperation}) and json_type(${table.pendingOperation}) = 'object')`,
     ),
+    recoveryDescriptorCheck: check(
+      "agent_runtime_sessions_recovery_descriptor_check",
+      sql`${table.recoveryDescriptor} is null or (json_valid(${table.recoveryDescriptor}) and json_type(${table.recoveryDescriptor}) = 'object')`,
+    ),
+    recoveryLeaseCheck: check(
+      "agent_runtime_sessions_recovery_lease_check",
+      sql`(
+        ${table.recoveryLeaseOwner} is null
+        and ${table.recoveryLeaseToken} is null
+        and ${table.recoveryLeaseExpiresAt} is null
+      ) or (
+        length(trim(${table.recoveryLeaseOwner})) between 1 and 256
+        and length(trim(${table.recoveryLeaseToken})) between 1 and 256
+        and ${table.recoveryLeaseExpiresAt} is not null
+      )`,
+    ),
+    recoveryFailureCheck: check(
+      "agent_runtime_sessions_recovery_failure_check",
+      sql`(
+        ${table.recoveryErrorCode} is null
+        and ${table.recoveryErrorMessage} is null
+        and ${table.recoveryFailedAt} is null
+      ) or (
+        length(trim(${table.recoveryErrorCode})) between 1 and 128
+        and length(trim(${table.recoveryErrorMessage})) between 1 and 8000
+        and ${table.recoveryFailedAt} is not null
+      )`,
+    ),
     timestampsCheck: check(
       "agent_runtime_sessions_timestamps_check",
       sql`${table.updatedAt} >= ${table.createdAt}`,
@@ -2958,6 +2997,64 @@ export type AgentRuntimeSessionRecord = InferSelectModel<
 >;
 export type InsertAgentRuntimeSessionRecord = InferInsertModel<
   typeof agentRuntimeSessions
+>;
+
+export const agentRuntimeProviderEvents = sqliteTable(
+  "agent_runtime_provider_events",
+  {
+    ownerId: text("owner_id").notNull(),
+    runtimeSessionId: text("runtime_session_id").notNull(),
+    runEpoch: integer("run_epoch").notNull(),
+    eventKey: text("event_key").notNull(),
+    providerEventId: text("provider_event_id").notNull(),
+    providerSessionId: text("provider_session_id"),
+    eventFingerprint: text("event_fingerprint").notNull(),
+    observedAt: integer("observed_at", { mode: "timestamp" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    primaryKey: primaryKey({
+      columns: [
+        table.ownerId,
+        table.runtimeSessionId,
+        table.runEpoch,
+        table.eventKey,
+      ],
+      name: "agent_runtime_provider_events_pkey",
+    }),
+    sessionForeignKey: foreignKey({
+      columns: [table.ownerId, table.runtimeSessionId],
+      foreignColumns: [agentRuntimeSessions.ownerId, agentRuntimeSessions.id],
+      name: "agent_runtime_provider_events_owner_session_fkey",
+    }).onDelete("cascade"),
+    providerEventIdx: index(
+      "agent_runtime_provider_events_provider_event_idx",
+    ).on(table.ownerId, table.runtimeSessionId, table.providerEventId),
+    epochCheck: check(
+      "agent_runtime_provider_events_epoch_check",
+      sql`${table.runEpoch} >= 0`,
+    ),
+    identityCheck: check(
+      "agent_runtime_provider_events_identity_check",
+      sql`length(trim(${table.eventKey})) between 1 and 256
+        and length(trim(${table.providerEventId})) between 1 and 256
+        and length(${table.eventFingerprint}) = 64
+        and (${table.providerSessionId} is null or length(trim(${table.providerSessionId})) between 1 and 256)`,
+    ),
+    timestampsCheck: check(
+      "agent_runtime_provider_events_timestamps_check",
+      sql`${table.createdAt} >= 0 and ${table.observedAt} >= 0`,
+    ),
+  }),
+);
+
+export type AgentRuntimeProviderEventRecord = InferSelectModel<
+  typeof agentRuntimeProviderEvents
+>;
+export type InsertAgentRuntimeProviderEventRecord = InferInsertModel<
+  typeof agentRuntimeProviderEvents
 >;
 
 export const agentGoals = sqliteTable(

--- a/apps/web/tests/api/agent-goals.route.test.ts
+++ b/apps/web/tests/api/agent-goals.route.test.ts
@@ -135,6 +135,7 @@ const dependencies = {
   goals: {
     activate: vi.fn(),
     update: vi.fn(),
+    resume: vi.fn(),
     upsertContext: vi.fn(),
     removeContext: vi.fn(),
   },
@@ -160,6 +161,8 @@ const goalInput = {
 
 const collectionRoute = await import("@/app/api/agent-goals/route");
 const goalRoute = await import("@/app/api/agent-goals/[goalId]/route");
+const resumeRoute =
+  await import("@/app/api/agent-goals/[goalId]/resume/route");
 const contextRoute =
   await import("@/app/api/agent-goals/[goalId]/context/route");
 
@@ -180,6 +183,7 @@ beforeEach(() => {
   dependencies.runtimeSessions.ensure.mockResolvedValue({});
   dependencies.goals.activate.mockResolvedValue(acceptedCommand);
   dependencies.goals.update.mockResolvedValue(acceptedCommand);
+  dependencies.goals.resume.mockResolvedValue(acceptedCommand);
   dependencies.goals.upsertContext.mockResolvedValue(acceptedCommand);
   dependencies.goals.removeContext.mockResolvedValue(acceptedCommand);
   dependencies.queries.listBySession.mockResolvedValue([]);
@@ -424,6 +428,30 @@ describe("Agent Goal API", () => {
         },
       }),
     );
+  });
+
+  test("resumes a paused or blocked Goal without requiring a live Runtime", async () => {
+    dependencies.liveSessions.resolve.mockResolvedValueOnce(undefined);
+    const response = await resumeRoute.POST(
+      request("POST", `/api/agent-goals/${goalId}/resume`, {
+        runtimeSessionId,
+        expectedRevision: 2,
+        reason: "  Continue after resolving the blocker  ",
+      }),
+      goalContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(dependencies.goals.resume).toHaveBeenCalledWith({
+      ownerId: "user-a",
+      runtimeSessionId,
+      goalId,
+      expectedRevision: 2,
+      idempotencyKey: "request-1",
+      source: { type: "user", authority: "user" },
+      reason: "Continue after resolving the blocker",
+    });
+    expect(dependencies.runtimeSessions.ensure).not.toHaveBeenCalled();
   });
 
   test("routes context changes with user provenance", async () => {

--- a/apps/web/tests/helpers/claude-runtime.ts
+++ b/apps/web/tests/helpers/claude-runtime.ts
@@ -10,10 +10,15 @@ export interface ControlledClaudeQuery {
   readonly query: Query;
   readonly interrupt: ReturnType<typeof vi.fn<() => Promise<void>>>;
   readonly close: ReturnType<typeof vi.fn<() => void>>;
+  readonly iteratorReturn: ReturnType<
+    typeof vi.fn<() => Promise<IteratorResult<SDKMessage>>>
+  >;
   push(message: SDKMessage): void;
 }
 
-export function createControlledClaudeQuery(): ControlledClaudeQuery {
+export function createControlledClaudeQuery(
+  options: { hangOnIteratorReturn?: boolean } = {},
+): ControlledClaudeQuery {
   const pending: SDKMessage[] = [];
   const waiters: Array<(result: IteratorResult<SDKMessage>) => void> = [];
   let closed = false;
@@ -27,6 +32,13 @@ export function createControlledClaudeQuery(): ControlledClaudeQuery {
   };
   const interrupt = vi.fn(async () => {});
   const close = vi.fn(finish);
+  const iteratorReturn = vi.fn(() => {
+    if (options.hangOnIteratorReturn) {
+      return new Promise<IteratorResult<SDKMessage>>(() => {});
+    }
+    finish();
+    return Promise.resolve({ value: undefined, done: true } as const);
+  });
   const iterator = {
     next: () => {
       const message = pending.shift();
@@ -38,21 +50,20 @@ export function createControlledClaudeQuery(): ControlledClaudeQuery {
         waiters.push(resolve);
       });
     },
-    return: async () => {
-      finish();
-      return { value: undefined, done: true } as const;
-    },
+    return: iteratorReturn,
     [Symbol.asyncIterator]() {
       return this;
     },
     interrupt,
     close,
+    iteratorReturn,
   } as unknown as Query;
 
   return {
     query: iterator,
     interrupt,
     close,
+    iteratorReturn,
     push(message: SDKMessage) {
       if (closed) throw new Error("Fake Query is closed");
       const waiter = waiters.shift();

--- a/apps/web/tests/unit/agent-chat-recovery-presentation.test.ts
+++ b/apps/web/tests/unit/agent-chat-recovery-presentation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAgentChatRuntimePresentation } from "@/lib/ai/chat/runtime-presentation";
+
+describe("AgentChatPanel recovery presentation", () => {
+  it("rejects a second send and omits a fake stop during server recovery", () => {
+    expect(
+      resolveAgentChatRuntimePresentation({
+        browserRunActive: false,
+        serverRecoveryActive: true,
+      }),
+    ).toEqual({
+      effectiveRunning: true,
+      composerLocked: true,
+      canStartRun: false,
+      canStopFromBrowser: false,
+    });
+  });
+
+  it("keeps the real browser stop available for an ordinary local run", () => {
+    expect(
+      resolveAgentChatRuntimePresentation({
+        browserRunActive: true,
+        serverRecoveryActive: false,
+      }),
+    ).toEqual({
+      effectiveRunning: true,
+      composerLocked: false,
+      canStartRun: false,
+      canStopFromBrowser: true,
+    });
+  });
+
+  it("keeps a real browser stop when both live-state sources observe the run", () => {
+    expect(
+      resolveAgentChatRuntimePresentation({
+        browserRunActive: true,
+        serverRecoveryActive: true,
+      }),
+    ).toMatchObject({
+      composerLocked: false,
+      canStartRun: false,
+      canStopFromBrowser: true,
+    });
+  });
+
+  it("locks an explicit chat while recovery ownership is still loading", () => {
+    expect(
+      resolveAgentChatRuntimePresentation({
+        browserRunActive: false,
+        serverRecoveryActive: false,
+        serverRecoveryPending: true,
+      }),
+    ).toEqual({
+      effectiveRunning: false,
+      composerLocked: true,
+      canStartRun: false,
+      canStopFromBrowser: false,
+    });
+  });
+});

--- a/apps/web/tests/unit/agent-goal-api-client.test.ts
+++ b/apps/web/tests/unit/agent-goal-api-client.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentGoalApiError,
   fetchAgentGoalSession,
   removeAgentGoalContext,
+  resumeAgentGoal,
   updateAgentGoal,
   upsertAgentGoalContext,
 } from "@/lib/ai/runtime-instructions/api/client";
@@ -43,6 +44,15 @@ describe("Agent Goal API client", () => {
       },
       "update-once",
     );
+    await resumeAgentGoal(
+      "goal/a",
+      {
+        runtimeSessionId: "chat-a",
+        expectedRevision: 4,
+        reason: "The blocker is resolved",
+      },
+      "resume-once",
+    );
     await upsertAgentGoalContext(
       "goal/a",
       {
@@ -63,10 +73,19 @@ describe("Agent Goal API client", () => {
     );
     expect(fetchMock.mock.calls.map(([url, init]) => [url, init.method])).toEqual([
       ["/api/agent-goals/goal%2Fa", "PATCH"],
+      ["/api/agent-goals/goal%2Fa/resume", "POST"],
       ["/api/agent-goals/goal%2Fa/context", "PUT"],
       ["/api/agent-goals/goal%2Fa/context", "DELETE"],
     ]);
-    const removeInit = fetchMock.mock.calls[2]?.[1] as RequestInit | undefined;
+    const resumeInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    expect(new Headers(resumeInit?.headers).get("idempotency-key")).toBe(
+      "resume-once",
+    );
+    expect(JSON.parse(String(resumeInit?.body))).toMatchObject({
+      expectedRevision: 4,
+      reason: "The blocker is resolved",
+    });
+    const removeInit = fetchMock.mock.calls[3]?.[1] as RequestInit | undefined;
     expect(JSON.parse(String(removeInit?.body))).toMatchObject({
       expectedRevision: 5,
       contextRefId: "doc",

--- a/apps/web/tests/unit/agent-goal-ui-model.test.ts
+++ b/apps/web/tests/unit/agent-goal-ui-model.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/ai/runtime-instructions/api";
 import {
   blankGoalDraft,
+  canResumeGoal,
   createGoalCommandIdempotencyKeys,
   goalDraft,
   goalInputFromDraft,
@@ -132,6 +133,13 @@ describe("Goal UI model", () => {
     expect(shouldPollGoal(summary("blocked"))).toBe(false);
     expect(shouldPollGoal(summary("completed"))).toBe(false);
     expect(shouldPollGoal(summary("budget_limited"))).toBe(false);
+  });
+
+  test("offers an explicit continuation only for paused or blocked Goals", () => {
+    expect(canResumeGoal("paused")).toBe(true);
+    expect(canResumeGoal("blocked")).toBe(true);
+    expect(canResumeGoal("active")).toBe(false);
+    expect(canResumeGoal("completed")).toBe(false);
   });
 
   test("reuses a command key until success and rotates it when input changes", () => {

--- a/apps/web/tests/unit/boot-with-secrets-signal.test.ts
+++ b/apps/web/tests/unit/boot-with-secrets-signal.test.ts
@@ -95,35 +95,33 @@ describe("boot-with-secrets.js — signal forwarding (#516)", () => {
   });
 
   it("forwards SIGTERM to the inner child and exits with 143", async () => {
-    wrapper = spawn("node", [WRAPPER, fakeServer!], {
+    if (!fakeServer) throw new Error("Fake server fixture was not created");
+    const runningWrapper = spawn("node", [WRAPPER, fakeServer], {
       cwd: REPO_ROOT,
       stdio: ["pipe", "pipe", "pipe"],
     });
+    wrapper = runningWrapper;
     // Capture stdout/stderr so a failing test prints useful diagnostics.
     const stderrChunks: Buffer[] = [];
     const stdoutChunks: Buffer[] = [];
-    wrapper.stderr!.on("data", (b: Buffer) => stderrChunks.push(b));
-    wrapper.stdout!.on("data", (b: Buffer) => stdoutChunks.push(b));
+    runningWrapper.stderr?.on("data", (b: Buffer) => stderrChunks.push(b));
+    runningWrapper.stdout?.on("data", (b: Buffer) => stdoutChunks.push(b));
     // No real secrets — pass an empty JSON object so the wrapper
     // proceeds straight to spawning the inner child.
-    wrapper.stdin!.end("{}");
+    runningWrapper.stdin?.end("{}");
 
-    const wrapperPid = wrapper.pid;
+    const wrapperPid = runningWrapper.pid;
     expect(wrapperPid).toBeTypeOf("number");
-    await waitForInner(wrapper);
+    await waitForInner(runningWrapper);
 
     // Send SIGTERM only to the wrapper, mimicking the pre-#516
     // Tauri cleanup path that called `child.kill()`. The wrapper
     // must forward it to the inner so we don't get the orphaned
     // server that the bug report was about.
-    const killResult = wrapper.kill("SIGTERM");
+    const killResult = runningWrapper.kill("SIGTERM");
     expect(
       killResult,
-      `wrapper.kill returned false — wrapper may have exited already. ` +
-        `pid=${wrapperPid} exitCode=${wrapper!.exitCode} ` +
-        `signalCode=${wrapper!.signalCode} ` +
-        `stderr=${Buffer.concat(stderrChunks).toString() || "<empty>"} ` +
-        `stdout=${Buffer.concat(stdoutChunks).toString() || "<empty>"}`,
+      `wrapper.kill returned false — wrapper may have exited already. pid=${wrapperPid} exitCode=${runningWrapper.exitCode} signalCode=${runningWrapper.signalCode} stderr=${Buffer.concat(stderrChunks).toString() || "<empty>"} stdout=${Buffer.concat(stdoutChunks).toString() || "<empty>"}`,
     ).toBe(true);
 
     // Wait up to 2 s for the wrapper to exit. With signal forwarding
@@ -132,9 +130,8 @@ describe("boot-with-secrets.js — signal forwarding (#516)", () => {
       code: number | null;
       signal: NodeJS.Signals | null;
     } | null>((resolveExit) => {
-      if (!wrapper) return resolveExit(null);
       const t = setTimeout(() => resolveExit(null), 2000);
-      wrapper.on("exit", (code, signal) => {
+      runningWrapper.on("exit", (code, signal) => {
         clearTimeout(t);
         resolveExit({ code, signal });
       });
@@ -144,72 +141,84 @@ describe("boot-with-secrets.js — signal forwarding (#516)", () => {
       exit,
       `wrapper should exit within 2 s of SIGTERM. stderr=${Buffer.concat(stderrChunks).toString() || "<empty>"}`,
     ).not.toBeNull();
+    if (!exit) throw new Error("Wrapper did not exit after SIGTERM");
     // The wrapper should exit with code 143 (the conventional code for
     // SIGTERM-induced death) — see boot-with-secrets.js signalExitCodes.
     // We accept either a non-null signal-induced code OR a signal exit
     // — Node APIs differ slightly between platforms.
-    if (exit!.code !== null) {
-      expect(exit!.code).toBe(143);
+    if (exit.code !== null) {
+      expect(exit.code).toBe(143);
     } else {
-      expect(exit!.signal).toBe("SIGTERM");
+      expect(exit.signal).toBe("SIGTERM");
     }
   });
 
   it("forwards SIGINT to the inner child and exits with 130", async () => {
-    wrapper = spawn("node", [WRAPPER, fakeServer!], {
+    if (!fakeServer) throw new Error("Fake server fixture was not created");
+    const runningWrapper = spawn("node", [WRAPPER, fakeServer], {
       cwd: REPO_ROOT,
       stdio: ["pipe", "pipe", "pipe"],
     });
-    wrapper.stdin!.end("{}");
-    await waitForInner(wrapper);
+    wrapper = runningWrapper;
+    runningWrapper.stdin?.end("{}");
+    await waitForInner(runningWrapper);
 
-    wrapper.kill("SIGINT");
+    runningWrapper.kill("SIGINT");
     const exit = await new Promise<{
       code: number | null;
       signal: NodeJS.Signals | null;
     } | null>((r) => {
-      if (!wrapper) return r(null);
       const t = setTimeout(() => r(null), 2000);
-      wrapper.on("exit", (code, signal) => {
+      runningWrapper.on("exit", (code, signal) => {
         clearTimeout(t);
         r({ code, signal });
       });
     });
 
     expect(exit).not.toBeNull();
-    if (exit!.code !== null) {
-      expect(exit!.code).toBe(130);
+    if (!exit) throw new Error("Wrapper did not exit after SIGINT");
+    if (exit.code !== null) {
+      expect(exit.code).toBe(130);
     } else {
-      expect(exit!.signal).toBe("SIGINT");
+      expect(exit.signal).toBe("SIGINT");
     }
   });
 
-  it("forwards SIGHUP to the inner child and exits with 129", async () => {
-    wrapper = spawn("node", [WRAPPER, fakeServer!], {
-      cwd: REPO_ROOT,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    wrapper.stdin!.end("{}");
-    await waitForInner(wrapper);
-
-    wrapper.kill("SIGHUP");
-    const exit = await new Promise<{
-      code: number | null;
-      signal: NodeJS.Signals | null;
-    } | null>((r) => {
-      if (!wrapper) return r(null);
-      const t = setTimeout(() => r(null), 2000);
-      wrapper.on("exit", (code, signal) => {
-        clearTimeout(t);
-        r({ code, signal });
+  // Windows does not support POSIX SIGHUP delivery semantics: Node maps only
+  // a limited subset of signals to native process termination, so the child
+  // cannot reliably observe and handle SIGHUP there. Keep the integration
+  // assertion on platforms where the signal can actually be forwarded.
+  it.skipIf(process.platform === "win32")(
+    "forwards SIGHUP to the inner child and exits with 129",
+    async () => {
+      if (!fakeServer) throw new Error("Fake server fixture was not created");
+      const runningWrapper = spawn("node", [WRAPPER, fakeServer], {
+        cwd: REPO_ROOT,
+        stdio: ["pipe", "pipe", "pipe"],
       });
-    });
+      wrapper = runningWrapper;
+      runningWrapper.stdin?.end("{}");
+      await waitForInner(runningWrapper);
 
-    expect(exit).not.toBeNull();
-    if (exit!.code !== null) {
-      expect(exit!.code).toBe(129);
-    } else {
-      expect(exit!.signal).toBe("SIGHUP");
-    }
-  });
+      runningWrapper.kill("SIGHUP");
+      const exit = await new Promise<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      } | null>((r) => {
+        const t = setTimeout(() => r(null), 2000);
+        runningWrapper.on("exit", (code, signal) => {
+          clearTimeout(t);
+          r({ code, signal });
+        });
+      });
+
+      expect(exit).not.toBeNull();
+      if (!exit) throw new Error("Wrapper did not exit after SIGHUP");
+      if (exit.code !== null) {
+        expect(exit.code).toBe(129);
+      } else {
+        expect(exit.signal).toBe("SIGHUP");
+      }
+    },
+  );
 });

--- a/apps/web/tests/unit/chat-startup-selection.test.ts
+++ b/apps/web/tests/unit/chat-startup-selection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { selectStartupChat } from "@/lib/ai/chat/startup-selection";
+
+const base = {
+  pathname: "/",
+  page: null,
+  recoveryLoaded: true,
+  restoredChatId: "restored-chat",
+  newChatId: "new-chat",
+};
+
+describe("selectStartupChat", () => {
+  it("always gives an explicit URL chat the highest priority", () => {
+    expect(
+      selectStartupChat({
+        ...base,
+        urlChatId: "url-chat",
+        recoveryChatId: "recovery-chat",
+      }),
+    ).toEqual({ pending: false, chatId: "url-chat", source: "url" });
+  });
+
+  it("waits for the recovery read model on a cold home start", () => {
+    expect(selectStartupChat({ ...base, recoveryLoaded: false })).toEqual({
+      pending: true,
+      chatId: null,
+      source: null,
+    });
+  });
+
+  it("restores a recoverable Goal chat before local storage", () => {
+    expect(
+      selectStartupChat({ ...base, recoveryChatId: "recovery-chat" }),
+    ).toEqual({
+      pending: false,
+      chatId: "recovery-chat",
+      source: "recovery",
+    });
+  });
+
+  it("uses the locally restored chat when no Goal is recovering", () => {
+    expect(selectStartupChat(base)).toEqual({
+      pending: false,
+      chatId: "restored-chat",
+      source: "restored",
+    });
+  });
+
+  it("does not let recovery hijack an explicit chat-page navigation", () => {
+    expect(
+      selectStartupChat({
+        ...base,
+        page: "chat",
+        recoveryChatId: "recovery-chat",
+      }),
+    ).toEqual({
+      pending: false,
+      chatId: "restored-chat",
+      source: "restored",
+    });
+  });
+});

--- a/apps/web/tests/unit/claude-message-converter.test.ts
+++ b/apps/web/tests/unit/claude-message-converter.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CLAUDE_API_ERROR_SENTINEL,
   convertClaudeSdkMessage,
   extractClaudeResultUsage,
 } from "@/lib/ai/extensions/agent/claude/message-converter";
@@ -127,5 +128,38 @@ describe("convertClaudeSdkMessage — result events", () => {
       content: "success",
     });
     expect("usage" in (messages[0] as object)).toBe(false);
+  });
+});
+
+describe("convertClaudeSdkMessage — provider API errors", () => {
+  it("converts Claude's synthetic API-error assistant into a safe terminal error", () => {
+    const messages = Array.from(
+      convertClaudeSdkMessage({
+        message: {
+          type: "assistant",
+          isApiErrorMessage: true,
+          error: "unknown",
+          message: {
+            model: "<synthetic>",
+            content: [
+              { type: "text", text: "API Error: Content block not found" },
+            ],
+          },
+        },
+        sentTextHashes: new Set<string>(),
+        sentToolIds: new Set<string>(),
+        hasStreamedText: false,
+        createMessageId: () => "api-error-message",
+      }),
+    );
+
+    expect(messages).toEqual([
+      {
+        type: "error",
+        message: CLAUDE_API_ERROR_SENTINEL,
+        messageId: "api-error-message",
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("Content block not found");
   });
 });

--- a/apps/web/tests/unit/claude-provider-failure-monitor.test.ts
+++ b/apps/web/tests/unit/claude-provider-failure-monitor.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createClaudeProviderFailureSessionStore,
+  isFatalClaudeProviderDiagnostic,
+} from "@/lib/ai/extensions/agent/claude/runtime";
+
+describe("Claude provider failure monitor", () => {
+  it("reports only authoritative API-error entries from the expected main transcript", async () => {
+    const onProviderFailure = vi.fn();
+    const store = createClaudeProviderFailureSessionStore({
+      expectedSessionId: "expected-session",
+      onProviderFailure,
+    });
+
+    await store.append(
+      { projectKey: "project", sessionId: "expected-session" },
+      [
+        { type: "assistant", isApiErrorMessage: false },
+        { type: "assistant", isApiErrorMessage: true },
+      ],
+    );
+    await store.append(
+      {
+        projectKey: "project",
+        sessionId: "expected-session",
+        subpath: "agent-a.jsonl",
+      },
+      [{ type: "assistant", isApiErrorMessage: true }],
+    );
+    await store.append(
+      { projectKey: "project", sessionId: "different-session" },
+      [{ type: "assistant", isApiErrorMessage: true }],
+    );
+
+    expect(onProviderFailure).toHaveBeenCalledOnce();
+    await expect(
+      store.load({ projectKey: "project", sessionId: "expected-session" }),
+    ).resolves.toBeNull();
+  });
+
+  it("recognizes terminal request diagnostics but not retry or arbitrary stderr", () => {
+    expect(
+      isFatalClaudeProviderDiagnostic(
+        "2026-08-12T02:57:36.340Z [ERROR] Error in API request: Content block not found",
+      ),
+    ).toBe(true);
+    expect(
+      isFatalClaudeProviderDiagnostic(
+        "2026-08-12T02:57:35.340Z [ERROR] API error (attempt 1/11): 429",
+      ),
+    ).toBe(false);
+    expect(
+      isFatalClaudeProviderDiagnostic(
+        "tool stderr: Error in API request: user-controlled text",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/claude-query-options.test.ts
+++ b/apps/web/tests/unit/claude-query-options.test.ts
@@ -1,0 +1,49 @@
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/ai/mcp", () => ({
+  createBusinessToolsMcpServer: vi.fn(),
+}));
+
+import { createClaudeQueryOptions } from "@/lib/ai/extensions/agent/claude/query-options";
+
+describe("Claude query recovery options", () => {
+  it("resumes the exact provider session in its persisted working directory", () => {
+    const options = createClaudeQueryOptions({
+      sessionId: "runtime-session",
+      cwd: "D:\\workspace\\persisted-session",
+      settingSources: ["project"],
+      allowedTools: ["Read", "Bash"],
+      abortController: new AbortController(),
+      env: { ANTHROPIC_API_KEY: "test-key" },
+      config: { provider: "claude", model: "claude-test" },
+      claudeCodePath: "claude-code",
+      isDev: false,
+      debugFilePath: "openloomi.log",
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      spawnClaudeCodeProcess: vi.fn() as unknown as NonNullable<
+        Options["spawnClaudeCodeProcess"]
+      >,
+      systemPrompt: "system prompt",
+      permissionLogMode: "run",
+      resumeProviderSessionId: "claude-provider-session",
+    });
+
+    expect(options).toMatchObject({
+      cwd: "D:\\workspace\\persisted-session",
+      resume: "claude-provider-session",
+      model: "claude-test",
+      allowedTools: ["Read", "Bash"],
+      env: {
+        ANTHROPIC_API_KEY: "test-key",
+      },
+    });
+    expect(Object.hasOwn(options, "continue")).toBe(false);
+    expect(Object.hasOwn(options, "sessionId")).toBe(false);
+    expect(Object.hasOwn(options, "forkSession")).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/claude-runtime-session.test.ts
+++ b/apps/web/tests/unit/claude-runtime-session.test.ts
@@ -9,7 +9,10 @@ import {
   type RuntimeInstructionTransportPort,
 } from "@openloomi/ai/agent/runtime-instructions";
 import { AgentSupplementalInputQueue } from "@openloomi/ai/agent/supplemental-input";
-import type { AgentSupplementalInputSource } from "@openloomi/ai/agent/types";
+import type {
+  AgentRuntimeRecovery,
+  AgentSupplementalInputSource,
+} from "@openloomi/ai/agent/types";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -18,9 +21,11 @@ import {
   ClaudeGoalRuntimeRegistrationError,
   ClaudeInputMultiplexer,
   ClaudeRuntimeSession,
+  createClaudeRecoveryInitialPrompt,
   createClaudeSupplementalInputHooks,
   startClaudeGoalRuntimeSession,
 } from "@/lib/ai/extensions/agent/claude/runtime";
+import { CLAUDE_API_ERROR_SENTINEL } from "@/lib/ai/extensions/agent/claude/message-converter";
 import { createInMemoryAgentGoalRuntime } from "@/lib/ai/runtime-instructions/runtime";
 import {
   createControlledClaudeQuery,
@@ -48,6 +53,18 @@ function assistantMessage(text: string): SDKMessage {
     type: "assistant",
     message: { content: [{ type: "text", text }] },
   } as SDKMessage;
+}
+
+function apiErrorAssistantMessage(): SDKMessage {
+  return {
+    type: "assistant",
+    isApiErrorMessage: true,
+    error: "unknown",
+    message: {
+      model: "<synthetic>",
+      content: [{ type: "text", text: "API Error: Content block not found" }],
+    },
+  } as unknown as SDKMessage;
 }
 
 function resultMessage(overrides: Record<string, unknown> = {}): SDKMessage {
@@ -105,7 +122,7 @@ describe("Claude Goal runtime registration", () => {
       goalRuntime.sessions.resolve("authenticated-owner", SESSION_ID),
     ).resolves.toBe(runtime);
 
-    registration?.release();
+    await registration?.release();
     await expect(
       goalRuntime.sessions.resolve("authenticated-owner", SESSION_ID),
     ).resolves.toBeNull();
@@ -309,6 +326,239 @@ describe("Claude Goal runtime registration", () => {
     expect(matchingEpochSdk.queryInput).toBeUndefined();
     expect(matchingEpochRuntime.state).toBe("closed");
   });
+
+  it("recovers a persisted epoch only after Claude confirms the expected provider session", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const runtime = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 4,
+      expectedProviderSessionId: "claude-provider-session",
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const goalRuntime = createInMemoryAgentGoalRuntime();
+    vi.spyOn(goalRuntime.goals, "getRuntimeSessionRunEpoch").mockResolvedValue(
+      4,
+    );
+    const replay = vi.spyOn(goalRuntime.goals, "replayPendingInstructions");
+    const initializeRecoveredProgress = vi.spyOn(
+      goalRuntime.dispatcher,
+      "initializeRecoveredProgress",
+    );
+    let continuationResult: unknown;
+    const initialized = vi.fn(
+      async (
+        context: Parameters<
+          NonNullable<AgentRuntimeRecovery["onProviderSessionInitialized"]>
+        >[0],
+      ) => {
+        continuationResult = await context.continueGoal();
+      },
+    );
+    const captureContext = vi.spyOn(goalRuntime.observations, "captureContext");
+
+    const registrationPromise = startClaudeGoalRuntimeSession({
+      session: { user: { id: "authenticated-owner" } },
+      runtime,
+      start: {
+        initialPrompt: createClaudeRecoveryInitialPrompt(),
+        queryOptions: { resume: "claude-provider-session" },
+      },
+      goalRuntime,
+      recovery: {
+        instructionSettlements: [],
+        onProviderSessionInitialized: initialized,
+      },
+    });
+
+    await vi.waitFor(() => expect(sdk.queryInput).toBeDefined());
+    expect(registrationPromise).toBeInstanceOf(Promise);
+    const prompt = sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>;
+    const input = prompt[Symbol.asyncIterator]();
+    await expect(input.next()).resolves.toMatchObject({
+      value: {
+        type: "user",
+        message: { role: "user", content: "" },
+        isSynthetic: true,
+        shouldQuery: false,
+      },
+      done: false,
+    });
+    await expect(
+      goalRuntime.sessions.resolve("authenticated-owner", SESSION_ID),
+    ).resolves.toBeNull();
+    expect(initializeRecoveredProgress).not.toHaveBeenCalled();
+    expect(replay).not.toHaveBeenCalled();
+    expect(initialized).not.toHaveBeenCalled();
+
+    handle.push(initMessage());
+
+    const registration = await registrationPromise;
+    expect(runtime.runEpoch).toBe(4);
+    await expect(
+      goalRuntime.sessions.resolve("authenticated-owner", SESSION_ID),
+    ).resolves.toBe(runtime);
+    expect(initializeRecoveredProgress).toHaveBeenCalledWith({
+      ownerId: "authenticated-owner",
+      runtimeSessionId: SESSION_ID,
+      transport: runtime,
+      settlements: [],
+    });
+    expect(replay).toHaveBeenCalledWith("authenticated-owner", SESSION_ID);
+    expect(
+      initializeRecoveredProgress.mock.invocationCallOrder[0],
+    ).toBeLessThan(replay.mock.invocationCallOrder[0]);
+    expect(initialized).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeSessionId: SESSION_ID,
+        providerSessionId: "claude-provider-session",
+        runEpoch: 4,
+        continueGoal: expect.any(Function),
+      }),
+    );
+    expect(captureContext).toHaveBeenCalledWith({
+      ownerId: "authenticated-owner",
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 4,
+    });
+    expect(continuationResult).toEqual({
+      decision: "allow",
+      outcome: "no_active_goal",
+    });
+
+    await registration?.release();
+    await runtime.close();
+  });
+
+  it("uses the recovery claim as the synthetic evaluation boundary across restarts", async () => {
+    const goalRuntime = createInMemoryAgentGoalRuntime();
+    vi.spyOn(goalRuntime.goals, "getRuntimeSessionRunEpoch").mockResolvedValue(
+      4,
+    );
+    const assistantTurnIds: string[] = [];
+    vi.spyOn(goalRuntime.controller, "forSession").mockImplementation(() => ({
+      evaluateStop: async (input) => {
+        assistantTurnIds.push(input.assistantTurnId);
+        return { decision: "allow", outcome: "no_active_goal" };
+      },
+    }));
+
+    for (const recoveryLeaseToken of ["recovery-claim-a", "recovery-claim-b"]) {
+      const handle = createControlledClaudeQuery();
+      const sdk = createFakeClaudeSdkTransport(handle);
+      const runtime = new ClaudeRuntimeSession({
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 4,
+        expectedProviderSessionId: "claude-provider-session",
+        sdkTransport: sdk.transport,
+        logger: logger(),
+        createMessageId: () => "message-id",
+      });
+      const initialized = vi.fn(
+        async (
+          context: Parameters<
+            NonNullable<AgentRuntimeRecovery["onProviderSessionInitialized"]>
+          >[0],
+        ) => {
+          await context.continueGoal();
+        },
+      );
+      const registrationPromise = startClaudeGoalRuntimeSession({
+        session: { user: { id: "authenticated-owner" } },
+        runtime,
+        start: {
+          initialPrompt: createClaudeRecoveryInitialPrompt(),
+          queryOptions: { resume: "claude-provider-session" },
+        },
+        goalRuntime,
+        recovery: {
+          recoveryLeaseToken,
+          instructionSettlements: [],
+          onProviderSessionInitialized: initialized,
+        },
+      });
+
+      await vi.waitFor(() => expect(sdk.queryInput).toBeDefined());
+      handle.push(initMessage());
+      const registration = await registrationPromise;
+      expect(initialized).toHaveBeenCalledOnce();
+      await registration?.release();
+      await runtime.close();
+    }
+
+    expect(assistantTurnIds).toEqual([
+      `recovery:${SESSION_ID}:4:recovery-claim-a`,
+      `recovery:${SESSION_ID}:4:recovery-claim-b`,
+    ]);
+  });
+
+  it("fails recovery before registration or replay when Claude resumes a different provider session", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const runtime = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 4,
+      expectedProviderSessionId: "expected-provider-session",
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    const goalRuntime = createInMemoryAgentGoalRuntime();
+    vi.spyOn(goalRuntime.goals, "getRuntimeSessionRunEpoch").mockResolvedValue(
+      4,
+    );
+    const replay = vi.spyOn(goalRuntime.goals, "replayPendingInstructions");
+    const initializeRecoveredProgress = vi.spyOn(
+      goalRuntime.dispatcher,
+      "initializeRecoveredProgress",
+    );
+    const initialized = vi.fn();
+
+    const registrationPromise = startClaudeGoalRuntimeSession({
+      session: { user: { id: "authenticated-owner" } },
+      runtime,
+      start: {
+        initialPrompt: createClaudeRecoveryInitialPrompt(),
+        queryOptions: { resume: "expected-provider-session" },
+      },
+      goalRuntime,
+      recovery: {
+        instructionSettlements: [],
+        onProviderSessionInitialized: initialized,
+      },
+    });
+
+    await vi.waitFor(() => expect(sdk.queryInput).toBeDefined());
+    const prompt = sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>;
+    await expect(prompt[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+      value: {
+        message: { content: "" },
+        isSynthetic: true,
+        shouldQuery: false,
+      },
+      done: false,
+    });
+    await expect(
+      goalRuntime.sessions.resolve("authenticated-owner", SESSION_ID),
+    ).resolves.toBeNull();
+
+    handle.push({
+      ...initMessage(),
+      session_id: "different-provider-session",
+    } as SDKMessage);
+
+    await expect(registrationPromise).rejects.toMatchObject({
+      code: "provider_session_mismatch",
+    });
+    expect(goalRuntime.sessions.size).toBe(0);
+    expect(initializeRecoveredProgress).not.toHaveBeenCalled();
+    expect(replay).not.toHaveBeenCalled();
+    expect(initialized).not.toHaveBeenCalled();
+    expect(runtime.claudeSessionId).toBeUndefined();
+    expect(runtime.state).toBe("closed");
+  });
 });
 
 describe("ClaudeRuntimeSession", () => {
@@ -353,6 +603,128 @@ describe("ClaudeRuntimeSession", () => {
     await session.close();
     expect(handle.close).toHaveBeenCalledOnce();
     expect(session.state).toBe("closed");
+  });
+
+  it("terminates the Query when Claude emits a synthetic provider API error", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const observeSdkMessage = vi.fn(async () => {});
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    session.attachEventObserver({
+      instructionWritten: vi.fn(async () => {}),
+      captureTurnContexts: vi.fn(async () => []),
+      observeSdkMessage,
+      observeStopAssistantReport: vi.fn(async () => {}),
+      captureToolStart: vi.fn(async () => {}),
+      observeToolOutcome: vi.fn(async () => {}),
+      flush: vi.fn(async () => {}),
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+
+    handle.push(initMessage());
+    await vi.waitFor(() => expect(observeSdkMessage).toHaveBeenCalledOnce());
+    handle.push(apiErrorAssistantMessage());
+
+    await expect(output.next()).resolves.toMatchObject({
+      value: {
+        type: "error",
+        message: CLAUDE_API_ERROR_SENTINEL,
+        runEpoch: 0,
+      },
+    });
+    await expect(output.next()).resolves.toEqual({
+      value: undefined,
+      done: true,
+    });
+    await vi.waitFor(() => expect(session.state).toBe("failed"));
+    expect(handle.close).toHaveBeenCalledOnce();
+    expect(observeSdkMessage).toHaveBeenCalledOnce();
+
+    await session.close();
+    expect(handle.close).toHaveBeenCalledOnce();
+  });
+
+  it("confirms the expected provider session and starts recovery with no original prompt", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 3,
+      expectedProviderSessionId: "claude-provider-session",
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    session.start({ initialPrompt: createClaudeRecoveryInitialPrompt() });
+    const prompt = sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>;
+    const input = prompt[Symbol.asyncIterator]();
+    await expect(input.next()).resolves.toMatchObject({
+      value: {
+        type: "user",
+        message: { role: "user", content: "" },
+        isSynthetic: true,
+        shouldQuery: false,
+      },
+      done: false,
+    });
+    const firstGoalInput = input.next();
+    const initialized = session.waitUntilProviderSessionInitialized();
+
+    handle.push(initMessage());
+    await expect(initialized).resolves.toBe("claude-provider-session");
+    await session.deliver(runtimeInstruction({ sequence: 1 }));
+    await expect(firstGoalInput).resolves.toMatchObject({
+      value: {
+        message: {
+          content: expect.stringContaining("context.remove"),
+        },
+      },
+    });
+
+    await session.close();
+  });
+
+  it("fails recovery when Claude initializes a different provider session", async () => {
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 1,
+      expectedProviderSessionId: "expected-provider-session",
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+    });
+    session.start({ initialPrompt: createClaudeRecoveryInitialPrompt() });
+    const prompt = sdk.queryInput?.prompt as AsyncIterable<SDKUserMessage>;
+    await expect(prompt[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+      value: {
+        message: { content: "" },
+        isSynthetic: true,
+        shouldQuery: false,
+      },
+      done: false,
+    });
+    const initialized = session.waitUntilProviderSessionInitialized();
+
+    handle.push({
+      ...initMessage(),
+      session_id: "different-provider-session",
+    } as SDKMessage);
+
+    await expect(initialized).rejects.toMatchObject({
+      code: "provider_session_mismatch",
+    });
+    await vi.waitFor(() => expect(session.state).toBe("failed"));
+    expect(session.claudeSessionId).toBeUndefined();
+    await session.close();
   });
 
   it("delivers formatted instructions through its live input channel and interrupts the Query", async () => {

--- a/apps/web/tests/unit/claude-runtime-session.test.ts
+++ b/apps/web/tests/unit/claude-runtime-session.test.ts
@@ -416,6 +416,7 @@ describe("Claude Goal runtime registration", () => {
         providerSessionId: "claude-provider-session",
         runEpoch: 4,
         continueGoal: expect.any(Function),
+        finalizeGoalWithoutContinuation: expect.any(Function),
       }),
     );
     expect(captureContext).toHaveBeenCalledWith({
@@ -438,9 +439,14 @@ describe("Claude Goal runtime registration", () => {
       4,
     );
     const assistantTurnIds: string[] = [];
+    const finalizationIds: string[] = [];
     vi.spyOn(goalRuntime.controller, "forSession").mockImplementation(() => ({
       evaluateStop: async (input) => {
         assistantTurnIds.push(input.assistantTurnId);
+        return { decision: "allow", outcome: "no_active_goal" };
+      },
+      finalizeWithoutContinuation: async (input) => {
+        finalizationIds.push(input.evaluationId);
         return { decision: "allow", outcome: "no_active_goal" };
       },
     }));
@@ -463,6 +469,7 @@ describe("Claude Goal runtime registration", () => {
           >[0],
         ) => {
           await context.continueGoal();
+          await context.finalizeGoalWithoutContinuation?.();
         },
       );
       const registrationPromise = startClaudeGoalRuntimeSession({
@@ -491,6 +498,10 @@ describe("Claude Goal runtime registration", () => {
     expect(assistantTurnIds).toEqual([
       `recovery:${SESSION_ID}:4:recovery-claim-a`,
       `recovery:${SESSION_ID}:4:recovery-claim-b`,
+    ]);
+    expect(finalizationIds).toEqual([
+      `recovery-terminal:${SESSION_ID}:4:recovery-claim-a`,
+      `recovery-terminal:${SESSION_ID}:4:recovery-claim-b`,
     ]);
   });
 
@@ -605,16 +616,59 @@ describe("ClaudeRuntimeSession", () => {
     expect(session.state).toBe("closed");
   });
 
-  it("terminates the Query when Claude emits a synthetic provider API error", async () => {
+  it("waits for normal output observation to finish before closing", async () => {
     const handle = createControlledClaudeQuery();
     const sdk = createFakeClaudeSdkTransport(handle);
-    const observeSdkMessage = vi.fn(async () => {});
+    let finishObservation!: () => void;
+    const observationPending = new Promise<void>((resolve) => {
+      finishObservation = resolve;
+    });
+    const observeSdkMessage = vi.fn(() => observationPending);
     const session = new ClaudeRuntimeSession({
       runtimeSessionId: SESSION_ID,
       runEpoch: 0,
       sdkTransport: sdk.transport,
       logger: logger(),
       createMessageId: () => "message-id",
+    });
+    session.attachEventObserver({
+      instructionWritten: vi.fn(async () => {}),
+      captureTurnContexts: vi.fn(async () => []),
+      observeSdkMessage,
+      observeStopAssistantReport: vi.fn(async () => {}),
+      captureToolStart: vi.fn(async () => {}),
+      observeToolOutcome: vi.fn(async () => {}),
+      flush: vi.fn(async () => {}),
+    });
+    session.start({ initialPrompt: "initial request" });
+    handle.push(initMessage());
+    await vi.waitFor(() => expect(observeSdkMessage).toHaveBeenCalledOnce());
+
+    let closed = false;
+    const closePromise = session.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    finishObservation();
+    await closePromise;
+    expect(closed).toBe(true);
+    expect(session.state).toBe("closed");
+  });
+
+  it("terminates the Query when Claude emits a synthetic provider API error", async () => {
+    const handle = createControlledClaudeQuery({ hangOnIteratorReturn: true });
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const observeSdkMessage = vi.fn(async () => {});
+    const abortProvider = vi.fn();
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "message-id",
+      abortProvider,
     });
     session.attachEventObserver({
       instructionWritten: vi.fn(async () => {}),
@@ -645,10 +699,50 @@ describe("ClaudeRuntimeSession", () => {
     });
     await vi.waitFor(() => expect(session.state).toBe("failed"));
     expect(handle.close).toHaveBeenCalledOnce();
+    expect(handle.iteratorReturn).not.toHaveBeenCalled();
+    expect(abortProvider).toHaveBeenCalledOnce();
     expect(observeSdkMessage).toHaveBeenCalledOnce();
 
     await session.close();
     expect(handle.close).toHaveBeenCalledOnce();
+  });
+
+  it("reports an external provider failure once without exposing diagnostics", async () => {
+    const handle = createControlledClaudeQuery({ hangOnIteratorReturn: true });
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const abortProvider = vi.fn();
+    const session = new ClaudeRuntimeSession({
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 4,
+      sdkTransport: sdk.transport,
+      logger: logger(),
+      createMessageId: () => "safe-error-id",
+      abortProvider,
+    });
+    const output = session.subscribe()[Symbol.asyncIterator]();
+    session.start({ initialPrompt: "initial request" });
+
+    expect(session.reportProviderFailure("stderr")).toBe(true);
+    expect(session.reportProviderFailure("session_store")).toBe(false);
+    await expect(output.next()).resolves.toEqual({
+      value: {
+        type: "error",
+        message: CLAUDE_API_ERROR_SENTINEL,
+        messageId: "safe-error-id",
+        runEpoch: 4,
+      },
+      done: false,
+    });
+    await expect(output.next()).resolves.toEqual({
+      value: undefined,
+      done: true,
+    });
+
+    expect(session.state).toBe("failed");
+    expect(abortProvider).toHaveBeenCalledOnce();
+    expect(handle.close).toHaveBeenCalledOnce();
+    expect(handle.iteratorReturn).not.toHaveBeenCalled();
+    await session.close();
   });
 
   it("confirms the expected provider session and starts recovery with no original prompt", async () => {

--- a/apps/web/tests/unit/codex-agent.test.ts
+++ b/apps/web/tests/unit/codex-agent.test.ts
@@ -30,7 +30,12 @@ afterEach(async () => {
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
     if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
+      await rm(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
     }
   }
 });
@@ -1304,6 +1309,12 @@ const fs = require("node:fs");
 const models = ${JSON.stringify(models)};
 const requests = [];
 let buffer = "";
+function send(value) {
+  process.stdout.write(JSON.stringify(value) + "\\n");
+}
+function sendAndExit(value) {
+  process.stdout.write(JSON.stringify(value) + "\\n", () => process.exit(0));
+}
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => {
   buffer += chunk;
@@ -1315,15 +1326,15 @@ process.stdin.on("data", (chunk) => {
     requests.push(message);
     fs.writeFileSync("app-server-requests.json", JSON.stringify(requests));
     if (message.method === "initialize") {
-      console.log(JSON.stringify({ id: message.id, result: { userAgent: "fake-codex" } }));
+      send({ id: message.id, result: { userAgent: "fake-codex" } });
     } else if (message.method === "model/list") {
-      console.log(JSON.stringify({
+      sendAndExit({
         id: message.id,
         result: {
           data: models.map((model) => ({ id: model, model, displayName: model })),
           nextCursor: null
         }
-      }));
+      });
     }
   }
 });

--- a/apps/web/tests/unit/hermes-agent.test.ts
+++ b/apps/web/tests/unit/hermes-agent.test.ts
@@ -13,7 +13,12 @@ afterEach(async () => {
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
     if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
+      await rm(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
     }
   }
 });
@@ -403,8 +408,20 @@ function send(value) {
 function respond(id, result) {
   send({ id, result });
 }
+function respondAndExit(id, result) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n",
+    () => process.exit(0)
+  );
+}
 function fail(id, message) {
   send({ id, error: { code: -32000, message } });
+}
+function failAndExit(id, message) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", id, error: { code: -32000, message } }) + "\\n",
+    () => process.exit(0)
+  );
 }
 function update(sessionId, update) {
   send({ method: "session/update", params: { sessionId, update } });
@@ -435,13 +452,13 @@ rl.on("line", (line) => {
       sessionUpdate: "agent_message_chunk",
       content: textContent("permission:" + optionId)
     });
-    respond(promptId, { stopReason: "end_turn" });
+    respondAndExit(promptId, { stopReason: "end_turn" });
     return;
   }
 
   if (!message.method && message.id === "unsupported-1") {
     append("unsupported.jsonl", message);
-    respond(promptId, { stopReason: "end_turn" });
+    respondAndExit(promptId, { stopReason: "end_turn" });
     return;
   }
 
@@ -462,14 +479,14 @@ rl.on("line", (line) => {
     case "session/cancel":
       append("cancels.jsonl", message);
       if (promptId) {
-        respond(promptId, { stopReason: "cancelled" });
+        respondAndExit(promptId, { stopReason: "cancelled" });
       }
       break;
     case "session/prompt": {
       promptId = message.id;
       const prompt = message.params.prompt.map((block) => block.text || "").join("");
       if (prompt.includes("jsonrpc-error")) {
-        fail(message.id, "fake prompt failure");
+        failAndExit(message.id, "fake prompt failure");
         return;
       }
       if (prompt.includes("hang forever")) {
@@ -536,7 +553,7 @@ rl.on("line", (line) => {
         usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 }
       });
       update(sessionId, { sessionUpdate: "unknown_event", raw: true });
-      respond(message.id, {
+      respondAndExit(message.id, {
         stopReason: "end_turn",
         usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 }
       });
@@ -552,7 +569,6 @@ rl.on("line", (line) => {
   }
 });
 
-rl.on("close", () => process.exit(0));
 `;
 }
 
@@ -564,6 +580,12 @@ function send(value) {
 }
 function respond(id, result) {
   send({ id, result });
+}
+function respondAndExit(id, result) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n",
+    () => process.exit(0)
+  );
 }
 function update(sessionId, update) {
   send({ method: "session/update", params: { sessionId, update } });
@@ -586,7 +608,7 @@ rl.on("line", (line) => {
       sessionUpdate: "agent_message_chunk",
       content: { type: "text", text: JSON.stringify(response) }
     });
-    respond(message.id, { stopReason: "end_turn" });
+    respondAndExit(message.id, { stopReason: "end_turn" });
   }
 });
 `;
@@ -598,6 +620,12 @@ const readline = require("node:readline");
 function send(value) {
   process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
 }
+function sendAndExit(value) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n",
+    () => process.exit(0)
+  );
+}
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
   const message = JSON.parse(line);
@@ -606,7 +634,7 @@ rl.on("line", (line) => {
   } else if (message.method === "session/new") {
     send({ id: message.id, result: { sessionId: "hermes-session-1" } });
   } else if (message.method === "session/prompt") {
-    send({ id: message.id, error: { code: -32000, message: "execution failed" } });
+    sendAndExit({ id: message.id, error: { code: -32000, message: "execution failed" } });
   }
 });
 `;
@@ -617,6 +645,12 @@ function successFakeAcpScript() {
 const readline = require("node:readline");
 function send(value) {
   process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
+}
+function sendAndExit(value) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n",
+    () => process.exit(0)
+  );
 }
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
@@ -636,7 +670,7 @@ rl.on("line", (line) => {
         }
       }
     });
-    send({ id: message.id, result: { stopReason: "end_turn" } });
+    sendAndExit({ id: message.id, result: { stopReason: "end_turn" } });
   }
 });
 `;

--- a/apps/web/tests/unit/loop/cli-path.test.ts
+++ b/apps/web/tests/unit/loop/cli-path.test.ts
@@ -64,8 +64,24 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 let TMP_ROOT = "";
+let originalCwd = "";
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let originalLoopCli: string | undefined;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, name);
+  } else {
+    process.env[name] = value;
+  }
+}
 
 beforeEach(() => {
+  originalCwd = process.cwd();
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  originalLoopCli = process.env.OPENLOOMI_LOOP_CLI;
   // Each test starts in a clean tmp dir; the resolver walks up from
   // `process.cwd()` looking for `apps/web/scripts/loop-cli.mjs`, so we
   // `process.chdir` into the tmp root before importing the module so
@@ -74,13 +90,18 @@ beforeEach(() => {
   TMP_ROOT = mkdtempSync(join(tmpdir(), "loomi-cli-path-"));
 });
 afterEach(() => {
+  // Windows cannot remove the directory that is still the process cwd.
+  // Restore the caller's cwd before cleaning up the per-test fixture.
+  process.chdir(originalCwd);
+  restoreEnv("HOME", originalHome);
+  restoreEnv("USERPROFILE", originalUserProfile);
+  restoreEnv("OPENLOOMI_LOOP_CLI", originalLoopCli);
+  existsSyncAllFalse = false;
+  vi.resetModules();
+
   if (TMP_ROOT && existsSync(TMP_ROOT)) {
     rmSync(TMP_ROOT, { recursive: true, force: true });
   }
-  // Reset the global flag — vitest runs tests in declaration order
-  // but the mock factory closure is shared across them, so an
-  // unset flag is the only safe default.
-  existsSyncAllFalse = false;
 });
 
 describe("resolveLoopCli", () => {
@@ -92,7 +113,7 @@ describe("resolveLoopCli", () => {
       const { resolveLoopCli } = await import("@/lib/loop/cli-path");
       expect(resolveLoopCli()).toBe(envPath);
     } finally {
-      process.env.OPENLOOMI_LOOP_CLI = undefined;
+      Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     }
   });
 
@@ -108,7 +129,7 @@ describe("resolveLoopCli", () => {
       const { resolveLoopCli } = await import("@/lib/loop/cli-path");
       expect(resolveLoopCli()).toBeNull();
     } finally {
-      process.env.OPENLOOMI_LOOP_CLI = undefined;
+      Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     }
   });
 
@@ -124,7 +145,7 @@ describe("resolveLoopCli", () => {
     const devFile = join(devRoot, "loop-cli.mjs");
     writeFileSync(devFile, "#!/usr/bin/env node\n");
     process.chdir(TMP_ROOT);
-    process.env.OPENLOOMI_LOOP_CLI = undefined;
+    Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     // Reach inside the module's cwd-relative probe walk — the
     // selfRelativeCandidates() fallback may still find the real dev
     // workspace if it exists, so disambiguate by writing the file
@@ -138,8 +159,8 @@ describe("resolveLoopCli", () => {
   it("finds `loop-cli.mjs` at the packaged `~/.openloomi/runtime/` location", async () => {
     // Mirror the Tauri optimizer's destination. We can't reach the
     // real `~/.openloomi/runtime/` from this test (it might actually
-    // be populated on a dev machine), so we point `HOME` at TMP_ROOT
-    // and re-execute the resolver under that env.
+    // be populated on a dev machine), so we point both Unix HOME and
+    // Windows USERPROFILE at TMP_ROOT and re-execute the resolver.
     const fakeHome = join(TMP_ROOT, "home");
     mkdirSync(fakeHome, { recursive: true });
     const packagedDir = join(fakeHome, ".openloomi", "runtime");
@@ -147,29 +168,30 @@ describe("resolveLoopCli", () => {
     const packagedFile = join(packagedDir, "loop-cli.mjs");
     writeFileSync(packagedFile, "#!/usr/bin/env node\n");
     process.chdir(TMP_ROOT);
-    process.env.OPENLOOMI_LOOP_CLI = undefined;
+    Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     // Disable other probes so the packaged-RUNTIME dir wins cleanly.
     existsSyncAllFalse = true;
 
-    const realHome = process.env.HOME;
     process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
     try {
       vi.resetModules();
       const { resolveLoopCli } = await import("@/lib/loop/cli-path");
       expect(resolveLoopCli()).toBe(packagedFile);
     } finally {
-      if (realHome === undefined) process.env.HOME = undefined;
-      else process.env.HOME = realHome;
+      restoreEnv("HOME", originalHome);
+      restoreEnv("USERPROFILE", originalUserProfile);
       vi.resetModules();
     }
   });
 
   it("returns null when no candidate exists on disk", async () => {
     process.chdir(TMP_ROOT);
-    process.env.OPENLOOMI_LOOP_CLI = undefined;
-    // Move HOME aside so the packaged-runtime probe also misses.
-    const realHome = process.env.HOME;
+    Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
+    // Move both home variables aside so the packaged-runtime probe also
+    // misses on Unix and Windows.
     process.env.HOME = join(TMP_ROOT, "no-home");
+    process.env.USERPROFILE = join(TMP_ROOT, "no-home");
     // The `selfRelativeCandidates()` walk uses `import.meta.url` /
     // `__filename` to find the on-disk location of cli-path.ts and
     // derives `<repo>/apps/web/scripts` from it. That derivation
@@ -181,15 +203,15 @@ describe("resolveLoopCli", () => {
       const { resolveLoopCli } = await import("@/lib/loop/cli-path");
       expect(resolveLoopCli()).toBeNull();
     } finally {
-      if (realHome === undefined) process.env.HOME = undefined;
-      else process.env.HOME = realHome;
+      restoreEnv("HOME", originalHome);
+      restoreEnv("USERPROFILE", originalUserProfile);
       vi.resetModules();
     }
   });
 
   it("dryRun returns the probe path even when nothing exists", async () => {
     process.chdir(TMP_ROOT);
-    process.env.OPENLOOMI_LOOP_CLI = undefined;
+    Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     const { resolveLoopCli } = await import("@/lib/loop/cli-path");
     // dryRun must return the first candidate it would have inspected
     // so callers can render an actionable diagnostic. We don't pin
@@ -216,7 +238,7 @@ describe("listLoopCliCandidates", () => {
       const anyExists = rows.some((r) => r.exists);
       expect(typeof anyExists).toBe("boolean");
     } finally {
-      process.env.OPENLOOMI_LOOP_CLI = undefined;
+      Reflect.deleteProperty(process.env, "OPENLOOMI_LOOP_CLI");
     }
   });
 });

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -324,6 +324,70 @@ describe("native agent runner", () => {
     expect(messages).toEqual([{ type: "text", content: "ok" }]);
   });
 
+  it("accepts runtime recovery only from the trusted runner context", async () => {
+    const trustedAgent = new CapturingAgent();
+    const getDefaultMemoryContext = vi.fn();
+    const runtimeRecovery = {
+      runtimeSessionId: "persisted-runtime-session",
+      providerSessionId: "persisted-claude-session",
+      workingDirectory: join(tmpdir(), "persisted-runtime-session"),
+      runEpoch: 3,
+      recoveryLeaseToken: "trusted-lease",
+      instructionSettlements: [],
+    };
+    const trustedRun = await runNativeAgentRequest(
+      {
+        prompt: "host recovery placeholder",
+        provider: "claude",
+        modelConfig: {
+          model: "persisted-session-model",
+          thinkingLevel: "adaptive",
+        },
+      },
+      {
+        ...createContext(),
+        runtimeRecovery,
+      },
+      {
+        registry: createRegistry(trustedAgent),
+        getDefaultMemoryContext,
+        getUserLlmProviderConfig: async () => ({
+          apiKey: "current-trusted-key",
+          baseUrl: "https://current-provider.example.test",
+          model: "current-user-model",
+        }),
+        logger: silentLogger,
+      },
+    );
+    await collectMessages(trustedRun.generator);
+    expect(trustedAgent.options?.runtimeRecovery).toEqual(runtimeRecovery);
+    expect(trustedAgent.config).toMatchObject({
+      apiKey: "current-trusted-key",
+      baseUrl: "https://current-provider.example.test",
+      model: "persisted-session-model",
+      thinkingLevel: "adaptive",
+    });
+    expect(getDefaultMemoryContext).not.toHaveBeenCalled();
+
+    const requestAgent = new CapturingAgent();
+    const untrustedRun = await runNativeAgentRequest(
+      {
+        prompt: "request recovery attempt",
+        provider: "claude",
+        runtimeRecovery,
+      } as Parameters<typeof runNativeAgentRequest>[0] & {
+        runtimeRecovery: typeof runtimeRecovery;
+      },
+      createContext(),
+      {
+        registry: createRegistry(requestAgent),
+        logger: silentLogger,
+      },
+    );
+    await collectMessages(untrustedRun.generator);
+    expect(requestAgent.options?.runtimeRecovery).toBeUndefined();
+  });
+
   it("injects materialized default memory context into the actual agent prompt", async () => {
     const agent = new CapturingAgent();
     const getDefaultMemoryContext = vi.fn(async () => ({

--- a/apps/web/tests/unit/openclaw-agent.test.ts
+++ b/apps/web/tests/unit/openclaw-agent.test.ts
@@ -13,7 +13,14 @@ const tempDirs: string[] = [];
 afterEach(async () => {
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
-    if (dir) await rm(dir, { recursive: true, force: true });
+    if (dir) {
+      await rm(dir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
+    }
   }
 });
 
@@ -124,6 +131,12 @@ fs.writeFileSync("args.json", JSON.stringify(process.argv.slice(2)));
 function send(value) {
   process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n");
 }
+function sendAndExit(value) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", ...value }) + "\\n",
+    () => process.exit(0)
+  );
+}
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
   const message = JSON.parse(line);
@@ -143,10 +156,9 @@ rl.on("line", (line) => {
         }
       }
     });
-    send({ id: message.id, result: { stopReason: "end_turn" } });
+    sendAndExit({ id: message.id, result: { stopReason: "end_turn" } });
   }
 });
-rl.on("close", () => process.exit(0));
 `,
     "utf8",
   );

--- a/apps/web/tests/unit/runtime-instructions/goal-controller.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-controller.test.ts
@@ -501,6 +501,72 @@ describe("GoalController Claude Stop integration", () => {
     }
   });
 
+  it("continues instead of blocking when semantic evidence is outside the evaluation snapshot", async () => {
+    const semanticEvaluator = {
+      evaluate: vi.fn().mockResolvedValue({
+        completed: true,
+        confidence: 1,
+        satisfiedCriteria: ["semantic-review"],
+        missingCriteria: [],
+        evidence: [
+          {
+            criterionId: "semantic-review",
+            evidenceIds: ["40000000-0000-4000-8000-000000000001"],
+          },
+        ],
+        reason: "The implementation appears complete.",
+      }),
+    };
+    const fixture = await createFixture({ semanticEvaluator });
+    try {
+      await activateGoal(fixture, {
+        objective: "Verify the implementation semantically",
+        successCriteria: [
+          {
+            id: "semantic-review",
+            description: "The implementation satisfies the requested behavior",
+            verification: { type: "model_evidence" },
+            required: true,
+          },
+        ],
+        constraints: [],
+        contextRefs: [],
+        priority: 80,
+        maxTurns: 5,
+        completionPolicy: "model_evaluator",
+        source: { type: "user" },
+      });
+      await observeAssistantTurn(
+        fixture,
+        "assistant-foreign-evidence",
+        "The implementation appears complete.",
+      );
+
+      await expect(
+        fixture.claude.evaluateStop({
+          runEpoch: 0,
+          assistantTurnId: "assistant-foreign-evidence",
+          lastAssistantMessage: "The implementation appears complete.",
+          stopHookActive: false,
+        }),
+      ).resolves.toMatchObject({ decision: "block", outcome: "continue" });
+      await expect(
+        fixture.runtime.observations.listGoalRuns(OWNER_ID, SESSION_ID),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          status: "running",
+          lastEvaluation: expect.objectContaining({
+            satisfiedCriteria: [],
+            missingCriteria: ["semantic-review"],
+            evidence: [],
+          }),
+        }),
+      ]);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
   it("allows a stale Stop callback without evaluating or continuing the current run", async () => {
     const fixture = await createFixture();
     try {

--- a/apps/web/tests/unit/runtime-instructions/goal-controller.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-controller.test.ts
@@ -88,6 +88,22 @@ async function closeFixture(fixture: Fixture) {
   await fixture.claude.close();
 }
 
+async function expectPausedGoal(fixture: Fixture, goalId: string) {
+  await expect(
+    fixture.runtime.queries.getById({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId,
+    }),
+  ).resolves.toMatchObject({
+    goal: { goal: { status: "paused", revision: 2 } },
+    latestRun: {
+      status: "paused",
+      lastEvaluation: { completed: false },
+    },
+  });
+}
+
 async function observeAssistantTurn(
   fixture: Fixture,
   assistantTurnId: string,
@@ -214,10 +230,10 @@ describe("GoalController Claude Stop integration", () => {
     }
   });
 
-  it("fails closed on recursive Stop without a new assistant turn", async () => {
+  it("pauses on recursive Stop without a new assistant turn", async () => {
     const fixture = await createFixture();
     try {
-      await activateGoal(fixture, commandGoal());
+      const activation = await activateGoal(fixture, commandGoal());
       await observeAssistantTurn(fixture, "assistant-recursive-stop");
       await fixture.claude.evaluateStop({
         runEpoch: 0,
@@ -233,7 +249,8 @@ describe("GoalController Claude Stop integration", () => {
           lastAssistantMessage: "The test has not run yet.",
           stopHookActive: true,
         }),
-      ).resolves.toMatchObject({ decision: "allow", outcome: "blocked" });
+      ).resolves.toMatchObject({ decision: "allow", outcome: "paused" });
+      await expectPausedGoal(fixture, activation.goal.goal.id);
     } finally {
       await closeFixture(fixture);
     }
@@ -262,7 +279,7 @@ describe("GoalController Claude Stop integration", () => {
     }
   });
 
-  it("allows Stop and completes the Goal when deterministic command evidence satisfies it", async () => {
+  it("finalizes without continuation when durable command evidence satisfies the Goal", async () => {
     const fixture = await createFixture();
     try {
       await activateGoal(fixture, commandGoal());
@@ -300,11 +317,16 @@ describe("GoalController Claude Stop integration", () => {
       });
 
       await expect(
-        fixture.claude.evaluateStop({
+        fixture.runtime.controller
+          .forSession({
+            ownerId: OWNER_ID,
+            runtimeSessionId: SESSION_ID,
+            transport: fixture.claude,
+          })
+          .finalizeWithoutContinuation({
           runEpoch: 0,
-          assistantTurnId: "assistant-turn-complete",
-          lastAssistantMessage: "The required test passed.",
-          stopHookActive: false,
+          evaluationId: "provider-failure-complete",
+          turnContext: context,
         }),
       ).resolves.toMatchObject({ decision: "allow", outcome: "completed" });
     } finally {
@@ -410,10 +432,10 @@ describe("GoalController Claude Stop integration", () => {
     }
   });
 
-  it("never automatically completes a manual criterion", async () => {
+  it("pauses instead of automatically completing a manual criterion", async () => {
     const fixture = await createFixture();
     try {
-      await activateGoal(fixture, {
+      const activation = await activateGoal(fixture, {
         objective: "Obtain approval",
         successCriteria: [
           {
@@ -439,19 +461,20 @@ describe("GoalController Claude Stop integration", () => {
           lastAssistantMessage: "I believe the result is ready.",
           stopHookActive: false,
         }),
-      ).resolves.toMatchObject({ decision: "allow", outcome: "blocked" });
+      ).resolves.toMatchObject({ decision: "allow", outcome: "paused" });
+      await expectPausedGoal(fixture, activation.goal.goal.id);
     } finally {
       await closeFixture(fixture);
     }
   });
 
-  it("fails closed when the semantic evaluator fails", async () => {
+  it("pauses when the semantic evaluator fails", async () => {
     const semanticEvaluator = {
       evaluate: vi.fn().mockRejectedValue(new Error("evaluator unavailable")),
     };
     const fixture = await createFixture({ semanticEvaluator });
     try {
-      await activateGoal(fixture, {
+      const activation = await activateGoal(fixture, {
         objective: "Verify the implementation semantically",
         successCriteria: [
           {
@@ -481,7 +504,8 @@ describe("GoalController Claude Stop integration", () => {
           lastAssistantMessage: "The implementation appears complete.",
           stopHookActive: false,
         }),
-      ).resolves.toMatchObject({ decision: "allow", outcome: "blocked" });
+      ).resolves.toMatchObject({ decision: "allow", outcome: "paused" });
+      await expectPausedGoal(fixture, activation.goal.goal.id);
       expect(semanticEvaluator.evaluate).toHaveBeenCalledTimes(1);
       expect(semanticEvaluator.evaluate).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -495,6 +519,211 @@ describe("GoalController Claude Stop integration", () => {
             }),
           ]),
         }),
+      );
+
+      const resumed = await fixture.runtime.goals.resume({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activation.goal.goal.id,
+        expectedRevision: 2,
+        idempotencyKey: "resume-after-evaluator-error",
+        source: { type: "user", authority: "user" },
+      });
+      expect(resumed).toMatchObject({
+        goal: { goal: { status: "active", revision: 3 } },
+        instruction: { kind: "goal.resume", goalRevision: 3 },
+        dispatch: { status: "accepted" },
+      });
+      await fixture.sdkInput.next();
+      await vi.waitFor(async () => {
+        await expect(
+          fixture.runtime.queries.getById({
+            ownerId: OWNER_ID,
+            runtimeSessionId: SESSION_ID,
+            goalId: activation.goal.goal.id,
+          }),
+        ).resolves.toMatchObject({
+          goal: { goal: { status: "active", revision: 3 } },
+          latestRun: {
+            status: "running",
+            goalRevision: 3,
+            lastEvaluation: expect.objectContaining({
+              completed: false,
+              reason: expect.stringContaining(
+                "The semantic Goal evaluator failed",
+              ),
+            }),
+          },
+        });
+      });
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("pauses without creating a continuation when final evidence is incomplete", async () => {
+    const fixture = await createFixture();
+    try {
+      const activation = await activateGoal(fixture, commandGoal());
+      const context = await fixture.runtime.observations.captureContext({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 0,
+      });
+      if (context === null) {
+        throw new Error("Expected an active Goal observation context");
+      }
+
+      await expect(
+        fixture.runtime.controller
+          .forSession({
+            ownerId: OWNER_ID,
+            runtimeSessionId: SESSION_ID,
+            transport: fixture.claude,
+          })
+          .finalizeWithoutContinuation({
+            runEpoch: 0,
+            evaluationId: "provider-failure-incomplete",
+            turnContext: context,
+          }),
+      ).resolves.toMatchObject({ decision: "allow", outcome: "paused" });
+      await expectPausedGoal(fixture, activation.goal.goal.id);
+      await expect(
+        fixture.runtime.state.listInstructions(OWNER_ID, SESSION_ID),
+      ).resolves.toEqual([
+        expect.objectContaining({ kind: "goal.activate" }),
+      ]);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("preserves proven criteria when final semantic evaluation fails", async () => {
+    const fixture = await createFixture({
+      semanticEvaluator: {
+        evaluate: vi.fn().mockRejectedValue(new Error("evaluator unavailable")),
+      },
+    });
+    try {
+      const activation = await activateGoal(
+        fixture,
+        commandGoal({
+          completionPolicy: "model_evaluator",
+          successCriteria: [
+            {
+              id: "tests-pass",
+              description: "Required tests pass",
+              verification: {
+                type: "command_result",
+                commandPattern: "pnpm test",
+                expectedExitCode: 0,
+              },
+              required: true,
+            },
+            {
+              id: "behavior-correct",
+              description: "The behavior is correct",
+              verification: { type: "model_evidence" },
+              required: true,
+            },
+          ],
+        }),
+      );
+      const context = await fixture.runtime.observations.captureContext({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 0,
+      });
+      if (context === null) {
+        throw new Error("Expected an active Goal observation context");
+      }
+      await fixture.runtime.observations.observeProviderEvent({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 0,
+        eventKey: "provider-failure-test-result",
+        providerEventId: "provider-failure-test-result",
+        observedAt: NOW.toISOString(),
+        context,
+        evidence: [
+          {
+            type: "test_result",
+            sourceEventId: "provider-failure-test-result",
+            summary: "Test command succeeded: pnpm test",
+            success: true,
+            payload: {
+              provider: "claude",
+              toolName: "Bash",
+              command: "pnpm test",
+              exitCode: 0,
+            },
+            observedAt: NOW.toISOString(),
+          },
+        ],
+      });
+
+      await expect(
+        fixture.runtime.controller
+          .forSession({
+            ownerId: OWNER_ID,
+            runtimeSessionId: SESSION_ID,
+            transport: fixture.claude,
+          })
+          .finalizeWithoutContinuation({
+            runEpoch: 0,
+            evaluationId: "provider-failure-preserves-progress",
+            turnContext: context,
+          }),
+      ).resolves.toMatchObject({ decision: "allow", outcome: "paused" });
+      await expect(
+        fixture.runtime.queries.getById({
+          ownerId: OWNER_ID,
+          runtimeSessionId: SESSION_ID,
+          goalId: activation.goal.goal.id,
+        }),
+      ).resolves.toMatchObject({
+        goal: { goal: { status: "paused" } },
+        latestRun: {
+          status: "paused",
+          lastEvaluation: {
+            satisfiedCriteria: ["tests-pass"],
+            missingCriteria: ["behavior-correct"],
+          },
+        },
+        progress: { completedCriteria: 1, totalCriteria: 2 },
+      });
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("pauses after repeated evaluations make no progress", async () => {
+    const fixture = await createFixture();
+    try {
+      const activation = await activateGoal(fixture, commandGoal());
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        const assistantTurnId = `assistant-no-progress-${attempt}`;
+        await observeAssistantTurn(fixture, assistantTurnId);
+        const decision = await fixture.claude.evaluateStop({
+          runEpoch: 0,
+          assistantTurnId,
+          lastAssistantMessage: "The required test has not run yet.",
+          stopHookActive: false,
+        });
+        expect(decision).toMatchObject(
+          attempt < 3
+            ? { decision: "block", outcome: "continue" }
+            : { decision: "allow", outcome: "paused" },
+        );
+      }
+
+      await expectPausedGoal(fixture, activation.goal.goal.id);
+      const [run] = await fixture.runtime.observations.listGoalRuns(
+        OWNER_ID,
+        SESSION_ID,
+      );
+      expect(run?.lastEvaluation?.reason).toContain(
+        "Automatic continuation stopped after 3 evaluations without new evidence or satisfied criteria.",
       );
     } finally {
       await closeFixture(fixture);
@@ -616,6 +845,54 @@ describe("GoalController Claude Stop integration", () => {
         goalRevision: 1,
       });
       expect(semanticEvaluator.evaluate).not.toHaveBeenCalled();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("invalidates the prior evaluation when the Goal definition changes", async () => {
+    const fixture = await createFixture();
+    try {
+      const activated = await activateGoal(fixture, commandGoal());
+      await observeAssistantTurn(fixture, "assistant-before-goal-update");
+      await expect(
+        fixture.claude.evaluateStop({
+          runEpoch: 0,
+          assistantTurnId: "assistant-before-goal-update",
+          lastAssistantMessage: "The required test has not run yet.",
+          stopHookActive: false,
+        }),
+      ).resolves.toMatchObject({ decision: "block", outcome: "continue" });
+      await expect(
+        fixture.runtime.queries.getById({
+          ownerId: OWNER_ID,
+          runtimeSessionId: SESSION_ID,
+          goalId: activated.goal.goal.id,
+        }),
+      ).resolves.toMatchObject({
+        latestRun: { lastEvaluation: expect.objectContaining({ completed: false }) },
+      });
+
+      await fixture.runtime.goals.update({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activated.goal.goal.id,
+        expectedRevision: 1,
+        idempotencyKey: "change-goal-definition",
+        source: { type: "user", authority: "user" },
+        update: { objective: "Run and preserve the revised test result" },
+      });
+      await fixture.sdkInput.next();
+
+      await expect(
+        fixture.runtime.queries.getById({
+          ownerId: OWNER_ID,
+          runtimeSessionId: SESSION_ID,
+          goalId: activated.goal.goal.id,
+        }),
+      ).resolves.toMatchObject({
+        latestRun: { goalRevision: 2, lastEvaluation: undefined },
+      });
     } finally {
       await closeFixture(fixture);
     }

--- a/apps/web/tests/unit/runtime-instructions/goal-evaluator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-evaluator.test.ts
@@ -490,7 +490,7 @@ describe("GoalEvaluator", () => {
     );
   });
 
-  it("fails closed when semantic evaluation is unavailable, throws, or references foreign evidence", async () => {
+  it("fails closed when semantic evaluation is unavailable or throws", async () => {
     const agentGoal = goal(
       [criterion("behavior-correct", { type: "model_evidence" })],
       "model_evaluator",
@@ -523,25 +523,133 @@ describe("GoalEvaluator", () => {
     await expect(throwing.evaluate(input)).rejects.toMatchObject({
       code: "semantic_evaluator_failed",
     } satisfies Partial<GoalEvaluatorError>);
+  });
 
+  it("keeps criteria with unscoped semantic evidence unsatisfied", async () => {
+    const agentGoal = goal(
+      [
+        criterion("behavior-correct", { type: "model_evidence" }),
+        criterion("tests-pass", { type: "model_evidence" }),
+      ],
+      "model_evaluator",
+    );
+    const reportEvidence = evidence(
+      "30000000-0000-4000-8000-000000000009",
+      agentGoal,
+      {
+        type: "agent_report",
+        success: true,
+        summary: "A scoped report",
+        payload: {},
+      },
+    );
     const foreignEvidence = new GoalEvaluator({
       evaluate: async () => ({
         completed: true,
         confidence: 0.8,
-        satisfiedCriteria: ["behavior-correct"],
+        satisfiedCriteria: ["behavior-correct", "tests-pass"],
         missingCriteria: [],
         evidence: [
           {
             criterionId: "behavior-correct",
             evidenceIds: ["40000000-0000-4000-8000-000000000001"],
           },
+          {
+            criterionId: "tests-pass",
+            evidenceIds: [reportEvidence.id],
+          },
         ],
         reason: "Referenced evidence is outside the snapshot.",
       }),
     });
-    await expect(foreignEvidence.evaluate(input)).rejects.toMatchObject({
-      code: "invalid_semantic_evaluation",
-    } satisfies Partial<GoalEvaluatorError>);
+    const result = await foreignEvidence.evaluate({
+      goal: agentGoal,
+      run: run(agentGoal),
+      evidence: [reportEvidence],
+    });
+
+    expect(result).toMatchObject({
+      completed: false,
+      satisfiedCriteria: ["tests-pass"],
+      missingCriteria: ["behavior-correct"],
+      evidence: [
+        { criterionId: "tests-pass", evidenceIds: [reportEvidence.id] },
+      ],
+    });
+    expect(result.reason).toContain(
+      "affected criteria remain unsatisfied: behavior-correct",
+    );
+  });
+
+  it("requires one unambiguous scoped evidence association per satisfied criterion", async () => {
+    const agentGoal = goal(
+      [criterion("behavior-correct", { type: "model_evidence" })],
+      "model_evaluator",
+    );
+    const reportEvidence = evidence(
+      "30000000-0000-4000-8000-000000000009",
+      agentGoal,
+      {
+        type: "agent_report",
+        success: true,
+        summary: "A scoped report",
+        payload: {},
+      },
+    );
+    const evaluator = new GoalEvaluator({
+      evaluate: async () => ({
+        completed: true,
+        confidence: 1,
+        satisfiedCriteria: ["behavior-correct"],
+        missingCriteria: [],
+        evidence: [
+          {
+            criterionId: "behavior-correct",
+            evidenceIds: [reportEvidence.id],
+          },
+          {
+            criterionId: "behavior-correct",
+            evidenceIds: [reportEvidence.id],
+          },
+        ],
+        reason: "The criterion has duplicate evidence associations.",
+      }),
+    });
+
+    await expect(
+      evaluator.evaluate({
+        goal: agentGoal,
+        run: run(agentGoal),
+        evidence: [reportEvidence],
+      }),
+    ).resolves.toMatchObject({
+      completed: false,
+      satisfiedCriteria: [],
+      missingCriteria: ["behavior-correct"],
+      evidence: [],
+    });
+  });
+
+  it("ignores semantic evidence associated with a missing criterion", async () => {
+    const agentGoal = goal(
+      [criterion("behavior-correct", { type: "model_evidence" })],
+      "model_evaluator",
+    );
+    const reportEvidence = evidence(
+      "30000000-0000-4000-8000-000000000009",
+      agentGoal,
+      {
+        type: "agent_report",
+        success: true,
+        summary: "A scoped report",
+        payload: {},
+      },
+    );
+    const input = {
+      goal: agentGoal,
+      run: run(agentGoal),
+      evidence: [reportEvidence],
+    };
 
     const evidenceForMissingCriterion = new GoalEvaluator({
       evaluate: async () => ({
@@ -554,14 +662,24 @@ describe("GoalEvaluator", () => {
             criterionId: "behavior-correct",
             evidenceIds: [reportEvidence.id],
           },
+          {
+            criterionId: "criterion-outside-delegation",
+            evidenceIds: [reportEvidence.id],
+          },
         ],
         reason: "A missing criterion must not receive evidence associations.",
       }),
     });
-    await expect(
-      evidenceForMissingCriterion.evaluate(input),
-    ).rejects.toMatchObject({
-      code: "invalid_semantic_evaluation",
-    } satisfies Partial<GoalEvaluatorError>);
+    await expect(evidenceForMissingCriterion.evaluate(input)).resolves.toMatchObject(
+      {
+        completed: false,
+        satisfiedCriteria: [],
+        missingCriteria: ["behavior-correct"],
+        evidence: [],
+        reason: expect.stringContaining(
+          "Invalid semantic evidence associations outside the delegated criteria were ignored",
+        ),
+      },
+    );
   });
 });

--- a/apps/web/tests/unit/runtime-instructions/goal-evaluator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-evaluator.test.ts
@@ -1,4 +1,5 @@
 import {
+  AgentGoalSchema,
   createAgentGoal,
   type AgentGoal,
   type AgentGoalRun,
@@ -522,7 +523,117 @@ describe("GoalEvaluator", () => {
     });
     await expect(throwing.evaluate(input)).rejects.toMatchObject({
       code: "semantic_evaluator_failed",
+    });
+  });
+
+  it("carries already-proven scoped progress when semantic evaluation fails", async () => {
+    const agentGoal = goal(
+      [
+        criterion("tests-pass", {
+          type: "command_result",
+          expectedExitCode: 0,
+        }),
+        criterion("behavior-correct", { type: "model_evidence" }),
+      ],
+      "model_evaluator",
+    );
+    const commandEvidence = evidence(
+      "30000000-0000-4000-8000-000000000023",
+      agentGoal,
+      {
+        type: "test_result",
+        success: true,
+        summary: "The required command passed",
+        payload: { exitCode: 0 },
+      },
+    );
+    const evaluator = new GoalEvaluator({
+      evaluate: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+    });
+
+    await expect(
+      evaluator.evaluate({
+        goal: agentGoal,
+        run: run(agentGoal),
+        evidence: [commandEvidence],
+      }),
+    ).rejects.toMatchObject({
+      code: "semantic_evaluator_failed",
+      partialEvaluation: {
+        completed: false,
+        confidence: 0,
+        satisfiedCriteria: ["tests-pass"],
+        missingCriteria: ["behavior-correct"],
+        evidence: [
+          { criterionId: "tests-pass", evidenceIds: [commandEvidence.id] },
+        ],
+        reason: expect.any(String),
+      },
     } satisfies Partial<GoalEvaluatorError>);
+  });
+
+  it("accepts lifecycle-era evidence within the semantic revision floor only", async () => {
+    const created = goal([
+      criterion("tests-pass", {
+        type: "command_result",
+        commandPattern: "vitest",
+        expectedExitCode: 0,
+      }),
+    ]);
+    const agentGoal = AgentGoalSchema.parse({
+      ...created,
+      revision: 5,
+      updatedAt: new Date(NOW.getTime() + 4_000).toISOString(),
+    });
+    const beforeFloor = evidence(
+      "30000000-0000-4000-8000-000000000020",
+      agentGoal,
+      {
+        type: "test_result",
+        success: true,
+        summary: "Test passed before the current semantic scope",
+        payload: { command: "pnpm vitest run", exitCode: 0 },
+        goalRevision: 2,
+      },
+    );
+    const lifecycleEra = evidence(
+      "30000000-0000-4000-8000-000000000021",
+      agentGoal,
+      {
+        type: "test_result",
+        success: true,
+        summary: "Test passed before a pause and resume",
+        payload: { command: "pnpm vitest run", exitCode: 0 },
+        goalRevision: 3,
+      },
+    );
+    const future = evidence(
+      "30000000-0000-4000-8000-000000000022",
+      agentGoal,
+      {
+        type: "test_result",
+        success: true,
+        summary: "Test belongs to a future Goal revision",
+        payload: { command: "pnpm vitest run", exitCode: 0 },
+        goalRevision: 6,
+      },
+    );
+
+    const result = await new GoalEvaluator().evaluate({
+      goal: agentGoal,
+      run: run(agentGoal),
+      evidence: [beforeFloor, lifecycleEra, future],
+      evidenceRevisionFloor: 3,
+    });
+
+    expect(result).toMatchObject({
+      completed: true,
+      satisfiedCriteria: ["tests-pass"],
+      missingCriteria: [],
+      evidence: [
+        { criterionId: "tests-pass", evidenceIds: [lifecycleEra.id] },
+      ],
+    });
   });
 
   it("keeps criteria with unscoped semantic evidence unsatisfied", async () => {

--- a/apps/web/tests/unit/runtime-instructions/goal-lifecycle-recovery-wake.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-lifecycle-recovery-wake.test.ts
@@ -1,0 +1,74 @@
+import type { AgentGoalStatePort } from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  GoalLifecycleService,
+  type RuntimeSessionRecoveryWakePort,
+} from "@/lib/ai/runtime-instructions/goal-lifecycle-service";
+import type { RuntimeInstructionDispatcher } from "@/lib/ai/runtime-instructions/instruction-dispatcher";
+import { RuntimeSessionRegistry } from "@/lib/ai/runtime-instructions/runtime-session-registry";
+
+const OWNER_ID = "recovery-wake-owner";
+const SESSION_ID = "recovery-wake-session";
+const INSTRUCTION_ID = "recovery-wake-resume-instruction";
+const NOW = "2026-08-10T12:00:00.000Z";
+
+describe("Goal lifecycle recovery wake", () => {
+  it("wakes a dormant recovered runtime and returns the resumed delivery receipt", async () => {
+    const replay = {
+      instruction: { id: INSTRUCTION_ID },
+    };
+    const state = {
+      findCommitByIdempotency: vi.fn(async () => replay),
+    } as unknown as AgentGoalStatePort;
+    const unavailable = {
+      status: "unavailable" as const,
+      runtimeSessionId: SESSION_ID,
+      instructionId: INSTRUCTION_ID,
+    };
+    const accepted = {
+      status: "accepted" as const,
+      instructionId: INSTRUCTION_ID,
+      receipt: {
+        instructionId: INSTRUCTION_ID,
+        runtimeSessionId: SESSION_ID,
+        state: "written_to_sdk" as const,
+        recordedAt: NOW,
+      },
+    };
+    const drain = vi
+      .fn()
+      .mockResolvedValueOnce(unavailable)
+      .mockResolvedValueOnce(accepted);
+    const dispatcher = { drain } as unknown as RuntimeInstructionDispatcher;
+    const recoveryWake: RuntimeSessionRecoveryWakePort = {
+      wake: vi.fn(async () => true),
+    };
+    const lifecycle = new GoalLifecycleService(
+      state,
+      dispatcher,
+      new RuntimeSessionRegistry(),
+      { now: () => new Date(NOW) },
+      { generate: () => "unused-id" },
+      30_000,
+      undefined,
+      recoveryWake,
+    );
+
+    const result = await lifecycle.resume({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: "paused-goal",
+      expectedRevision: 2,
+      idempotencyKey: "resume-after-restart",
+      source: { type: "user", authority: "user" },
+    });
+
+    expect(recoveryWake.wake).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+    });
+    expect(drain).toHaveBeenCalledTimes(2);
+    expect(result.dispatch).toEqual(accepted);
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
@@ -125,6 +125,56 @@ function cancelInput(goal: AgentGoal) {
 }
 
 describe("InMemoryAgentGoalState lifecycle transition barriers", () => {
+  it("resumes a blocked Goal through the ordinary lifecycle commit", async () => {
+    const { state, goal } = await activeState();
+    const blocked = transitionAgentGoal({
+      current: goal,
+      expectedRevision: goal.revision,
+      status: "blocked",
+      now: TRANSITIONED_AT,
+    });
+    await state.commitEvaluationTransition({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      expectedRevision: goal.revision,
+      expectedRunEpoch: 0,
+      goal: blocked,
+    });
+    const resumed = transitionAgentGoal({
+      current: blocked,
+      expectedRevision: blocked.revision,
+      status: "active",
+      now: new Date("2026-07-29T08:02:00.000Z"),
+    });
+    const idempotencyKey = "resume-blocked-goal";
+
+    await expect(
+      state.commitTransition({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        expectedRevision: blocked.revision,
+        goal: resumed,
+        instruction: {
+          schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+          id: uuid(6),
+          goalId: goal.id,
+          goalRevision: resumed.revision,
+          kind: "goal.resume",
+          deliveryMode: "steer",
+          targetSessionId: SESSION_ID,
+          payload: { reason: "The blocker is resolved" },
+          source: { type: "user", authority: "user" },
+          idempotencyKey,
+          issuedAt: resumed.updatedAt,
+        },
+        command: command(idempotencyKey, "d"),
+      }),
+    ).resolves.toMatchObject({
+      goal: { goal: { status: "active", revision: 3 } },
+      instruction: { kind: "goal.resume" },
+    });
+  });
+
   it("advances cancel through a durable boundary before releasing its slot", async () => {
     const { state, goal } = await activeState();
     const input = cancelInput(goal);

--- a/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-lifecycle-transition-state.test.ts
@@ -125,6 +125,49 @@ function cancelInput(goal: AgentGoal) {
 }
 
 describe("InMemoryAgentGoalState lifecycle transition barriers", () => {
+  it("persists an evaluator pause while retaining the primary Goal slot", async () => {
+    const { state, goal } = await activeState();
+    const paused = transitionAgentGoal({
+      current: goal,
+      expectedRevision: goal.revision,
+      status: "paused",
+      now: TRANSITIONED_AT,
+    });
+
+    await expect(
+      state.commitEvaluationTransition({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        expectedRevision: goal.revision,
+        expectedRunEpoch: 0,
+        goal: paused,
+      }),
+    ).resolves.toMatchObject({
+      goal: { goal: { status: "paused", revision: 2 } },
+    });
+    await expect(
+      state.getActivePrimaryGoal(OWNER_ID, SESSION_ID),
+    ).resolves.toBeNull();
+    const conflicting = newGoal(
+      uuid(7),
+      "Conflicting Goal",
+      TRANSITIONED_AT,
+    );
+    await expect(
+      state.commitActivation({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goal: conflicting,
+        instruction: activationDraft(
+          conflicting,
+          uuid(8),
+          "conflicting-activation",
+        ),
+        command: command("conflicting-activation", "e"),
+      }),
+    ).rejects.toMatchObject({ code: "active_primary_goal_conflict" });
+  });
+
   it("resumes a blocked Goal through the ordinary lifecycle commit", async () => {
     const { state, goal } = await activeState();
     const blocked = transitionAgentGoal({

--- a/apps/web/tests/unit/runtime-instructions/goal-query-service.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-query-service.test.ts
@@ -63,7 +63,12 @@ const run: AgentGoalRun = {
     confidence: 0.8,
     satisfiedCriteria: ["api-ready"],
     missingCriteria: [],
-    evidence: [],
+    evidence: [
+      {
+        criterionId: "api-ready",
+        evidenceIds: ["10000000-0000-4000-8000-000000000005"],
+      },
+    ],
     reason: "The API is ready for review",
   },
 };
@@ -155,5 +160,74 @@ describe("AgentGoalQueryService", () => {
       runId,
       100,
     );
+  });
+
+  it("hides evaluations before a semantic update but keeps them across resume", async () => {
+    const activationInstruction = {
+      ...instruction,
+      id: "10000000-0000-4000-8000-000000000006",
+      sequence: 1,
+      goalRevision: 1,
+      kind: "goal.activate",
+    } as RuntimeInstruction;
+    const staleRun = { ...run, goalRevision: 1 };
+    const source = {
+      listGoals: vi.fn(async () => [goal]),
+      getGoal: vi.fn(async () => goal),
+      listRuns: vi.fn(async () => [staleRun]),
+      listInstructions: vi.fn(async () => [activationInstruction, instruction]),
+      listDeliveries: vi.fn(async () => [delivery]),
+      listEvidence: vi.fn(async () => [{ ...evidence, goalRevision: 1 }]),
+    } satisfies AgentGoalReadSource;
+    const service = new AgentGoalQueryService(source);
+
+    await expect(
+      service.getById({ ownerId, runtimeSessionId, goalId }),
+    ).resolves.toMatchObject({
+      latestRun: { lastEvaluation: undefined },
+      evidence: [],
+      progress: { completedCriteria: 0, totalCriteria: 1 },
+    });
+
+    // A recovered/legacy row can have the current lifecycle revision while
+    // still citing evidence from before the latest semantic boundary.
+    source.listRuns.mockResolvedValue([run]);
+    await expect(
+      service.getById({ ownerId, runtimeSessionId, goalId }),
+    ).resolves.toMatchObject({
+      latestRun: { goalRevision: 2, lastEvaluation: undefined },
+      evidence: [],
+      progress: { completedCriteria: 0, totalCriteria: 1 },
+    });
+
+    const resumedGoal = {
+      ...goal,
+      goal: { ...goal.goal, revision: 3 },
+    };
+    const resumeInstruction = {
+      ...instruction,
+      id: "10000000-0000-4000-8000-000000000007",
+      sequence: 2,
+      goalRevision: 3,
+      kind: "goal.resume",
+    } as RuntimeInstruction;
+    source.getGoal.mockResolvedValue(resumedGoal);
+    source.listGoals.mockResolvedValue([resumedGoal]);
+    source.listRuns.mockResolvedValue([{ ...run, goalRevision: 3 }]);
+    source.listInstructions.mockResolvedValue([
+      activationInstruction,
+      resumeInstruction,
+    ]);
+
+    await expect(
+      service.getById({ ownerId, runtimeSessionId, goalId }),
+    ).resolves.toMatchObject({
+      latestRun: {
+        goalRevision: 3,
+        lastEvaluation: { satisfiedCriteria: ["api-ready"] },
+      },
+      evidence: [{ goalRevision: 1 }],
+      progress: { completedCriteria: 1, totalCriteria: 1 },
+    });
   });
 });

--- a/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
@@ -1,0 +1,725 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { NativeAgentRun } from "@openloomi/ai/agent/native-runner";
+import type { AgentMessage } from "@openloomi/ai/agent/types";
+
+import type { RuntimeRecoveryChatRecorder } from "@/lib/ai/runtime-instructions/recovery/chat-message-recorder";
+import {
+  GoalRuntimeRecoveryCoordinator,
+  type RuntimeRecoveryCoordinatorDependencies,
+} from "@/lib/ai/runtime-instructions/recovery/coordinator";
+import type {
+  RuntimeRecoveryClaim,
+  RuntimeRecoverySnapshot,
+  RuntimeSessionRecoveryPersistencePort,
+} from "@/lib/ai/runtime-instructions/runtime-session-persistence";
+
+const OWNER_ID = "goal-recovery-owner";
+const RUNTIME_SESSION_ID = "goal-recovery-session";
+const PROVIDER_SESSION_ID = "claude-provider-session";
+const WORKING_DIRECTORY = "D:\\openloomi\\sessions\\goal-recovery";
+const LEASE_TOKEN = "goal-recovery-lease-token";
+const NOW = "2026-08-10T10:00:00.000Z";
+
+describe("GoalRuntimeRecoveryCoordinator", () => {
+  it("keeps paused Goals dormant without starting Claude", async () => {
+    const snapshot = recoverySnapshot("paused", { sessionState: "running" });
+    const harness = createHarness(snapshot);
+    const report = await harness.coordinator.start();
+
+    expect(report.outcomes).toEqual([
+      expect.objectContaining({ status: "dormant", reason: "goal_paused" }),
+    ]);
+    expect(harness.persistState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedState: "running",
+        state: "idle",
+        recoveryLeaseToken: LEASE_TOKEN,
+      }),
+    );
+    expect(harness.releaseRecoveryLease).toHaveBeenCalledOnce();
+    expect(harness.attachObservationLease).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      leaseToken: LEASE_TOKEN,
+    });
+    expect(harness.releaseObservationLease).toHaveBeenCalledOnce();
+    expect(harness.providerPreflight).not.toHaveBeenCalled();
+    expect(harness.nativeRun).not.toHaveBeenCalled();
+  });
+
+  it("resumes the exact Claude session and treats its intentional stop as success", async () => {
+    const snapshot = recoverySnapshot("active");
+    const harness = createHarness(snapshot, {
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        if (context.abortController.signal.aborted) {
+          yield { type: "error", message: "expected provider abort" };
+        }
+        yield { type: "done" };
+      },
+    });
+
+    const report = await harness.coordinator.start();
+    expect(report.outcomes[0]?.status).toBe("resumed");
+    expect(harness.providerPreflight).toHaveBeenCalledWith({
+      providerSessionId: PROVIDER_SESSION_ID,
+      workingDirectory: WORKING_DIRECTORY,
+    });
+
+    const firstNativeRun = harness.nativeRun.mock.calls[0];
+    if (!firstNativeRun) {
+      throw new Error("Expected recovery to start the native runtime");
+    }
+    const [request, context] = firstNativeRun;
+    expect(request).toMatchObject({
+      provider: "claude",
+      sessionId: RUNTIME_SESSION_ID,
+      workDir: WORKING_DIRECTORY,
+      useProvidedWorkDir: true,
+    });
+    expect(request).not.toHaveProperty("conversation");
+    expect(request.prompt).not.toContain("original user prompt");
+    expect(context.runtimeRecovery).toMatchObject({
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      providerSessionId: PROVIDER_SESSION_ID,
+      workingDirectory: WORKING_DIRECTORY,
+      runEpoch: 0,
+      recoveryLeaseToken: LEASE_TOKEN,
+    });
+    await expect(context.permissionHandler({} as never)).resolves.toEqual({
+      behavior: "deny",
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledWith({
+        ownerId: OWNER_ID,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        leaseOwner: "test-recovery-host",
+        leaseToken: LEASE_TOKEN,
+        expectedRunEpoch: 0,
+      });
+    });
+    expect(harness.persistState).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ expectedState: "idle", state: "running" }),
+    );
+    expect(harness.persistState).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        expectedState: "running",
+        state: "interrupted",
+      }),
+    );
+    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+  });
+
+  it("keeps recovery successful when chat presentation persistence fails", async () => {
+    const chatRecorder: RuntimeRecoveryChatRecorder = {
+      record: vi.fn(async () => {
+        throw new Error("message database unavailable");
+      }),
+      flush: vi.fn(async () => undefined),
+      close: vi.fn(async () => {
+        throw new Error("final message flush unavailable");
+      }),
+    };
+    const harness = createHarness(recoverySnapshot("active"), {
+      chatRecorder,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        yield { type: "text", content: "recovered output" };
+        yield { type: "done" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
+    });
+    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+    expect(chatRecorder.record).toHaveBeenCalled();
+    expect(chatRecorder.close).toHaveBeenCalledOnce();
+  });
+
+  it("retains the recovery lease until the provider generator terminates", async () => {
+    let finishProvider!: () => void;
+    const providerFinished = new Promise<void>((resolve) => {
+      finishProvider = resolve;
+    });
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        await providerFinished;
+        yield { type: "done" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    expect(harness.persistState).toHaveBeenLastCalledWith(
+      expect.objectContaining({ state: "interrupted" }),
+    );
+    expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
+
+    finishProvider();
+    await vi.waitFor(() => {
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("wakes one resumed dormant session without waiting for another boot scan", async () => {
+    const snapshot = recoverySnapshot("active");
+    const harness = createHarness(snapshot, {
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        yield { type: "done" };
+      },
+    });
+
+    await expect(
+      harness.coordinator.wake({
+        ownerId: OWNER_ID,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+      }),
+    ).resolves.toMatchObject({ status: "resumed" });
+    expect(harness.listRecoverable).not.toHaveBeenCalled();
+    expect(harness.claimRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerId: OWNER_ID,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+      }),
+    );
+  });
+
+  it("rescans after a previous live host lease expires", async () => {
+    vi.useFakeTimers();
+    const snapshot = recoverySnapshot("active");
+    const harness = createHarness(snapshot, {
+      rescanIntervalMs: 1_000,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        yield { type: "done" };
+      },
+    });
+    harness.listRecoverable
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([recoverableCandidate()])
+      .mockResolvedValue([]);
+
+    try {
+      harness.coordinator.startMonitoring();
+      await expect(harness.coordinator.start()).resolves.toEqual({
+        scanned: 0,
+        outcomes: [],
+      });
+      expect(harness.nativeRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(harness.listRecoverable).toHaveBeenCalledTimes(2);
+      expect(harness.nativeRun).toHaveBeenCalledOnce();
+      await vi.waitFor(() => {
+        expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
+      });
+    } finally {
+      harness.coordinator.stopMonitoring();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not blacklist a dormant scope that later becomes actionable", async () => {
+    const paused = recoverySnapshot("paused");
+    const active = recoverySnapshot("active");
+    const harness = createHarness(paused, {
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        yield { type: "done" };
+      },
+    });
+    harness.claimRecovery
+      .mockResolvedValueOnce({ ...harness.claim, snapshot: paused })
+      .mockResolvedValueOnce({ ...harness.claim, snapshot: active });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "dormant" })],
+    });
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+
+    expect(harness.claimRecovery).toHaveBeenCalledTimes(2);
+    expect(harness.nativeRun).toHaveBeenCalledOnce();
+  });
+
+  it("does not overlap slow rescans and stops monitoring idempotently", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness(recoverySnapshot("active"), {
+      rescanIntervalMs: 1_000,
+    });
+    let resolveScan!: (
+      candidates: ReturnType<typeof recoverableCandidate>[],
+    ) => void;
+    harness.listRecoverable.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve;
+        }),
+    );
+
+    try {
+      harness.coordinator.startMonitoring();
+      harness.coordinator.startMonitoring();
+      const initialScan = harness.coordinator.start();
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(harness.listRecoverable).toHaveBeenCalledOnce();
+
+      resolveScan([]);
+      await expect(initialScan).resolves.toEqual({ scanned: 0, outcomes: [] });
+      await vi.runAllTicks();
+
+      harness.coordinator.stopMonitoring();
+      harness.coordinator.stopMonitoring();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(harness.listRecoverable).toHaveBeenCalledOnce();
+    } finally {
+      harness.coordinator.stopMonitoring();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not enqueue a second continuation after replaying pending input", async () => {
+    const snapshot = recoverySnapshot("active", {
+      replayableInstructionIds: ["pending-instruction"],
+    });
+    const completed = recoverySnapshot("completed", {
+      sessionState: "running",
+    });
+    const continueGoal = vi.fn();
+    const harness = createHarness(snapshot, {
+      refreshSnapshot: completed,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal,
+        });
+        yield { type: "done" };
+      },
+    });
+
+    const report = await harness.coordinator.start();
+    expect(report.outcomes[0]?.status).toBe("resumed");
+    await vi.waitFor(() => {
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
+    });
+    expect(continueGoal).not.toHaveBeenCalled();
+    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the fenced snapshot after reconciling an interrupted operation", async () => {
+    const claimed: RuntimeRecoverySnapshot = {
+      ...recoverySnapshot("paused"),
+      pendingOperation: {
+        ownerId: OWNER_ID,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+      } as never,
+    };
+    const refreshed = recoverySnapshot("active");
+    const harness = createHarness(claimed, {
+      refreshSnapshot: refreshed,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "allow",
+            outcome: "completed",
+          }),
+        });
+        yield { type: "done" };
+      },
+    });
+
+    const report = await harness.coordinator.start();
+    expect(report.outcomes[0]?.status).toBe("resumed");
+    expect(harness.reconcilePendingOperation).toHaveBeenCalledOnce();
+    expect(harness.refreshRecovery).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      leaseOwner: "test-recovery-host",
+      leaseToken: LEASE_TOKEN,
+    });
+    const reconcileOrder =
+      harness.reconcilePendingOperation.mock.invocationCallOrder[0];
+    const refreshOrder = harness.refreshRecovery.mock.invocationCallOrder[0];
+    const runOrder = harness.nativeRun.mock.invocationCallOrder[0];
+    if (
+      reconcileOrder === undefined ||
+      refreshOrder === undefined ||
+      runOrder === undefined
+    ) {
+      throw new Error("Expected all recovery stages to run in order");
+    }
+    expect(reconcileOrder).toBeLessThan(refreshOrder);
+    expect(refreshOrder).toBeLessThan(runOrder);
+  });
+
+  it("blocks recovery when the persisted provider transcript is unavailable", async () => {
+    const snapshot = recoverySnapshot("active");
+    const harness = createHarness(snapshot, {
+      preflightError: Object.assign(new Error("transcript missing"), {
+        code: "provider_session_unavailable",
+      }),
+    });
+
+    const report = await harness.coordinator.start();
+    expect(report.outcomes[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        reason: "transcript missing",
+      }),
+    );
+    expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedRunEpoch: 0,
+        errorCode: "provider_session_unavailable",
+        errorMessage: "transcript missing",
+      }),
+    );
+    expect(harness.nativeRun).not.toHaveBeenCalled();
+  });
+
+  it("fences a delayed provider failure against the latest recovered epoch", async () => {
+    const initial = recoverySnapshot("active");
+    const advanced = {
+      ...recoverySnapshot("active", { sessionState: "running" }),
+      session: {
+        ...initial.session,
+        state: "running" as const,
+        runEpoch: 2,
+      },
+    };
+    const harness = createHarness(initial, {
+      refreshSnapshot: advanced,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+        });
+        yield { type: "error", message: "provider failed after replacement" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedRunEpoch: 2,
+          errorCode: "provider_resume_failed",
+          errorMessage: "provider failed after replacement",
+        }),
+      );
+    });
+  });
+
+  it("clears the live recovery presentation after a provider error", async () => {
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+        });
+        yield { type: "error", message: "safe provider failure" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedRunEpoch: 0,
+          errorCode: "provider_resume_failed",
+          errorMessage: "safe provider failure",
+        }),
+      );
+    });
+
+    expect(harness.currentRuntimeState()).toBe("failed");
+    expect(harness.hasRecoveryLease()).toBe(false);
+    await expect(harness.listRecoveryPresentationSessions()).resolves.toEqual(
+      [],
+    );
+    expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
+    expect(harness.releaseObservationLease).toHaveBeenCalledOnce();
+  });
+});
+
+type RecoveryContext = Parameters<
+  RuntimeRecoveryCoordinatorDependencies["nativeRunner"]["run"]
+>[1];
+
+function createHarness(
+  initialSnapshot: RuntimeRecoverySnapshot,
+  options: {
+    refreshSnapshot?: RuntimeRecoverySnapshot;
+    preflightError?: Error;
+    rescanIntervalMs?: number;
+    nativeGenerator?: (
+      context: RecoveryContext,
+    ) => AsyncGenerator<AgentMessage>;
+    chatRecorder?: RuntimeRecoveryChatRecorder;
+  } = {},
+) {
+  let state = initialSnapshot.session.state;
+  let recoveryLeaseHeld = true;
+  let recoveryFailed = false;
+  const claim: RuntimeRecoveryClaim = {
+    ownerId: OWNER_ID,
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    leaseOwner: "test-recovery-host",
+    leaseToken: LEASE_TOKEN,
+    leaseExpiresAt: "2026-08-10T10:01:00.000Z",
+    snapshot: initialSnapshot,
+  };
+  const persistState = vi.fn(async (input) => {
+    state = input.state;
+    return { ...initialSnapshot.session, state };
+  });
+  const releaseRecoveryLease = vi.fn(async () => {
+    recoveryLeaseHeld = false;
+  });
+  const releaseLiveRuntime = vi.fn(async () => {
+    state = "idle";
+    recoveryLeaseHeld = false;
+    return {
+      ...initialSnapshot.session,
+      state: "idle" as const,
+    };
+  });
+  const markRecoveryFailed = vi.fn(async () => {
+    state = "failed";
+    recoveryFailed = true;
+    recoveryLeaseHeld = false;
+  });
+  const listRecoveryPresentationSessions = vi.fn(async () =>
+    recoveryFailed
+      ? []
+      : [
+          {
+            runtimeSessionId: RUNTIME_SESSION_ID,
+            state,
+            runEpoch: initialSnapshot.session.runEpoch,
+            updatedAt: NOW,
+          },
+        ],
+  );
+  const refreshRecovery = vi.fn(
+    async () => options.refreshSnapshot ?? initialSnapshot,
+  );
+  const listRecoverable = vi.fn(async () => [recoverableCandidate()]);
+  const claimRecovery = vi.fn(async () => claim);
+  const persistence = {
+    listRecoverable,
+    claimRecovery,
+    refreshRecovery,
+    renewRecoveryLease: vi.fn(async () => "2026-08-10T10:02:00.000Z"),
+    releaseRecoveryLease,
+    releaseLiveRuntime,
+    persistState,
+    markRecoveryFailed,
+    listRecoveryPresentationSessions,
+  } as unknown as RuntimeSessionRecoveryPersistencePort;
+  const providerPreflight = vi.fn(async () => {
+    if (options.preflightError) throw options.preflightError;
+  });
+  const nativeRun = vi.fn(async (_request, context: RecoveryContext) => {
+    const generator = options.nativeGenerator
+      ? options.nativeGenerator(context)
+      : (async function* () {
+          yield { type: "done" as const };
+        })();
+    return { generator, shouldAbortOnClose: () => false } as NativeAgentRun;
+  });
+  const reconcilePendingOperation = vi.fn();
+  const releaseObservationLease = vi.fn();
+  const attachObservationLease = vi.fn(() => ({
+    release: releaseObservationLease,
+  }));
+  const chatRecorder = options.chatRecorder;
+  const coordinator = new GoalRuntimeRecoveryCoordinator({
+    persistence,
+    providerPreflight: { verify: providerPreflight },
+    nativeRunner: { run: nativeRun },
+    loadOwnerSession: async () => ({
+      user: { id: OWNER_ID },
+      expires: "2026-08-11T10:00:00.000Z",
+    }),
+    reconcilePendingOperation,
+    attachObservationLease,
+    ...(chatRecorder ? { createChatRecorder: async () => chatRecorder } : {}),
+    leaseOwner: "test-recovery-host",
+    leaseDurationMs: 60_000,
+    heartbeatIntervalMs: 30_000,
+    ...(options.rescanIntervalMs === undefined
+      ? {}
+      : { rescanIntervalMs: options.rescanIntervalMs }),
+    initializationTimeoutMs: 1_000,
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  });
+  return {
+    coordinator,
+    providerPreflight,
+    nativeRun,
+    persistState,
+    releaseRecoveryLease,
+    releaseLiveRuntime,
+    markRecoveryFailed,
+    refreshRecovery,
+    reconcilePendingOperation,
+    attachObservationLease,
+    releaseObservationLease,
+    claim,
+    listRecoverable,
+    claimRecovery,
+    listRecoveryPresentationSessions,
+    currentRuntimeState: () => state,
+    hasRecoveryLease: () => recoveryLeaseHeld,
+  };
+}
+
+function recoverableCandidate() {
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    providerSessionId: PROVIDER_SESSION_ID,
+    workingDirectory: WORKING_DIRECTORY,
+    runEpoch: 0,
+    updatedAt: NOW,
+  };
+}
+
+function recoverySnapshot(
+  goalStatus: "active" | "paused" | "completed",
+  options: {
+    sessionState?: RuntimeRecoverySnapshot["session"]["state"];
+    replayableInstructionIds?: string[];
+  } = {},
+): RuntimeRecoverySnapshot {
+  return {
+    session: {
+      id: RUNTIME_SESSION_ID,
+      ownerId: OWNER_ID,
+      provider: "claude",
+      providerSessionId: PROVIDER_SESSION_ID,
+      workingDirectory: WORKING_DIRECTORY,
+      state: options.sessionState ?? "idle",
+      runEpoch: 0,
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    recoveryDescriptor: {
+      schemaVersion: 1,
+      permissionMode: "default",
+      allowedTools: ["Read", "Write"],
+      skillsConfig: {
+        enabled: true,
+        userDirEnabled: true,
+        appDirEnabled: true,
+      },
+      mcpConfig: {
+        enabled: true,
+        userDirEnabled: true,
+        appDirEnabled: false,
+      },
+    },
+    activeGoal: {
+      ownerId: OWNER_ID,
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      slot: "primary",
+      goal: { id: "goal-id", status: goalStatus } as never,
+    },
+    runs: [],
+    instructions: [],
+    deliveries: [],
+    evidence: [],
+    replayableInstructionIds: options.replayableInstructionIds ?? [],
+    instructionSettlements: [],
+    reconciliation: {
+      evaluationsReset: 0,
+      leasesReclaimed: 0,
+      queuedAttemptsRetried: 0,
+      writtenAttemptsRetried: 0,
+      expired: 0,
+      superseded: 0,
+    },
+  };
+}

--- a/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
@@ -525,11 +525,235 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
     expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
     expect(harness.releaseObservationLease).toHaveBeenCalledOnce();
   });
+
+  it("finalizes a completed Goal instead of pausing after a provider error", async () => {
+    const finalEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      outcome: "completed" as const,
+    }));
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await initializeRecoveredProvider(context, {
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+          finalizeGoalWithoutContinuation: finalEvaluation,
+        });
+        yield { type: "error", message: "safe provider failure" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(finalEvaluation).toHaveBeenCalledOnce();
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerId: OWNER_ID,
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          expectedRunEpoch: 0,
+        }),
+      );
+    });
+
+    expect(harness.pauseAfterRecoveryFailure).not.toHaveBeenCalled();
+    expect(harness.currentRuntimeState()).toBe("idle");
+    expect(harness.hasRecoveryLease()).toBe(false);
+  });
+
+  it("keeps the evaluated progress when provider failure pauses an incomplete Goal", async () => {
+    const finalEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      outcome: "paused" as const,
+    }));
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await initializeRecoveredProvider(context, {
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+          finalizeGoalWithoutContinuation: finalEvaluation,
+        });
+        yield { type: "error", message: "safe provider failure" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(finalEvaluation).toHaveBeenCalledOnce();
+      expect(harness.releaseLiveRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerId: OWNER_ID,
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          expectedRunEpoch: 0,
+        }),
+      );
+    });
+
+    expect(harness.pauseAfterRecoveryFailure).not.toHaveBeenCalled();
+    expect(harness.currentRuntimeState()).toBe("idle");
+    expect(harness.hasRecoveryLease()).toBe(false);
+  });
+
+  it("pauses and releases recovery when final evaluation fails", async () => {
+    const finalEvaluation = vi.fn(async () => {
+      throw new Error("final evaluation unavailable");
+    });
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await initializeRecoveredProvider(context, {
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+          finalizeGoalWithoutContinuation: finalEvaluation,
+        });
+        yield { type: "error", message: "safe provider failure" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(finalEvaluation).toHaveBeenCalledOnce();
+      expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedRunEpoch: 0,
+          errorCode: "provider_resume_failed",
+          errorMessage: "safe provider failure",
+        }),
+      );
+    });
+
+    expect(harness.currentRuntimeState()).toBe("idle");
+    expect(harness.hasRecoveryLease()).toBe(false);
+  });
+
+  it("does not release an active Goal when final evaluation is stale", async () => {
+    const finalEvaluation = vi.fn(async () => ({
+      decision: "allow" as const,
+      outcome: "stale" as const,
+      goalId: "goal-id",
+      goalRevision: 1,
+    }));
+    const harness = createHarness(recoverySnapshot("active"), {
+      nativeGenerator: async function* (context) {
+        await initializeRecoveredProvider(context, {
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+          finalizeGoalWithoutContinuation: finalEvaluation,
+        });
+        yield { type: "error", message: "safe provider failure" };
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(finalEvaluation).toHaveBeenCalledOnce();
+      expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedRunEpoch: 0,
+          errorCode: "provider_resume_failed",
+        }),
+      );
+    });
+    expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
+    expect(harness.hasRecoveryLease()).toBe(false);
+  });
+
+  it("pauses and releases recovery without waiting for provider cleanup", async () => {
+    let cleanupStarted = false;
+    const cleanupNeverFinishes = new Promise<void>(() => undefined);
+    const chatRecorder: RuntimeRecoveryChatRecorder = {
+      record: vi.fn(async () => undefined),
+      flush: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(recoverySnapshot("active"), {
+      chatRecorder,
+      nativeGenerator: async function* (context) {
+        await context.runtimeRecovery.onProviderSessionInitialized?.({
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          providerSessionId: PROVIDER_SESSION_ID,
+          runEpoch: 0,
+          continueGoal: async () => ({
+            decision: "block",
+            outcome: "continue",
+          }),
+        });
+        try {
+          yield { type: "error", message: "terminal provider failure" };
+        } finally {
+          cleanupStarted = true;
+          await cleanupNeverFinishes;
+        }
+      },
+    });
+
+    await expect(harness.coordinator.start()).resolves.toMatchObject({
+      outcomes: [expect.objectContaining({ status: "resumed" })],
+    });
+    await vi.waitFor(() => {
+      expect(cleanupStarted).toBe(true);
+      expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedRunEpoch: 0,
+          errorCode: "provider_resume_failed",
+          errorMessage: "terminal provider failure",
+        }),
+      );
+    });
+
+    expect(chatRecorder.record).toHaveBeenCalledWith({
+      type: "error",
+      message: "terminal provider failure",
+    });
+    expect(chatRecorder.close).toHaveBeenCalledOnce();
+    expect(harness.currentRuntimeState()).toBe("idle");
+    expect(harness.hasRecoveryLease()).toBe(false);
+    expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
+  });
 });
 
 type RecoveryContext = Parameters<
   RuntimeRecoveryCoordinatorDependencies["nativeRunner"]["run"]
 >[1];
+
+type RecoveredProviderInitialization = Parameters<
+  NonNullable<
+    NonNullable<
+      RecoveryContext["runtimeRecovery"]
+    >["onProviderSessionInitialized"]
+  >
+>[0];
+
+type RecoveredProviderFinalEvaluation = Pick<
+  RecoveredProviderInitialization,
+  "continueGoal" | "finalizeGoalWithoutContinuation"
+>;
+
+async function initializeRecoveredProvider(
+  context: RecoveryContext,
+  callbacks: RecoveredProviderFinalEvaluation,
+): Promise<void> {
+  const initialization: RecoveredProviderInitialization = {
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    providerSessionId: PROVIDER_SESSION_ID,
+    runEpoch: 0,
+    ...callbacks,
+  };
+  await context.runtimeRecovery.onProviderSessionInitialized?.(initialization);
+}
 
 function createHarness(
   initialSnapshot: RuntimeRecoverySnapshot,

--- a/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import type { NativeAgentRun } from "@openloomi/ai/agent/native-runner";
@@ -17,7 +19,7 @@ import type {
 const OWNER_ID = "goal-recovery-owner";
 const RUNTIME_SESSION_ID = "goal-recovery-session";
 const PROVIDER_SESSION_ID = "claude-provider-session";
-const WORKING_DIRECTORY = "D:\\openloomi\\sessions\\goal-recovery";
+const WORKING_DIRECTORY = resolve("sessions", "goal-recovery");
 const LEASE_TOKEN = "goal-recovery-lease-token";
 const NOW = "2026-08-10T10:00:00.000Z";
 

--- a/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/goal-runtime-recovery-coordinator.test.ts
@@ -119,7 +119,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
         state: "interrupted",
       }),
     );
-    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+    expect(harness.pauseAfterRecoveryFailure).not.toHaveBeenCalled();
   });
 
   it("keeps recovery successful when chat presentation persistence fails", async () => {
@@ -155,7 +155,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
     await vi.waitFor(() => {
       expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
     });
-    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+    expect(harness.pauseAfterRecoveryFailure).not.toHaveBeenCalled();
     expect(chatRecorder.record).toHaveBeenCalled();
     expect(chatRecorder.close).toHaveBeenCalledOnce();
   });
@@ -367,7 +367,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
       expect(harness.releaseLiveRuntime).toHaveBeenCalledOnce();
     });
     expect(continueGoal).not.toHaveBeenCalled();
-    expect(harness.markRecoveryFailed).not.toHaveBeenCalled();
+    expect(harness.pauseAfterRecoveryFailure).not.toHaveBeenCalled();
   });
 
   it("refreshes the fenced snapshot after reconciling an interrupted operation", async () => {
@@ -419,7 +419,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
     expect(refreshOrder).toBeLessThan(runOrder);
   });
 
-  it("blocks recovery when the persisted provider transcript is unavailable", async () => {
+  it("pauses recovery when the persisted provider transcript is unavailable", async () => {
     const snapshot = recoverySnapshot("active");
     const harness = createHarness(snapshot, {
       preflightError: Object.assign(new Error("transcript missing"), {
@@ -434,13 +434,14 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
         reason: "transcript missing",
       }),
     );
-    expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+    expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
       expect.objectContaining({
         expectedRunEpoch: 0,
         errorCode: "provider_session_unavailable",
         errorMessage: "transcript missing",
       }),
     );
+    expect(harness.currentRuntimeState()).toBe("idle");
     expect(harness.nativeRun).not.toHaveBeenCalled();
   });
 
@@ -474,7 +475,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
       outcomes: [expect.objectContaining({ status: "resumed" })],
     });
     await vi.waitFor(() => {
-      expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+      expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
         expect.objectContaining({
           expectedRunEpoch: 2,
           errorCode: "provider_resume_failed",
@@ -484,7 +485,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
     });
   });
 
-  it("clears the live recovery presentation after a provider error", async () => {
+  it("keeps the paused recovery visible after a provider error", async () => {
     const harness = createHarness(recoverySnapshot("active"), {
       nativeGenerator: async function* (context) {
         await context.runtimeRecovery.onProviderSessionInitialized?.({
@@ -504,7 +505,7 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
       outcomes: [expect.objectContaining({ status: "resumed" })],
     });
     await vi.waitFor(() => {
-      expect(harness.markRecoveryFailed).toHaveBeenCalledWith(
+      expect(harness.pauseAfterRecoveryFailure).toHaveBeenCalledWith(
         expect.objectContaining({
           expectedRunEpoch: 0,
           errorCode: "provider_resume_failed",
@@ -513,11 +514,14 @@ describe("GoalRuntimeRecoveryCoordinator", () => {
       );
     });
 
-    expect(harness.currentRuntimeState()).toBe("failed");
+    expect(harness.currentRuntimeState()).toBe("idle");
     expect(harness.hasRecoveryLease()).toBe(false);
-    await expect(harness.listRecoveryPresentationSessions()).resolves.toEqual(
-      [],
-    );
+    await expect(harness.listRecoveryPresentationSessions()).resolves.toEqual([
+      expect.objectContaining({
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        state: "idle",
+      }),
+    ]);
     expect(harness.releaseLiveRuntime).not.toHaveBeenCalled();
     expect(harness.releaseObservationLease).toHaveBeenCalledOnce();
   });
@@ -541,7 +545,6 @@ function createHarness(
 ) {
   let state = initialSnapshot.session.state;
   let recoveryLeaseHeld = true;
-  let recoveryFailed = false;
   const claim: RuntimeRecoveryClaim = {
     ownerId: OWNER_ID,
     runtimeSessionId: RUNTIME_SESSION_ID,
@@ -565,23 +568,18 @@ function createHarness(
       state: "idle" as const,
     };
   });
-  const markRecoveryFailed = vi.fn(async () => {
-    state = "failed";
-    recoveryFailed = true;
+  const pauseAfterRecoveryFailure = vi.fn(async () => {
+    state = "idle";
     recoveryLeaseHeld = false;
   });
-  const listRecoveryPresentationSessions = vi.fn(async () =>
-    recoveryFailed
-      ? []
-      : [
-          {
-            runtimeSessionId: RUNTIME_SESSION_ID,
-            state,
-            runEpoch: initialSnapshot.session.runEpoch,
-            updatedAt: NOW,
-          },
-        ],
-  );
+  const listRecoveryPresentationSessions = vi.fn(async () => [
+    {
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      state,
+      runEpoch: initialSnapshot.session.runEpoch,
+      updatedAt: NOW,
+    },
+  ]);
   const refreshRecovery = vi.fn(
     async () => options.refreshSnapshot ?? initialSnapshot,
   );
@@ -595,7 +593,7 @@ function createHarness(
     releaseRecoveryLease,
     releaseLiveRuntime,
     persistState,
-    markRecoveryFailed,
+    pauseAfterRecoveryFailure,
     listRecoveryPresentationSessions,
   } as unknown as RuntimeSessionRecoveryPersistencePort;
   const providerPreflight = vi.fn(async () => {
@@ -642,7 +640,7 @@ function createHarness(
     persistState,
     releaseRecoveryLease,
     releaseLiveRuntime,
-    markRecoveryFailed,
+    pauseAfterRecoveryFailure,
     refreshRecovery,
     reconcilePendingOperation,
     attachObservationLease,

--- a/apps/web/tests/unit/runtime-instructions/instruction-dispatcher.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/instruction-dispatcher.test.ts
@@ -98,6 +98,70 @@ function queuedReceipt(
 }
 
 describe("RuntimeInstructionDispatcher ordered outbox drain", () => {
+  it("hydrates durable recovery progress and only retries unsettled instructions", async () => {
+    const instructions = outbox(3);
+    const transport = new ScriptedTransport(SESSION_ID);
+    const dispatcher = registeredDispatcher(transport, instructions);
+
+    await dispatcher.initializeRecoveredProgress({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      transport,
+      settlements: [
+        {
+          instructionId: instructions[0].id,
+          disposition: "accepted",
+          providerEventId: "claude-event-1",
+          recordedAt: NOW,
+        },
+        {
+          instructionId: instructions[2].id,
+          disposition: "superseded",
+          reason: "stale Goal revision",
+          recordedAt: NOW,
+        },
+      ],
+    });
+
+    await expect(
+      dispatcher.drain({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        targetInstructionId: instructions[2].id,
+      }),
+    ).resolves.toEqual({
+      status: "superseded",
+      runtimeSessionId: SESSION_ID,
+      instructionId: instructions[2].id,
+      reason: "stale Goal revision",
+    });
+    expect(transport.delivered.map(({ id }) => id)).toEqual([
+      instructions[1].id,
+    ]);
+  });
+
+  it("rejects recovery progress for an instruction outside the durable outbox", async () => {
+    const instructions = outbox(1);
+    const transport = new ScriptedTransport(SESSION_ID);
+    const dispatcher = registeredDispatcher(transport, instructions);
+
+    await expect(
+      dispatcher.initializeRecoveredProgress({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        transport,
+        settlements: [
+          {
+            instructionId: INSTRUCTION_IDS[3],
+            disposition: "accepted",
+            recordedAt: NOW,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "outbox_progress_conflict" });
+    expect(transport.delivered).toEqual([]);
+  });
+
   it("keeps an unavailable predecessor pending, then replays in order for each replacement transport", async () => {
     const sessions = new RuntimeSessionRegistry();
     const instructions = outbox();

--- a/apps/web/tests/unit/runtime-instructions/pending-operation-recovery.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/pending-operation-recovery.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PendingGoalOperationRecovery } from "@/lib/ai/runtime-instructions/recovery/pending-operation-reconciler";
+
+const OWNER_ID = "recovery-owner";
+const SESSION_ID = "recovery-session";
+const INSTRUCTION_ID = "recovery-pause-instruction";
+const RECORDED_AT = new Date("2026-08-10T12:00:00.000Z");
+
+function finalizedPause() {
+  return {
+    ownerId: OWNER_ID,
+    runtimeSessionId: SESSION_ID,
+    action: "pause",
+    transitionedGoal: { goal: { id: "paused-goal" } },
+    instruction: {
+      id: INSTRUCTION_ID,
+      idempotencyKey: "pause-command",
+    },
+    expectedRunEpoch: 0,
+    runEpoch: 0,
+    phase: "finalized",
+  } as const;
+}
+
+function createHarness(deliveryState: "pending" | "observed") {
+  const finalizeControlInstruction = vi.fn();
+  const supersedeDeliveries = vi.fn();
+  const recovery = new PendingGoalOperationRecovery(
+    {} as never,
+    {
+      getStoredById: vi.fn().mockResolvedValue({
+        instruction: {
+          id: INSTRUCTION_ID,
+          idempotencyKey: "pause-command",
+        },
+        requestFingerprint: "a".repeat(64),
+      }),
+    },
+    {
+      getActiveByInstruction: vi.fn().mockResolvedValue({
+        state: deliveryState,
+      }),
+    } as never,
+    { finalizeControlInstruction, supersedeDeliveries } as never,
+    { now: () => RECORDED_AT },
+  );
+  return { recovery, finalizeControlInstruction, supersedeDeliveries };
+}
+
+describe("pending Goal operation recovery", () => {
+  it("supersedes a control instruction that never became provider-visible", async () => {
+    const harness = createHarness("pending");
+
+    await expect(
+      harness.recovery.reconcile(finalizedPause() as never),
+    ).resolves.toMatchObject({ disposition: "dormant", runEpoch: 0 });
+    expect(harness.supersedeDeliveries).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      instructionIds: [INSTRUCTION_ID],
+      reason: "Settled paused during Runtime recovery before provider delivery",
+    });
+    expect(harness.finalizeControlInstruction).not.toHaveBeenCalled();
+  });
+
+  it("finalizes an already provider-visible control instruction", async () => {
+    const harness = createHarness("observed");
+
+    await harness.recovery.reconcile(finalizedPause() as never);
+
+    expect(harness.finalizeControlInstruction).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      instructionId: INSTRUCTION_ID,
+      runEpoch: 0,
+      status: "paused",
+      recordedAt: RECORDED_AT.toISOString(),
+    });
+    expect(harness.supersedeDeliveries).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/recovery-chat-message-recorder.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/recovery-chat-message-recorder.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createRuntimeRecoveryChatRecorder,
+  recoveryAssistantMessageId,
+} from "@/lib/ai/runtime-instructions/recovery/chat-message-recorder";
+import { MESSAGE_ID_SCOPE_CONFLICT } from "@/lib/db/queries";
+
+const input = {
+  ownerId: "owner-a",
+  runtimeSessionId: "chat-a",
+  providerSessionId: "provider-a",
+  runEpoch: 3,
+};
+
+describe("Runtime recovery chat recorder", () => {
+  it("reopens the same recovery epoch in one deterministic message row", async () => {
+    let storedMessage: any;
+    const save = vi.fn(async ({ messages }) => {
+      storedMessage = structuredClone(messages[0]);
+    });
+    const dependencies = {
+      getChatById: vi.fn(async () => ({ id: "chat-a", userId: "owner-a" })),
+      getMessageById: vi.fn(async () =>
+        storedMessage ? [structuredClone(storedMessage)] : [],
+      ),
+      saveMessages: save,
+      flushDelayMs: 60_000,
+      now: () => new Date("2026-08-11T01:00:00.000Z"),
+    };
+
+    const first = await createRuntimeRecoveryChatRecorder(
+      input,
+      dependencies as never,
+    );
+    await first.record({ type: "text", content: "first" });
+    await first.close();
+
+    const second = await createRuntimeRecoveryChatRecorder(
+      input,
+      dependencies as never,
+    );
+    await second.record({ type: "text", content: " second" });
+    await second.close();
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save.mock.calls[0]?.[0].messages[0].id).toBe(
+      recoveryAssistantMessageId(input),
+    );
+    expect(save.mock.calls[1]?.[0].messages[0]).toMatchObject({
+      id: recoveryAssistantMessageId(input),
+      chatId: "chat-a",
+      parts: [{ type: "text", text: "first second" }],
+    });
+    expect(save.mock.calls[1]?.[0]).toMatchObject({
+      expectedUserId: "owner-a",
+      expectedMessages: [
+        {
+          id: recoveryAssistantMessageId(input),
+          chatId: "chat-a",
+          parts: [{ type: "text", text: "first" }],
+        },
+      ],
+    });
+  });
+
+  it("rebases pending output when another recovery writer wins the message CAS", async () => {
+    let storedMessage: any;
+    const save = vi.fn(async ({ messages, expectedMessages }) => {
+      const expected = expectedMessages[0];
+      if (
+        (storedMessage && !expected) ||
+        (!storedMessage && expected) ||
+        (storedMessage &&
+          JSON.stringify(storedMessage.parts) !==
+            JSON.stringify(expected?.parts))
+      ) {
+        throw new Error(MESSAGE_ID_SCOPE_CONFLICT);
+      }
+      storedMessage = structuredClone(messages[0]);
+    });
+    const dependencies = {
+      getChatById: vi.fn(async () => ({ id: "chat-a", userId: "owner-a" })),
+      getMessageById: vi.fn(async () =>
+        storedMessage ? [structuredClone(storedMessage)] : [],
+      ),
+      saveMessages: save,
+      flushDelayMs: 60_000,
+      now: () => new Date("2026-08-11T01:00:00.000Z"),
+    };
+    // Both recorders deliberately start from the same absent-row snapshot.
+    const first = await createRuntimeRecoveryChatRecorder(
+      input,
+      dependencies as never,
+    );
+    const stale = await createRuntimeRecoveryChatRecorder(
+      input,
+      dependencies as never,
+    );
+
+    await first.record({ type: "text", content: "first writer" });
+    await first.close();
+    await stale.record({ type: "text", content: " + stale writer" });
+    await stale.close();
+
+    expect(save).toHaveBeenCalledTimes(3);
+    expect(storedMessage).toMatchObject({
+      id: recoveryAssistantMessageId(input),
+      chatId: "chat-a",
+      role: "assistant",
+      parts: [{ type: "text", text: "first writer + stale writer" }],
+    });
+    expect(dependencies.getChatById).toHaveBeenCalledTimes(3);
+    expect(dependencies.getMessageById).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a chat outside the recovery owner scope", async () => {
+    const save = vi.fn();
+    await expect(
+      createRuntimeRecoveryChatRecorder(input, {
+        getChatById: vi.fn(async () => ({
+          id: "chat-a",
+          userId: "another-owner",
+        })) as never,
+        getMessageById: vi.fn() as never,
+        saveMessages: save as never,
+      }),
+    ).rejects.toThrow("is not owned by owner-a");
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("flushes buffered text when the recovered generator closes", async () => {
+    const save = vi.fn(async () => undefined);
+    const recorder = await createRuntimeRecoveryChatRecorder(input, {
+      getChatById: vi.fn(async () => ({
+        id: "chat-a",
+        userId: "owner-a",
+      })) as never,
+      getMessageById: vi.fn(async () => []) as never,
+      saveMessages: save as never,
+      flushDelayMs: 60_000,
+    });
+
+    await recorder.record({ type: "text", content: "buffered output" });
+    expect(save).not.toHaveBeenCalled();
+    await recorder.close();
+    expect(save).toHaveBeenCalledOnce();
+  });
+
+  it("marks an unfinished recovered tool as failed on final close", async () => {
+    const save = vi.fn(async (_input: any) => undefined);
+    const recorder = await createRuntimeRecoveryChatRecorder(input, {
+      getChatById: vi.fn(async () => ({
+        id: "chat-a",
+        userId: "owner-a",
+      })) as never,
+      getMessageById: vi.fn(async () => []) as never,
+      saveMessages: save as never,
+      flushDelayMs: 60_000,
+    });
+
+    await recorder.record({
+      type: "tool_use",
+      id: "tool-a",
+      name: "shell",
+      input: { command: "pnpm test" },
+    });
+    await recorder.close();
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save.mock.calls[1]?.[0].messages[0].parts).toEqual([
+      expect.objectContaining({
+        type: "tool-native",
+        toolUseId: "tool-a",
+        status: "error",
+        isError: true,
+      }),
+    ]);
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/runtime-observation.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/runtime-observation.test.ts
@@ -1,0 +1,69 @@
+import type { RuntimeInstruction } from "@openloomi/ai/agent/runtime-instructions";
+import { describe, expect, it } from "vitest";
+
+import { resolveGoalEvidenceRevisionFloor } from "@/lib/ai/runtime-instructions/runtime-observation";
+
+const GOAL_ID = "10000000-0000-4000-8000-000000000001";
+
+type EvidenceBoundaryKind = Extract<
+  RuntimeInstruction["kind"],
+  | "goal.update"
+  | "context.upsert"
+  | "context.remove"
+  | "constraint.upsert"
+  | "constraint.remove"
+>;
+
+function instruction(
+  kind: RuntimeInstruction["kind"],
+  goalRevision: number,
+  goalId = GOAL_ID,
+): RuntimeInstruction {
+  // The resolver intentionally reads only immutable instruction identity. The
+  // payload is irrelevant to this focused boundary test.
+  return { kind, goalId, goalRevision } as RuntimeInstruction;
+}
+
+describe("resolveGoalEvidenceRevisionFloor", () => {
+  it("keeps activation evidence across lifecycle-only revisions", () => {
+    expect(
+      resolveGoalEvidenceRevisionFloor(GOAL_ID, 5, [
+        instruction("goal.activate", 1),
+        instruction("goal.pause", 2),
+        instruction("goal.resume", 3),
+        instruction("goal.continue", 3),
+        instruction("control.interrupt", 4),
+      ]),
+    ).toBe(1);
+  });
+
+  it.each<EvidenceBoundaryKind>([
+    "goal.update",
+    "context.upsert",
+    "context.remove",
+    "constraint.upsert",
+    "constraint.remove",
+  ])("moves the evidence boundary to the latest %s instruction", (kind) => {
+    expect(
+      resolveGoalEvidenceRevisionFloor(GOAL_ID, 8, [
+        instruction("goal.activate", 1),
+        instruction(kind, 6),
+        instruction("goal.pause", 7),
+        instruction("goal.resume", 8),
+      ]),
+    ).toBe(6);
+  });
+
+  it("fails closed when no applicable instruction history is available", () => {
+    expect(
+      resolveGoalEvidenceRevisionFloor(GOAL_ID, 5, [
+        instruction(
+          "goal.activate",
+          1,
+          "20000000-0000-4000-8000-000000000001",
+        ),
+        instruction("goal.update", 6),
+      ]),
+    ).toBe(5);
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
@@ -309,9 +309,40 @@ describe("SqliteAgentGoalState", () => {
       instruction: updateDraft(revised, "revise-durable-goal", uuid(102)),
       command: command("revise-durable-goal", "c"),
     };
+    const run = database.prepare("SELECT id FROM agent_goal_runs").get() as {
+      id: string;
+    };
+    const runs = new SqliteRunRepository(runtimeDatabase);
+    await runs.updateProgress({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      runId: run.id,
+      expectedRunEpoch: 0,
+      expectedStatus: "queued",
+      updatedAt: NOW.toISOString(),
+      lastEvaluation: {
+        completed: false,
+        confidence: 0,
+        satisfiedCriteria: [],
+        missingCriteria: ["durable-result"],
+        evidence: [],
+        reason: "This evaluation belongs to the old Goal definition.",
+      },
+    });
     await expect(state.commitRevision(update)).resolves.toMatchObject({
       goal: { goal: { revision: 2 } },
       instruction: { sequence: 2 },
+    });
+    await expect(
+      runs.findByGoalEpoch({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        goalId: revised.id,
+        runEpoch: 0,
+      }),
+    ).resolves.toMatchObject({
+      goalRevision: 2,
+      lastEvaluation: undefined,
     });
     const dispatchable = await new SqliteDeliveryRepository(
       runtimeDatabase,
@@ -458,6 +489,152 @@ describe("SqliteAgentGoalState", () => {
       state.getActivePrimaryGoal(OWNER_A, SESSION_A),
     ).resolves.toBeNull();
   });
+
+  it("atomically pauses an evaluator-owned Goal and its current Run", async () => {
+    const { database, runtimeDatabase, state } = createHarness();
+    const input = activationInput();
+    await state.commitActivation(input);
+    const run = database.prepare("SELECT id FROM agent_goal_runs").get() as {
+      id: string;
+    };
+    await new SqliteRunRepository(runtimeDatabase).transition({
+      ownerId: OWNER_A,
+      runtimeSessionId: SESSION_A,
+      runId: run.id,
+      expectedRunEpoch: 0,
+      expectedStatus: "queued",
+      nextStatus: "evaluating",
+      updatedAt: "2026-08-05T08:00:30.000Z",
+    });
+    const paused = transitionAgentGoal({
+      current: input.goal,
+      expectedRevision: 1,
+      status: "paused",
+      now: new Date("2026-08-05T08:01:00.000Z"),
+    });
+
+    await expect(
+      state.commitEvaluationTransition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        expectedRevision: 1,
+        expectedRunEpoch: 0,
+        goal: paused,
+      }),
+    ).resolves.toMatchObject({ goal: { goal: { status: "paused" } } });
+    expect(
+      database.prepare("SELECT status, slot_state FROM agent_goals").get(),
+    ).toEqual({ status: "paused", slot_state: "assigned" });
+    expect(
+      database
+        .prepare(
+          "SELECT status, goal_revision, completed_at FROM agent_goal_runs",
+        )
+        .get(),
+    ).toEqual({ status: "paused", goal_revision: 2, completed_at: null });
+  });
+
+  it.each(["paused", "blocked"] as const)(
+    "retains the previous evaluation when resuming a %s Goal Run",
+    async (stoppedStatus) => {
+      const { database, runtimeDatabase, state } = createHarness();
+      const input = activationInput();
+      await state.commitActivation(input);
+      const run = database.prepare("SELECT id FROM agent_goal_runs").get() as {
+        id: string;
+      };
+      const runs = new SqliteRunRepository(runtimeDatabase);
+      await runs.transition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: "queued",
+        nextStatus: "evaluating",
+        updatedAt: NOW.toISOString(),
+      });
+      const stopped = transitionAgentGoal({
+        current: input.goal,
+        expectedRevision: 1,
+        status: stoppedStatus,
+        now: new Date("2026-08-05T08:01:00.000Z"),
+      });
+      await state.commitEvaluationTransition({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        expectedRevision: 1,
+        expectedRunEpoch: 0,
+        goal: stopped,
+      });
+      await runs.updateProgress({
+        ownerId: OWNER_A,
+        runtimeSessionId: SESSION_A,
+        runId: run.id,
+        expectedRunEpoch: 0,
+        expectedStatus: stoppedStatus,
+        updatedAt: NOW.toISOString(),
+        lastEvaluation: {
+          completed: false,
+          confidence: 0,
+          satisfiedCriteria: [],
+          missingCriteria: ["durable-result"],
+          evidence: [],
+          reason: "The previous evaluation could not confirm completion.",
+        },
+      });
+      const resumed = transitionAgentGoal({
+        current: stopped,
+        expectedRevision: 2,
+        status: "active",
+        now: new Date("2026-08-05T08:02:00.000Z"),
+      });
+      const idempotencyKey = `resume-${stoppedStatus}-goal`;
+
+      await expect(
+        state.commitTransition({
+          ownerId: OWNER_A,
+          runtimeSessionId: SESSION_A,
+          expectedRevision: 2,
+          goal: resumed,
+          instruction: {
+            schemaVersion: RUNTIME_INSTRUCTION_SCHEMA_VERSION,
+            id: uuid(stoppedStatus === "paused" ? 107 : 108),
+            goalId: resumed.id,
+            goalRevision: resumed.revision,
+            kind: "goal.resume",
+            deliveryMode: "steer",
+            targetSessionId: SESSION_A,
+            payload: {},
+            source: { type: "user", authority: "user" },
+            idempotencyKey,
+            issuedAt: resumed.updatedAt,
+          },
+          command: command(
+            idempotencyKey,
+            stoppedStatus === "paused" ? "7" : "8",
+          ),
+        }),
+      ).resolves.toMatchObject({
+        goal: { goal: { status: "active", revision: 3 } },
+      });
+      await expect(
+        runs.findByGoalEpoch({
+          ownerId: OWNER_A,
+          runtimeSessionId: SESSION_A,
+          goalId: resumed.id,
+          runEpoch: 0,
+        }),
+      ).resolves.toMatchObject({
+        status: "running",
+        goalRevision: 3,
+        lastEvaluation: expect.objectContaining({
+          completed: false,
+          reason: "The previous evaluation could not confirm completion.",
+        }),
+        completedAt: undefined,
+      });
+    },
+  );
 
   it("persists a cancel barrier, advances its epoch, and replays every phase exactly", async () => {
     const { database, state } = createHarness();

--- a/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-agent-goal-persistence.test.ts
@@ -30,12 +30,18 @@ const OWNER_B = "10000000-0000-4000-8000-000000000002";
 const SESSION_A = "sqlite-runtime-a";
 const SESSION_B = "sqlite-runtime-b";
 const NOW = new Date("2026-08-05T08:00:00.000Z");
-const MIGRATION = readFileSync(
-  join(
-    dirname(fileURLToPath(import.meta.url)),
-    "../../../lib/db/migrations-sqlite/0107_agent_goal_runtime.sql",
+const MIGRATIONS = [
+  "0107_agent_goal_runtime.sql",
+  "0108_agent_goal_runtime_recovery.sql",
+].map((migration) =>
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../lib/db/migrations-sqlite",
+      migration,
+    ),
+    "utf8",
   ),
-  "utf8",
 );
 
 const databases: Database.Database[] = [];
@@ -136,7 +142,7 @@ function createHarness() {
   databases.push(database);
   database.pragma("foreign_keys = ON");
   database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
-  database.exec(MIGRATION);
+  for (const migration of MIGRATIONS) database.exec(migration);
   database
     .prepare('INSERT INTO "User" (id) VALUES (?), (?)')
     .run(OWNER_A, OWNER_B);

--- a/apps/web/tests/unit/runtime-instructions/sqlite-goal-runtime-wiring.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-goal-runtime-wiring.test.ts
@@ -80,6 +80,221 @@ function goalInput() {
 }
 
 describe("SQLite Agent Goal runtime composition", () => {
+  it("records a paused evaluation on the atomically paused Goal Run", async () => {
+    const { runtime, advance } = harness();
+    await runtime.runtimeSessions.ensure(OWNER_ID, SESSION_ID);
+    const liveLease = await runtime.runtimeSessions.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: "sqlite-paused-evaluation-test",
+    });
+    if (!liveLease) throw new Error("Expected a live Runtime lease");
+    const observationLease = runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseToken: liveLease.leaseToken,
+    });
+    const activation = await runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "activate-paused-evaluation",
+      source: { type: "user", authority: "user" },
+      goal: goalInput(),
+    });
+    const evaluationKey = "stop:paused";
+    expect(
+      await runtime.observations.beginGoalEvaluation({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activation.goal.goal.id,
+        goalRevision: 1,
+        runEpoch: 0,
+        evaluationKey,
+        recordedAt: advance(1),
+      }),
+    ).not.toBeNull();
+    const evaluation = {
+      completed: false,
+      confidence: 0,
+      satisfiedCriteria: [],
+      missingCriteria: ["tests-pass"],
+      evidence: [],
+      reason: "Goal evaluation failed and requires a retry.",
+    };
+    await runtime.state.commitEvaluationTransition({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      expectedRevision: 1,
+      expectedRunEpoch: 0,
+      runtimeLeaseToken: liveLease.leaseToken,
+      evaluation,
+      goal: transitionAgentGoal({
+        current: activation.goal.goal,
+        expectedRevision: 1,
+        status: "paused",
+        now: new Date(advance(1)),
+      }),
+    });
+    await expect(
+      runtime.queries.getById({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activation.goal.goal.id,
+      }),
+    ).resolves.toMatchObject({
+      goal: { goal: { status: "paused", revision: 2 } },
+      latestRun: { status: "paused", lastEvaluation: evaluation },
+      progress: { completedCriteria: 0, totalCriteria: 1 },
+    });
+    expect(
+      await runtime.observations.finishGoalEvaluation({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activation.goal.goal.id,
+        goalRevision: 1,
+        runEpoch: 0,
+        evaluationKey,
+        evaluation,
+        outcome: "paused",
+        recordedAt: advance(1),
+      }),
+    ).toBe(true);
+    await expect(
+      runtime.queries.getById({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        goalId: activation.goal.goal.id,
+      }),
+    ).resolves.toMatchObject({
+      goal: { goal: { status: "paused", revision: 2 } },
+      latestRun: {
+        status: "paused",
+        lastEvaluation: evaluation,
+        completedAt: undefined,
+      },
+    });
+    observationLease.release();
+    await runtime.runtimeSessions.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: 0,
+    });
+  });
+
+  it("includes pre-pause evidence when evaluating a resumed Goal revision", async () => {
+    const { runtime, advance } = harness();
+    await runtime.runtimeSessions.ensure(OWNER_ID, SESSION_ID);
+    const liveLease = await runtime.runtimeSessions.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: "sqlite-resume-evidence-test",
+    });
+    if (!liveLease) throw new Error("Expected a live Runtime lease");
+    const observationLease = runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseToken: liveLease.leaseToken,
+    });
+    const activation = await runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      idempotencyKey: "activate-resume-evidence",
+      source: { type: "user", authority: "user" },
+      goal: goalInput(),
+    });
+    await runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: activation.instruction,
+    });
+    await runtime.observations.recordInstructionHandoff({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      instructionId: activation.instruction.id,
+      runEpoch: 0,
+      recordedAt: advance(1),
+    });
+    const context = await runtime.observations.captureContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      runEpoch: 0,
+    });
+    if (!context) throw new Error("Expected the activation observation context");
+    const observedAt = advance(1);
+    expect(
+      await runtime.observations.observeProviderEvent({
+        ownerId: OWNER_ID,
+        runtimeSessionId: SESSION_ID,
+        runEpoch: 0,
+        eventKey: "pre-pause-evidence",
+        providerEventId: "pre-pause-evidence",
+        observedAt,
+        context,
+        evidence: [
+          {
+            type: "tool_result",
+            sourceEventId: "pre-pause-tool-result",
+            summary: "The focused test passed before the Goal was paused",
+            success: true,
+            payload: { toolName: "test", outputPreview: "passed" },
+            observedAt,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    await runtime.state.commitEvaluationTransition({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      expectedRevision: 1,
+      expectedRunEpoch: 0,
+      goal: transitionAgentGoal({
+        current: activation.goal.goal,
+        expectedRevision: 1,
+        status: "paused",
+        now: new Date(advance(1)),
+      }),
+    });
+    const resumed = await runtime.goals.resume({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activation.goal.goal.id,
+      expectedRevision: 2,
+      idempotencyKey: "resume-with-existing-evidence",
+      source: { type: "user", authority: "user" },
+    });
+    expect(resumed.goal.goal.revision).toBe(3);
+
+    const snapshot = await runtime.observations.beginGoalEvaluation({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      goalId: activation.goal.goal.id,
+      goalRevision: 3,
+      runEpoch: 0,
+      evaluationKey: "stop:after-resume",
+      recordedAt: advance(1),
+    });
+    expect(snapshot).toMatchObject({
+      evidenceRevisionFloor: 1,
+      evidence: [
+        {
+          goalRevision: 1,
+          sourceEventId: "pre-pause-tool-result",
+        },
+      ],
+    });
+
+    observationLease.release();
+    await runtime.runtimeSessions.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: 0,
+    });
+  });
+
   it("keeps an old turn result scoped to its immutable instruction context", async () => {
     const { database, runtime, advance } = harness();
     await runtime.runtimeSessions.ensure(OWNER_ID, SESSION_ID);

--- a/apps/web/tests/unit/runtime-instructions/sqlite-goal-runtime-wiring.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-goal-runtime-wiring.test.ts
@@ -11,12 +11,18 @@ import { createSqliteAgentGoalRuntime } from "@/lib/ai/runtime-instructions/runt
 const OWNER_ID = "10000000-0000-4000-8000-000000000001";
 const SESSION_ID = "sqlite-runtime-wiring";
 const START = new Date("2026-08-06T08:00:00.000Z");
-const MIGRATION = readFileSync(
-  join(
-    dirname(fileURLToPath(import.meta.url)),
-    "../../../lib/db/migrations-sqlite/0107_agent_goal_runtime.sql",
+const MIGRATIONS = [
+  "0107_agent_goal_runtime.sql",
+  "0108_agent_goal_runtime_recovery.sql",
+].map((migration) =>
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../lib/db/migrations-sqlite",
+      migration,
+    ),
+    "utf8",
   ),
-  "utf8",
 );
 
 const databases: Database.Database[] = [];
@@ -30,7 +36,7 @@ function harness() {
   databases.push(database);
   database.pragma("foreign_keys = ON");
   database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
-  database.exec(MIGRATION);
+  for (const migration of MIGRATIONS) database.exec(migration);
   database.prepare('INSERT INTO "User" (id) VALUES (?)').run(OWNER_ID);
   let now = START;
   let nextId = 1;
@@ -77,6 +83,17 @@ describe("SQLite Agent Goal runtime composition", () => {
   it("keeps an old turn result scoped to its immutable instruction context", async () => {
     const { database, runtime, advance } = harness();
     await runtime.runtimeSessions.ensure(OWNER_ID, SESSION_ID);
+    const liveLease = await runtime.runtimeSessions.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: "sqlite-wiring-test",
+    });
+    if (!liveLease) throw new Error("Expected a live Runtime lease");
+    const observationLease = runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseToken: liveLease.leaseToken,
+    });
     const activation = await runtime.goals.activate({
       ownerId: OWNER_ID,
       runtimeSessionId: SESSION_ID,
@@ -161,11 +178,30 @@ describe("SQLite Agent Goal runtime composition", () => {
         ({ instructionId }) => instructionId === updated.instruction.id,
       ),
     ).toMatchObject({ state: "written_to_sdk" });
+    observationLease.release();
+    await runtime.runtimeSessions.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: 0,
+    });
   });
 
   it("uses one durable source for delivery, observation, evaluation, and queries", async () => {
     const { database, runtime, advance } = harness();
     await runtime.runtimeSessions.ensure(OWNER_ID, SESSION_ID);
+    const liveLease = await runtime.runtimeSessions.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: "sqlite-wiring-test",
+    });
+    if (!liveLease) throw new Error("Expected a live Runtime lease");
+    const observationLease = runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseToken: liveLease.leaseToken,
+    });
     const activation = await runtime.goals.activate({
       ownerId: OWNER_ID,
       runtimeSessionId: SESSION_ID,
@@ -211,6 +247,7 @@ describe("SQLite Agent Goal runtime composition", () => {
       ownerId: OWNER_ID,
       runtimeSessionId: SESSION_ID,
       providerSessionId: "claude-query-1",
+      runEpoch: 0,
     });
     const context = await runtime.observations.captureContext({
       ownerId: OWNER_ID,
@@ -244,6 +281,7 @@ describe("SQLite Agent Goal runtime composition", () => {
         ],
       }),
     ).toBe(true);
+    const replayedAt = advance(1);
     expect(
       await runtime.observations.observeProviderEvent({
         ownerId: OWNER_ID,
@@ -251,8 +289,20 @@ describe("SQLite Agent Goal runtime composition", () => {
         runEpoch: 0,
         eventKey: "claude:event:1",
         providerEventId: "provider-event-1",
-        observedAt,
+        providerSessionId: "claude-query-1",
+        observedAt: replayedAt,
         context,
+        usage: { turnsUsed: 1, tokensUsed: 25 },
+        evidence: [
+          {
+            type: "tool_result",
+            sourceEventId: "tool-result-1",
+            summary: "The focused test passed",
+            success: true,
+            payload: { toolName: "test" },
+            observedAt: replayedAt,
+          },
+        ],
       }),
     ).toBe(false);
 
@@ -346,6 +396,14 @@ describe("SQLite Agent Goal runtime composition", () => {
         .prepare("SELECT count(*) AS count FROM agent_goal_evidence")
         .get(),
     ).toEqual({ count: 1 });
+    observationLease.release();
+    await runtime.runtimeSessions.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: 0,
+    });
   });
 
   it("reclaims terminal-free chat rows but fails closed on unfinished Goals", async () => {
@@ -370,10 +428,22 @@ describe("SQLite Agent Goal runtime composition", () => {
         )
         .get(SESSION_ID),
     ).toEqual({ provider_session_id: null });
+    const liveLease = await runtime.runtimeSessions.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: "ordinary-chat-test",
+    });
+    if (!liveLease) throw new Error("Expected a live Runtime lease");
+    const observationLease = runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseToken: liveLease.leaseToken,
+    });
     await runtime.observations.setProviderSession({
       ownerId: OWNER_ID,
       runtimeSessionId: SESSION_ID,
       providerSessionId: "ordinary-chat-query",
+      runEpoch: 0,
     });
     expect(
       database
@@ -381,7 +451,7 @@ describe("SQLite Agent Goal runtime composition", () => {
           "SELECT provider_session_id FROM agent_runtime_sessions WHERE id = ?",
         )
         .get(SESSION_ID),
-    ).toEqual({ provider_session_id: null });
+    ).toEqual({ provider_session_id: "ordinary-chat-query" });
 
     await runtime.goals.activate({
       ownerId: OWNER_ID,
@@ -390,6 +460,21 @@ describe("SQLite Agent Goal runtime composition", () => {
       source: { type: "user", authority: "user" },
       goal: goalInput(),
     });
+    observationLease.release();
+    await runtime.runtimeSessions.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId: SESSION_ID,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: 0,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT provider_session_id FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(SESSION_ID),
+    ).toEqual({ provider_session_id: "ordinary-chat-query" });
     const restarted = createSqliteAgentGoalRuntime(database);
     await expect(
       restarted.runtimeSessions.ensure(OWNER_ID, SESSION_ID),

--- a/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
@@ -1,0 +1,2033 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ClaudeRuntimeSession,
+  startClaudeGoalRuntimeSession,
+} from "@/lib/ai/extensions/agent/claude/runtime";
+
+import {
+  createSqliteAgentGoalRuntime,
+  type SqliteAgentGoalRuntime,
+} from "@/lib/ai/runtime-instructions/runtime";
+import { GoalRuntimeRecoveryCoordinator } from "@/lib/ai/runtime-instructions/recovery/coordinator";
+import {
+  RuntimeSessionPersistenceError,
+  SqliteRuntimeSessionPersistence,
+  type RuntimeRecoveryDescriptor,
+  type RuntimeSessionRecoveryPersistencePort,
+} from "@/lib/ai/runtime-instructions/runtime-session-persistence";
+import {
+  createControlledClaudeQuery,
+  createFakeClaudeSdkTransport,
+} from "../../helpers/claude-runtime";
+
+const OWNER_ID = "10000000-0000-4000-8000-000000000001";
+const START = new Date("2026-08-10T08:00:00.000Z");
+const MIGRATIONS = [
+  "0107_agent_goal_runtime.sql",
+  "0108_agent_goal_runtime_recovery.sql",
+].map((migration) =>
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../lib/db/migrations-sqlite",
+      migration,
+    ),
+    "utf8",
+  ),
+);
+
+const openDatabases = new Set<Database.Database>();
+const temporaryDirectories = new Set<string>();
+
+afterEach(() => {
+  for (const database of openDatabases) database.close();
+  openDatabases.clear();
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+  }
+  temporaryDirectories.clear();
+});
+
+interface FileBackedRuntime {
+  readonly database: Database.Database;
+  readonly path: string;
+  readonly runtime: SqliteAgentGoalRuntime;
+  readonly recovery: RuntimeSessionRecoveryPersistencePort;
+  readonly workingDirectory: string;
+  advance(seconds: number): void;
+  close(): void;
+  reopen(): FileBackedRuntime;
+}
+
+function createFileBackedRuntime(): FileBackedRuntime {
+  const directory = mkdtempSync(join(tmpdir(), "openloomi-goal-recovery-"));
+  temporaryDirectories.add(directory);
+  const path = join(directory, "runtime.sqlite");
+  let now = START;
+  initializeDatabase(path);
+
+  const open = (): FileBackedRuntime => {
+    const database = new Database(path);
+    database.pragma("foreign_keys = ON");
+    openDatabases.add(database);
+    const clock = { now: () => now };
+    const runtime = createSqliteAgentGoalRuntime(database, { clock });
+    const recovery = runtime.runtimeSessions;
+    if (!(recovery instanceof SqliteRuntimeSessionPersistence)) {
+      throw new Error(
+        "Expected the SQLite Runtime Session persistence adapter",
+      );
+    }
+    return {
+      database,
+      path,
+      runtime,
+      recovery,
+      workingDirectory: resolve(directory, "workspace"),
+      advance(seconds) {
+        now = new Date(now.getTime() + seconds * 1_000);
+      },
+      close() {
+        database.close();
+        openDatabases.delete(database);
+      },
+      reopen: open,
+    };
+  };
+
+  return open();
+}
+
+function initializeDatabase(path: string): void {
+  const database = new Database(path);
+  database.pragma("foreign_keys = ON");
+  database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
+  for (const migration of MIGRATIONS) database.exec(migration);
+  database.prepare('INSERT INTO "User" (id) VALUES (?)').run(OWNER_ID);
+  database.close();
+}
+
+function goalInput(objective: string) {
+  return {
+    objective,
+    successCriteria: [
+      {
+        id: "result-recorded",
+        description: "The requested result is recorded",
+        verification: {
+          type: "tool_result" as const,
+          toolName: "test",
+          expectedOutcome: "passed",
+        },
+        required: true,
+      },
+    ],
+    constraints: [],
+    contextRefs: [],
+    priority: 80,
+    maxTurns: 8,
+    completionPolicy: "tool_evidence" as const,
+    source: { type: "user" as const },
+  };
+}
+
+async function activate(runtime: FileBackedRuntime, runtimeSessionId: string) {
+  await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+  return runtime.runtime.goals.activate({
+    ownerId: OWNER_ID,
+    runtimeSessionId,
+    idempotencyKey: `activate-${runtimeSessionId}`,
+    source: { type: "user", authority: "user" },
+    goal: goalInput(`Recover ${runtimeSessionId}`),
+  });
+}
+
+function deliveryRows(database: Database.Database, runtimeSessionId: string) {
+  return database
+    .prepare(
+      `SELECT instruction_id AS instructionId, state, attempt,
+              lease_token AS leaseToken, error_code AS errorCode
+         FROM agent_runtime_deliveries
+        WHERE owner_id = ? AND runtime_session_id = ?
+        ORDER BY attempt ASC`,
+    )
+    .all(OWNER_ID, runtimeSessionId) as Array<{
+    instructionId: string;
+    state: string;
+    attempt: number;
+    leaseToken: string | null;
+    errorCode: string | null;
+  }>;
+}
+
+function recoveryErrorCode(error: unknown): string | undefined {
+  return error instanceof RuntimeSessionPersistenceError
+    ? error.code
+    : undefined;
+}
+
+function claudeInitMessage(providerSessionId: string): SDKMessage {
+  return {
+    type: "system",
+    subtype: "init",
+    session_id: providerSessionId,
+  } as SDKMessage;
+}
+
+function claudeResultMessage(): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 10,
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 4, output_tokens: 2 },
+  } as SDKMessage;
+}
+
+describe("SQLite Runtime restart recovery", () => {
+  it("persists live recovery metadata only for the runtime that wins ownership", async () => {
+    const first = createFileBackedRuntime();
+    const competing = first.reopen();
+    const runtimeSessionId = "live-metadata-ownership";
+    const firstDescriptor: RuntimeRecoveryDescriptor = {
+      schemaVersion: 1,
+      model: "claude-sonnet-first",
+    };
+    const competingDescriptor: RuntimeRecoveryDescriptor = {
+      schemaVersion: 1,
+      model: "claude-sonnet-competing",
+    };
+    const firstWorkingDirectory = resolve(
+      dirname(first.path),
+      "workspace-first",
+    );
+    const competingWorkingDirectory = resolve(
+      dirname(first.path),
+      "workspace-competing",
+    );
+
+    const [firstLease, competingLease] = await Promise.all([
+      first.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "first-live-host",
+        workingDirectory: firstWorkingDirectory,
+        recoveryDescriptor: firstDescriptor,
+      }),
+      competing.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "competing-live-host",
+        workingDirectory: competingWorkingDirectory,
+        recoveryDescriptor: competingDescriptor,
+      }),
+    ]);
+    expect([firstLease, competingLease].filter(Boolean)).toHaveLength(1);
+
+    const winningLease = firstLease ?? competingLease;
+    if (!winningLease) throw new Error("Expected one live Runtime owner");
+    const winner = firstLease
+      ? {
+          workingDirectory: firstWorkingDirectory,
+          descriptor: firstDescriptor,
+        }
+      : {
+          workingDirectory: competingWorkingDirectory,
+          descriptor: competingDescriptor,
+        };
+    expect(
+      first.database
+        .prepare(
+          `SELECT working_directory AS workingDirectory,
+                  recovery_descriptor AS recoveryDescriptor
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({
+      workingDirectory: winner.workingDirectory,
+      recoveryDescriptor: JSON.stringify(winner.descriptor),
+    });
+
+    await (firstLease ? first.recovery : competing.recovery).releaseLiveRuntime(
+      {
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: winningLease.leaseOwner,
+        leaseToken: winningLease.leaseToken,
+        expectedRunEpoch: winningLease.runEpoch,
+      },
+    );
+  });
+
+  it("atomically releases live ownership and preserves resumable Goal state", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "live-release-unfinished";
+    await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const lease = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "ordinary-runtime-host",
+      leaseDurationMs: 30_000,
+    });
+    if (!lease) throw new Error("Expected live Runtime ownership");
+    await runtime.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: `activate-${runtimeSessionId}`,
+      source: { type: "user", authority: "user" },
+      goal: goalInput(`Recover ${runtimeSessionId}`),
+    });
+
+    await runtime.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "claude-live-unfinished",
+      runtimeLeaseToken: lease.leaseToken,
+      expectedRunEpoch: lease.runEpoch,
+    });
+    await runtime.recovery.persistState({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      expectedState: lease.state,
+      expectedRunEpoch: lease.runEpoch,
+      state: "running",
+      recoveryLeaseToken: lease.leaseToken,
+    });
+    await expect(
+      runtime.recovery.releaseProviderSession(OWNER_ID, runtimeSessionId, {
+        runtimeLeaseToken: "stale-live-lease-token",
+        expectedRunEpoch: lease.runEpoch,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    expect(
+      runtime.database
+        .prepare(
+          "SELECT provider_session_id FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ provider_session_id: "claude-live-unfinished" });
+
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: lease.leaseOwner,
+        leaseToken: lease.leaseToken,
+        expectedRunEpoch: lease.runEpoch,
+      }),
+    ).resolves.toMatchObject({
+      state: "interrupted",
+      providerSessionId: "claude-live-unfinished",
+      runEpoch: lease.runEpoch,
+    });
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT state, provider_session_id AS providerSessionId,
+                  recovery_lease_token AS leaseToken
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({
+      state: "interrupted",
+      providerSessionId: "claude-live-unfinished",
+      leaseToken: null,
+    });
+  });
+
+  it("returns a finished live Runtime to idle and forgets its provider handle", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "live-release-finished";
+    await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const lease = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "ordinary-runtime-host",
+    });
+    if (!lease) throw new Error("Expected live Runtime ownership");
+    await runtime.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "claude-live-finished",
+      runtimeLeaseToken: lease.leaseToken,
+      expectedRunEpoch: lease.runEpoch,
+    });
+    await runtime.recovery.persistState({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      expectedState: lease.state,
+      expectedRunEpoch: lease.runEpoch,
+      state: "running",
+      recoveryLeaseToken: lease.leaseToken,
+    });
+
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: lease.leaseOwner,
+        leaseToken: lease.leaseToken,
+        expectedRunEpoch: lease.runEpoch,
+      }),
+    ).resolves.toMatchObject({ state: "idle", runEpoch: lease.runEpoch });
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT state, provider_session_id AS providerSessionId,
+                  recovery_lease_token AS leaseToken
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ state: "idle", providerSessionId: null, leaseToken: null });
+  });
+
+  it.each([
+    ["queued", "superseded", "runtime_execution_already_terminal"],
+    ["written_to_sdk", "failed", "runtime_execution_already_terminal"],
+    ["observed", "applied", null],
+  ] as const)(
+    "settles a delivery-only %s crash before releasing the recovered Session",
+    async (crashedState, settledState, errorCode) => {
+      const first = createFileBackedRuntime();
+      const runtimeSessionId = `delivery-only-${crashedState}`;
+      const liveLease = await first.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "crashed-live-host",
+        leaseDurationMs: 10_000,
+      });
+      if (!liveLease) throw new Error("Expected live Runtime ownership");
+      const activation = await first.runtime.goals.activate({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        idempotencyKey: `activate-${runtimeSessionId}`,
+        source: { type: "user", authority: "user" },
+        goal: goalInput(`Finish before settling ${crashedState}`),
+      });
+      await first.recovery.bindProviderSession({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        providerSessionId: `claude-${runtimeSessionId}`,
+        runtimeLeaseToken: liveLease.leaseToken,
+        expectedRunEpoch: liveLease.runEpoch,
+      });
+      await first.recovery.persistState({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        expectedState: liveLease.state,
+        expectedRunEpoch: liveLease.runEpoch,
+        state: "running",
+        recoveryLeaseToken: liveLease.leaseToken,
+      });
+
+      const terminalAt = START.toISOString();
+      const terminalAtSeconds = Math.floor(START.getTime() / 1_000);
+      first.database
+        .prepare(
+          `UPDATE agent_goals
+              SET slot_state = 'released', revision = revision + 1,
+                  status = 'completed',
+                  goal_snapshot = json_set(
+                    goal_snapshot,
+                    '$.revision', revision + 1,
+                    '$.status', 'completed',
+                    '$.updatedAt', ?
+                  ),
+                  updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ?`,
+        )
+        .run(terminalAt, terminalAtSeconds, OWNER_ID, runtimeSessionId);
+      first.database
+        .prepare(
+          `UPDATE agent_goal_runs
+              SET goal_revision = goal_revision + 1, status = 'completed',
+                  last_activity_at = ?, completed_at = ?, updated_at = ?
+            WHERE owner_id = ? AND runtime_session_id = ?`,
+        )
+        .run(
+          terminalAtSeconds,
+          terminalAtSeconds,
+          terminalAtSeconds,
+          OWNER_ID,
+          runtimeSessionId,
+        );
+      first.database
+        .prepare(
+          `UPDATE agent_runtime_deliveries
+              SET state = ?, provider_event_id = ?
+            WHERE instruction_id = ?`,
+        )
+        .run(
+          crashedState,
+          crashedState === "observed" ? "provider-observed-before-crash" : null,
+          activation.instruction.id,
+        );
+
+      first.advance(11);
+      first.close();
+      const recovered = first.reopen();
+      const nativeRun = vi.fn();
+      const coordinator = new GoalRuntimeRecoveryCoordinator({
+        persistence: recovered.recovery,
+        providerPreflight: { verify: vi.fn() },
+        nativeRunner: { run: nativeRun },
+        loadOwnerSession: vi.fn(async () => null),
+        reconcilePendingOperation: vi.fn(),
+        leaseOwner: "delivery-cleanup-host",
+        leaseDurationMs: 60_000,
+        heartbeatIntervalMs: 30_000,
+        initializationTimeoutMs: 1_000,
+        logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      });
+
+      await expect(coordinator.start()).resolves.toMatchObject({
+        scanned: 1,
+        outcomes: [
+          expect.objectContaining({
+            status: "dormant",
+            reason: "no_active_goal",
+          }),
+        ],
+      });
+      expect(nativeRun).not.toHaveBeenCalled();
+      expect(deliveryRows(recovered.database, runtimeSessionId)).toEqual([
+        expect.objectContaining({
+          state: settledState,
+          errorCode,
+          attempt: 1,
+        }),
+      ]);
+      expect(
+        recovered.database
+          .prepare(
+            `SELECT state, recovery_lease_token AS leaseToken
+               FROM agent_runtime_sessions WHERE id = ?`,
+          )
+          .get(runtimeSessionId),
+      ).toEqual({ state: "idle", leaseToken: null });
+      await expect(recovered.recovery.listRecoverable()).resolves.toEqual([]);
+
+      const nextLiveLease = await recovered.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "next-live-host",
+      });
+      expect(nextLiveLease).toMatchObject({ state: "idle" });
+      if (!nextLiveLease)
+        throw new Error("Expected the Session to be reusable");
+      await recovered.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: nextLiveLease.leaseOwner,
+        leaseToken: nextLiveLease.leaseToken,
+        expectedRunEpoch: nextLiveLease.runEpoch,
+      });
+    },
+  );
+
+  it("applies an observed crash boundary before terminal cleanup releases the runtime", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "observed-crash-terminal-cleanup";
+    await first.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const liveLease = await first.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "crashed-live-host",
+      leaseDurationMs: 10_000,
+    });
+    if (!liveLease) throw new Error("Expected live Runtime ownership");
+    const observationLease = first.runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseToken: liveLease.leaseToken,
+    });
+    const activation = await first.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: `activate-${runtimeSessionId}`,
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Finish an observed Goal after restart"),
+    });
+    await first.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "claude-observed-before-crash",
+      runtimeLeaseToken: liveLease.leaseToken,
+      expectedRunEpoch: liveLease.runEpoch,
+    });
+    await first.recovery.persistState({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      expectedState: liveLease.state,
+      expectedRunEpoch: liveLease.runEpoch,
+      state: "running",
+      recoveryLeaseToken: liveLease.leaseToken,
+    });
+    await first.runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: activation.instruction,
+    });
+    await first.runtime.observations.recordInstructionHandoff({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      instructionId: activation.instruction.id,
+      runEpoch: liveLease.runEpoch,
+      recordedAt: START.toISOString(),
+    });
+    const context = await first.runtime.observations.captureContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      runEpoch: liveLease.runEpoch,
+    });
+    if (!context) throw new Error("Expected an observation context");
+    await first.runtime.observations.observeProviderEvent({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      runEpoch: liveLease.runEpoch,
+      eventKey: "assistant-observed-before-crash",
+      providerEventId: "assistant-observed-before-crash",
+      observedAt: START.toISOString(),
+      terminal: false,
+      context,
+      evidence: [
+        {
+          type: "tool_result",
+          sourceEventId: "assistant-observed-before-crash:test",
+          summary: "Focused test passed before the host crashed",
+          success: true,
+          payload: { toolName: "test", outcome: "passed" },
+          observedAt: START.toISOString(),
+        },
+      ],
+    });
+    expect(deliveryRows(first.database, runtimeSessionId)).toEqual([
+      expect.objectContaining({ state: "observed", attempt: 1 }),
+    ]);
+
+    // Simulate a hard process exit: the durable lease is not released, but it
+    // expires before another process reopens the same SQLite database.
+    observationLease.release();
+    first.advance(11);
+    first.close();
+
+    const recovered = first.reopen();
+    const recoveryClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "recovery-host",
+    });
+    if (!recoveryClaim) throw new Error("Expected recovery ownership");
+    expect(deliveryRows(recovered.database, runtimeSessionId)).toEqual([
+      expect.objectContaining({ state: "applied", attempt: 1 }),
+    ]);
+    expect(recoveryClaim.snapshot).toMatchObject({
+      replayableInstructionIds: [],
+      instructionSettlements: [
+        {
+          instructionId: activation.instruction.id,
+          disposition: "accepted",
+          providerEventId: "assistant-observed-before-crash",
+        },
+      ],
+    });
+
+    const recoveredObservationLease =
+      recovered.runtime.observations.attachRuntimeLease({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseToken: recoveryClaim.leaseToken,
+      });
+    const recoveredContext =
+      await recovered.runtime.observations.captureContext({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        runEpoch: recoveryClaim.snapshot.session.runEpoch,
+      });
+    if (!recoveredContext)
+      throw new Error("Expected the recovered observation context");
+    const controller = recovered.runtime.controller.forSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      transport: {
+        runtimeSessionId,
+        async deliver(instruction) {
+          return {
+            instructionId: instruction.id,
+            runtimeSessionId,
+            state: "written_to_sdk",
+            recordedAt: START.toISOString(),
+          };
+        },
+        async interrupt() {},
+      },
+    });
+    await expect(
+      controller.evaluateStop({
+        runEpoch: recoveryClaim.snapshot.session.runEpoch,
+        assistantTurnId: "recovered-terminal-boundary",
+        turnContext: recoveredContext,
+        stopHookActive: false,
+      }),
+    ).resolves.toMatchObject({ decision: "allow", outcome: "completed" });
+    recoveredObservationLease.release();
+
+    await expect(
+      recovered.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: recoveryClaim.leaseOwner,
+        leaseToken: recoveryClaim.leaseToken,
+        expectedRunEpoch: recoveryClaim.snapshot.session.runEpoch,
+      }),
+    ).resolves.toMatchObject({ state: "idle" });
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT state, provider_session_id AS providerSessionId,
+                  recovery_lease_token AS leaseToken
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ state: "idle", providerSessionId: null, leaseToken: null });
+    await expect(
+      recovered.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "next-live-host",
+      }),
+    ).resolves.toMatchObject({ state: "idle" });
+  });
+
+  it("rejects provider writes and release from expired or reclaimed live tokens", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "live-lease-fencing";
+    await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const expired = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "expired-live-host",
+      leaseDurationMs: 10_000,
+    });
+    if (!expired) throw new Error("Expected the first live lease");
+    runtime.advance(11);
+
+    await expect(
+      runtime.recovery.bindProviderSession({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        providerSessionId: "stale-provider-session",
+        runtimeLeaseToken: expired.leaseToken,
+        expectedRunEpoch: expired.runEpoch,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: expired.leaseOwner,
+        leaseToken: expired.leaseToken,
+        expectedRunEpoch: expired.runEpoch,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+
+    const current = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "replacement-live-host",
+    });
+    if (!current)
+      throw new Error("Expected an expired lease to be reclaimable");
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: expired.leaseOwner,
+        leaseToken: expired.leaseToken,
+        expectedRunEpoch: expired.runEpoch,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    await runtime.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "current-provider-session",
+      runtimeLeaseToken: current.leaseToken,
+      expectedRunEpoch: current.runEpoch,
+    });
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: current.leaseOwner,
+        leaseToken: current.leaseToken,
+        expectedRunEpoch: current.runEpoch,
+      }),
+    ).resolves.toMatchObject({ state: "idle" });
+  });
+
+  it("does not release live ownership across a run epoch boundary", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "live-release-epoch-fence";
+    await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const lease = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "epoch-live-host",
+    });
+    if (!lease) throw new Error("Expected live Runtime ownership");
+    await runtime.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "epoch-provider-session",
+      runtimeLeaseToken: lease.leaseToken,
+      expectedRunEpoch: lease.runEpoch,
+    });
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_sessions SET run_epoch = run_epoch + 1
+          WHERE owner_id = ? AND id = ?`,
+      )
+      .run(OWNER_ID, runtimeSessionId);
+
+    await expect(
+      runtime.recovery.releaseLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: lease.leaseOwner,
+        leaseToken: lease.leaseToken,
+        expectedRunEpoch: lease.runEpoch,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT provider_session_id AS providerSessionId,
+                  recovery_lease_token AS leaseToken, run_epoch AS runEpoch
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({
+      providerSessionId: "epoch-provider-session",
+      leaseToken: lease.leaseToken,
+      runEpoch: lease.runEpoch + 1,
+    });
+  });
+
+  it("hands an unfinished Runtime to one recovery worker after its live lease expires", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "live-expiry-recovery-handoff";
+    await runtime.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const liveLease = await runtime.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "live-runtime-host",
+      leaseDurationMs: 10_000,
+    });
+    if (!liveLease) throw new Error("Expected live Runtime ownership");
+    await runtime.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: `activate-${runtimeSessionId}`,
+      source: { type: "user", authority: "user" },
+      goal: goalInput(`Recover ${runtimeSessionId}`),
+    });
+    const competing = runtime.reopen();
+
+    await expect(runtime.recovery.listRecoverable()).resolves.toEqual([]);
+    await expect(
+      runtime.runtime.runtimeSessions.listRecoveryPresentationSessions(
+        OWNER_ID,
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ runtimeSessionId, state: "starting" }),
+    ]);
+    await expect(
+      runtime.runtime.runtimeSessions.listRecoveryPresentationSessions(
+        "another-owner",
+      ),
+    ).resolves.toEqual([]);
+    await expect(
+      competing.recovery.ensure(OWNER_ID, runtimeSessionId),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    await expect(
+      runtime.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "early-recovery-worker",
+      }),
+    ).resolves.toBeNull();
+
+    runtime.advance(11);
+    await expect(
+      competing.recovery.claimLiveRuntime({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "incorrect-ordinary-host",
+      }),
+    ).resolves.toBeNull();
+    await expect(runtime.recovery.listRecoverable()).resolves.toEqual([
+      expect.objectContaining({ ownerId: OWNER_ID, runtimeSessionId }),
+    ]);
+    const recovered = await runtime.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "winning-recovery-worker",
+    });
+    expect(recovered).not.toBeNull();
+    await expect(
+      competing.runtime.runtimeSessions.listRecoveryPresentationSessions(
+        OWNER_ID,
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ runtimeSessionId, state: "starting" }),
+    ]);
+    await expect(
+      competing.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "losing-recovery-worker",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects delayed provider observations after live ownership is reclaimed", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "stale-live-provider-observation";
+    await first.recovery.ensure(OWNER_ID, runtimeSessionId);
+    const liveLease = await first.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "original-live-runtime",
+      leaseDurationMs: 10_000,
+    });
+    if (!liveLease) throw new Error("Expected live Runtime ownership");
+    const observationLease = first.runtime.observations.attachRuntimeLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseToken: liveLease.leaseToken,
+    });
+    const activation = await first.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: `activate-${runtimeSessionId}`,
+      source: { type: "user", authority: "user" },
+      goal: goalInput(`Recover ${runtimeSessionId}`),
+    });
+    await first.runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: activation.instruction,
+    });
+    await first.runtime.observations.recordInstructionHandoff({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      instructionId: activation.instruction.id,
+      runEpoch: 0,
+      recordedAt: START.toISOString(),
+    });
+    const staleContext = await first.runtime.observations.captureContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      runEpoch: 0,
+    });
+    if (!staleContext) throw new Error("Expected observation context");
+
+    first.advance(11);
+    const competing = first.reopen();
+    const recoveryClaim = await competing.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "replacement-runtime",
+    });
+    if (!recoveryClaim) throw new Error("Expected recovery ownership");
+
+    await expect(
+      first.runtime.observations.observeProviderEvent({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        runEpoch: 0,
+        eventKey: "delayed-old-runtime-result",
+        providerEventId: "delayed-old-runtime-result",
+        observedAt: new Date(START.getTime() + 11_000).toISOString(),
+        terminal: true,
+        context: staleContext,
+        usage: { turnsUsed: 1, tokensUsed: 50 },
+        evidence: [
+          {
+            type: "tool_result",
+            sourceEventId: "delayed-old-runtime-result:test",
+            summary: "This stale result must not be persisted",
+            success: true,
+            payload: { toolName: "test", outcome: "passed" },
+            observedAt: new Date(START.getTime() + 11_000).toISOString(),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "conflict",
+      message: expect.stringContaining("no longer owns"),
+    });
+    expect(
+      competing.database
+        .prepare(
+          `SELECT
+             (SELECT count(*) FROM agent_runtime_provider_events
+               WHERE runtime_session_id = ?) AS providerEvents,
+             (SELECT count(*) FROM agent_goal_evidence
+               WHERE runtime_session_id = ?) AS evidence`,
+        )
+        .get(runtimeSessionId, runtimeSessionId),
+    ).toEqual({ providerEvents: 0, evidence: 0 });
+    observationLease.release();
+  });
+
+  it("keeps stable paused Goals out of periodic scans but available to an explicit wake", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "paused-explicit-recovery";
+    await activate(runtime, runtimeSessionId);
+    runtime.database
+      .prepare(
+        `UPDATE agent_goals
+            SET status = 'paused',
+                goal_snapshot = json_set(goal_snapshot, '$.status', 'paused')
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(OWNER_ID, runtimeSessionId);
+    runtime.database
+      .prepare(
+        `UPDATE agent_goal_runs SET status = 'paused'
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(OWNER_ID, runtimeSessionId);
+
+    await expect(runtime.recovery.listRecoverable()).resolves.toEqual([]);
+    await expect(
+      runtime.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "explicit-pause-wake",
+      }),
+    ).resolves.toMatchObject({
+      snapshot: {
+        activeGoal: { goal: { status: "paused" } },
+        runs: [expect.objectContaining({ status: "paused" })],
+      },
+    });
+  });
+
+  it("prevents recovery from claiming an ordinary live Claude runtime", async () => {
+    const runtime = createFileBackedRuntime();
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const claude = new ClaudeRuntimeSession({
+      runtimeSessionId: "ordinary-live-runtime",
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "ordinary-live-message",
+    });
+    const registration = await startClaudeGoalRuntimeSession({
+      session: { user: { id: OWNER_ID } },
+      runtime: claude,
+      start: { initialPrompt: "Keep this ordinary runtime live" },
+      goalRuntime: runtime.runtime,
+      persistence: { workingDirectory: runtime.workingDirectory },
+    });
+
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT state, recovery_lease_token AS leaseToken
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get("ordinary-live-runtime"),
+    ).toEqual({ state: "running", leaseToken: expect.any(String) });
+    const competing = runtime.reopen();
+    await expect(
+      competing.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId: "ordinary-live-runtime",
+        leaseOwner: "competing-recovery-host",
+      }),
+    ).resolves.toBeNull();
+
+    registration?.release();
+    await claude.close();
+    await vi.waitFor(() => {
+      expect(
+        runtime.database
+          .prepare(
+            `SELECT recovery_lease_token AS leaseToken
+               FROM agent_runtime_sessions WHERE id = ?`,
+          )
+          .get("ordinary-live-runtime"),
+      ).toEqual({ leaseToken: null });
+    });
+  });
+
+  it("hands a fresh Goal created after an ordinary turn to the next live Claude runtime", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "fresh-goal-after-idle-turn";
+    const ordinaryHandle = createControlledClaudeQuery();
+    const ordinarySdk = createFakeClaudeSdkTransport(ordinaryHandle);
+    const ordinaryClaude = new ClaudeRuntimeSession({
+      runtimeSessionId,
+      runEpoch: 0,
+      sdkTransport: ordinarySdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "ordinary-turn-message",
+    });
+    const ordinaryOutput = ordinaryClaude.subscribe()[Symbol.asyncIterator]();
+    const ordinaryRegistration = await startClaudeGoalRuntimeSession({
+      session: { user: { id: OWNER_ID } },
+      runtime: ordinaryClaude,
+      start: { initialPrompt: "Finish an ordinary chat turn" },
+      goalRuntime: first.runtime,
+      persistence: { workingDirectory: first.workingDirectory },
+    });
+    const ordinaryPrompt = ordinarySdk.queryInput?.prompt as
+      | AsyncIterable<SDKUserMessage>
+      | undefined;
+    if (!ordinaryPrompt) throw new Error("Expected the ordinary SDK prompt");
+    await expect(
+      ordinaryPrompt[Symbol.asyncIterator]().next(),
+    ).resolves.toMatchObject({
+      value: { message: { content: "Finish an ordinary chat turn" } },
+    });
+
+    ordinaryHandle.push(claudeInitMessage("ordinary-provider-session"));
+    ordinaryHandle.push(claudeResultMessage());
+    await expect(ordinaryOutput.next()).resolves.toMatchObject({
+      value: { type: "result", content: "success" },
+    });
+    await vi.waitFor(() => expect(ordinaryClaude.state).toBe("idle"));
+    await ordinaryRegistration?.release();
+    await ordinaryClaude.close();
+    expect(
+      first.database
+        .prepare(
+          `SELECT state, provider_session_id AS providerSessionId,
+                  recovery_lease_token AS leaseToken
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ state: "idle", providerSessionId: null, leaseToken: null });
+
+    const activation = await first.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: `activate-${runtimeSessionId}`,
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Deliver this fresh Goal on the next Claude turn"),
+    });
+    expect(activation.dispatch).toMatchObject({ status: "unavailable" });
+    expect(
+      first.database
+        .prepare(
+          `SELECT
+             (SELECT state FROM agent_runtime_sessions
+               WHERE owner_id = ? AND id = ?) AS sessionState,
+             (SELECT provider_session_id FROM agent_runtime_sessions
+               WHERE owner_id = ? AND id = ?) AS providerSessionId,
+             (SELECT status FROM agent_goals
+               WHERE owner_id = ? AND runtime_session_id = ?) AS goalStatus,
+             (SELECT status FROM agent_goal_runs
+               WHERE owner_id = ? AND runtime_session_id = ?) AS runStatus,
+             (SELECT kind FROM agent_runtime_instructions
+               WHERE owner_id = ? AND runtime_session_id = ?) AS instructionKind,
+             (SELECT count(*) FROM agent_runtime_deliveries
+               WHERE owner_id = ? AND runtime_session_id = ?) AS deliveryAttempts`,
+        )
+        .get(
+          OWNER_ID,
+          runtimeSessionId,
+          OWNER_ID,
+          runtimeSessionId,
+          OWNER_ID,
+          runtimeSessionId,
+          OWNER_ID,
+          runtimeSessionId,
+          OWNER_ID,
+          runtimeSessionId,
+          OWNER_ID,
+          runtimeSessionId,
+        ),
+    ).toEqual({
+      sessionState: "idle",
+      providerSessionId: null,
+      goalStatus: "active",
+      runStatus: "queued",
+      instructionKind: "goal.activate",
+      deliveryAttempts: 1,
+    });
+    expect(deliveryRows(first.database, runtimeSessionId)).toEqual([
+      expect.objectContaining({
+        instructionId: activation.instruction.id,
+        state: "pending",
+        attempt: 1,
+        leaseToken: null,
+      }),
+    ]);
+    await expect(
+      first.runtime.runtimeSessions.ensure(OWNER_ID, runtimeSessionId),
+    ).resolves.toMatchObject({ state: "idle" });
+    first.close();
+
+    const next = first.reopen();
+    await expect(next.recovery.listRecoverable()).resolves.toEqual([]);
+    await expect(
+      next.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "periodic-recovery-monitor",
+      }),
+    ).resolves.toBeNull();
+    const nextHandle = createControlledClaudeQuery();
+    const nextSdk = createFakeClaudeSdkTransport(nextHandle);
+    const nextClaude = new ClaudeRuntimeSession({
+      runtimeSessionId,
+      runEpoch: 0,
+      sdkTransport: nextSdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "next-turn-message",
+    });
+    const claimLiveRuntime = vi.spyOn(next.recovery, "claimLiveRuntime");
+    let nextRegistration:
+      | Awaited<ReturnType<typeof startClaudeGoalRuntimeSession>>
+      | undefined;
+    try {
+      nextRegistration = await startClaudeGoalRuntimeSession({
+        session: { user: { id: OWNER_ID } },
+        runtime: nextClaude,
+        start: { initialPrompt: "Continue after the idle boundary" },
+        goalRuntime: next.runtime,
+        persistence: { workingDirectory: next.workingDirectory },
+      });
+      expect(claimLiveRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerId: OWNER_ID, runtimeSessionId }),
+      );
+      expect(
+        next.database
+          .prepare(
+            `SELECT state, recovery_lease_token AS leaseToken
+               FROM agent_runtime_sessions WHERE id = ?`,
+          )
+          .get(runtimeSessionId),
+      ).toEqual({ state: "running", leaseToken: expect.any(String) });
+      expect(deliveryRows(next.database, runtimeSessionId)).toEqual([
+        expect.objectContaining({
+          instructionId: activation.instruction.id,
+          state: "queued",
+          attempt: 1,
+        }),
+      ]);
+
+      const nextPrompt = nextSdk.queryInput?.prompt as
+        | AsyncIterable<SDKUserMessage>
+        | undefined;
+      if (!nextPrompt) throw new Error("Expected the next SDK prompt");
+      const prompt = nextPrompt[Symbol.asyncIterator]();
+      await expect(prompt.next()).resolves.toMatchObject({
+        value: { message: { content: "Continue after the idle boundary" } },
+      });
+      await expect(prompt.next()).resolves.toMatchObject({
+        value: {
+          message: {
+            content: expect.stringContaining(
+              "Deliver this fresh Goal on the next Claude turn",
+            ),
+          },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(deliveryRows(next.database, runtimeSessionId)).toEqual([
+          expect.objectContaining({
+            instructionId: activation.instruction.id,
+            state: "written_to_sdk",
+            attempt: 1,
+          }),
+        ]);
+      });
+    } finally {
+      await nextRegistration?.release();
+      await nextClaude.close();
+    }
+  });
+
+  it("persists the exact resume identity and fences recovery claims across reopen", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "recovery-identity";
+    const descriptor: RuntimeRecoveryDescriptor = {
+      schemaVersion: 1,
+      model: "claude-sonnet",
+      permissionMode: "default",
+      allowedTools: ["Read", "Edit"],
+      disallowedTools: ["Bash(rm:*)"],
+      sandbox: { enabled: true, provider: "docker", image: "openloomi:test" },
+      skillsConfig: {
+        enabled: true,
+        userDirEnabled: true,
+        appDirEnabled: false,
+      },
+      mcpConfig: {
+        enabled: true,
+        userDirEnabled: false,
+        appDirEnabled: true,
+      },
+    };
+
+    await first.recovery.ensure(OWNER_ID, runtimeSessionId, {
+      workingDirectory: first.workingDirectory,
+      recoveryDescriptor: descriptor,
+    });
+    const liveLease = await first.recovery.claimLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "initial-runtime-host",
+    });
+    if (!liveLease) throw new Error("Expected initial live Runtime ownership");
+    const activation = await first.runtime.goals.activate({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      idempotencyKey: "activate-recovery-identity",
+      source: { type: "user", authority: "user" },
+      goal: goalInput("Resume the same Claude execution"),
+    });
+    await first.recovery.bindProviderSession({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      providerSessionId: "claude-session-resume-1",
+      runtimeLeaseToken: liveLease.leaseToken,
+      expectedRunEpoch: liveLease.runEpoch,
+    });
+    await first.recovery.releaseLiveRuntime({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: liveLease.leaseOwner,
+      leaseToken: liveLease.leaseToken,
+      expectedRunEpoch: liveLease.runEpoch,
+    });
+    expect(
+      first.database
+        .prepare(
+          "SELECT provider_session_id FROM agent_runtime_sessions WHERE id = ?",
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ provider_session_id: "claude-session-resume-1" });
+    first.close();
+
+    const recovered = first.reopen();
+    await expect(recovered.recovery.listRecoverable()).resolves.toEqual([
+      expect.objectContaining({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        providerSessionId: "claude-session-resume-1",
+        workingDirectory: recovered.workingDirectory,
+        runEpoch: 0,
+      }),
+    ]);
+    const firstClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "recovery-worker-a",
+      leaseDurationMs: 30_000,
+    });
+    expect(firstClaim).not.toBeNull();
+    if (!firstClaim) {
+      throw new Error("Expected the first recovery claim to succeed");
+    }
+    expect(firstClaim?.snapshot).toMatchObject({
+      session: {
+        providerSessionId: "claude-session-resume-1",
+        workingDirectory: recovered.workingDirectory,
+      },
+      recoveryDescriptor: descriptor,
+      activeGoal: { goal: { id: activation.goal.goal.id } },
+      replayableInstructionIds: [activation.instruction.id],
+    });
+
+    const competing = recovered.reopen();
+    await expect(
+      competing.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "recovery-worker-b",
+        leaseDurationMs: 30_000,
+      }),
+    ).resolves.toBeNull();
+
+    recovered.advance(31);
+    const replacementClaim = await competing.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "recovery-worker-b",
+      leaseDurationMs: 30_000,
+    });
+    expect(replacementClaim?.leaseToken).toEqual(expect.any(String));
+    expect(replacementClaim?.leaseToken).not.toBe(firstClaim?.leaseToken);
+    if (!replacementClaim) {
+      throw new Error("Expected the expired recovery claim to be reclaimable");
+    }
+
+    await expect(
+      recovered.recovery.ensure(OWNER_ID, runtimeSessionId, {
+        recoveryLeaseToken: firstClaim.leaseToken,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+    await expect(
+      recovered.recovery.releaseRecoveryLease({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "recovery-worker-a",
+        leaseToken: firstClaim.leaseToken,
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+
+    await competing.recovery.releaseRecoveryLease({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "recovery-worker-b",
+      leaseToken: replacementClaim.leaseToken,
+    });
+    expect(
+      competing.database
+        .prepare(
+          `SELECT provider_session_id, recovery_lease_token
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({
+      provider_session_id: "claude-session-resume-1",
+      recovery_lease_token: null,
+    });
+  });
+
+  it("starts a normal runtime with only the disabled sandbox state persisted", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "disabled-legacy-sandbox";
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const claude = new ClaudeRuntimeSession({
+      runtimeSessionId,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "disabled-sandbox-message",
+    });
+    const legacySandbox = {
+      enabled: false,
+      provider: "docker",
+      image:
+        "https://registry-user:registry-secret@registry.example.com/openloomi:test",
+      apiEndpoint: "https://sandbox.example.test?token=legacy-secret",
+      providerConfig: { networkToken: "legacy-secret" },
+    } as NonNullable<RuntimeRecoveryDescriptor["sandbox"]>;
+
+    const registration = await startClaudeGoalRuntimeSession({
+      session: { user: { id: OWNER_ID } },
+      runtime: claude,
+      start: { initialPrompt: "Start without sandboxing" },
+      goalRuntime: runtime.runtime,
+      persistence: {
+        workingDirectory: runtime.workingDirectory,
+        recoveryDescriptor: {
+          schemaVersion: 1,
+          sandbox: legacySandbox,
+        },
+      },
+    });
+
+    expect(sdk.queryInput).toBeDefined();
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT recovery_descriptor AS recoveryDescriptor
+             FROM agent_runtime_sessions WHERE id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({
+      recoveryDescriptor: JSON.stringify({
+        schemaVersion: 1,
+        sandbox: { enabled: false },
+      }),
+    });
+
+    await registration?.release();
+    await claude.close();
+  });
+
+  it("rejects the same legacy sandbox metadata when sandboxing is enabled", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "enabled-legacy-sandbox";
+    const handle = createControlledClaudeQuery();
+    const sdk = createFakeClaudeSdkTransport(handle);
+    const claude = new ClaudeRuntimeSession({
+      runtimeSessionId,
+      runEpoch: 0,
+      sdkTransport: sdk.transport,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      createMessageId: () => "enabled-sandbox-message",
+    });
+
+    await expect(
+      startClaudeGoalRuntimeSession({
+        session: { user: { id: OWNER_ID } },
+        runtime: claude,
+        start: { initialPrompt: "Start with sandboxing" },
+        goalRuntime: runtime.runtime,
+        persistence: {
+          workingDirectory: runtime.workingDirectory,
+          recoveryDescriptor: {
+            schemaVersion: 1,
+            sandbox: {
+              enabled: true,
+              provider: "docker",
+              image:
+                "https://registry-user:registry-secret@registry.example.com/openloomi:test",
+            },
+          },
+        },
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_configuration_invalid",
+    );
+    expect(sdk.queryInput).toBeUndefined();
+    expect(
+      runtime.database
+        .prepare("SELECT count(*) AS count FROM agent_runtime_sessions")
+        .get(),
+    ).toEqual({ count: 0 });
+  });
+
+  it("enforces recovery metadata invariants in migrated SQLite databases", async () => {
+    const runtime = createFileBackedRuntime();
+    await runtime.recovery.ensure(OWNER_ID, "recovery-database-checks");
+
+    expect(() =>
+      runtime.database
+        .prepare(
+          `UPDATE agent_runtime_sessions SET recovery_descriptor = '[]'
+            WHERE id = ?`,
+        )
+        .run("recovery-database-checks"),
+    ).toThrow("invalid agent runtime recovery state");
+    expect(() =>
+      runtime.database
+        .prepare(
+          `UPDATE agent_runtime_sessions SET recovery_lease_owner = 'orphan'
+            WHERE id = ?`,
+        )
+        .run("recovery-database-checks"),
+    ).toThrow("invalid agent runtime recovery state");
+  });
+
+  it("replays delivery attempts until Claude has observed them", async () => {
+    const runtime = createFileBackedRuntime();
+    const written = await activate(runtime, "recovery-written");
+    const observed = await activate(runtime, "recovery-observed");
+    const staleObserved = await activate(runtime, "recovery-stale-observed");
+    const leased = await activate(runtime, "recovery-leased");
+    const queued = await activate(runtime, "recovery-queued");
+
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_deliveries
+            SET state = 'written_to_sdk', provider_event_id = 'provider-write-1'
+          WHERE instruction_id = ?`,
+      )
+      .run(written.instruction.id);
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_deliveries
+            SET state = 'observed', provider_event_id = 'provider-observed-1'
+          WHERE instruction_id = ?`,
+      )
+      .run(observed.instruction.id);
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_deliveries
+            SET state = 'observed', provider_event_id = 'provider-stale-observed-1'
+          WHERE instruction_id = ?`,
+      )
+      .run(staleObserved.instruction.id);
+    const currentUpdate = await runtime.runtime.goals.update({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-stale-observed",
+      goalId: staleObserved.goal.goal.id,
+      expectedRevision: staleObserved.goal.goal.revision,
+      idempotencyKey: "revise-recovery-stale-observed",
+      source: { type: "user", authority: "user" },
+      update: { priority: 81 },
+    });
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_deliveries
+            SET state = 'leased', lease_token = 'dead-lease',
+                lease_owner = 'dead-worker', lease_expires_at = ?
+          WHERE instruction_id = ?`,
+      )
+      .run(Math.floor(START.getTime() / 1_000) - 1, leased.instruction.id);
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_deliveries SET state = 'queued'
+          WHERE instruction_id = ?`,
+      )
+      .run(queued.instruction.id);
+    runtime.close();
+
+    const recovered = runtime.reopen();
+    const writtenClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-written",
+      leaseOwner: "delivery-recovery",
+    });
+    expect(writtenClaim?.snapshot).toMatchObject({
+      replayableInstructionIds: [written.instruction.id],
+      instructionSettlements: [],
+      reconciliation: { writtenAttemptsRetried: 1 },
+    });
+    expect(deliveryRows(recovered.database, "recovery-written")).toEqual([
+      expect.objectContaining({
+        state: "failed",
+        attempt: 1,
+        errorCode: "runtime_restarted_before_provider_observation",
+      }),
+      expect.objectContaining({ state: "pending", attempt: 2 }),
+    ]);
+    if (!writtenClaim) {
+      throw new Error(
+        "Expected the written Delivery recovery claim to succeed",
+      );
+    }
+    const redeliveredInstructionIds: string[] = [];
+    const transport = {
+      runtimeSessionId: "recovery-written",
+      async deliver(instruction: (typeof written)["instruction"]) {
+        redeliveredInstructionIds.push(instruction.id);
+        return {
+          instructionId: instruction.id,
+          runtimeSessionId: instruction.targetSessionId,
+          state: "written_to_sdk" as const,
+          recordedAt: START.toISOString(),
+        };
+      },
+      async interrupt() {},
+    };
+    const registration = recovered.runtime.sessions.register({
+      ownerId: OWNER_ID,
+      transport,
+    });
+    await recovered.runtime.dispatcher.initializeRecoveredProgress({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-written",
+      transport,
+      settlements: writtenClaim.snapshot.instructionSettlements,
+    });
+    await expect(
+      recovered.runtime.goals.replayPendingInstructions(
+        OWNER_ID,
+        "recovery-written",
+      ),
+    ).resolves.toMatchObject({ status: "accepted" });
+    expect(redeliveredInstructionIds).toEqual([written.instruction.id]);
+    registration.release();
+
+    const observedClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-observed",
+      leaseOwner: "delivery-recovery",
+    });
+    expect(observedClaim?.snapshot).toMatchObject({
+      replayableInstructionIds: [],
+      instructionSettlements: [
+        {
+          instructionId: observed.instruction.id,
+          disposition: "accepted",
+          providerEventId: "provider-observed-1",
+        },
+      ],
+    });
+    expect(deliveryRows(recovered.database, "recovery-observed")).toEqual([
+      expect.objectContaining({ state: "applied", attempt: 1 }),
+    ]);
+
+    const staleObservedClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-stale-observed",
+      leaseOwner: "delivery-recovery",
+    });
+    expect(staleObservedClaim?.snapshot).toMatchObject({
+      replayableInstructionIds: [currentUpdate.instruction.id],
+      instructionSettlements: [
+        {
+          instructionId: staleObserved.instruction.id,
+          disposition: "superseded",
+          reason: expect.stringContaining("stale Goal revision"),
+        },
+      ],
+    });
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT state, error_code AS errorCode
+             FROM agent_runtime_deliveries WHERE instruction_id = ?`,
+        )
+        .get(staleObserved.instruction.id),
+    ).toEqual({ state: "failed", errorCode: "stale_runtime_fence" });
+
+    const leasedClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-leased",
+      leaseOwner: "delivery-recovery",
+    });
+    expect(leasedClaim?.snapshot).toMatchObject({
+      replayableInstructionIds: [leased.instruction.id],
+      reconciliation: { leasesReclaimed: 1 },
+    });
+    expect(deliveryRows(recovered.database, "recovery-leased")).toEqual([
+      expect.objectContaining({
+        state: "pending",
+        attempt: 1,
+        leaseToken: null,
+      }),
+    ]);
+
+    const queuedClaim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-queued",
+      leaseOwner: "delivery-recovery",
+    });
+    expect(queuedClaim?.snapshot).toMatchObject({
+      replayableInstructionIds: [queued.instruction.id],
+      reconciliation: { queuedAttemptsRetried: 1 },
+    });
+    expect(deliveryRows(recovered.database, "recovery-queued")).toEqual([
+      expect.objectContaining({
+        state: "failed",
+        attempt: 1,
+        errorCode: "runtime_restarted_before_provider_write",
+      }),
+      expect.objectContaining({ state: "pending", attempt: 2 }),
+    ]);
+  });
+
+  it("fences delayed recovery failures by run epoch and lease expiry", async () => {
+    const runtime = createFileBackedRuntime();
+    await activate(runtime, "recovery-stale-epoch");
+    await activate(runtime, "recovery-expired-lease");
+
+    const epochClaim = await runtime.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-stale-epoch",
+      leaseOwner: "failure-worker",
+      leaseDurationMs: 30_000,
+    });
+    const expiryClaim = await runtime.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId: "recovery-expired-lease",
+      leaseOwner: "failure-worker",
+      leaseDurationMs: 30_000,
+    });
+    if (!epochClaim || !expiryClaim) {
+      throw new Error("Expected both Runtimes to be claimed");
+    }
+
+    runtime.database
+      .prepare(
+        `UPDATE agent_runtime_sessions SET run_epoch = run_epoch + 1
+          WHERE owner_id = ? AND id = ?`,
+      )
+      .run(OWNER_ID, "recovery-stale-epoch");
+    await expect(
+      runtime.recovery.markRecoveryFailed({
+        ownerId: OWNER_ID,
+        runtimeSessionId: "recovery-stale-epoch",
+        leaseOwner: "failure-worker",
+        leaseToken: epochClaim.leaseToken,
+        expectedRunEpoch: epochClaim.snapshot.session.runEpoch,
+        errorCode: "provider_resume_failed",
+        errorMessage: "Delayed failure from the prior epoch",
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+
+    runtime.advance(31);
+    await expect(
+      runtime.recovery.markRecoveryFailed({
+        ownerId: OWNER_ID,
+        runtimeSessionId: "recovery-expired-lease",
+        leaseOwner: "failure-worker",
+        leaseToken: expiryClaim.leaseToken,
+        expectedRunEpoch: expiryClaim.snapshot.session.runEpoch,
+        errorCode: "provider_resume_failed",
+        errorMessage: "Delayed failure after the lease expired",
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        recoveryErrorCode(error) === "runtime_recovery_claim_conflict",
+    );
+
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT id, state FROM agent_runtime_sessions
+            WHERE id IN (?, ?) ORDER BY id`,
+        )
+        .all("recovery-stale-epoch", "recovery-expired-lease"),
+    ).toEqual([
+      { id: "recovery-expired-lease", state: "starting" },
+      { id: "recovery-stale-epoch", state: "starting" },
+    ]);
+    expect(
+      runtime.database
+        .prepare(
+          `SELECT runtime_session_id AS runtimeSessionId, status
+             FROM agent_goals
+            WHERE runtime_session_id IN (?, ?)
+            ORDER BY runtime_session_id`,
+        )
+        .all("recovery-stale-epoch", "recovery-expired-lease"),
+    ).toEqual([
+      { runtimeSessionId: "recovery-expired-lease", status: "active" },
+      { runtimeSessionId: "recovery-stale-epoch", status: "active" },
+    ]);
+  });
+
+  it("atomically blocks active Goal state when provider resume fails", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "recovery-resume-failed";
+    await activate(first, runtimeSessionId);
+    first.database
+      .prepare(
+        `UPDATE agent_goal_runs SET status = 'running'
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(OWNER_ID, runtimeSessionId);
+    first.close();
+
+    const recovered = first.reopen();
+    const claim = await recovered.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "resume-worker",
+    });
+    if (!claim) throw new Error("Expected the failed Runtime to be claimed");
+
+    recovered.database.exec(`
+      CREATE TRIGGER reject_blocked_run
+      BEFORE UPDATE OF status ON agent_goal_runs
+      WHEN NEW.status = 'blocked'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced Goal Run failure');
+      END;
+    `);
+    await expect(
+      recovered.recovery.markRecoveryFailed({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "resume-worker",
+        leaseToken: claim.leaseToken,
+        expectedRunEpoch: claim.snapshot.session.runEpoch,
+        errorCode: "provider_session_missing",
+        errorMessage: "Claude could not resume the persisted session",
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) => recoveryErrorCode(error) === "storage_failure",
+    );
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT
+             (SELECT state FROM agent_runtime_sessions WHERE id = ?) AS sessionState,
+             (SELECT status FROM agent_goals WHERE runtime_session_id = ?) AS goalStatus,
+             (SELECT status FROM agent_goal_runs WHERE runtime_session_id = ?) AS runStatus,
+             (SELECT recovery_lease_token FROM agent_runtime_sessions WHERE id = ?) AS leaseToken`,
+        )
+        .get(
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+        ),
+    ).toEqual({
+      sessionState: "starting",
+      goalStatus: "active",
+      runStatus: "running",
+      leaseToken: claim.leaseToken,
+    });
+
+    recovered.database.exec("DROP TRIGGER reject_blocked_run");
+    await recovered.recovery.markRecoveryFailed({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "resume-worker",
+      leaseToken: claim.leaseToken,
+      expectedRunEpoch: claim.snapshot.session.runEpoch,
+      errorCode: "provider_session_missing",
+      errorMessage: "Claude could not resume the persisted session",
+    });
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT
+             (SELECT state FROM agent_runtime_sessions WHERE id = ?) AS sessionState,
+             (SELECT recovery_error_code FROM agent_runtime_sessions WHERE id = ?) AS errorCode,
+             (SELECT recovery_lease_token FROM agent_runtime_sessions WHERE id = ?) AS leaseToken,
+             (SELECT status FROM agent_goals WHERE runtime_session_id = ?) AS goalStatus,
+             (SELECT revision FROM agent_goals WHERE runtime_session_id = ?) AS goalRevision,
+             (SELECT status FROM agent_goal_runs WHERE runtime_session_id = ?) AS runStatus,
+             (SELECT goal_revision FROM agent_goal_runs WHERE runtime_session_id = ?) AS runRevision`,
+        )
+        .get(
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+        ),
+    ).toEqual({
+      sessionState: "failed",
+      errorCode: "provider_session_missing",
+      leaseToken: null,
+      goalStatus: "blocked",
+      goalRevision: 2,
+      runStatus: "blocked",
+      runRevision: 2,
+    });
+    await expect(recovered.recovery.listRecoverable()).resolves.toEqual([]);
+  });
+
+  it("deduplicates a provider event durably after the database is reopened", async () => {
+    const first = createFileBackedRuntime();
+    const runtimeSessionId = "recovery-provider-event";
+    const activation = await activate(first, runtimeSessionId);
+    await first.runtime.observations.prepareDelivery({
+      ownerId: OWNER_ID,
+      instruction: activation.instruction,
+    });
+    await first.runtime.observations.recordInstructionHandoff({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      instructionId: activation.instruction.id,
+      runEpoch: 0,
+      recordedAt: START.toISOString(),
+    });
+    const context = await first.runtime.observations.captureContext({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      runEpoch: 0,
+    });
+    if (!context) throw new Error("Expected a durable observation context");
+
+    const observation = {
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      runEpoch: 0,
+      eventKey: "claude-result-1",
+      providerEventId: "claude-result-1",
+      observedAt: START.toISOString(),
+      terminal: true,
+      context,
+      usage: { turnsUsed: 1, tokensUsed: 7 },
+      evidence: [
+        {
+          type: "tool_result" as const,
+          sourceEventId: "claude-result-1:test",
+          summary: "Focused test passed",
+          success: true,
+          payload: { toolName: "test", outcome: "passed" },
+          observedAt: START.toISOString(),
+        },
+      ],
+    };
+    await expect(
+      first.runtime.observations.observeProviderEvent(observation),
+    ).resolves.toBe(true);
+    first.close();
+
+    const recovered = first.reopen();
+    const replayedAt = new Date(START.getTime() + 30_000).toISOString();
+    const replayedObservation = {
+      ...observation,
+      observedAt: replayedAt,
+      evidence: observation.evidence.map((item) => ({
+        ...item,
+        observedAt: replayedAt,
+      })),
+    };
+    await expect(
+      recovered.runtime.observations.observeProviderEvent(replayedObservation),
+    ).resolves.toBe(false);
+    await expect(
+      recovered.runtime.observations.observeProviderEvent({
+        ...replayedObservation,
+        usage: { turnsUsed: 1, tokensUsed: 8 },
+      }),
+    ).rejects.toMatchObject({
+      code: "conflict",
+      message: expect.stringContaining("reused with different event data"),
+    });
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT turns_used AS turnsUsed, tokens_used AS tokensUsed
+             FROM agent_goal_runs WHERE runtime_session_id = ?`,
+        )
+        .get(runtimeSessionId),
+    ).toEqual({ turnsUsed: 1, tokensUsed: 7 });
+    expect(
+      recovered.database
+        .prepare(
+          `SELECT
+             (SELECT count(*) FROM agent_runtime_provider_events
+               WHERE runtime_session_id = ?) AS providerEvents,
+             (SELECT count(*) FROM agent_goal_evidence
+               WHERE runtime_session_id = ?) AS evidence`,
+        )
+        .get(runtimeSessionId, runtimeSessionId),
+    ).toEqual({ providerEvents: 1, evidence: 1 });
+  });
+});

--- a/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
@@ -33,7 +33,7 @@ import {
 
 const OWNER_ID = "10000000-0000-4000-8000-000000000001";
 const START = new Date("2026-08-10T08:00:00.000Z");
-const MIGRATIONS = [
+const BASE_MIGRATIONS = [
   "0107_agent_goal_runtime.sql",
   "0108_agent_goal_runtime_recovery.sql",
 ].map((migration) =>
@@ -46,6 +46,14 @@ const MIGRATIONS = [
     "utf8",
   ),
 );
+const RECOVERY_PAUSE_MIGRATION = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../lib/db/migrations-sqlite/0109_agent_goal_recovery_pause.sql",
+  ),
+  "utf8",
+);
+const MIGRATIONS = [...BASE_MIGRATIONS, RECOVERY_PAUSE_MIGRATION];
 
 const openDatabases = new Set<Database.Database>();
 const temporaryDirectories = new Set<string>();
@@ -75,12 +83,14 @@ interface FileBackedRuntime {
   reopen(): FileBackedRuntime;
 }
 
-function createFileBackedRuntime(): FileBackedRuntime {
+function createFileBackedRuntime(
+  migrations: readonly string[] = MIGRATIONS,
+): FileBackedRuntime {
   const directory = mkdtempSync(join(tmpdir(), "openloomi-goal-recovery-"));
   temporaryDirectories.add(directory);
   const path = join(directory, "runtime.sqlite");
   let now = START;
-  initializeDatabase(path);
+  initializeDatabase(path, migrations);
 
   const open = (): FileBackedRuntime => {
     const database = new Database(path);
@@ -114,11 +124,11 @@ function createFileBackedRuntime(): FileBackedRuntime {
   return open();
 }
 
-function initializeDatabase(path: string): void {
+function initializeDatabase(path: string, migrations: readonly string[]): void {
   const database = new Database(path);
   database.pragma("foreign_keys = ON");
   database.exec('CREATE TABLE "User" ("id" text PRIMARY KEY NOT NULL)');
-  for (const migration of MIGRATIONS) database.exec(migration);
+  for (const migration of migrations) database.exec(migration);
   database.prepare('INSERT INTO "User" (id) VALUES (?)').run(OWNER_ID);
   database.close();
 }
@@ -1778,7 +1788,7 @@ describe("SQLite Runtime restart recovery", () => {
       )
       .run(OWNER_ID, "recovery-stale-epoch");
     await expect(
-      runtime.recovery.markRecoveryFailed({
+      runtime.recovery.pauseAfterRecoveryFailure({
         ownerId: OWNER_ID,
         runtimeSessionId: "recovery-stale-epoch",
         leaseOwner: "failure-worker",
@@ -1794,7 +1804,7 @@ describe("SQLite Runtime restart recovery", () => {
 
     runtime.advance(31);
     await expect(
-      runtime.recovery.markRecoveryFailed({
+      runtime.recovery.pauseAfterRecoveryFailure({
         ownerId: OWNER_ID,
         runtimeSessionId: "recovery-expired-lease",
         leaseOwner: "failure-worker",
@@ -1834,7 +1844,167 @@ describe("SQLite Runtime restart recovery", () => {
     ]);
   });
 
-  it("atomically blocks active Goal state when provider resume fails", async () => {
+  it("repairs only legacy restart-recovery failures into resumable paused state", async () => {
+    const legacy = createFileBackedRuntime(BASE_MIGRATIONS);
+    const blockedSessionId = "legacy-recovery-blocked";
+    const failedSessionId = "legacy-recovery-failed";
+    const evaluatorBlockedSessionId = "ordinary-evaluator-blocked";
+    for (const runtimeSessionId of [
+      blockedSessionId,
+      failedSessionId,
+      evaluatorBlockedSessionId,
+    ]) {
+      await activate(legacy, runtimeSessionId);
+    }
+
+    const legacyEvaluation = JSON.stringify({
+      completed: false,
+      confidence: 0,
+      satisfiedCriteria: [],
+      missingCriteria: ["result-recorded"],
+      evidence: [],
+      reason: "Goal recovery failed: persisted provider session was missing",
+    });
+    for (const runtimeSessionId of [blockedSessionId, failedSessionId]) {
+      legacy.database
+        .prepare(
+          `UPDATE agent_runtime_sessions
+              SET state = 'failed', provider_session_id = ?,
+                  recovery_error_code = 'provider_session_unavailable',
+                  recovery_error_message = 'persisted provider session was missing',
+                  recovery_failed_at = unixepoch(), updated_at = unixepoch()
+            WHERE owner_id = ? AND id = ?`,
+        )
+        .run(`provider-${runtimeSessionId}`, OWNER_ID, runtimeSessionId);
+      legacy.database
+        .prepare(
+          `UPDATE agent_goals
+              SET revision = 2, status = 'blocked',
+                  goal_snapshot = json_set(
+                    goal_snapshot, '$.revision', 2, '$.status', 'blocked'
+                  )
+            WHERE owner_id = ? AND runtime_session_id = ?`,
+        )
+        .run(OWNER_ID, runtimeSessionId);
+    }
+    legacy.database
+      .prepare(
+        `UPDATE agent_goal_runs
+            SET goal_revision = 2, status = 'blocked',
+                last_evaluation = ?
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(legacyEvaluation, OWNER_ID, blockedSessionId);
+    legacy.database
+      .prepare(
+        `UPDATE agent_goal_runs
+            SET goal_revision = 2, status = 'failed',
+                completed_at = unixepoch(), last_evaluation = ?
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(legacyEvaluation, OWNER_ID, failedSessionId);
+
+    legacy.database
+      .prepare(
+        `UPDATE agent_runtime_sessions SET state = 'interrupted'
+          WHERE owner_id = ? AND id = ?`,
+      )
+      .run(OWNER_ID, evaluatorBlockedSessionId);
+    legacy.database
+      .prepare(
+        `UPDATE agent_goals
+            SET status = 'blocked',
+                goal_snapshot = json_set(goal_snapshot, '$.status', 'blocked')
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(OWNER_ID, evaluatorBlockedSessionId);
+    legacy.database
+      .prepare(
+        `UPDATE agent_goal_runs SET status = 'blocked'
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(OWNER_ID, evaluatorBlockedSessionId);
+
+    legacy.database.exec(RECOVERY_PAUSE_MIGRATION);
+    legacy.database.exec(RECOVERY_PAUSE_MIGRATION);
+
+    for (const runtimeSessionId of [blockedSessionId, failedSessionId]) {
+      const repaired = legacy.database
+        .prepare(
+          `SELECT
+             session.state AS sessionState,
+             session.provider_session_id AS providerSessionId,
+             session.recovery_error_code AS errorCode,
+             session.recovery_error_message AS errorMessage,
+             session.recovery_failed_at AS recoveryFailedAt,
+             session.recovery_lease_token AS leaseToken,
+             goal.status AS goalStatus,
+             goal.revision AS goalRevision,
+             json_extract(goal.goal_snapshot, '$.status') AS snapshotStatus,
+             json_extract(goal.goal_snapshot, '$.updatedAt') AS snapshotUpdatedAt,
+             goal.updated_at AS goalUpdatedAt,
+             run.status AS runStatus,
+             run.completed_at AS completedAt,
+             json_extract(run.last_evaluation, '$.reason') AS failureReason
+           FROM agent_runtime_sessions AS session
+           JOIN agent_goals AS goal
+             ON goal.owner_id = session.owner_id
+            AND goal.runtime_session_id = session.id
+            AND goal.slot_state = 'assigned'
+           JOIN agent_goal_runs AS run
+             ON run.owner_id = session.owner_id
+            AND run.runtime_session_id = session.id
+            AND run.goal_id = goal.id
+            AND run.run_epoch = session.run_epoch
+          WHERE session.owner_id = ? AND session.id = ?`,
+        )
+        .get(OWNER_ID, runtimeSessionId) as Record<string, unknown>;
+      expect(repaired).toMatchObject({
+        sessionState: "idle",
+        providerSessionId: `provider-${runtimeSessionId}`,
+        errorCode: null,
+        errorMessage: null,
+        recoveryFailedAt: null,
+        leaseToken: null,
+        goalStatus: "paused",
+        goalRevision: 2,
+        snapshotStatus: "paused",
+        runStatus: "paused",
+        completedAt: null,
+        failureReason:
+          "Goal recovery failed: persisted provider session was missing",
+      });
+      expect(
+        Math.floor(
+          new Date(String(repaired.snapshotUpdatedAt)).getTime() / 1_000,
+        ),
+      ).toBe(repaired.goalUpdatedAt);
+    }
+
+    expect(
+      legacy.database
+        .prepare(
+          `SELECT session.state AS sessionState, goal.status AS goalStatus,
+                  run.status AS runStatus
+             FROM agent_runtime_sessions AS session
+             JOIN agent_goals AS goal
+               ON goal.owner_id = session.owner_id
+              AND goal.runtime_session_id = session.id
+             JOIN agent_goal_runs AS run
+               ON run.owner_id = goal.owner_id
+              AND run.runtime_session_id = goal.runtime_session_id
+              AND run.goal_id = goal.id
+            WHERE session.owner_id = ? AND session.id = ?`,
+        )
+        .get(OWNER_ID, evaluatorBlockedSessionId),
+    ).toEqual({
+      sessionState: "interrupted",
+      goalStatus: "blocked",
+      runStatus: "blocked",
+    });
+  });
+
+  it("atomically pauses active Goal state when provider resume fails", async () => {
     const first = createFileBackedRuntime();
     const runtimeSessionId = "recovery-resume-failed";
     await activate(first, runtimeSessionId);
@@ -1844,6 +2014,12 @@ describe("SQLite Runtime restart recovery", () => {
           WHERE owner_id = ? AND runtime_session_id = ?`,
       )
       .run(OWNER_ID, runtimeSessionId);
+    first.database
+      .prepare(
+        `UPDATE agent_runtime_sessions SET provider_session_id = ?
+          WHERE owner_id = ? AND id = ?`,
+      )
+      .run("provider-resume-failed", OWNER_ID, runtimeSessionId);
     first.close();
 
     const recovered = first.reopen();
@@ -1855,15 +2031,15 @@ describe("SQLite Runtime restart recovery", () => {
     if (!claim) throw new Error("Expected the failed Runtime to be claimed");
 
     recovered.database.exec(`
-      CREATE TRIGGER reject_blocked_run
+      CREATE TRIGGER reject_paused_run
       BEFORE UPDATE OF status ON agent_goal_runs
-      WHEN NEW.status = 'blocked'
+      WHEN NEW.status = 'paused'
       BEGIN
         SELECT RAISE(ABORT, 'forced Goal Run failure');
       END;
     `);
     await expect(
-      recovered.recovery.markRecoveryFailed({
+      recovered.recovery.pauseAfterRecoveryFailure({
         ownerId: OWNER_ID,
         runtimeSessionId,
         leaseOwner: "resume-worker",
@@ -1897,8 +2073,8 @@ describe("SQLite Runtime restart recovery", () => {
       leaseToken: claim.leaseToken,
     });
 
-    recovered.database.exec("DROP TRIGGER reject_blocked_run");
-    await recovered.recovery.markRecoveryFailed({
+    recovered.database.exec("DROP TRIGGER reject_paused_run");
+    await recovered.recovery.pauseAfterRecoveryFailure({
       ownerId: OWNER_ID,
       runtimeSessionId,
       leaseOwner: "resume-worker",
@@ -1913,7 +2089,10 @@ describe("SQLite Runtime restart recovery", () => {
           `SELECT
              (SELECT state FROM agent_runtime_sessions WHERE id = ?) AS sessionState,
              (SELECT recovery_error_code FROM agent_runtime_sessions WHERE id = ?) AS errorCode,
+             (SELECT recovery_error_message FROM agent_runtime_sessions WHERE id = ?) AS errorMessage,
+             (SELECT recovery_failed_at FROM agent_runtime_sessions WHERE id = ?) AS recoveryFailedAt,
              (SELECT recovery_lease_token FROM agent_runtime_sessions WHERE id = ?) AS leaseToken,
+             (SELECT provider_session_id FROM agent_runtime_sessions WHERE id = ?) AS providerSessionId,
              (SELECT status FROM agent_goals WHERE runtime_session_id = ?) AS goalStatus,
              (SELECT revision FROM agent_goals WHERE runtime_session_id = ?) AS goalRevision,
              (SELECT status FROM agent_goal_runs WHERE runtime_session_id = ?) AS runStatus,
@@ -1927,18 +2106,72 @@ describe("SQLite Runtime restart recovery", () => {
           runtimeSessionId,
           runtimeSessionId,
           runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
+          runtimeSessionId,
         ),
     ).toEqual({
-      sessionState: "failed",
-      errorCode: "provider_session_missing",
+      sessionState: "idle",
+      errorCode: null,
+      errorMessage: null,
+      recoveryFailedAt: null,
       leaseToken: null,
-      goalStatus: "blocked",
+      providerSessionId: "provider-resume-failed",
+      goalStatus: "paused",
       goalRevision: 2,
-      runStatus: "blocked",
+      runStatus: "paused",
       runRevision: 2,
     });
     await expect(recovered.recovery.listRecoverable()).resolves.toEqual([]);
   });
+
+  it.each(["queued", "evaluating", "continuing"] as const)(
+    "pauses a %s Goal Run without finalizing it after recovery failure",
+    async (runStatus) => {
+      const runtime = createFileBackedRuntime();
+      const runtimeSessionId = `recovery-pause-${runStatus}`;
+      await activate(runtime, runtimeSessionId);
+      if (runStatus !== "queued") {
+        runtime.database
+          .prepare(
+            `UPDATE agent_goal_runs SET status = ?
+              WHERE owner_id = ? AND runtime_session_id = ?`,
+          )
+          .run(runStatus, OWNER_ID, runtimeSessionId);
+      }
+      const claim = await runtime.recovery.claimRecovery({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "resume-worker",
+      });
+      if (!claim) throw new Error("Expected the Runtime to be claimed");
+
+      await runtime.recovery.pauseAfterRecoveryFailure({
+        ownerId: OWNER_ID,
+        runtimeSessionId,
+        leaseOwner: "resume-worker",
+        leaseToken: claim.leaseToken,
+        expectedRunEpoch: claim.snapshot.session.runEpoch,
+        errorCode: "provider_resume_failed",
+        errorMessage: `${runStatus} provider failure`,
+      });
+
+      expect(
+        runtime.database
+          .prepare(
+            `SELECT status, completed_at AS completedAt,
+                    json_extract(last_evaluation, '$.reason') AS reason
+               FROM agent_goal_runs
+              WHERE owner_id = ? AND runtime_session_id = ?`,
+          )
+          .get(OWNER_ID, runtimeSessionId),
+      ).toEqual({
+        status: "paused",
+        completedAt: null,
+        reason: `Goal recovery paused (provider_resume_failed): ${runStatus} provider failure`,
+      });
+    },
+  );
 
   it("deduplicates a provider event durably after the database is reopened", async () => {
     const first = createFileBackedRuntime();

--- a/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
+++ b/apps/web/tests/unit/runtime-instructions/sqlite-runtime-recovery.test.ts
@@ -53,7 +53,20 @@ const RECOVERY_PAUSE_MIGRATION = readFileSync(
   ),
   "utf8",
 );
-const MIGRATIONS = [...BASE_MIGRATIONS, RECOVERY_PAUSE_MIGRATION];
+const EVALUATION_PAUSE_MIGRATION = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../../../lib/db/migrations-sqlite/0110_agent_goal_evaluation_pause.sql",
+      import.meta.url,
+    ),
+  ),
+  "utf8",
+);
+const MIGRATIONS = [
+  ...BASE_MIGRATIONS,
+  RECOVERY_PAUSE_MIGRATION,
+  EVALUATION_PAUSE_MIGRATION,
+];
 
 const openDatabases = new Set<Database.Database>();
 const temporaryDirectories = new Set<string>();
@@ -1844,7 +1857,7 @@ describe("SQLite Runtime restart recovery", () => {
     ]);
   });
 
-  it("repairs only legacy restart-recovery failures into resumable paused state", async () => {
+  it("repairs legacy recovery and evaluator blocks into resumable paused state", async () => {
     const legacy = createFileBackedRuntime(BASE_MIGRATIONS);
     const blockedSessionId = "legacy-recovery-blocked";
     const failedSessionId = "legacy-recovery-failed";
@@ -1920,10 +1933,11 @@ describe("SQLite Runtime restart recovery", () => {
       .run(OWNER_ID, evaluatorBlockedSessionId);
     legacy.database
       .prepare(
-        `UPDATE agent_goal_runs SET status = 'blocked'
+        `UPDATE agent_goal_runs
+            SET status = 'blocked', last_evaluation = ?
           WHERE owner_id = ? AND runtime_session_id = ?`,
       )
-      .run(OWNER_ID, evaluatorBlockedSessionId);
+      .run(legacyEvaluation, OWNER_ID, evaluatorBlockedSessionId);
 
     legacy.database.exec(RECOVERY_PAUSE_MIGRATION);
     legacy.database.exec(RECOVERY_PAUSE_MIGRATION);
@@ -2002,6 +2016,51 @@ describe("SQLite Runtime restart recovery", () => {
       goalStatus: "blocked",
       runStatus: "blocked",
     });
+
+    legacy.database.exec(EVALUATION_PAUSE_MIGRATION);
+    legacy.database.exec(EVALUATION_PAUSE_MIGRATION);
+    expect(
+      legacy.database
+        .prepare(
+          `SELECT session.state AS sessionState, goal.status AS goalStatus,
+                  json_extract(goal.goal_snapshot, '$.status') AS snapshotStatus,
+                  run.status AS runStatus, run.completed_at AS completedAt,
+                  json_extract(run.last_evaluation, '$.reason') AS evaluationReason
+             FROM agent_runtime_sessions AS session
+             JOIN agent_goals AS goal
+               ON goal.owner_id = session.owner_id
+              AND goal.runtime_session_id = session.id
+             JOIN agent_goal_runs AS run
+               ON run.owner_id = goal.owner_id
+              AND run.runtime_session_id = goal.runtime_session_id
+              AND run.goal_id = goal.id
+              AND run.run_epoch = session.run_epoch
+            WHERE session.owner_id = ? AND session.id = ?`,
+        )
+        .get(OWNER_ID, evaluatorBlockedSessionId) as Record<string, unknown>,
+    ).toMatchObject({
+      sessionState: "interrupted",
+      goalStatus: "paused",
+      snapshotStatus: "paused",
+      runStatus: "paused",
+      completedAt: null,
+      evaluationReason:
+        "Goal recovery failed: persisted provider session was missing",
+    });
+    const normalizedEvaluator = legacy.database
+      .prepare(
+        `SELECT json_extract(goal_snapshot, '$.updatedAt') AS snapshotUpdatedAt,
+                updated_at AS goalUpdatedAt
+           FROM agent_goals
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .get(OWNER_ID, evaluatorBlockedSessionId) as {
+      snapshotUpdatedAt: string;
+      goalUpdatedAt: number;
+    };
+    expect(
+      Math.floor(Date.parse(normalizedEvaluator.snapshotUpdatedAt) / 1_000),
+    ).toBe(normalizedEvaluator.goalUpdatedAt);
   });
 
   it("atomically pauses active Goal state when provider resume fails", async () => {
@@ -2172,6 +2231,74 @@ describe("SQLite Runtime restart recovery", () => {
       });
     },
   );
+
+  it("preserves certified progress when a later provider failure pauses recovery", async () => {
+    const runtime = createFileBackedRuntime();
+    const runtimeSessionId = "recovery-pause-preserves-progress";
+    await activate(runtime, runtimeSessionId);
+    runtime.database
+      .prepare(
+        `UPDATE agent_goal_runs
+            SET status = 'running',
+                last_evaluation = json(?)
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .run(
+        JSON.stringify({
+          completed: false,
+          confidence: 0.8,
+          satisfiedCriteria: ["result-recorded"],
+          missingCriteria: [],
+          evidence: [
+            {
+              criterionId: "result-recorded",
+              evidenceIds: ["00000000-0000-4000-8000-000000000099"],
+            },
+          ],
+          reason: "The durable result was previously certified.",
+        }),
+        OWNER_ID,
+        runtimeSessionId,
+      );
+    const claim = await runtime.recovery.claimRecovery({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "resume-worker",
+    });
+    if (!claim) throw new Error("Expected the Runtime to be claimed");
+
+    await runtime.recovery.pauseAfterRecoveryFailure({
+      ownerId: OWNER_ID,
+      runtimeSessionId,
+      leaseOwner: "resume-worker",
+      leaseToken: claim.leaseToken,
+      expectedRunEpoch: claim.snapshot.session.runEpoch,
+      errorCode: "provider_resume_failed",
+      errorMessage: "provider stopped after producing evidence",
+    });
+
+    const evaluation = runtime.database
+      .prepare(
+        `SELECT last_evaluation AS lastEvaluation
+           FROM agent_goal_runs
+          WHERE owner_id = ? AND runtime_session_id = ?`,
+      )
+      .get(OWNER_ID, runtimeSessionId) as { lastEvaluation: string };
+    expect(JSON.parse(evaluation.lastEvaluation)).toMatchObject({
+      completed: false,
+      confidence: 0.8,
+      satisfiedCriteria: ["result-recorded"],
+      missingCriteria: [],
+      evidence: [
+        {
+          criterionId: "result-recorded",
+          evidenceIds: ["00000000-0000-4000-8000-000000000099"],
+        },
+      ],
+      reason:
+        "Goal recovery paused (provider_resume_failed): provider stopped after producing evidence",
+    });
+  });
 
   it("deduplicates a provider event durably after the database is reopened", async () => {
     const first = createFileBackedRuntime();

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -104,6 +104,12 @@ export interface NativeAgentRunnerContext {
   applicabilityContexts?: MemoryApplicabilityContext[];
   permissionHandler?: AgentRuntimePermissionHandler;
   emitPermissionRequestEvents?: boolean;
+  /**
+   * Trusted recovery state loaded by the host. This intentionally lives on
+   * the runner context rather than NativeAgentRequest so HTTP JSON cannot
+   * select an arbitrary provider session to resume.
+   */
+  runtimeRecovery?: AgentOptions["runtimeRecovery"];
 }
 
 export type NativeAgentMemoryContextStatus =
@@ -238,7 +244,12 @@ export async function runNativeAgentRequest(
 
   const promptBuild = await buildNativeAgentPrompt(preparedBody, context, host);
   const userSettings = await host.getUserInsightSettings?.(context.userId);
-  const config = await buildAgentConfig(preparedBody, context.userId, host);
+  const config = await buildAgentConfig(
+    preparedBody,
+    context.userId,
+    host,
+    context.runtimeRecovery !== undefined,
+  );
   const agentOptions = buildAgentOptions(preparedBody, context, {
     aiSoulPrompt: userSettings?.aiSoulPrompt ?? null,
     language: userSettings?.language ?? null,
@@ -270,6 +281,7 @@ async function buildAgentConfig(
   body: NativeAgentRequest,
   userId: string,
   host: NativeAgentHost,
+  recoveringRuntime: boolean,
 ): Promise<AgentConfig> {
   const provider = body.provider || "claude";
   const useAnthropicCompatibleConfig = provider === "claude";
@@ -281,13 +293,22 @@ async function buildAgentConfig(
       })
     : undefined;
 
-  const effectiveModelConfig = {
-    ...body.modelConfig,
-    ...userAnthropicConfig,
-  };
+  const effectiveModelConfig = recoveringRuntime
+    ? {
+        // Reuse current trusted credentials, but preserve the model/runtime
+        // choices stored with the exact provider session being resumed.
+        ...userAnthropicConfig,
+        model: body.modelConfig?.model ?? userAnthropicConfig?.model,
+        thinkingLevel: body.modelConfig?.thinkingLevel,
+      }
+    : {
+        ...body.modelConfig,
+        ...userAnthropicConfig,
+      };
 
-  // User-saved Anthropic settings win over request defaults such as the
-  // frontend's selectedModel fallback to claude-sonnet-4.6.
+  // Normal requests prefer user-saved Anthropic settings over frontend
+  // defaults. Recovery reloads only trusted credentials while retaining the
+  // model and runtime choices persisted with the provider session.
   return {
     provider,
     apiKey: useAnthropicCompatibleConfig
@@ -318,6 +339,7 @@ function buildAgentOptions(
     session: context.session,
     authToken: body.authToken,
     conversation: body.conversation,
+    runtimeRecovery: context.runtimeRecovery,
     cwd: body.workDir,
     useProvidedWorkDir: body.useProvidedWorkDir,
     taskId: body.taskId,
@@ -372,6 +394,23 @@ async function buildNativeAgentPrompt(
   prompt: string;
   memoryContext: NativeAgentMemoryContextDiagnostic;
 }> {
+  if (context.runtimeRecovery) {
+    // Claude restores its original transcript through the provider resume
+    // handle. Re-materializing memory, RAG, files, or permission prose here
+    // would create a second synthetic prompt before the durable Goal outbox is
+    // replayed. The non-empty bootstrap text only satisfies the shared runner
+    // contract; the Claude adapter replaces it with its live input stream.
+    return {
+      prompt: body.prompt,
+      memoryContext: {
+        status: "no-op",
+        reasonCodes: ["runtime_recovery_uses_provider_transcript"],
+        sourceCount: 0,
+        appliedMode: "baseline",
+      },
+    };
+  }
+
   const contextParts: string[] = [];
 
   const memoryContext = await resolveDefaultMemoryContext(body, context, host);

--- a/packages/ai/src/agent/runtime-instructions/ports.ts
+++ b/packages/ai/src/agent/runtime-instructions/ports.ts
@@ -2,6 +2,7 @@ import type {
   AgentGoal,
   AgentGoalLifecycleTransition,
   AgentGoalReplacement,
+  GoalEvaluationResult,
   GoalLifecycleTransitionAction,
   PersistedAgentGoal,
   RuntimeDeliveryReceipt,
@@ -195,6 +196,9 @@ export interface AgentGoalEvaluationStatePort {
     expectedRevision: number;
     expectedRunEpoch: number;
     goal: AgentGoal;
+    evaluation?: GoalEvaluationResult;
+    /** Fences recovery-only terminal evaluation against lease takeover. */
+    runtimeLeaseToken?: string;
   }): Promise<GoalEvaluationTransitionCommit>;
 }
 

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -438,6 +438,12 @@ export interface AgentRuntimeRecovery {
     providerSessionId: string;
     runEpoch: number;
     continueGoal: () => Promise<AgentRuntimeRecoveryContinuationResult>;
+    /**
+     * Evaluates durable evidence after provider loss without producing another
+     * instruction for the failed provider. Implementations either complete or
+     * pause the Goal at this boundary.
+     */
+    finalizeGoalWithoutContinuation?: () => Promise<AgentRuntimeRecoveryGoalFinalizationResult>;
   }) => void | Promise<void>;
 }
 
@@ -456,6 +462,7 @@ export type AgentRuntimeRecoveryContinuationResult =
         | "no_active_goal"
         | "stale"
         | "completed"
+        | "paused"
         | "blocked"
         | "budget_limited"
         | "expired";
@@ -464,6 +471,13 @@ export type AgentRuntimeRecoveryContinuationResult =
       decision: "block";
       outcome: "continue";
     };
+
+export type AgentRuntimeRecoveryGoalFinalizationResult = {
+  decision: "allow";
+  outcome: "no_active_goal" | "stale" | "completed" | "paused";
+  goalId?: string;
+  goalRevision?: number;
+};
 
 export interface AgentOptions {
   /** Session ID for continuing conversations */

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -402,6 +402,69 @@ export interface McpConfig {
   mcpConfigPath?: string;
 }
 
+/**
+ * Trusted host-only state used to reconnect an unfinished runtime to the
+ * provider session that was persisted before process shutdown.
+ *
+ * This is deliberately carried outside public request payloads. Hosts may
+ * populate it only after authenticating the owner and loading the durable
+ * Runtime Session record.
+ */
+export interface AgentRuntimeRecovery {
+  /** Durable OpenLoomi Runtime Session identity. */
+  runtimeSessionId: string;
+  /** Exact provider session that must be resumed (never forked). */
+  providerSessionId: string;
+  /** Persisted provider working directory. */
+  workingDirectory: string;
+  /** Persisted runtime fencing epoch. */
+  runEpoch: number;
+  /** Opaque durable recovery claim issued by the trusted persistence layer. */
+  recoveryLeaseToken?: string;
+  /**
+   * Durable delivery settlement used to rebuild process-local dispatcher
+   * progress before the outbox is replayed. An explicit empty list means the
+   * coordinator verified that every canonical instruction remains retryable.
+   */
+  instructionSettlements: readonly AgentRuntimeInstructionSettlement[];
+  /**
+   * Called only after Claude confirms that the expected provider session was
+   * resumed and any settlement-aware outbox replay has finished. The host may
+   * repair an interrupted evaluation and ask the attached GoalController for
+   * one canonical continuation through `continueGoal`.
+   */
+  onProviderSessionInitialized?: (context: {
+    runtimeSessionId: string;
+    providerSessionId: string;
+    runEpoch: number;
+    continueGoal: () => Promise<AgentRuntimeRecoveryContinuationResult>;
+  }) => void | Promise<void>;
+}
+
+export interface AgentRuntimeInstructionSettlement {
+  instructionId: string;
+  disposition: "accepted" | "superseded";
+  recordedAt: string;
+  providerEventId?: string;
+  reason?: string;
+}
+
+export type AgentRuntimeRecoveryContinuationResult =
+  | {
+      decision: "allow";
+      outcome:
+        | "no_active_goal"
+        | "stale"
+        | "completed"
+        | "blocked"
+        | "budget_limited"
+        | "expired";
+    }
+  | {
+      decision: "block";
+      outcome: "continue";
+    };
+
 export interface AgentOptions {
   /** Session ID for continuing conversations */
   sessionId?: string;
@@ -413,6 +476,8 @@ export interface AgentOptions {
   conversation?: ConversationMessage[];
   /** Additional user inputs delivered to an already-active run. */
   supplementalInput?: AgentSupplementalInputSource;
+  /** Trusted host-only restart recovery state; never accepted from HTTP. */
+  runtimeRecovery?: AgentRuntimeRecovery;
   /** Working directory */
   cwd?: string;
   /** Use cwd exactly instead of wrapping it in an OpenLoomi session folder */


### PR DESCRIPTION
## Summary

Adds durable restart recovery for the built-in Claude Agent SDK Goal Runtime.

Refs #176

## Changes

- Persist Claude runtime recovery metadata, provider session identity, working directory, and credential-free runtime configuration.
- Resume the exact Claude SDK session after OpenLoomi restarts.
- Reconcile pending operations, instruction deliveries, and provider observations before continuing.
- Add recovery leases, heartbeats, epoch fencing, and provider-event deduplication.
- Restore recovered output to the original chat and prevent a second browser Query while recovery is running.
- Detect terminal provider failures and safely stop stuck SDK iterators.
- Evaluate persisted evidence before finalizing a failed recovery:
  - complete the Goal when its criteria are satisfied;
  - otherwise pause it while preserving verified progress.
- Add Continue/Retry support for paused Goals.
- Preserve valid evidence across pause/resume revisions while invalidating it after Goal, context, or constraint changes.
- Migrate legacy recovery failures and assigned blocked Goals to resumable paused states.
- Stabilize related Windows process and temporary-directory tests.

## Scope

This PR covers restart recovery for OpenLoomi’s built-in Claude SDK runtime.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm tsc`
- `pnpm test`
- `git diff --check origin/main...HEAD`

Test result: 206 files passed, 2,356 tests passed, 0 failures.