### PR TITLE
fix: roll back RAG document rows when the vector-store write fails

### DIFF
--- a/apps/web/lib/ai/rag/langchain-service.ts
+++ b/apps/web/lib/ai/rag/langchain-service.ts
@@ -297,7 +297,16 @@ export async function processDocument(
       },
     }));
 
-    await vectorStore.addChunks(vectorChunks);
+    try {
+      await vectorStore.addChunks(vectorChunks);
+    } catch (error) {
+      // These rows are already committed; roll them back or the document
+      // becomes an orphan that is visible in getUserDocuments() but
+      // unreachable via searchSimilarChunks() forever.
+      await db.delete(ragChunks).where(eq(ragChunks.documentId, document.id));
+      await db.delete(ragDocuments).where(eq(ragDocuments.id, document.id));
+      throw error;
+    }
     console.log("[RAG] Added chunks to vector store", {
       documentId: document.id,
       chunks: vectorChunks.length,

--- a/apps/web/tests/unit/rag-orphan-vectorstore-write.test.ts
+++ b/apps/web/tests/unit/rag-orphan-vectorstore-write.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for issue #535: processDocument() committed the document
+ * and chunk rows to SQL before the vector-store write, and never rolled
+ * them back if that write failed, leaving a document that is fully visible
+ * in getUserDocuments()/getUserRAGStats() but permanently unreachable via
+ * searchSimilarChunks().
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { addChunksMock, insertedDocumentIds, deleteCalls } = vi.hoisted(() => ({
+  addChunksMock: vi.fn(),
+  insertedDocumentIds: [] as string[],
+  deleteCalls: [] as string[],
+}));
+
+vi.mock("@/lib/env", () => ({
+  isTauriMode: () => false,
+  TAURI_DB_PATH: "/tmp/openloomi-test.db",
+}));
+
+vi.mock("@/lib/ai", () => ({
+  estimateTokens: (text: string) => text.length,
+}));
+
+vi.mock("@/lib/ai/user-embedding-settings", () => ({
+  createUserEmbeddingProvider: () => ({
+    embedDocuments: async (texts: string[]) =>
+      texts.map(() => [0.1, 0.2, 0.3]),
+  }),
+  getUserEmbeddingModelName: async () => "openai/text-embedding-3-small",
+  hasUserEmbeddingProviderConfig: () => true,
+}));
+
+vi.mock("@melandlabs/ai-rag/chroma-store", () => ({
+  getChromaVectorStore: () => ({ addChunks: addChunksMock }),
+}));
+
+vi.mock("@/lib/db", async () => {
+  const schema = await import("@/lib/db/schema");
+  return {
+    db: {
+      insert: (table: unknown) => ({
+        values: (data: any) => {
+          if (table === schema.ragDocuments) {
+            insertedDocumentIds.push(data.id);
+            // Only the document insert is followed by .returning(); the
+            // chunk batch insert below is awaited directly.
+            return { returning: async () => [{ ...data }] };
+          }
+          return Promise.resolve(undefined);
+        },
+      }),
+      delete: (table: unknown) => ({
+        where: async () => {
+          deleteCalls.push(table === schema.ragDocuments ? "documents" : "chunks");
+        },
+      }),
+    },
+  };
+});
+
+describe("processDocument vector-store write failure (issue #535)", () => {
+  beforeEach(() => {
+    addChunksMock.mockReset();
+    insertedDocumentIds.length = 0;
+    deleteCalls.length = 0;
+    process.env.RAG_VECTOR_STORE_BACKEND = "chroma";
+  });
+
+  it("VS-01: rolls back the document and its chunks when the vector-store write fails", async () => {
+    addChunksMock.mockRejectedValueOnce(new Error("vector store unavailable"));
+    const { processDocument } = await import("@/lib/ai/rag/langchain-service");
+
+    await expect(
+      processDocument("user-1", "free", "notes.txt", "text/plain", "hello world"),
+    ).rejects.toThrow("vector store unavailable");
+
+    expect(addChunksMock).toHaveBeenCalledTimes(1);
+    expect(insertedDocumentIds).toHaveLength(1);
+    // Final state: both the chunk rows and the document row were removed,
+    // chunks first (they carry the documentId foreign key).
+    expect(deleteCalls).toEqual(["chunks", "documents"]);
+  });
+
+  it("VS-02: leaves the document and its chunks committed when the vector-store write succeeds", async () => {
+    addChunksMock.mockResolvedValueOnce(undefined);
+    const { processDocument } = await import("@/lib/ai/rag/langchain-service");
+
+    const result = await processDocument(
+      "user-1",
+      "free",
+      "notes.txt",
+      "text/plain",
+      "hello world",
+    );
+
+    expect(addChunksMock).toHaveBeenCalledTimes(1);
+    expect(result.documentId).toBe(insertedDocumentIds[0]);
+    expect(deleteCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
`processDocument()` (`apps/web/lib/ai/rag/langchain-service.ts`) inserts the `ragDocuments` row and all `ragChunks` rows before calling `vectorStore.addChunks()`. If that call throws (network failure, native binding error, disk issue), the already-committed rows were never rolled back: the document showed up as fully processed in `getUserDocuments()`/`getUserRAGStats()` but stayed permanently unreachable via `searchSimilarChunks()`, since the vector-store side never received it, with no user-facing error and no retry path.

Fix: wrap the `vectorStore.addChunks()` call in try/catch. On failure, delete the just-inserted chunk and document rows (chunks first, they carry the `documentId` foreign key) before re-throwing, so a failed write leaves no trace instead of an orphan.

Scope note: `deleteUserDocuments()` in the same file has a related, lower-severity issue (a mid-loop vector-store-delete failure can abort before the SQL-side bulk deletes run). Left out of this PR to keep one focused change; happy to follow up separately if useful.

## Verification

- New test (`apps/web/tests/unit/rag-orphan-vectorstore-write.test.ts`): `VS-01` fails on `main` (asserts the rollback deletes) and passes on this branch; `VS-02` (success path leaves rows committed) passes on both. Ran both ways in the same container.
- Full `apps/web` suite (`pnpm --filter web test`, Node 22, matching this repo's CI install-per-version): 222/222 files, 2493/2493 tests pass, no regressions.
- `pnpm --filter web lint`, `prettier --check`, `pnpm --filter web tsc`: all clean on the changed files.
- Not independently re-run: the full suite on Node 24 (the second CI matrix leg). The new regression test itself passes there; the rest of the suite shares one `node_modules` across both local containers in my setup, which breaks native `better-sqlite3` bindings across Node versions unrelated to this change, so I did not treat that run as a clean signal.
