### PR TITLE
feat(agent): detect and select local agent runtimes

### DIFF
--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -237,9 +237,9 @@ OpenLoomi Desktop includes the Claude Agent SDK runtime, so users do not install
 | OpenClaw   | ✅ Supported   | Gateway-backed `openclaw acp` bridge                    |
 | DeepAgents | 🔜 Coming Soon | Metadata exists; a production adapter is not registered |
 
-In the desktop app, open **Settings → Agent runtime** to choose **Claude** or **Codex CLI**. Claude uses the runtime bundled with OpenLoomi and a saved Anthropic-compatible configuration or existing Claude authentication. Codex requires a local CLI installation and `codex login`. OpenLoomi performs read-only version and authentication checks before enabling a switch; it does not start a model request. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted. Use **Use environment/default** to remove that override.
+In the desktop app, open **Settings → Agent runtime** to choose Claude, Codex, OpenCode, Hermes, or OpenClaw. Claude uses the runtime bundled with OpenLoomi; the others require their local CLI. Hermes can reuse the current user's saved Anthropic-compatible OpenLoomi API setting, while the remaining CLIs use their runtime-specific authentication or setup. OpenLoomi performs bounded, read-only readiness checks before enabling a switch; it does not start a model request. The saved device preference applies to new tasks and takes precedence over `OPENLOOMI_AGENT_PROVIDER`; running tasks are not interrupted. Use **Use environment/default** to remove that override.
 
-Server/headless deployments—and the OpenCode, Hermes, and OpenClaw runtimes—remain environment-controlled. Claude is used when neither a desktop preference nor `OPENLOOMI_AGENT_PROVIDER` is set; supported environment values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
+Server/headless deployments remain environment-controlled. Claude is used when neither a desktop preference nor `OPENLOOMI_AGENT_PROVIDER` is set; supported environment values are `claude`, `codex`, `opencode`, `hermes`, and `openclaw`.
 
 ```bash
 # OpenCode
@@ -273,7 +273,7 @@ See the **[Agent Runtimes reference](/docs/reference/agent-runtimes)** for detai
 
 **Configure Claude in the desktop app**
 
-In **Settings → Conversation models**, save the API key or gateway token, base URL, and model under **Anthropic compatible**. Return to **Agent runtime**, select **Check again**, and choose Claude when its status is **Ready**. Use **Test connection** as an endpoint check, then start a new task to confirm the complete Agent SDK path.
+In **Settings → Conversation models**, save the API key or gateway token, base URL, and model under **Anthropic compatible**. Return to **Agent runtime**, select **Re-detect**, and choose Claude when its status is **Ready**. Use **Test connection** as an endpoint check, then start a new task to confirm the complete Agent SDK path.
 
 <Callout type="warning">
   **Security:** OpenLoomi stores the saved credential as an encrypted user

--- a/apps/marketing/content/reference/agent-runtimes/claude.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/claude.mdx
@@ -46,7 +46,7 @@ See the official [Claude Code installation guide](https://code.claude.com/docs/e
 
 ### Select it in the desktop app
 
-Open **Settings → Agent runtime** and choose **Claude**. Save a complete Anthropic-compatible configuration in **Conversation models**, or reuse supported Claude authentication already available to the same OS account, then select **Check again**. Once the status is **Ready**, use it for new tasks. If the built-in runtime is unavailable, update or repair OpenLoomi Desktop rather than installing a second copy of Claude Code.
+Open **Settings → Agent runtime** and choose **Claude**. Save a complete Anthropic-compatible configuration in **Conversation models**, or reuse supported Claude authentication already available to the same OS account, then select **Re-detect**. Once the status is **Ready**, use it for new tasks. If the built-in runtime is unavailable, update or repair OpenLoomi Desktop rather than installing a second copy of Claude Code.
 
 ## Authentication and model configuration
 
@@ -127,7 +127,7 @@ To verify a custom Anthropic-compatible provider, use the same endpoint, token, 
 
 ## Troubleshooting
 
-- **Built-in runtime unavailable in OpenLoomi Desktop:** update or repair the desktop installation, then select **Check again**. For a development/server build only, run `claude --version` as the service user, set `CLAUDE_CODE_PATH` to an absolute executable path, or build with the runtime bundle.
+- **Built-in runtime unavailable in OpenLoomi Desktop:** update or repair the desktop installation, then select **Re-detect**. For a development/server build only, run `claude --version` as the service user, set `CLAUDE_CODE_PATH` to an absolute executable path, or build with the runtime bundle.
 - **Authentication fails:** check the saved OpenLoomi API setting and environment for conflicting credentials. `ANTHROPIC_AUTH_TOKEN` takes precedence over `ANTHROPIC_API_KEY`; use `/status` inside Claude Code or the official authentication guide to confirm the active method.
 - **Model not found:** verify the saved model or `ANTHROPIC_MODEL` is valid for the selected endpoint. Custom gateways may use model identifiers that differ from Anthropic's public IDs.
 - **Compatible endpoint rejects a request:** confirm it implements the Anthropic Messages and tool-use behavior required by the Agent SDK. Some text-only compatibility layers cannot run the Claude agent loop.

--- a/apps/marketing/content/reference/agent-runtimes/codex.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/codex.mdx
@@ -30,7 +30,7 @@ See the official [Codex non-interactive mode documentation](https://learn.chatgp
 
 ### Select it in the desktop app
 
-Open **Settings → Agent runtime** and choose **Codex CLI**. The page checks `codex --version` and `codex login status` without starting a model request. Follow the installation or login guidance, select **Check again**, and switch once the status is **Ready**. The change applies to new tasks. **Ready** confirms discovery and authentication, not that a model override or network path can complete a request; use the verification command above for that stronger check. Select **Use environment/default** to remove the desktop override later.
+Open **Settings → Agent runtime** and choose **Codex CLI**. The page checks `codex --version`, `codex login status`, and `codex exec --help` without starting a model request. Follow the installation or login guidance, select **Re-detect**, and switch once the status is **Ready**. The change applies to new tasks. **Ready** confirms discovery, authentication, and JSON execution support, not that a model override or network path can complete a request; use the verification command above for that stronger check. Select **Use environment/default** to remove the desktop override later.
 
 ## Configure OpenLoomi
 

--- a/apps/marketing/content/reference/agent-runtimes/hermes.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/hermes.mdx
@@ -5,7 +5,7 @@ description: "Run OpenLoomi native agent tasks through Hermes over Agent Client 
 
 # Hermes ACP Runtime
 
-The Hermes adapter launches `hermes acp` as a stdio Agent Client Protocol (ACP) server. OpenLoomi initializes the protocol, creates a session rooted at the task working directory, optionally selects a model with `session/set_model`, streams ACP updates, and relays permission requests. OpenLoomi does not install Hermes or create its profiles and provider credentials.
+The Hermes adapter launches `hermes acp` as a stdio Agent Client Protocol (ACP) server. OpenLoomi initializes the protocol, creates a session rooted at the task working directory, optionally selects a model with `session/set_model`, streams ACP updates, and relays permission requests. OpenLoomi does not install Hermes or create its profiles. When the current user has a complete Anthropic-compatible API setting in OpenLoomi, the adapter passes that endpoint, key, and model only to the Hermes child process; it does not copy the key into `~/.hermes`.
 
 ## Install and configure Hermes
 
@@ -35,6 +35,10 @@ hermes model
 The standard installer includes ACP support. A minimal source installation must include the `acp` extra; the official CLI reference documents `pip install -e '.[acp]'` for that case. See the Hermes [quickstart](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/quickstart.md) and [CLI command reference](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/cli-commands.md).
 
 Hermes normally stores secrets in `~/.hermes/.env` and non-secret configuration in `~/.hermes/config.yaml`. Profiles isolate configuration, sessions, skills, and memory. Confirm a profile exists with `hermes profile list` before naming it in OpenLoomi.
+
+### Select it in the desktop app
+
+Open **Settings → Agent runtime** and choose **Hermes**. OpenLoomi checks the CLI version, Hermes status, and ACP command availability without starting a model request. Hermes reports **Ready** when its own credentials are usable or the current user has a complete Anthropic-compatible API setting in OpenLoomi. Otherwise, run `hermes setup` and select **Re-detect**.
 
 ## Configure OpenLoomi
 
@@ -75,7 +79,7 @@ Hermes ACP `session/request_permission` calls are relayed to OpenLoomi's permiss
 
 OpenLoomi never launches Hermes with `--yolo`. This protects the ACP approval path, but Hermes remains a process running as the OpenLoomi operating-system user. Hermes tool configuration and terminal backend still determine the underlying filesystem and command isolation. The official Hermes configuration guide warns that the default local terminal backend has the user's filesystem access; use a containerized backend or another host sandbox where appropriate.
 
-The child process receives common provider keys, `HERMES_*` variables, and additional variable names explicitly allowed through `OPENLOOMI_AGENT_ENV_ALLOWLIST`. A selected profile can still load its own `.env` and configuration files.
+The child process receives common provider keys, `HERMES_*` variables, and additional variable names explicitly allowed through `OPENLOOMI_AGENT_ENV_ALLOWLIST`. For the OpenLoomi API fallback, the saved key and endpoint are injected into this process environment and the saved model is selected through ACP. A selected Hermes profile can still load its own `.env` and configuration files.
 
 ## Verify the integration
 

--- a/apps/marketing/content/reference/agent-runtimes/index.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/index.mdx
@@ -5,7 +5,7 @@ description: "Choose and configure the agent runtime used for OpenLoomi native a
 
 # Agent Runtimes
 
-OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude or Codex CLI under **Settings → Agent runtime**. Claude's runtime is bundled with the desktop app and accepts a complete saved Anthropic-compatible API configuration or supported existing Claude authentication; Codex requires a local installation and CLI login. The app performs read-only version and authentication checks before enabling a switch. Server/headless deployments and the other runtimes use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
+OpenLoomi can delegate native agent tasks to its built-in Claude Agent SDK runtime or to locally installed CLI runtimes. Desktop users can select Claude, Codex, OpenCode, Hermes, or OpenClaw under **Settings → Agent runtime**. Claude's runtime is bundled with the desktop app; the other runtimes normally use their local CLI configuration and authentication. Hermes can also reuse the current user's saved Anthropic-compatible OpenLoomi API setting without copying it into Hermes files. The app performs bounded, read-only readiness checks before enabling a switch. Server/headless deployments use `OPENLOOMI_AGENT_PROVIDER`. A chat/API request cannot change the runtime.
 
 ## Overview
 
@@ -23,9 +23,9 @@ Selecting a runtime chooses the `AgentPlugin`/`IAgent` implementation that execu
 | --------------------------------------------------- | --------- | ------------------------------------- | --------------------------- |
 | [Claude](/docs/reference/agent-runtimes/claude)     | Default   | Agent SDK + bundled Claude runtime    | Desktop setting / API / env |
 | [Codex](/docs/reference/agent-runtimes/codex)       | Secondary | `codex exec --json`                   | Desktop setting / Codex CLI |
-| [OpenCode](/docs/reference/agent-runtimes/opencode) | Optional  | `opencode run --format json`          | Environment and OpenCode    |
-| [Hermes](/docs/reference/agent-runtimes/hermes)     | Optional  | `hermes acp`                          | Environment and Hermes      |
-| [OpenClaw](/docs/reference/agent-runtimes/openclaw) | Optional  | `openclaw acp` plus a running Gateway | Environment and OpenClaw    |
+| [OpenCode](/docs/reference/agent-runtimes/opencode) | Optional  | `opencode run --format json`          | Desktop setting / OpenCode  |
+| [Hermes](/docs/reference/agent-runtimes/hermes)     | Optional  | `hermes acp`                          | Desktop setting / Hermes    |
+| [OpenClaw](/docs/reference/agent-runtimes/openclaw) | Optional  | `openclaw acp` plus a running Gateway | Desktop setting / OpenClaw  |
 
 Each runtime guide covers installation, authentication, OpenLoomi environment variables, permission behavior, verification, and troubleshooting:
 
@@ -37,7 +37,7 @@ Each runtime guide covers installation, authentication, OpenLoomi environment va
 
 Desktop runtime selection resolves in this order:
 
-1. The device preference saved from Settings (Claude or Codex)
+1. The device preference saved from Settings
 2. `OPENLOOMI_AGENT_PROVIDER`
 3. Claude as the default
 

--- a/apps/marketing/content/reference/agent-runtimes/openclaw.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/openclaw.mdx
@@ -28,6 +28,10 @@ openclaw gateway status
 
 Onboarding configures a model provider and normally creates token-authenticated Gateway settings. A remote Gateway must already be configured and reachable from the OpenLoomi host.
 
+### Select it in the desktop app
+
+Open **Settings → Agent runtime** and choose **OpenClaw**. OpenLoomi checks the CLI version and performs a read-only Gateway RPC status probe. Complete onboarding or start the configured Gateway if required, select **Re-detect**, then use OpenClaw once it reports **Ready**.
+
 ## Configure OpenLoomi
 
 A local Gateway configuration can use an explicit WebSocket URL and token file:

--- a/apps/marketing/content/reference/agent-runtimes/opencode.mdx
+++ b/apps/marketing/content/reference/agent-runtimes/opencode.mdx
@@ -28,6 +28,10 @@ opencode models
 
 Saved provider credentials are loaded from OpenCode's user data directory. OpenCode can also use supported provider environment variables and project `.env` files; review the official [provider documentation](https://opencode.ai/docs/providers/) before running it in a repository containing secrets.
 
+### Select it in the desktop app
+
+Open **Settings → Agent runtime** and choose **OpenCode**. OpenLoomi checks the CLI version, saved provider authentication, and JSON output capability without starting a model request. Complete `opencode auth login` if prompted, select **Re-detect**, then use OpenCode once it reports **Ready**.
+
 ## Configure OpenLoomi
 
 Set environment variables before starting OpenLoomi:

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { SELECTABLE_AGENT_RUNTIMES } from "@/lib/ai/native-agent/runtime-contract";
 import {
   clearAgentRuntimePreference,
   readAgentRuntimePreference,
@@ -13,19 +14,23 @@ import { isTauriMode } from "@/lib/env/constants";
 
 const runtimePreferenceSchema = z
   .object({
-    provider: z.enum(["claude", "codex"]),
+    provider: z.enum(SELECTABLE_AGENT_RUNTIMES),
   })
   .strict();
 
 const noStoreHeaders = { "Cache-Control": "no-store" };
 
-async function hasUsableClaudeApiConfiguration(userId: string) {
-  return Boolean(
+async function getRuntimeApiConfiguration(userId: string) {
+  const anthropicApiConfigured = Boolean(
     await getUserLlmProviderConfig({
       userId,
       providerType: "anthropic_compatible",
     }),
   );
+  return {
+    claudeApiConfigured: anthropicApiConfigured,
+    hermesApiConfigured: anthropicApiConfigured,
+  };
 }
 
 export async function GET(request: Request) {
@@ -37,10 +42,10 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const forceRefresh = url.searchParams.get("refresh") === "1";
-    const claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
+    const apiConfiguration = await getRuntimeApiConfiguration(user.id);
     const settings = await getAgentRuntimeSettings({
       forceRefresh,
-      claudeApiConfigured,
+      ...apiConfiguration,
     });
     return NextResponse.json(settings, { headers: noStoreHeaders });
   } catch (error) {
@@ -74,22 +79,23 @@ export async function PUT(request: Request) {
   }
 
   try {
-    let claudeApiConfigured = await hasUsableClaudeApiConfiguration(user.id);
+    let apiConfiguration = await getRuntimeApiConfiguration(user.id);
     let readiness = await getAgentRuntimeSettings({
       forceRefresh: true,
-      claudeApiConfigured,
+      ...apiConfiguration,
     });
 
     // The runtime probe can take several seconds. If the user saves or removes
-    // the Claude API configuration while it is running, remap readiness against
+    // the shared API configuration while it is running, remap readiness against
     // the latest setting before persisting the choice.
-    if (parsed.data.provider === "claude") {
-      const latestClaudeApiConfigured = await hasUsableClaudeApiConfiguration(
-        user.id,
-      );
-      if (latestClaudeApiConfigured !== claudeApiConfigured) {
-        claudeApiConfigured = latestClaudeApiConfigured;
-        readiness = await getAgentRuntimeSettings({ claudeApiConfigured });
+    if (parsed.data.provider === "claude" || parsed.data.provider === "hermes") {
+      const latestApiConfiguration = await getRuntimeApiConfiguration(user.id);
+      if (
+        latestApiConfiguration.claudeApiConfigured !==
+        apiConfiguration.claudeApiConfigured
+      ) {
+        apiConfiguration = latestApiConfiguration;
+        readiness = await getAgentRuntimeSettings(apiConfiguration);
       }
     }
 
@@ -135,12 +141,10 @@ export async function DELETE(request: Request) {
     const previousPreference = readAgentRuntimePreference();
     clearAgentRuntimePreference();
     try {
-      const claudeApiConfigured = await hasUsableClaudeApiConfiguration(
-        user.id,
-      );
+      const apiConfiguration = await getRuntimeApiConfiguration(user.id);
       const settings = await getAgentRuntimeSettings({
         forceRefresh: true,
-        claudeApiConfigured,
+        ...apiConfiguration,
       });
       return NextResponse.json(settings, { headers: noStoreHeaders });
     } catch (error) {

--- a/apps/web/components/agent-runtime-settings.tsx
+++ b/apps/web/components/agent-runtime-settings.tsx
@@ -12,6 +12,7 @@ import {
   type AgentRuntimeSettingsResponse,
   type SelectableAgentRuntime,
   canSaveAgentRuntime,
+  isSelectableAgentRuntime,
 } from "@/lib/ai/native-agent/runtime-contract";
 import {
   CODEX_LOGIN_COMMAND,
@@ -29,6 +30,7 @@ const runtimeOptions: Array<{
   descriptionFallback: string;
   docsUrl: string;
   loginCommand?: string;
+  setupCommand?: string;
 }> = [
   {
     provider: "claude",
@@ -48,11 +50,37 @@ const runtimeOptions: Array<{
     docsUrl: "https://learn.chatgpt.com/docs/codex/cli",
     loginCommand: CODEX_LOGIN_COMMAND,
   },
+  {
+    provider: "opencode",
+    name: "OpenCode",
+    builtIn: false,
+    descriptionKey: "settings.agentRuntimeOpenCodeDescription",
+    descriptionFallback:
+      "Use your local OpenCode CLI and its configured model providers.",
+    docsUrl: "https://openloomi.ai/docs/reference/agent-runtimes/opencode",
+    loginCommand: "opencode auth login",
+  },
+  {
+    provider: "hermes",
+    name: "Hermes",
+    builtIn: false,
+    descriptionKey: "settings.agentRuntimeHermesDescription",
+    descriptionFallback:
+      "Use your local Hermes ACP runtime and configured model provider.",
+    docsUrl: "https://openloomi.ai/docs/reference/agent-runtimes/hermes",
+    setupCommand: "hermes setup",
+  },
+  {
+    provider: "openclaw",
+    name: "OpenClaw",
+    builtIn: false,
+    descriptionKey: "settings.agentRuntimeOpenClawDescription",
+    descriptionFallback:
+      "Use your local OpenClaw CLI with a reachable authenticated Gateway.",
+    docsUrl: "https://openloomi.ai/docs/reference/agent-runtimes/openclaw",
+    setupCommand: "openclaw onboard --install-daemon",
+  },
 ];
-
-function isSelectableRuntime(value: string): value is SelectableAgentRuntime {
-  return value === "claude" || value === "codex";
-}
 
 export function AgentRuntimeSettings() {
   const { t } = useTranslation();
@@ -97,7 +125,7 @@ export function AgentRuntimeSettings() {
         setDraft(
           (current) =>
             current ??
-            (isSelectableRuntime(nextState.effective.provider)
+            (isSelectableAgentRuntime(nextState.effective.provider)
               ? nextState.effective.provider
               : null),
         );
@@ -246,7 +274,7 @@ export function AgentRuntimeSettings() {
       const nextState = (await response.json()) as AgentRuntimeSettingsResponse;
       setState(nextState);
       setDraft(
-        isSelectableRuntime(nextState.effective.provider)
+        isSelectableAgentRuntime(nextState.effective.provider)
           ? nextState.effective.provider
           : null,
       );
@@ -294,12 +322,12 @@ export function AgentRuntimeSettings() {
             id="agent-runtime-title"
             className="text-base font-semibold text-foreground-secondary"
           >
-            {t("settings.agentRuntimeTitle", "Agent runtime")}
+            {t("settings.agentRuntimeTitle", "Detected local agent runtimes")}
           </p>
           <p className="max-w-3xl text-sm text-muted-foreground">
             {t(
               "settings.agentRuntimeDescription",
-              "Choose the agent runtime OpenLoomi uses for new tasks. Claude is built in; Codex uses its local CLI. Running tasks are not interrupted.",
+              "Choose the local agent runtime OpenLoomi uses for new tasks. Running tasks are not interrupted.",
             )}
           </p>
         </div>
@@ -329,11 +357,11 @@ export function AgentRuntimeSettings() {
         ) : state?.editable && state.runtimes ? (
           <>
             {state.effective.source === "environment" &&
-              !isSelectableRuntime(state.effective.provider) && (
+              !isSelectableAgentRuntime(state.effective.provider) && (
                 <p className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
                   {t(
                     "settings.agentRuntimeManagedByEnvironment",
-                    "The current runtime is managed by the environment: {{provider}}. Choose Claude or Codex to create a desktop preference.",
+                    "The current runtime is managed by the environment: {{provider}}. Choose a detected runtime to create a desktop preference.",
                     { provider: state.effective.provider },
                   )}
                 </p>
@@ -457,24 +485,30 @@ export function AgentRuntimeSettings() {
 
 function RuntimeStatusLine({ probe }: { probe: AgentRuntimePublicProbe }) {
   const { t } = useTranslation();
-  const label =
-    probe.status === "ready"
-      ? t("settings.agentRuntimeReady", "Ready")
-      : probe.status === "login_required"
-        ? probe.provider === "claude"
-          ? t(
-              "settings.agentRuntimeAuthenticationRequired",
-              "Authentication required",
-            )
-          : t("settings.agentRuntimeLoginRequired", "Sign-in required")
-        : probe.status === "not_installed"
-          ? probe.provider === "claude"
-            ? t(
-                "settings.agentRuntimeBuiltInUnavailable",
-                "Built-in runtime unavailable",
-              )
-            : t("settings.agentRuntimeNotInstalled", "Not installed")
-          : t("settings.agentRuntimeUnverifiedShort", "Could not verify");
+  let label: string;
+  if (probe.status === "ready") {
+    label = t("settings.agentRuntimeReady", "Ready");
+  } else if (probe.status === "login_required") {
+    label =
+      probe.provider === "claude"
+        ? t(
+            "settings.agentRuntimeAuthenticationRequired",
+            "Authentication required",
+          )
+        : probe.provider === "hermes" || probe.provider === "openclaw"
+          ? t("settings.agentRuntimeSetupRequired", "Setup required")
+          : t("settings.agentRuntimeLoginRequired", "Sign-in required");
+  } else if (probe.status === "not_installed") {
+    label =
+      probe.provider === "claude"
+        ? t(
+            "settings.agentRuntimeBuiltInUnavailable",
+            "Built-in runtime unavailable",
+          )
+        : t("settings.agentRuntimeNotInstalled", "Not installed");
+  } else {
+    label = t("settings.agentRuntimeUnverifiedShort", "Could not verify");
+  }
   return (
     <span
       className={cn(
@@ -565,7 +599,7 @@ function RuntimeSetupPanel({
               size="size-4"
               className={refreshing ? "animate-spin" : undefined}
             />
-            {t("settings.agentRuntimeCheckAgain", "Check again")}
+            {t("settings.agentRuntimeCheckAgain", "Re-detect")}
           </Button>
           <Button
             type="button"
@@ -618,7 +652,7 @@ function RuntimeSetupSummary({
       <p className="text-sm text-muted-foreground">
         {t(
           "settings.agentRuntimeReadyDescription",
-          "{{runtime}} is installed and signed in. This check does not start a model request.",
+          "{{runtime}} is installed and configured. This check does not start a model request.",
           { runtime: option.name },
         )}
       </p>
@@ -637,29 +671,45 @@ function RuntimeSetupSummary({
       );
     }
 
+    const setupRequired =
+      option.provider === "hermes" || option.provider === "openclaw";
+    const command = option.loginCommand ?? option.setupCommand;
     return (
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">
-          {t(
-            "settings.agentRuntimeLoginDescription",
-            "Run this command in a terminal, finish signing in, then check again.",
-          )}
+          {setupRequired
+            ? t(
+                "settings.agentRuntimeSetupDescription",
+                "Run this command in a terminal, complete setup, then check again.",
+              )
+            : t(
+                "settings.agentRuntimeLoginDescription",
+                "Run this command in a terminal, finish signing in, then check again.",
+              )}
         </p>
-        {option.loginCommand && <CopyCommand command={option.loginCommand} />}
+        {command && <CopyCommand command={command} />}
       </div>
     );
   }
 
   if (probe.status === "not_installed") {
-    if (!isClaude) {
+    if (option.provider === "codex") {
       return <CodexInstallSteps platform={platform} />;
     }
 
-    return (
+    return isClaude ? (
       <p className="text-sm text-muted-foreground">
         {t(
           "settings.agentRuntimeClaudeUnavailableDescription",
           "OpenLoomi could not load its built-in Claude runtime. Update or repair the desktop app, then check again.",
+        )}
+      </p>
+    ) : (
+      <p className="text-sm text-muted-foreground">
+        {t(
+          "settings.agentRuntimeCliUnavailableDescription",
+          "{{runtime}} was not found. Open the official instructions, install it for this OS account, then check again.",
+          { runtime: option.name },
         )}
       </p>
     );
@@ -690,7 +740,7 @@ function CodexInstallSteps({
     platform === "windows"
       ? "PowerShell"
       : t("settings.agentRuntimeTerminal", "Terminal");
-  const checkAgain = t("settings.agentRuntimeCheckAgain", "Check again");
+  const checkAgain = t("settings.agentRuntimeCheckAgain", "Re-detect");
   const useCodex = t("settings.agentRuntimeUse", "Use {{runtime}}", {
     runtime: "Codex CLI",
   });

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -376,24 +376,31 @@ const en = {
       "Loop is on — Loomi reads your mail, calendar, code, and chat through your connectors in the background and combines that with screen memory to fill your morning brief. Toggle off here if you'd rather not.",
     aiSettingsDescription:
       "Configure per-user API settings for compatible AI providers.",
-    agentRuntimeTitle: "Agent runtime",
+    agentRuntimeTitle: "Detected local agent runtimes",
     agentRuntimeDescription:
-      "Choose the agent runtime OpenLoomi uses for new tasks. Claude is built in; Codex uses its local CLI. Running tasks are not interrupted.",
+      "Choose the local agent runtime OpenLoomi uses for new tasks. Running tasks are not interrupted.",
     agentRuntimeClaudeDescription:
       "Powered by Claude Agent SDK with its runtime bundled in OpenLoomi—no separate Claude CLI installation required. Use a saved Anthropic-compatible API configuration or existing Claude authentication.",
     agentRuntimeCodexDescription:
       "Use your local Codex CLI installation and account.",
+    agentRuntimeOpenCodeDescription:
+      "Use your local OpenCode CLI and its configured model providers.",
+    agentRuntimeHermesDescription:
+      "Use your local Hermes ACP runtime and configured model provider.",
+    agentRuntimeOpenClawDescription:
+      "Use your local OpenClaw CLI with a reachable authenticated Gateway.",
     agentRuntimeChecking: "Checking local runtimes…",
     agentRuntimeBuiltIn: "Built in",
     agentRuntimeReady: "Ready",
     agentRuntimeAuthenticationRequired: "Authentication required",
     agentRuntimeLoginRequired: "Sign-in required",
+    agentRuntimeSetupRequired: "Setup required",
     agentRuntimeNotInstalled: "Not installed",
     agentRuntimeBuiltInUnavailable: "Built-in runtime unavailable",
     agentRuntimeUnverifiedShort: "Could not verify",
     agentRuntimeInUse: "In use",
     agentRuntimeReadyDescription:
-      "{{runtime}} is installed and signed in. This check does not start a model request.",
+      "{{runtime}} is installed and configured. This check does not start a model request.",
     agentRuntimeClaudeApiReadyDescription:
       "The built-in Claude runtime will use your saved Anthropic-compatible configuration. Test the connection below, then confirm it with a new task.",
     agentRuntimeClaudeAuthReadyDescription:
@@ -402,6 +409,8 @@ const en = {
       "Save an Anthropic-compatible API configuration below. If this OS account already has Claude authentication, check again to reuse it.",
     agentRuntimeLoginDescription:
       "Run this command in a terminal, finish signing in, then check again.",
+    agentRuntimeSetupDescription:
+      "Run this command in a terminal, complete setup, then check again.",
     agentRuntimeCodexInstallTitle: "Install and sign in to Codex CLI",
     agentRuntimeCodexInstallOpenTerminal: "Open {{terminal}}.",
     agentRuntimeCodexInstallRunInstaller:
@@ -417,13 +426,15 @@ const en = {
     agentRuntimeTerminal: "Terminal",
     agentRuntimeClaudeUnavailableDescription:
       "OpenLoomi could not load its built-in Claude runtime. Update or repair the desktop app, then check again.",
+    agentRuntimeCliUnavailableDescription:
+      "{{runtime}} was not found. Open the official instructions, install it for this OS account, then check again.",
     agentRuntimeUnverified: "OpenLoomi could not verify the local runtimes.",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi could not verify this CLI. Confirm it runs in your terminal, then check again.",
     agentRuntimeClaudeUnverifiedDescription:
       "OpenLoomi could not verify the built-in Claude runtime. Open the troubleshooting guide, then check again.",
     agentRuntimeManagedByEnvironment:
-      "The current runtime is managed by the environment: {{provider}}. Choose Claude or Codex to create a desktop preference.",
+      "The current runtime is managed by the environment: {{provider}}. Choose a detected runtime to create a desktop preference.",
     agentRuntimePreferenceOverrideDescription:
       "This desktop preference overrides the environment/default runtime for new tasks.",
     agentRuntimeUseManagedSetting: "Use environment/default",
@@ -432,7 +443,7 @@ const en = {
     agentRuntimeOfficialInstructions: "Official instructions",
     agentRuntimeSetupGuide: "Setup guide",
     agentRuntimeTroubleshootingGuide: "Troubleshooting guide",
-    agentRuntimeCheckAgain: "Check again",
+    agentRuntimeCheckAgain: "Re-detect",
     agentRuntimeTryAgain: "Try again",
     agentRuntimeUse: "Use {{runtime}}",
     agentRuntimeCopy: "Copy",

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -358,23 +358,30 @@ const zh = {
       "Loop 已开启 —— Loomi 在后台通过连接器读取你的邮件、日历、代码与聊天等来源，并结合屏幕记忆来填你的早安简报。如果你不希望这样，可以在这里关掉。",
     aiSettingsDescription:
       "为当前用户配置兼容的 AI 服务商接口，保存后会优先使用用户配置。",
-    agentRuntimeTitle: "Agent 运行时",
+    agentRuntimeTitle: "检测到的本地 Agent 运行时",
     agentRuntimeDescription:
-      "选择 OpenLoomi 在新任务中使用的 Agent 运行时。Claude 已内置，Codex 使用本机 CLI；正在运行的任务不会被中断。",
+      "选择 OpenLoomi 在新任务中使用的本地 Agent 运行时；正在运行的任务不会被中断。",
     agentRuntimeClaudeDescription:
       "由 Claude Agent SDK 驱动，运行组件已随 OpenLoomi 内置，无需另装 Claude CLI。可使用已保存的 Anthropic 兼容 API 配置或已有 Claude 认证。",
     agentRuntimeCodexDescription: "使用本机 Codex CLI 及其登录账号。",
+    agentRuntimeOpenCodeDescription:
+      "使用本机 OpenCode CLI 及其已配置的模型服务商。",
+    agentRuntimeHermesDescription:
+      "使用本机 Hermes ACP 运行时及其已配置的模型服务商。",
+    agentRuntimeOpenClawDescription:
+      "使用本机 OpenClaw CLI 和可连接、已认证的 Gateway。",
     agentRuntimeChecking: "正在检查本地运行时…",
     agentRuntimeBuiltIn: "内置",
     agentRuntimeReady: "已就绪",
     agentRuntimeAuthenticationRequired: "需要认证",
     agentRuntimeLoginRequired: "需要登录",
+    agentRuntimeSetupRequired: "需要配置",
     agentRuntimeNotInstalled: "尚未安装",
     agentRuntimeBuiltInUnavailable: "内置运行组件不可用",
     agentRuntimeUnverifiedShort: "无法验证",
     agentRuntimeInUse: "使用中",
     agentRuntimeReadyDescription:
-      "{{runtime}} 已安装并登录；此检查不会实际发起模型请求。",
+      "{{runtime}} 已安装并完成配置；此检查不会实际发起模型请求。",
     agentRuntimeClaudeApiReadyDescription:
       "内置 Claude 运行时将使用已保存的 Anthropic 兼容配置；请先在下方测试连接，再通过一个新任务确认实际运行。",
     agentRuntimeClaudeAuthReadyDescription:
@@ -383,6 +390,8 @@ const zh = {
       "请在下方保存 Anthropic 兼容 API 配置；如果当前系统账号已有 Claude 认证，请重新检查以复用它。",
     agentRuntimeLoginDescription:
       "请在终端运行以下命令并完成登录，然后重新检查。",
+    agentRuntimeSetupDescription:
+      "请在终端运行以下命令并完成配置，然后重新检查。",
     agentRuntimeCodexInstallTitle: "安装并登录 Codex CLI",
     agentRuntimeCodexInstallOpenTerminal: "打开 {{terminal}}。",
     agentRuntimeCodexInstallRunInstaller: "复制并运行以下官方安装命令。",
@@ -397,13 +406,15 @@ const zh = {
     agentRuntimeTerminal: "终端",
     agentRuntimeClaudeUnavailableDescription:
       "OpenLoomi 无法加载内置 Claude 运行组件。请更新或修复桌面应用，然后重新检查。",
+    agentRuntimeCliUnavailableDescription:
+      "未找到 {{runtime}}。请打开官方说明，为当前系统账号安装后重新检查。",
     agentRuntimeUnverified: "OpenLoomi 无法验证本地运行时。",
     agentRuntimeUnverifiedDescription:
       "OpenLoomi 无法验证此 CLI。请确认它能在终端运行，然后重新检查。",
     agentRuntimeClaudeUnverifiedDescription:
       "OpenLoomi 无法验证内置 Claude 运行组件。请打开故障排查指南，然后重新检查。",
     agentRuntimeManagedByEnvironment:
-      "当前运行时由环境变量管理：{{provider}}。选择 Claude 或 Codex 后将创建桌面偏好。",
+      "当前运行时由环境变量管理：{{provider}}。选择已检测到的运行时后将创建桌面偏好。",
     agentRuntimePreferenceOverrideDescription:
       "此桌面偏好会覆盖环境变量或默认运行时，并用于新任务。",
     agentRuntimeUseManagedSetting: "使用环境变量/默认值",
@@ -412,7 +423,7 @@ const zh = {
     agentRuntimeOfficialInstructions: "查看官方说明",
     agentRuntimeSetupGuide: "配置指南",
     agentRuntimeTroubleshootingGuide: "故障排查指南",
-    agentRuntimeCheckAgain: "重新检查",
+    agentRuntimeCheckAgain: "重新检测",
     agentRuntimeTryAgain: "重试",
     agentRuntimeUse: "使用 {{runtime}}",
     agentRuntimeCopy: "复制",

--- a/apps/web/lib/ai/extensions/agent/acp/agent.ts
+++ b/apps/web/lib/ai/extensions/agent/acp/agent.ts
@@ -40,7 +40,12 @@ export interface AcpRuntimeDefinition {
   };
   normalizeProviderConfig: (providerConfig?: Record<string, unknown>) => {
     timeoutMs?: number;
+    env?: Record<string, string>;
   };
+  formatModelId?: (
+    model: string,
+    providerConfig?: Record<string, unknown>,
+  ) => string;
   supportsSetModel?: boolean;
 }
 
@@ -253,6 +258,7 @@ export class AcpAgent extends BaseAgent {
         cwd,
         signal: this.getSession(sessionId)?.abortController.signal,
         timeoutMs: providerConfig.timeoutMs,
+        env: providerConfig.env,
         onRequest: async (request) => {
           if (request.method !== "session/request_permission") {
             return { outcome: { outcome: "cancelled" } };
@@ -298,7 +304,11 @@ export class AcpAgent extends BaseAgent {
     if (this.config.model && this.runtime.supportsSetModel) {
       await client.request("session/set_model", {
         sessionId: acpSessionId,
-        modelId: this.config.model,
+        modelId:
+          this.runtime.formatModelId?.(
+            this.config.model,
+            this.config.providerConfig,
+          ) ?? this.config.model,
       });
     }
 

--- a/apps/web/lib/ai/extensions/agent/acp/stdio-client.ts
+++ b/apps/web/lib/ai/extensions/agent/acp/stdio-client.ts
@@ -120,6 +120,7 @@ export class AcpStdioClient {
       cwd: string;
       signal?: AbortSignal;
       timeoutMs?: number;
+      env?: Record<string, string>;
       onRequest?: AcpStdioClientRequestHandler;
     },
   ) {}
@@ -133,7 +134,7 @@ export class AcpStdioClient {
     try {
       proc = spawn(this.command, this.args, {
         cwd: this.options.cwd,
-        env: buildCliEnvironment(),
+        env: buildCliEnvironment(this.options.env),
         detached: shouldDetachCliProcess(),
         windowsHide: true,
       }) as ChildProcessWithoutNullStreams;

--- a/apps/web/lib/ai/extensions/agent/hermes/command.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/command.ts
@@ -2,6 +2,7 @@ export interface HermesProviderConfig {
   hermesPath?: string;
   profile?: string;
   timeoutMs?: number;
+  env?: Record<string, string>;
 }
 
 export interface HermesAcpCommand {
@@ -12,6 +13,15 @@ export interface HermesAcpCommand {
 export function normalizeHermesProviderConfig(
   value: Record<string, unknown> | undefined,
 ): HermesProviderConfig {
+  const env =
+    value?.env && typeof value.env === "object" && !Array.isArray(value.env)
+      ? Object.fromEntries(
+          Object.entries(value.env as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : undefined;
+
   return {
     hermesPath:
       typeof value?.hermesPath === "string" && value.hermesPath.trim()
@@ -27,6 +37,7 @@ export function normalizeHermesProviderConfig(
       value.timeoutMs > 0
         ? value.timeoutMs
         : undefined,
+    env,
   };
 }
 

--- a/apps/web/lib/ai/extensions/agent/hermes/index.ts
+++ b/apps/web/lib/ai/extensions/agent/hermes/index.ts
@@ -14,6 +14,13 @@ const HERMES_ACP_RUNTIME: AcpRuntimeDefinition = {
   displayName: "Hermes",
   buildCommand: buildHermesAcpCommand,
   normalizeProviderConfig: normalizeHermesProviderConfig,
+  formatModelId: (model, providerConfig) => {
+    const provider = normalizeHermesProviderConfig(providerConfig).env
+      ?.HERMES_INFERENCE_PROVIDER;
+    return provider && !model.startsWith(`${provider}:`)
+      ? `${provider}:${model}`
+      : model;
+  },
   supportsSetModel: true,
 };
 

--- a/apps/web/lib/ai/native-agent/provider-env.ts
+++ b/apps/web/lib/ai/native-agent/provider-env.ts
@@ -5,6 +5,7 @@ import {
 import type { AgentProvider } from "@melandlabs/ai/agent";
 import {
   readAgentRuntimePreference,
+  SELECTABLE_AGENT_RUNTIMES,
   type SelectableAgentRuntime,
 } from "./runtime-preference";
 
@@ -32,13 +33,7 @@ const OPENCODE_PROVIDER = "opencode";
 const HERMES_PROVIDER = "hermes";
 const OPENCLAW_PROVIDER = "openclaw";
 const CODEX_PROVIDER = "codex";
-const SUPPORTED_ENV_PROVIDERS = new Set([
-  "claude",
-  OPENCODE_PROVIDER,
-  HERMES_PROVIDER,
-  OPENCLAW_PROVIDER,
-  CODEX_PROVIDER,
-]);
+const SUPPORTED_ENV_PROVIDERS = new Set<string>(SELECTABLE_AGENT_RUNTIMES);
 
 export function getConfiguredDefaultAgentProvider(
   env: EnvSource = process.env,

--- a/apps/web/lib/ai/native-agent/runtime-contract.ts
+++ b/apps/web/lib/ai/native-agent/runtime-contract.ts
@@ -1,6 +1,18 @@
-export const SELECTABLE_AGENT_RUNTIMES = ["claude", "codex"] as const;
+export const SELECTABLE_AGENT_RUNTIMES = [
+  "claude",
+  "codex",
+  "opencode",
+  "hermes",
+  "openclaw",
+] as const;
 
 export type SelectableAgentRuntime = (typeof SELECTABLE_AGENT_RUNTIMES)[number];
+
+export function isSelectableAgentRuntime(
+  value: string,
+): value is SelectableAgentRuntime {
+  return SELECTABLE_AGENT_RUNTIMES.includes(value as SelectableAgentRuntime);
+}
 
 export type AgentRuntimeSetupStatus =
   | "ready"
@@ -21,6 +33,8 @@ export type AgentRuntimePublicProbe = {
     | "CLI_UNAVAILABLE"
     | "VERSION_FAILED"
     | "VERSION_TIMEOUT"
+    | "CAPABILITY_FAILED"
+    | "CAPABILITY_TIMEOUT"
     | "AUTH_REQUIRED"
     | "AUTH_UNAVAILABLE"
     | "AUTH_TIMEOUT"

--- a/apps/web/lib/ai/native-agent/runtime-probe.ts
+++ b/apps/web/lib/ai/native-agent/runtime-probe.ts
@@ -1,5 +1,5 @@
 /**
- * Server-side readiness probes for the local Claude Code and Codex CLIs.
+ * Server-side readiness probes for OpenLoomi's supported local agent runtimes.
  *
  * Probes are deliberately read-only: they check the executable version and
  * the CLI's own authentication status without starting a model request. Raw
@@ -28,8 +28,9 @@ import {
 } from "@/lib/ai/extensions/agent/codex/command-resolver";
 import { createLogger } from "@/lib/utils/logger";
 import { APP_DIR_NAME } from "@/lib/env/config/constants";
+import type { SelectableAgentRuntime } from "./runtime-contract";
 
-const PROBE_TIMEOUT_MS = 5000;
+const PROBE_TIMEOUT_MS = 10_000;
 const CACHE_TTL_MS = 30_000;
 
 const logger = createLogger("NativeAgentRuntime");
@@ -61,9 +62,42 @@ export type CodexRuntimeStatus =
   | "CODEX_CLI_AUTH_REQUIRED"
   | "CODEX_CLI_AUTH_STATUS_TIMEOUT"
   | "CODEX_CLI_AUTH_STATUS_UNAVAILABLE"
+  | "CODEX_CLI_CAPABILITY_FAILED"
+  | "CODEX_CLI_CAPABILITY_TIMEOUT"
   | "CODEX_CLI_VERSION_FAILED"
   | "CODEX_CLI_VERSION_TIMEOUT"
   | "CODEX_CLI_UNAVAILABLE";
+
+export type OpenCodeRuntimeStatus =
+  | "OPENCODE_CLI_AUTHENTICATED"
+  | "OPENCODE_CLI_AUTH_REQUIRED"
+  | "OPENCODE_CLI_AUTH_STATUS_TIMEOUT"
+  | "OPENCODE_CLI_AUTH_STATUS_UNAVAILABLE"
+  | "OPENCODE_CLI_CAPABILITY_FAILED"
+  | "OPENCODE_CLI_CAPABILITY_TIMEOUT"
+  | "OPENCODE_CLI_VERSION_FAILED"
+  | "OPENCODE_CLI_VERSION_TIMEOUT"
+  | "OPENCODE_CLI_UNAVAILABLE";
+
+export type HermesRuntimeStatus =
+  | "HERMES_CLI_AUTHENTICATED"
+  | "HERMES_CLI_AUTH_REQUIRED"
+  | "HERMES_CLI_AUTH_STATUS_TIMEOUT"
+  | "HERMES_CLI_AUTH_STATUS_UNAVAILABLE"
+  | "HERMES_CLI_CAPABILITY_FAILED"
+  | "HERMES_CLI_CAPABILITY_TIMEOUT"
+  | "HERMES_CLI_VERSION_FAILED"
+  | "HERMES_CLI_VERSION_TIMEOUT"
+  | "HERMES_CLI_UNAVAILABLE";
+
+export type OpenClawRuntimeStatus =
+  | "OPENCLAW_CLI_AUTHENTICATED"
+  | "OPENCLAW_CLI_AUTH_REQUIRED"
+  | "OPENCLAW_CLI_AUTH_STATUS_TIMEOUT"
+  | "OPENCLAW_CLI_AUTH_STATUS_UNAVAILABLE"
+  | "OPENCLAW_CLI_VERSION_FAILED"
+  | "OPENCLAW_CLI_VERSION_TIMEOUT"
+  | "OPENCLAW_CLI_UNAVAILABLE";
 
 export type ProbeResult = {
   ok: boolean;
@@ -80,11 +114,14 @@ type CliPathSource =
   | "PATH"
   | "CLAUDE_CODE_PATH"
   | "OPENLOOMI_AGENT_CODEX_COMMAND"
+  | "OPENLOOMI_AGENT_OPENCODE_COMMAND"
+  | "OPENLOOMI_AGENT_HERMES_COMMAND"
+  | "OPENLOOMI_AGENT_OPENCLAW_COMMAND"
   | "FALLBACK"
   | null;
 
 type BaseRuntimeProbe<
-  Provider extends "claude" | "codex",
+  Provider extends SelectableAgentRuntime,
   Status extends string,
 > = {
   checked: true;
@@ -101,6 +138,7 @@ type BaseRuntimeProbe<
   probes: {
     version?: ProbeResult;
     auth?: ProbeResult;
+    capability?: ProbeResult;
   };
 };
 
@@ -114,20 +152,50 @@ export type NativeRuntimeProbe = BaseRuntimeProbe<
 
 export type CodexRuntimeProbe = BaseRuntimeProbe<"codex", CodexRuntimeStatus>;
 
+export type OpenCodeRuntimeProbe = BaseRuntimeProbe<
+  "opencode",
+  OpenCodeRuntimeStatus
+>;
+
+export type HermesRuntimeProbe = BaseRuntimeProbe<
+  "hermes",
+  HermesRuntimeStatus
+>;
+
+export type OpenClawRuntimeProbe = BaseRuntimeProbe<
+  "openclaw",
+  OpenClawRuntimeStatus
+>;
+
+export type AgentRuntimeProbe =
+  | NativeRuntimeProbe
+  | CodexRuntimeProbe
+  | OpenCodeRuntimeProbe
+  | HermesRuntimeProbe
+  | OpenClawRuntimeProbe;
+
 type RuntimeDefinition<
-  Provider extends "claude" | "codex",
+  Provider extends SelectableAgentRuntime,
   Status extends string,
 > = {
   provider: Provider;
-  binary: Provider;
+  binary: string;
   explicitCommand: string | undefined;
   explicitSource: Exclude<CliPathSource, null>;
   authArgs: readonly string[];
+  authResultReady?: (result: ProbeResult) => boolean;
+  authFailureIsRequired?: (result: ProbeResult) => boolean;
+  capability?: {
+    args: readonly string[];
+    resultReady: (result: ProbeResult) => boolean;
+  };
   status: {
     ready: Status;
     authRequired: Status;
     authTimeout: Status;
     authUnavailable: Status;
+    capabilityFailed?: Status;
+    capabilityTimeout?: Status;
     versionFailed: Status;
     versionTimeout: Status;
     unavailable: Status;
@@ -141,10 +209,14 @@ type ResolvedCliPath = {
   argsPrefix: string[];
 };
 
-let claudeCache: { at: number; value: NativeRuntimeProbe } | null = null;
-let codexCache: { at: number; value: CodexRuntimeProbe } | null = null;
-let claudeInFlight: Promise<NativeRuntimeProbe> | null = null;
-let codexInFlight: Promise<CodexRuntimeProbe> | null = null;
+const runtimeCaches = new Map<
+  SelectableAgentRuntime,
+  { at: number; value: AgentRuntimeProbe }
+>();
+const runtimeInFlight = new Map<
+  SelectableAgentRuntime,
+  Promise<AgentRuntimeProbe>
+>();
 
 function candidateBinaries(binary: string): string[] {
   if (platform() === "win32") {
@@ -192,7 +264,7 @@ function isBareCommand(command: string): boolean {
 }
 
 function resolveCliPath(
-  definition: RuntimeDefinition<"claude" | "codex", string>,
+  definition: RuntimeDefinition<SelectableAgentRuntime, string>,
 ): ResolvedCliPath {
   const searchPath = buildAgentCliSearchPath();
 
@@ -232,7 +304,7 @@ function resolveCliPath(
 }
 
 function runCli(
-  provider: "claude" | "codex",
+  provider: SelectableAgentRuntime,
   command: string,
   args: readonly string[],
   timeoutMs: number,
@@ -326,7 +398,7 @@ function runCli(
 }
 
 function buildRuntimeProbeEnvironment(
-  provider: "claude" | "codex",
+  provider: SelectableAgentRuntime,
   overrides: Record<string, string>,
 ): NodeJS.ProcessEnv {
   const providerOverrides: Record<string, string> = {};
@@ -350,12 +422,24 @@ function buildRuntimeProbeEnvironment(
       PROBE_RUNTIME_PREFIXES.some((prefix) => normalized.startsWith(prefix));
     if (!isRuntimeCredential) continue;
 
+    const isCommonModelCredential =
+      normalized === "OPENAI_API_KEY" ||
+      normalized === "ANTHROPIC_API_KEY" ||
+      normalized === "OPENROUTER_API_KEY" ||
+      normalized === "GEMINI_API_KEY" ||
+      normalized === "GOOGLE_GENERATIVE_AI_API_KEY";
     const isProviderCredential =
       provider === "claude"
         ? normalized.startsWith("ANTHROPIC_") ||
           normalized === "CLAUDE_CONFIG_DIR" ||
           normalized === "CLAUDE_CODE_OAUTH_TOKEN"
-        : normalized === "OPENAI_API_KEY" || normalized.startsWith("CODEX_");
+        : provider === "codex"
+          ? normalized === "OPENAI_API_KEY" || normalized.startsWith("CODEX_")
+          : provider === "opencode"
+            ? isCommonModelCredential || normalized.startsWith("OPENCODE_")
+            : provider === "hermes"
+              ? isCommonModelCredential || normalized.startsWith("HERMES_")
+              : normalized.startsWith("OPENCLAW_");
     if (!isProviderCredential) {
       delete env[key];
     }
@@ -386,15 +470,17 @@ function isAuthCommandUnavailable(result: ProbeResult): boolean {
 }
 
 async function probeCliRuntime<
-  Provider extends "claude" | "codex",
+  Provider extends SelectableAgentRuntime,
   Status extends string,
 >(
   definition: RuntimeDefinition<Provider, Status>,
   resolvedOverride?: ResolvedCliPath,
-) {
+): Promise<BaseRuntimeProbe<Provider, Status>> {
   const resolved =
     resolvedOverride ??
-    resolveCliPath(definition as RuntimeDefinition<"claude" | "codex", string>);
+    resolveCliPath(
+      definition as RuntimeDefinition<SelectableAgentRuntime, string>,
+    );
   const base = { checked: true as const, provider: definition.provider };
 
   if (!resolved.path) {
@@ -413,14 +499,37 @@ async function probeCliRuntime<
     };
   }
 
-  const versionProbe = await runCli(
-    definition.provider,
-    resolved.path,
-    ["--version"],
-    PROBE_TIMEOUT_MS,
-    resolved.searchPath,
-    resolved.argsPrefix,
-  );
+  // Keep the whole provider probe within one timeout window by running its
+  // independent read-only checks together. A broken CLI must not make the
+  // settings page wait 5 seconds for every subcommand in sequence.
+  const [versionProbe, authProbe, capabilityProbe] = await Promise.all([
+    runCli(
+      definition.provider,
+      resolved.path,
+      ["--version"],
+      PROBE_TIMEOUT_MS,
+      resolved.searchPath,
+      resolved.argsPrefix,
+    ),
+    runCli(
+      definition.provider,
+      resolved.path,
+      definition.authArgs,
+      PROBE_TIMEOUT_MS,
+      resolved.searchPath,
+      resolved.argsPrefix,
+    ),
+    definition.capability
+      ? runCli(
+          definition.provider,
+          resolved.path,
+          definition.capability.args,
+          PROBE_TIMEOUT_MS,
+          resolved.searchPath,
+          resolved.argsPrefix,
+        )
+      : Promise.resolve(undefined),
+  ]);
   if (!versionProbe.ok) {
     const result = {
       ...base,
@@ -443,20 +552,19 @@ async function probeCliRuntime<
     return result;
   }
 
-  const authProbe = await runCli(
-    definition.provider,
-    resolved.path,
-    definition.authArgs,
-    PROBE_TIMEOUT_MS,
-    resolved.searchPath,
-    resolved.argsPrefix,
-  );
-  if (!authProbe.ok) {
-    const reason = authProbe.timedOut
-      ? definition.status.authTimeout
-      : isAuthCommandUnavailable(authProbe)
-        ? definition.status.authUnavailable
-        : definition.status.authRequired;
+  if (
+    capabilityProbe &&
+    (!capabilityProbe.ok ||
+      !definition.capability?.resultReady(capabilityProbe))
+  ) {
+    const reason = capabilityProbe.timedOut
+      ? definition.status.capabilityTimeout
+      : definition.status.capabilityFailed;
+    if (!reason) {
+      throw new Error(
+        `Missing capability failure status for ${definition.provider}`,
+      );
+    }
     return {
       ...base,
       available: true,
@@ -468,7 +576,41 @@ async function probeCliRuntime<
       cliPathSource: resolved.source,
       versionPresent: true,
       version: cleanVersion(versionProbe),
-      probes: { version: versionProbe, auth: authProbe },
+      probes: {
+        version: versionProbe,
+        auth: authProbe,
+        capability: capabilityProbe,
+      },
+    };
+  }
+
+  const authReady =
+    authProbe.ok && (definition.authResultReady?.(authProbe) ?? true);
+  if (!authReady) {
+    const reason = authProbe.timedOut
+      ? definition.status.authTimeout
+      : !authProbe.ok && isAuthCommandUnavailable(authProbe)
+        ? definition.status.authUnavailable
+        : authProbe.ok ||
+            (definition.authFailureIsRequired?.(authProbe) ?? true)
+          ? definition.status.authRequired
+          : definition.status.authUnavailable;
+    return {
+      ...base,
+      available: true,
+      authenticated: false,
+      active: false,
+      ready: false,
+      reason,
+      cliPathPresent: true,
+      cliPathSource: resolved.source,
+      versionPresent: true,
+      version: cleanVersion(versionProbe),
+      probes: {
+        version: versionProbe,
+        auth: authProbe,
+        capability: capabilityProbe,
+      },
     };
   }
 
@@ -483,48 +625,101 @@ async function probeCliRuntime<
     cliPathSource: resolved.source,
     versionPresent: true,
     version: cleanVersion(versionProbe),
-    probes: { version: versionProbe, auth: authProbe },
+    probes: {
+      version: versionProbe,
+      auth: authProbe,
+      capability: capabilityProbe,
+    },
   };
+}
+
+function outputContains(result: ProbeResult, ...values: string[]): boolean {
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  return values.every((value) => output.includes(value.toLowerCase()));
+}
+
+function hasListedCredentials(result: ProbeResult): boolean {
+  const output = `${result.stdout}\n${result.stderr}`.trim();
+  if (!output) return false;
+  return !/(?:no|0)\s+(?:stored\s+)?(?:credentials?|authenticated providers?)|not (?:logged in|authenticated)/i.test(
+    output,
+  );
+}
+
+function isHermesStatusReady(result: ProbeResult): boolean {
+  const ansiEscape = String.fromCharCode(27);
+  const ansiPattern = new RegExp(`${ansiEscape}\\[[0-?]*[ -/]*[@-~]`, "g");
+  const output = `${result.stdout}\n${result.stderr}`.replace(ansiPattern, "");
+  const model = output.match(/^\s*Model:\s*(.+?)\s*$/im)?.[1];
+  if (!model || model.toLowerCase() === "(not set)") return false;
+
+  // `hermes status` exits successfully even on a fresh install. Only mark it
+  // ready when the configured model also has a model credential or login.
+  return (
+    /^\s*(?:OpenRouter|OpenAI|Anthropic|Google \/ Gemini|DeepSeek|xAI \/ Grok|NVIDIA NIM|Z\.AI \/ GLM|Kimi(?: \/ Moonshot)?|StepFun Step Plan|MiniMax(?:-CN| \(China\))?)\s+✓/im.test(
+      output,
+    ) ||
+    /^\s*(?:Nous Portal|OpenAI Codex|Qwen OAuth|MiniMax OAuth|xAI OAuth)\s+✓/im.test(
+      output,
+    ) ||
+    /Nous inference key configured/i.test(output) ||
+    /^\s*LM Studio\s+✓\s+reachable/im.test(output)
+  );
+}
+
+function outputMatches(result: ProbeResult, pattern: RegExp): boolean {
+  return pattern.test(`${result.stdout}\n${result.stderr}`);
+}
+
+async function withRuntimeCache<Probe extends AgentRuntimeProbe>(
+  provider: Probe["provider"],
+  force: boolean,
+  operation: () => Promise<Probe>,
+): Promise<Probe> {
+  const cached = runtimeCaches.get(provider);
+  if (!force && cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.value as Probe;
+  }
+
+  const current = runtimeInFlight.get(provider);
+  if (current) return current as Promise<Probe>;
+
+  const pending = operation().then((value) => {
+    runtimeCaches.set(provider, { at: Date.now(), value });
+    return value;
+  });
+  runtimeInFlight.set(provider, pending);
+  try {
+    return await pending;
+  } finally {
+    if (runtimeInFlight.get(provider) === pending) {
+      runtimeInFlight.delete(provider);
+    }
+  }
 }
 
 export async function probeNativeClaudeRuntime(
   options: { force?: boolean } = {},
 ): Promise<NativeRuntimeProbe | null> {
-  if (
-    !options.force &&
-    claudeCache &&
-    Date.now() - claudeCache.at < CACHE_TTL_MS
-  ) {
-    return claudeCache.value;
-  }
-  if (claudeInFlight) return claudeInFlight;
-
-  const operation = probeCliRuntime({
-    provider: "claude",
-    binary: "claude",
-    explicitCommand: process.env.CLAUDE_CODE_PATH,
-    explicitSource: "CLAUDE_CODE_PATH",
-    authArgs: ["auth", "status"],
-    status: {
-      ready: "CLAUDE_CLI_AUTHENTICATED",
-      authRequired: "CLAUDE_CLI_AUTH_REQUIRED",
-      authTimeout: "CLAUDE_CLI_AUTH_STATUS_TIMEOUT",
-      authUnavailable: "CLAUDE_CLI_AUTH_STATUS_UNAVAILABLE",
-      versionFailed: "CLAUDE_CLI_VERSION_FAILED",
-      versionTimeout: "CLAUDE_CLI_VERSION_TIMEOUT",
-      unavailable: "CLAUDE_CLI_UNAVAILABLE",
-    },
-  }).then((result) => {
-    const probe: NativeRuntimeProbe = { ...result, defaultAgent: "claude" };
-    claudeCache = { at: Date.now(), value: probe };
-    return probe;
+  return withRuntimeCache("claude", options.force ?? false, async () => {
+    const result = await probeCliRuntime({
+      provider: "claude",
+      binary: "claude",
+      explicitCommand: process.env.CLAUDE_CODE_PATH,
+      explicitSource: "CLAUDE_CODE_PATH",
+      authArgs: ["auth", "status"],
+      status: {
+        ready: "CLAUDE_CLI_AUTHENTICATED",
+        authRequired: "CLAUDE_CLI_AUTH_REQUIRED",
+        authTimeout: "CLAUDE_CLI_AUTH_STATUS_TIMEOUT",
+        authUnavailable: "CLAUDE_CLI_AUTH_STATUS_UNAVAILABLE",
+        versionFailed: "CLAUDE_CLI_VERSION_FAILED",
+        versionTimeout: "CLAUDE_CLI_VERSION_TIMEOUT",
+        unavailable: "CLAUDE_CLI_UNAVAILABLE",
+      },
+    });
+    return { ...result, defaultAgent: "claude" };
   });
-  claudeInFlight = operation;
-  try {
-    return await operation;
-  } finally {
-    if (claudeInFlight === operation) claudeInFlight = null;
-  }
 }
 
 export async function probeNativeCodexRuntime(
@@ -533,32 +728,29 @@ export async function probeNativeCodexRuntime(
     resolverOptions?: Omit<ResolveCodexCommandOptions, "configuredCommand">;
   } = {},
 ): Promise<CodexRuntimeProbe | null> {
-  if (
-    !options.force &&
-    codexCache &&
-    Date.now() - codexCache.at < CACHE_TTL_MS
-  ) {
-    return codexCache.value;
-  }
-  if (codexInFlight) return codexInFlight;
-
   const definition: RuntimeDefinition<"codex", CodexRuntimeStatus> = {
     provider: "codex",
     binary: "codex",
     explicitCommand: process.env.OPENLOOMI_AGENT_CODEX_COMMAND,
     explicitSource: "OPENLOOMI_AGENT_CODEX_COMMAND",
     authArgs: ["login", "status"],
+    capability: {
+      args: ["exec", "--help"],
+      resultReady: (result) => outputContains(result, "--json"),
+    },
     status: {
       ready: "CODEX_CLI_AUTHENTICATED",
       authRequired: "CODEX_CLI_AUTH_REQUIRED",
       authTimeout: "CODEX_CLI_AUTH_STATUS_TIMEOUT",
       authUnavailable: "CODEX_CLI_AUTH_STATUS_UNAVAILABLE",
+      capabilityFailed: "CODEX_CLI_CAPABILITY_FAILED",
+      capabilityTimeout: "CODEX_CLI_CAPABILITY_TIMEOUT",
       versionFailed: "CODEX_CLI_VERSION_FAILED",
       versionTimeout: "CODEX_CLI_VERSION_TIMEOUT",
       unavailable: "CODEX_CLI_UNAVAILABLE",
     },
   };
-  const operation = (async () => {
+  return withRuntimeCache("codex", options.force ?? false, async () => {
     try {
       return await probeCliRuntime(
         definition,
@@ -577,16 +769,108 @@ export async function probeNativeCodexRuntime(
         argsPrefix: [],
       });
     }
-  })().then((result) => {
-    codexCache = { at: Date.now(), value: result };
-    return result;
   });
-  codexInFlight = operation;
-  try {
-    return await operation;
-  } finally {
-    if (codexInFlight === operation) codexInFlight = null;
-  }
+}
+
+export async function probeNativeOpenCodeRuntime(
+  options: { force?: boolean } = {},
+): Promise<OpenCodeRuntimeProbe | null> {
+  return withRuntimeCache("opencode", options.force ?? false, () =>
+    probeCliRuntime({
+      provider: "opencode",
+      binary: "opencode",
+      explicitCommand: process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND,
+      explicitSource: "OPENLOOMI_AGENT_OPENCODE_COMMAND",
+      authArgs: ["auth", "list"],
+      authResultReady: hasListedCredentials,
+      capability: {
+        args: ["run", "--help"],
+        resultReady: (result) => outputContains(result, "--format", "json"),
+      },
+      status: {
+        ready: "OPENCODE_CLI_AUTHENTICATED",
+        authRequired: "OPENCODE_CLI_AUTH_REQUIRED",
+        authTimeout: "OPENCODE_CLI_AUTH_STATUS_TIMEOUT",
+        authUnavailable: "OPENCODE_CLI_AUTH_STATUS_UNAVAILABLE",
+        capabilityFailed: "OPENCODE_CLI_CAPABILITY_FAILED",
+        capabilityTimeout: "OPENCODE_CLI_CAPABILITY_TIMEOUT",
+        versionFailed: "OPENCODE_CLI_VERSION_FAILED",
+        versionTimeout: "OPENCODE_CLI_VERSION_TIMEOUT",
+        unavailable: "OPENCODE_CLI_UNAVAILABLE",
+      },
+    }),
+  );
+}
+
+export async function probeNativeHermesRuntime(
+  options: { force?: boolean } = {},
+): Promise<HermesRuntimeProbe | null> {
+  const profile = process.env.OPENLOOMI_AGENT_HERMES_PROFILE?.trim();
+  return withRuntimeCache("hermes", options.force ?? false, () =>
+    probeCliRuntime({
+      provider: "hermes",
+      binary: "hermes",
+      explicitCommand: process.env.OPENLOOMI_AGENT_HERMES_COMMAND,
+      explicitSource: "OPENLOOMI_AGENT_HERMES_COMMAND",
+      authArgs: profile ? ["--profile", profile, "status"] : ["status"],
+      authResultReady: isHermesStatusReady,
+      authFailureIsRequired: (result) =>
+        outputMatches(
+          result,
+          /(?:setup|required|not configured|missing).*(?:auth|credential|model|provider)|(?:auth|credential|model|provider).*(?:required|not configured|missing)/i,
+        ),
+      capability: {
+        args: ["--help"],
+        resultReady: (result) => outputContains(result, "acp"),
+      },
+      status: {
+        ready: "HERMES_CLI_AUTHENTICATED",
+        authRequired: "HERMES_CLI_AUTH_REQUIRED",
+        authTimeout: "HERMES_CLI_AUTH_STATUS_TIMEOUT",
+        authUnavailable: "HERMES_CLI_AUTH_STATUS_UNAVAILABLE",
+        capabilityFailed: "HERMES_CLI_CAPABILITY_FAILED",
+        capabilityTimeout: "HERMES_CLI_CAPABILITY_TIMEOUT",
+        versionFailed: "HERMES_CLI_VERSION_FAILED",
+        versionTimeout: "HERMES_CLI_VERSION_TIMEOUT",
+        unavailable: "HERMES_CLI_UNAVAILABLE",
+      },
+    }),
+  );
+}
+
+export async function probeNativeOpenClawRuntime(
+  options: { force?: boolean } = {},
+): Promise<OpenClawRuntimeProbe | null> {
+  return withRuntimeCache("openclaw", options.force ?? false, () =>
+    probeCliRuntime({
+      provider: "openclaw",
+      binary: "openclaw",
+      explicitCommand: process.env.OPENLOOMI_AGENT_OPENCLAW_COMMAND,
+      explicitSource: "OPENLOOMI_AGENT_OPENCLAW_COMMAND",
+      authArgs: [
+        "gateway",
+        "status",
+        "--require-rpc",
+        "--json",
+        "--timeout",
+        "4000",
+      ],
+      authFailureIsRequired: (result) =>
+        outputMatches(
+          result,
+          /(?:unauthorized|authentication|required|missing|invalid).*(?:token|password|credential)|(?:token|password|credential).*(?:required|missing|invalid)/i,
+        ),
+      status: {
+        ready: "OPENCLAW_CLI_AUTHENTICATED",
+        authRequired: "OPENCLAW_CLI_AUTH_REQUIRED",
+        authTimeout: "OPENCLAW_CLI_AUTH_STATUS_TIMEOUT",
+        authUnavailable: "OPENCLAW_CLI_AUTH_STATUS_UNAVAILABLE",
+        versionFailed: "OPENCLAW_CLI_VERSION_FAILED",
+        versionTimeout: "OPENCLAW_CLI_VERSION_TIMEOUT",
+        unavailable: "OPENCLAW_CLI_UNAVAILABLE",
+      },
+    }),
+  );
 }
 
 function resolveCodexProbePath(
@@ -613,16 +897,15 @@ function resolveCodexProbePath(
 }
 
 export function clearNativeClaudeRuntimeCache(): void {
-  claudeCache = null;
+  runtimeCaches.delete("claude");
 }
 
 export function clearNativeCodexRuntimeCache(): void {
-  codexCache = null;
+  runtimeCaches.delete("codex");
 }
 
 export function clearNativeRuntimeCaches(): void {
-  clearNativeClaudeRuntimeCache();
-  clearNativeCodexRuntimeCache();
+  runtimeCaches.clear();
 }
 
 export function getRuntimePlatform(): "windows" | "macos" | "linux" {

--- a/apps/web/lib/ai/native-agent/runtime-settings.ts
+++ b/apps/web/lib/ai/native-agent/runtime-settings.ts
@@ -1,24 +1,26 @@
 import { isTauriMode } from "@/lib/env/constants";
 import { getConfiguredAgentProviderResolution } from "./provider-env";
-import type {
-  AgentRuntimePublicProbe,
-  AgentRuntimeSettingsResponse,
-  SelectableAgentRuntime,
+import {
+  SELECTABLE_AGENT_RUNTIMES,
+  type AgentRuntimePublicProbe,
+  type AgentRuntimeSettingsResponse,
+  type SelectableAgentRuntime,
 } from "./runtime-contract";
 import {
-  type CodexRuntimeProbe,
-  type NativeRuntimeProbe,
+  type AgentRuntimeProbe,
   getRuntimePlatform,
   probeNativeClaudeRuntime,
   probeNativeCodexRuntime,
+  probeNativeHermesRuntime,
+  probeNativeOpenClawRuntime,
+  probeNativeOpenCodeRuntime,
 } from "./runtime-probe";
-
-type RuntimeProbe = NativeRuntimeProbe | CodexRuntimeProbe;
 
 export async function getAgentRuntimeSettings(
   options: {
     forceRefresh?: boolean;
     claudeApiConfigured?: boolean;
+    hermesApiConfigured?: boolean;
   } = {},
 ): Promise<AgentRuntimeSettingsResponse> {
   const resolution = getConfiguredAgentProviderResolution();
@@ -36,10 +38,19 @@ export async function getAgentRuntimeSettings(
     };
   }
 
-  const [claude, codex] = await Promise.all([
-    safelyProbe("claude", options.forceRefresh, options.claudeApiConfigured),
-    safelyProbe("codex", options.forceRefresh),
-  ]);
+  const runtimes = Object.fromEntries(
+    await Promise.all(
+      SELECTABLE_AGENT_RUNTIMES.map(async (provider) => [
+        provider,
+        await safelyProbe(
+          provider,
+          options.forceRefresh,
+          options.claudeApiConfigured,
+          options.hermesApiConfigured,
+        ),
+      ]),
+    ),
+  ) as Record<SelectableAgentRuntime, AgentRuntimePublicProbe>;
 
   return {
     editable: true,
@@ -49,7 +60,7 @@ export async function getAgentRuntimeSettings(
       source: resolution.source,
     },
     platform: getRuntimePlatform(),
-    runtimes: { claude, codex },
+    runtimes,
   };
 }
 
@@ -57,23 +68,43 @@ async function safelyProbe(
   provider: SelectableAgentRuntime,
   forceRefresh = false,
   claudeApiConfigured = false,
+  hermesApiConfigured = false,
 ): Promise<AgentRuntimePublicProbe> {
   try {
-    const probe =
-      provider === "claude"
-        ? await probeNativeClaudeRuntime({ force: forceRefresh })
-        : await probeNativeCodexRuntime({ force: forceRefresh });
-    return toPublicProbe(provider, probe, { claudeApiConfigured });
+    const probe = await probeRuntime(provider, forceRefresh);
+    return toPublicProbe(provider, probe, {
+      claudeApiConfigured,
+      hermesApiConfigured,
+    });
   } catch (error) {
     console.warn(`[AgentRuntimeSettings] ${provider} probe failed`, error);
     return unverifiedProbe(provider);
   }
 }
 
+function probeRuntime(provider: SelectableAgentRuntime, force: boolean) {
+  const options = { force };
+  switch (provider) {
+    case "claude":
+      return probeNativeClaudeRuntime(options);
+    case "codex":
+      return probeNativeCodexRuntime(options);
+    case "opencode":
+      return probeNativeOpenCodeRuntime(options);
+    case "hermes":
+      return probeNativeHermesRuntime(options);
+    case "openclaw":
+      return probeNativeOpenClawRuntime(options);
+  }
+}
+
 export function toPublicProbe(
   provider: SelectableAgentRuntime,
-  probe: RuntimeProbe | null,
-  options: { claudeApiConfigured?: boolean } = {},
+  probe: AgentRuntimeProbe | null,
+  options: {
+    claudeApiConfigured?: boolean;
+    hermesApiConfigured?: boolean;
+  } = {},
 ): AgentRuntimePublicProbe {
   if (!probe) return unverifiedProbe(provider);
 
@@ -90,14 +121,14 @@ export function toPublicProbe(
     };
   }
 
-  // Claude Agent SDK needs its runtime executable, which packaged desktop
-  // builds bundle with OpenLoomi. A complete saved Anthropic-compatible
-  // configuration overrides existing Claude authentication during execution,
-  // so report it first when both credential sources exist.
+  // A complete saved Anthropic-compatible configuration is passed to Claude
+  // directly or injected into the Hermes ACP child process during execution.
   if (
-    provider === "claude" &&
-    options.claudeApiConfigured &&
-    probe.versionPresent
+    ((provider === "claude" && options.claudeApiConfigured) ||
+      (provider === "hermes" && options.hermesApiConfigured)) &&
+    probe.versionPresent &&
+    !probe.reason.endsWith("_CAPABILITY_FAILED") &&
+    !probe.reason.endsWith("_CAPABILITY_TIMEOUT")
   ) {
     return {
       provider,
@@ -141,11 +172,15 @@ export function toPublicProbe(
     ? "VERSION_TIMEOUT"
     : probe.reason.endsWith("_VERSION_FAILED")
       ? "VERSION_FAILED"
-      : probe.reason.endsWith("_AUTH_STATUS_TIMEOUT")
-        ? "AUTH_TIMEOUT"
-        : probe.reason.endsWith("_AUTH_STATUS_UNAVAILABLE")
-          ? "AUTH_UNAVAILABLE"
-          : "PROBE_FAILED";
+      : probe.reason.endsWith("_CAPABILITY_TIMEOUT")
+        ? "CAPABILITY_TIMEOUT"
+        : probe.reason.endsWith("_CAPABILITY_FAILED")
+          ? "CAPABILITY_FAILED"
+          : probe.reason.endsWith("_AUTH_STATUS_TIMEOUT")
+            ? "AUTH_TIMEOUT"
+            : probe.reason.endsWith("_AUTH_STATUS_UNAVAILABLE")
+              ? "AUTH_UNAVAILABLE"
+              : "PROBE_FAILED";
 
   return {
     provider,

--- a/apps/web/lib/ai/runtime/shared.ts
+++ b/apps/web/lib/ai/runtime/shared.ts
@@ -6,6 +6,7 @@
 
 import type { AgentConfig, AgentOptions } from "@melandlabs/ai/agent";
 import { getAgentRegistry } from "@melandlabs/ai/agent";
+import { buildHermesApiProviderConfig } from "@openloomi/ai/agent/native-runner";
 import {
   getUserTypeForService,
   getUserInsightSettings,
@@ -214,7 +215,7 @@ export async function handleAgentRuntime(
         ...(options.workDir && { workDir: options.workDir }),
       };
       const userAnthropicConfig =
-        agentConfig.provider === "claude"
+        agentConfig.provider === "claude" || agentConfig.provider === "hermes"
           ? await getUserLlmProviderConfig({
               userId: options.userId,
               providerType: "anthropic_compatible",
@@ -224,14 +225,21 @@ export async function handleAgentRuntime(
       // User-saved Anthropic settings win over runtime defaults such as the
       // frontend's selectedModel fallback to claude-sonnet-4.6.
       const effectiveModelConfig =
-        agentConfig.provider === "claude"
+        agentConfig.provider === "claude" || agentConfig.provider === "hermes"
           ? { ...options.modelConfig, ...userAnthropicConfig }
           : (runtimeRequest.modelConfig ?? {});
 
-      if (effectiveModelConfig.apiKey) {
+      if (agentConfig.provider === "hermes") {
+        agentConfig.providerConfig = buildHermesApiProviderConfig(
+          agentConfig.providerConfig,
+          userAnthropicConfig,
+        );
+      }
+
+      if (agentConfig.provider === "claude" && effectiveModelConfig.apiKey) {
         agentConfig.apiKey = effectiveModelConfig.apiKey;
       }
-      if (effectiveModelConfig.baseUrl) {
+      if (agentConfig.provider === "claude" && effectiveModelConfig.baseUrl) {
         agentConfig.baseUrl = effectiveModelConfig.baseUrl;
       }
       if (effectiveModelConfig.model) {

--- a/apps/web/tests/api/agent-runtime-preferences.route.test.ts
+++ b/apps/web/tests/api/agent-runtime-preferences.route.test.ts
@@ -15,6 +15,9 @@ const runtimeState = vi.hoisted(() => ({
     runtimes: {
       claude: { ready: true },
       codex: { ready: true },
+      opencode: { ready: true },
+      hermes: { ready: true },
+      openclaw: { ready: true },
     },
   },
   get: vi.fn(),
@@ -95,6 +98,7 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.get).toHaveBeenCalledWith({
       forceRefresh: true,
       claudeApiConfigured: false,
+      hermesApiConfigured: false,
     });
     expect(await response.json()).toEqual(runtimeState.response);
   });
@@ -108,15 +112,19 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.write).not.toHaveBeenCalled();
   });
 
-  test("strictly accepts only Claude or Codex", async () => {
-    const unsupported = await PUT(request("PUT", { provider: "opencode" }));
+  test("strictly accepts only the five supported runtimes", async () => {
+    for (const provider of ["opencode", "hermes", "openclaw"]) {
+      const response = await PUT(request("PUT", { provider }));
+      expect(response.status).toBe(200);
+    }
+    const unsupported = await PUT(request("PUT", { provider: "unknown" }));
     const extraField = await PUT(
       request("PUT", { provider: "codex", command: "custom" }),
     );
 
     expect(unsupported.status).toBe(400);
     expect(extraField.status).toBe(400);
-    expect(runtimeState.write).not.toHaveBeenCalled();
+    expect(runtimeState.write).toHaveBeenCalledTimes(3);
   });
 
   test("persists the choice and returns the selected effective state", async () => {
@@ -157,6 +165,7 @@ describe("agent runtime preferences route", () => {
     expect(response.status).toBe(409);
     expect(runtimeState.get).toHaveBeenNthCalledWith(2, {
       claudeApiConfigured: false,
+      hermesApiConfigured: false,
     });
     expect(runtimeState.write).not.toHaveBeenCalled();
   });
@@ -176,6 +185,7 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.get).toHaveBeenCalledWith({
       forceRefresh: true,
       claudeApiConfigured: false,
+      hermesApiConfigured: false,
     });
     expect(await response.json()).toEqual(restoredResponse);
   });
@@ -200,7 +210,7 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.write).toHaveBeenCalledWith("codex");
   });
 
-  test("passes a complete saved Claude API configuration into readiness", async () => {
+  test("passes a complete saved API configuration into runtime readiness", async () => {
     llmSettingsState.config = {
       apiKey: "decrypted-key",
       baseUrl: "https://api.example.test",
@@ -213,6 +223,7 @@ describe("agent runtime preferences route", () => {
     expect(runtimeState.get).toHaveBeenCalledWith({
       forceRefresh: false,
       claudeApiConfigured: true,
+      hermesApiConfigured: true,
     });
   });
 

--- a/apps/web/tests/unit/agent-runtime-settings.test.ts
+++ b/apps/web/tests/unit/agent-runtime-settings.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/ai/native-agent/runtime-contract";
 import type {
   CodexRuntimeProbe,
+  HermesRuntimeProbe,
   NativeRuntimeProbe,
 } from "@/lib/ai/native-agent/runtime-probe";
 import { toPublicProbe } from "@/lib/ai/native-agent/runtime-settings";
@@ -192,6 +193,32 @@ describe("agent runtime public probe", () => {
       status: "ready",
     });
   });
+
+  test("accepts saved API settings when Hermes ACP is available", () => {
+    const probe: HermesRuntimeProbe = {
+      checked: true,
+      provider: "hermes",
+      available: true,
+      authenticated: false,
+      active: false,
+      ready: false,
+      reason: "HERMES_CLI_AUTH_REQUIRED",
+      cliPathPresent: true,
+      cliPathSource: "PATH",
+      versionPresent: true,
+      version: "0.3.0",
+      probes: {},
+    };
+
+    expect(
+      toPublicProbe("hermes", probe, { hermesApiConfigured: true }),
+    ).toMatchObject({
+      installed: true,
+      ready: true,
+      readyVia: "api",
+      status: "ready",
+    });
+  });
 });
 
 describe("agent runtime selection", () => {
@@ -212,6 +239,9 @@ describe("agent runtime selection", () => {
             reason: "CODEX_CLI_AUTHENTICATED",
           }),
         ),
+        opencode: toPublicProbe("opencode", null),
+        hermes: toPublicProbe("hermes", null),
+        openclaw: toPublicProbe("openclaw", null),
       },
     };
 

--- a/apps/web/tests/unit/hermes-agent.test.ts
+++ b/apps/web/tests/unit/hermes-agent.test.ts
@@ -42,7 +42,13 @@ describe("Hermes ACP command builder", () => {
 describe("HermesAgent", () => {
   it("runs initialize/session/new/session/prompt and maps ACP updates", async () => {
     const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
-    const agent = createAgent(workDir);
+    const agent = createAgent(workDir, {
+      env: {
+        HERMES_INFERENCE_PROVIDER: "anthropic",
+        ANTHROPIC_API_KEY: "process-only-key",
+        ANTHROPIC_BASE_URL: "https://anthropic.example.test",
+      },
+    });
 
     const messages = await collectMessages(agent.run("normal run"));
 
@@ -89,6 +95,13 @@ describe("HermesAgent", () => {
       cwd: workDir,
       mcpServers: [],
     });
+    await expect(readFile(join(workDir, "env.json"), "utf8")).resolves.toBe(
+      JSON.stringify({
+        provider: "anthropic",
+        apiKey: "process-only-key",
+        baseUrl: "https://anthropic.example.test",
+      }),
+    );
   });
 
   it("applies an explicitly configured model to the new ACP session", async () => {
@@ -111,6 +124,23 @@ describe("HermesAgent", () => {
     expect(calls[2].params).toEqual({
       sessionId: "hermes-session-1",
       modelId: "openrouter:anthropic/claude-sonnet-4.6",
+    });
+  });
+
+  it("keeps custom endpoint models on the injected Anthropic provider", async () => {
+    const workDir = await createFakeHermesWorkDir(defaultFakeAcpScript());
+    const agent = createAgent(
+      workDir,
+      { env: { HERMES_INFERENCE_PROVIDER: "anthropic" } },
+      "gemini-3.7-flash",
+    );
+
+    await collectMessages(agent.run("normal run"));
+
+    const calls = await readJsonLines(join(workDir, "calls.jsonl"));
+    expect(calls[2].params).toEqual({
+      sessionId: "hermes-session-1",
+      modelId: "anthropic:gemini-3.7-flash",
     });
   });
 
@@ -398,6 +428,12 @@ function defaultFakeAcpScript() {
   return `
 const fs = require("node:fs");
 const readline = require("node:readline");
+
+fs.writeFileSync("env.json", JSON.stringify({
+  provider: process.env.HERMES_INFERENCE_PROVIDER,
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  baseUrl: process.env.ANTHROPIC_BASE_URL,
+}));
 
 function append(file, value) {
   fs.appendFileSync(file, JSON.stringify(value) + "\\n");

--- a/apps/web/tests/unit/native-agent-provider-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-provider-preference.test.ts
@@ -84,6 +84,18 @@ describe("desktop agent runtime selection", () => {
     expect(request.providerConfig).toBeUndefined();
   });
 
+  it("resolves the three optional CLI runtimes from desktop preferences", () => {
+    for (const provider of ["opencode", "hermes", "openclaw"] as const) {
+      writeAgentRuntimePreference(provider, preferencePath);
+      expect(
+        getConfiguredAgentProviderResolution(
+          { TAURI_MODE: "1", OPENLOOMI_AGENT_PROVIDER: "claude" },
+          { preferencePath },
+        ),
+      ).toEqual({ provider, preference: provider, source: "preference" });
+    }
+  });
+
   it("uses a trusted Runtime Session pin instead of a newer desktop preference", () => {
     writeAgentRuntimePreference("codex", preferencePath);
 

--- a/apps/web/tests/unit/native-agent-runner.test.ts
+++ b/apps/web/tests/unit/native-agent-runner.test.ts
@@ -161,9 +161,13 @@ describe("native agent runner", () => {
     expect(agent.config?.thinkingLevel).toBeUndefined();
   });
 
-  it("uses Hermes env defaults without reading Anthropic-compatible settings", async () => {
+  it("passes saved Anthropic-compatible settings to the Hermes process", async () => {
     const agent = new CapturingAgent();
-    const getUserLlmProviderConfig = vi.fn();
+    const getUserLlmProviderConfig = vi.fn(async () => ({
+      apiKey: "saved-hermes-key",
+      baseUrl: "https://anthropic.example.test",
+      model: "claude-hermes-test",
+    }));
     const host: NativeAgentHost = {
       registry: createRegistry(agent),
       prepareRequest: (body) =>
@@ -192,18 +196,26 @@ describe("native agent runner", () => {
 
     await collectMessages(run.generator);
 
-    expect(getUserLlmProviderConfig).not.toHaveBeenCalled();
+    expect(getUserLlmProviderConfig).toHaveBeenCalledWith({
+      userId: "user-1",
+      providerType: "anthropic_compatible",
+    });
     expect(agent.config).toMatchObject({
       provider: "hermes",
+      model: "claude-hermes-test",
       providerConfig: {
         hermesPath: "env-hermes",
         profile: "env-profile",
         timeoutMs: 5000,
+        env: {
+          HERMES_INFERENCE_PROVIDER: "anthropic",
+          ANTHROPIC_API_KEY: "saved-hermes-key",
+          ANTHROPIC_BASE_URL: "https://anthropic.example.test",
+        },
       },
     });
     expect(agent.config?.apiKey).toBeUndefined();
     expect(agent.config?.baseUrl).toBeUndefined();
-    expect(agent.config?.model).toBeUndefined();
     expect(agent.config?.thinkingLevel).toBeUndefined();
   });
 

--- a/apps/web/tests/unit/native-agent-runtime-preference.test.ts
+++ b/apps/web/tests/unit/native-agent-runtime-preference.test.ts
@@ -33,14 +33,21 @@ describe("agent runtime preference", () => {
     expect(readAgentRuntimePreference(filePath)).toBeUndefined();
   });
 
-  it("writes and replaces a Claude or Codex preference", () => {
+  it("writes and replaces any selectable runtime preference", () => {
     writeAgentRuntimePreference("claude", filePath);
     expect(readAgentRuntimePreference(filePath)).toBe("claude");
 
-    writeAgentRuntimePreference("codex", filePath);
-    expect(readAgentRuntimePreference(filePath)).toBe("codex");
+    for (const provider of [
+      "codex",
+      "opencode",
+      "hermes",
+      "openclaw",
+    ] as const) {
+      writeAgentRuntimePreference(provider, filePath);
+      expect(readAgentRuntimePreference(filePath)).toBe(provider);
+    }
     expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual({
-      provider: "codex",
+      provider: "openclaw",
     });
     expect(readdirSync(directory)).toEqual(["agent-runtime.json"]);
   });
@@ -60,7 +67,7 @@ describe("agent runtime preference", () => {
     writeFileSync(filePath, "not-json", "utf8");
     expect(readAgentRuntimePreference(filePath)).toBeUndefined();
 
-    writeFileSync(filePath, JSON.stringify({ provider: "opencode" }), "utf8");
+    writeFileSync(filePath, JSON.stringify({ provider: "unknown" }), "utf8");
     expect(readAgentRuntimePreference(filePath)).toBeUndefined();
     expect(warn).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/tests/unit/native-runtime-probe.test.ts
+++ b/apps/web/tests/unit/native-runtime-probe.test.ts
@@ -43,6 +43,9 @@ const {
   clearNativeRuntimeCaches,
   probeNativeClaudeRuntime,
   probeNativeCodexRuntime,
+  probeNativeHermesRuntime,
+  probeNativeOpenClawRuntime,
+  probeNativeOpenCodeRuntime,
 } = await import("@/lib/ai/native-agent/runtime-probe");
 const { resolveCodexCommand } =
   await import("@/lib/ai/extensions/agent/codex/command-resolver");
@@ -77,6 +80,21 @@ function completedProcess({
   return child as ChildProcess;
 }
 
+function hangingProcess(): ChildProcess {
+  type MutableChildProcess = {
+    -readonly [Key in keyof ChildProcess]: ChildProcess[Key];
+  };
+  const child = new EventEmitter() as MutableChildProcess;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = null;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.pid = 1234;
+  child.kill = vi.fn(() => true);
+  return child as ChildProcess;
+}
+
 describe("native agent runtime probes", () => {
   beforeEach(() => {
     clearNativeRuntimeCaches();
@@ -84,12 +102,21 @@ describe("native agent runtime probes", () => {
     existingPaths.clear();
     Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
     Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_CODEX_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_OPENCODE_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_HERMES_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_HERMES_PROFILE");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_OPENCLAW_COMMAND");
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     clearNativeRuntimeCaches();
     Reflect.deleteProperty(process.env, "CLAUDE_CODE_PATH");
     Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_CODEX_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_OPENCODE_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_HERMES_COMMAND");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_HERMES_PROFILE");
+    Reflect.deleteProperty(process.env, "OPENLOOMI_AGENT_OPENCLAW_COMMAND");
     vi.unstubAllEnvs();
   });
 
@@ -230,10 +257,16 @@ describe("native agent runtime probes", () => {
         completedProcess({ stdout: "Logged in using ChatGPT" }),
       )
       .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--json  Print events as JSONL" }),
+      )
+      .mockImplementationOnce(() =>
         completedProcess({ stdout: "codex-cli 1.2.1" }),
       )
       .mockImplementationOnce(() =>
         completedProcess({ stdout: "Logged in using ChatGPT" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--json  Print events as JSONL" }),
       );
 
     const initial = await probeNativeCodexRuntime();
@@ -247,13 +280,14 @@ describe("native agent runtime probes", () => {
     });
     expect(refreshed?.version).toBe("1.2.1");
     expect(spawnMock.mock.calls[1]?.[1]).toEqual(["login", "status"]);
+    expect(spawnMock.mock.calls[2]?.[1]).toEqual(["exec", "--help"]);
     expect(spawnMock.mock.calls[0]?.[2]?.env).toMatchObject({
       OPENAI_API_KEY: "codex-model-key",
     });
     expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty(
       "ANTHROPIC_AUTH_TOKEN",
     );
-    expect(spawnMock).toHaveBeenCalledTimes(4);
+    expect(spawnMock).toHaveBeenCalledTimes(6);
   });
 
   test("does not report an incomplete native Codex bundle as ready", async () => {
@@ -265,6 +299,9 @@ describe("native agent runtime probes", () => {
       )
       .mockImplementationOnce(() =>
         completedProcess({ stdout: "Logged in using ChatGPT" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--json  Print events as JSONL" }),
       );
 
     const probe = await probeNativeCodexRuntime({
@@ -303,6 +340,9 @@ describe("native agent runtime probes", () => {
       )
       .mockImplementationOnce(() =>
         completedProcess({ stdout: "Logged in using ChatGPT" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--json  Print events as JSONL" }),
       );
 
     const probe = await probeNativeCodexRuntime({
@@ -313,5 +353,154 @@ describe("native agent runtime probes", () => {
     expect(probe?.ready).toBe(true);
     expect(spawnMock.mock.calls[0]?.[0]).toBe(expectedCommand);
     expect(spawnMock.mock.calls[1]?.[0]).toBe(expectedCommand);
+    expect(spawnMock.mock.calls[2]?.[0]).toBe(expectedCommand);
+  });
+
+  test("checks OpenCode credentials and JSON output capability", async () => {
+    process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND = "C:\\fake\\opencode.exe";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "opencode 1.0.12" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "anthropic\nopenai" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--format <format>  default or json" }),
+      );
+
+    const probe = await probeNativeOpenCodeRuntime();
+
+    expect(probe).toMatchObject({
+      provider: "opencode",
+      ready: true,
+      authenticated: true,
+      version: "1.0.12",
+      reason: "OPENCODE_CLI_AUTHENTICATED",
+    });
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(["auth", "list"]);
+    expect(spawnMock.mock.calls[2]?.[1]).toEqual(["run", "--help"]);
+  });
+
+  test("reports OpenCode as needing sign-in when no credentials are listed", async () => {
+    process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND = "C:\\fake\\opencode.exe";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "1.0.12" }))
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "No credentials found" }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "--format <format>  default or json" }),
+      );
+
+    const probe = await probeNativeOpenCodeRuntime();
+
+    expect(probe).toMatchObject({
+      available: true,
+      ready: false,
+      reason: "OPENCODE_CLI_AUTH_REQUIRED",
+    });
+  });
+
+  test("checks Hermes setup and ACP capability", async () => {
+    process.env.OPENLOOMI_AGENT_HERMES_COMMAND = "C:\\fake\\hermes.exe";
+    process.env.OPENLOOMI_AGENT_HERMES_PROFILE = "coding";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_HERMES_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "0.9.0" }))
+      .mockImplementationOnce(() =>
+        completedProcess({
+          stdout:
+            "Provider: OpenRouter\nModel: test\nOpenRouter    ✓ configured",
+        }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "Commands:\n  acp" }),
+      );
+
+    const probe = await probeNativeHermesRuntime();
+
+    expect(probe).toMatchObject({
+      provider: "hermes",
+      ready: true,
+      version: "0.9.0",
+      reason: "HERMES_CLI_AUTHENTICATED",
+    });
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      "--profile",
+      "coding",
+      "status",
+    ]);
+    expect(spawnMock.mock.calls[2]?.[1]).toEqual(["--help"]);
+  });
+
+  test("does not report an unconfigured Hermes install as ready", async () => {
+    process.env.OPENLOOMI_AGENT_HERMES_COMMAND = "C:\\fake\\hermes.exe";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_HERMES_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "0.9.0" }))
+      .mockImplementationOnce(() =>
+        completedProcess({
+          stdout:
+            "Provider: OpenRouter\nModel: (not set)\nOpenRouter    ✗ (not set)",
+        }),
+      )
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: "Commands:\n  acp" }),
+      );
+
+    const probe = await probeNativeHermesRuntime();
+
+    expect(probe).toMatchObject({
+      provider: "hermes",
+      ready: false,
+      reason: "HERMES_CLI_AUTH_REQUIRED",
+    });
+  });
+
+  test("checks OpenClaw Gateway readiness without starting a task", async () => {
+    process.env.OPENLOOMI_AGENT_OPENCLAW_COMMAND = "C:\\fake\\openclaw.cmd";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_OPENCLAW_COMMAND);
+    spawnMock
+      .mockImplementationOnce(() => completedProcess({ stdout: "2026.7.1" }))
+      .mockImplementationOnce(() =>
+        completedProcess({ stdout: '{"rpc":{"ok":true}}' }),
+      );
+
+    const probe = await probeNativeOpenClawRuntime();
+
+    expect(probe).toMatchObject({
+      provider: "openclaw",
+      ready: true,
+      version: "2026.7.1",
+      reason: "OPENCLAW_CLI_AUTHENTICATED",
+    });
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      "gateway",
+      "status",
+      "--require-rpc",
+      "--json",
+      "--timeout",
+      "4000",
+    ]);
+  });
+
+  test("bounds all checks for one runtime to a single timeout window", async () => {
+    vi.useFakeTimers();
+    process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND = "C:\\fake\\opencode.exe";
+    existingPaths.add(process.env.OPENLOOMI_AGENT_OPENCODE_COMMAND);
+    spawnMock.mockImplementation(() => hangingProcess());
+
+    const pending = probeNativeOpenCodeRuntime();
+    await vi.advanceTimersByTimeAsync(10_000);
+    const probe = await pending;
+
+    expect(probe).toMatchObject({
+      ready: false,
+      reason: "OPENCODE_CLI_VERSION_TIMEOUT",
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -201,7 +201,7 @@ export interface NativeAgentHost {
   ) => Promise<NativeAgentInsightSettings | null>;
   getUserLlmProviderConfig?: (params: {
     userId: string;
-    providerType: "anthropic_compatible";
+    providerType: "openai_compatible" | "anthropic_compatible";
   }) => Promise<NativeAgentLlmProviderConfig | undefined>;
   getDocument?: (documentId: string) => Promise<NativeAgentDocument | null>;
   getDocumentChunks?: (
@@ -286,7 +286,8 @@ async function buildAgentConfig(
   recoveringRuntime: boolean,
 ): Promise<AgentConfig> {
   const provider = body.provider || "claude";
-  const useAnthropicCompatibleConfig = provider === "claude";
+  const useAnthropicCompatibleConfig =
+    provider === "claude" || provider === "hermes";
 
   const userAnthropicConfig = useAnthropicCompatibleConfig
     ? await host.getUserLlmProviderConfig?.({
@@ -313,10 +314,10 @@ async function buildAgentConfig(
   // model and runtime choices persisted with the provider session.
   return {
     provider,
-    apiKey: useAnthropicCompatibleConfig
+    apiKey: provider === "claude"
       ? effectiveModelConfig.apiKey
       : undefined,
-    baseUrl: useAnthropicCompatibleConfig
+    baseUrl: provider === "claude"
       ? effectiveModelConfig.baseUrl
       : undefined,
     model: effectiveModelConfig.model,
@@ -324,7 +325,42 @@ async function buildAgentConfig(
       ? body.modelConfig?.thinkingLevel
       : undefined,
     workDir: body.workDir,
-    providerConfig: body.providerConfig,
+    providerConfig:
+      provider === "hermes"
+        ? buildHermesApiProviderConfig(
+            body.providerConfig,
+            userAnthropicConfig,
+          )
+        : body.providerConfig,
+  };
+}
+
+/** Inject a saved OpenLoomi endpoint only into the Hermes child process. */
+export function buildHermesApiProviderConfig(
+  providerConfig: Record<string, unknown> | undefined,
+  apiConfig: NativeAgentLlmProviderConfig | undefined,
+): Record<string, unknown> | undefined {
+  if (!apiConfig?.apiKey || !apiConfig.baseUrl) return providerConfig;
+
+  const configuredEnv =
+    providerConfig?.env &&
+    typeof providerConfig.env === "object" &&
+    !Array.isArray(providerConfig.env)
+      ? Object.fromEntries(
+          Object.entries(providerConfig.env as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : {};
+
+  return {
+    ...providerConfig,
+    env: {
+      ...configuredEnv,
+      HERMES_INFERENCE_PROVIDER: "anthropic",
+      ANTHROPIC_API_KEY: apiConfig.apiKey,
+      ANTHROPIC_BASE_URL: apiConfig.baseUrl,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

This PR exposes all five supported local agent runtimes in the desktop settings:

- Claude
- Codex CLI
- OpenCode
- Hermes
- OpenClaw

Users can detect and select a runtime directly from the UI without configuring `OPENLOOMI_AGENT_PROVIDER`. The selected runtime is persisted as a desktop preference and applies to new tasks without interrupting running tasks.

Manual OpenAI-compatible and Anthropic-compatible API settings remain available and independent from runtime selection.

## Runtime detection

Add server-side readiness probes for installation, authentication, setup, and required runtime capabilities.

- Claude checks the bundled runtime, version, and authentication.
- Codex checks version, login status, JSON execution support, and Windows bundle completeness.
- OpenCode checks version, configured credentials, and JSON output support.
- Hermes checks version, configured model credentials, and ACP availability.
- OpenClaw checks version and authenticated Gateway RPC availability.

Probe failures are isolated per runtime. A broken or unavailable CLI is reported as not installed, sign-in required, setup required, or unable to verify instead of breaking the settings page.

The settings UI also provides runtime-specific installation or login guidance and supports re-detection without a full page reload.

During real-world testing, the original 5-second probe timeout was too short and occasionally caused installed runtimes to be missed, so the timeout has been unified to 10 seconds for more stable detection.

## Runtime configuration

Desktop runtime resolution now follows this order:

1. saved desktop preference
2. `OPENLOOMI_AGENT_PROVIDER`
3. Claude as the default

Codex probing uses the same Windows-aware command resolver as runtime execution. Incomplete native installations that cannot resolve the required sandbox helpers are not reported as ready. The probe also validates JSON execution support without starting a model request.

Hermes can reuse the current user's saved Anthropic-compatible endpoint, API key, and model. These values are passed only to the Hermes child-process environment and are not written into Hermes configuration files.

## Documentation and testing

Updated the runtime documentation and English/Chinese UI text for desktop selection, readiness states, setup guidance, and preference behavior.

Verification completed:

- TypeScript check passed
- 7 targeted test files passed
- 73 targeted tests passed
- staged diff check passed
- manually detected and selected the supported runtimes on Windows
- completed real chat requests through Hermes, OpenClaw, and OpenCode
- confirmed runtime preferences persist after reloading

Closes #408
Closes #502

<img width="1268" height="771" alt="image" src="https://github.com/user-attachments/assets/7f762f6a-0333-4d0f-a52c-2a2fe02b6ba6" />
