### PR TITLE
feat(agent): add one-click Codex CLI setup

### DIFF
--- a/apps/web/app/(chat)/api/preferences/agent-runtime/codex/install/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/codex/install/route.ts
@@ -1,0 +1,29 @@
+import { runCodexInstall } from "@/lib/ai/native-agent/codex-install";
+import {
+  authorizeCodexDesktopRequest,
+  codexErrorResponse,
+  codexNoStoreHeaders,
+} from "../route-helpers";
+
+export async function POST(request: Request) {
+  const authorization = await authorizeCodexDesktopRequest(request);
+  if (!authorization.authorized) return authorization.response;
+
+  const result = await runCodexInstall().catch(() => ({
+    status: "failed" as const,
+  }));
+  switch (result.status) {
+    case "completed":
+      return new Response(null, { status: 204, headers: codexNoStoreHeaders });
+    case "unsupported":
+      return codexErrorResponse("codex_install_unsupported_platform", 400);
+    case "powershell_unavailable":
+      return codexErrorResponse("codex_install_powershell_unavailable", 409);
+    case "verification_failed":
+      return codexErrorResponse("codex_install_verification_failed", 409);
+    case "timed_out":
+      return codexErrorResponse("codex_install_timed_out", 408);
+    case "failed":
+      return codexErrorResponse("codex_install_failed", 500);
+  }
+}

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/codex/login/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/codex/login/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+import { runCodexLogin } from "@/lib/ai/native-agent/codex-login";
+import { selectReadyAgentRuntime } from "@/lib/ai/native-agent/runtime-selection";
+import {
+  authorizeCodexDesktopRequest,
+  codexErrorResponse,
+  codexNoStoreHeaders,
+} from "../route-helpers";
+
+export async function POST(request: Request) {
+  const authorization = await authorizeCodexDesktopRequest(request);
+  if (!authorization.authorized) return authorization.response;
+
+  const result = await runCodexLogin().catch(() => ({
+    status: "failed" as const,
+  }));
+  switch (result.status) {
+    case "completed": {
+      try {
+        const selection = await selectReadyAgentRuntime(
+          authorization.userId,
+          "codex",
+        );
+        if (!selection.selected) {
+          return NextResponse.json(
+            { error: "runtime_not_ready", settings: selection.settings },
+            { status: 409, headers: codexNoStoreHeaders },
+          );
+        }
+        return NextResponse.json(selection.settings, {
+          headers: codexNoStoreHeaders,
+        });
+      } catch {
+        return codexErrorResponse("codex_runtime_enable_failed", 500);
+      }
+    }
+    case "unavailable":
+      return codexErrorResponse("codex_cli_unavailable", 409);
+    case "timed_out":
+      return codexErrorResponse("codex_login_timed_out", 408);
+    case "failed":
+      return codexErrorResponse("codex_login_failed", 500);
+  }
+}

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/codex/route-helpers.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/codex/route-helpers.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { getAuthUser } from "@/lib/auth/dual-auth";
+import { verifyToken } from "@/lib/auth/remote-auth-utils";
+import { isTauriMode } from "@/lib/env/constants";
+
+export const codexNoStoreHeaders = { "Cache-Control": "no-store" };
+const DESKTOP_REQUEST_HEADER = "OpenLoomiDesktop";
+
+export async function authorizeCodexDesktopRequest(
+  request: Request,
+): Promise<
+  | { authorized: true; userId: string }
+  | { authorized: false; response: NextResponse }
+> {
+  const authorization = request.headers.get("authorization");
+  let verifiedUserId: string | null = null;
+  if (authorization !== null) {
+    const token = authorization.startsWith("Bearer ")
+      ? authorization.slice(7).trim()
+      : "";
+    const verifiedToken = token ? verifyToken(token) : null;
+    if (!verifiedToken) {
+      return {
+        authorized: false,
+        response: codexErrorResponse("unauthorized", 401),
+      };
+    }
+    verifiedUserId = verifiedToken.id;
+  }
+
+  const user = await getAuthUser(request).catch(() => null);
+  if (!user || (verifiedUserId && user.id !== verifiedUserId)) {
+    return {
+      authorized: false,
+      response: codexErrorResponse("unauthorized", 401),
+    };
+  }
+  if (!isTauriMode()) {
+    return {
+      authorized: false,
+      response: codexErrorResponse("codex_setup_desktop_only", 403),
+    };
+  }
+  if (request.headers.get("x-requested-with") !== DESKTOP_REQUEST_HEADER) {
+    return {
+      authorized: false,
+      response: codexErrorResponse("invalid_desktop_request", 403),
+    };
+  }
+
+  return { authorized: true, userId: user.id };
+}
+
+export function codexErrorResponse(error: string, status: number) {
+  return NextResponse.json({ error }, { status, headers: codexNoStoreHeaders });
+}

--- a/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
+++ b/apps/web/app/(chat)/api/preferences/agent-runtime/route.ts
@@ -7,8 +7,11 @@ import {
   readAgentRuntimePreference,
   writeAgentRuntimePreference,
 } from "@/lib/ai/native-agent/runtime-preference";
+import {
+  getRuntimeApiConfiguration,
+  selectReadyAgentRuntime,
+} from "@/lib/ai/native-agent/runtime-selection";
 import { getAgentRuntimeSettings } from "@/lib/ai/native-agent/runtime-settings";
-import { getUserLlmProviderConfig } from "@/lib/ai/user-llm-api-settings";
 import { getAuthUser } from "@/lib/auth/dual-auth";
 import { isTauriMode } from "@/lib/env/constants";
 
@@ -19,19 +22,6 @@ const runtimePreferenceSchema = z
   .strict();
 
 const noStoreHeaders = { "Cache-Control": "no-store" };
-
-async function getRuntimeApiConfiguration(userId: string) {
-  const anthropicApiConfigured = Boolean(
-    await getUserLlmProviderConfig({
-      userId,
-      providerType: "anthropic_compatible",
-    }),
-  );
-  return {
-    claudeApiConfigured: anthropicApiConfigured,
-    hermesApiConfigured: anthropicApiConfigured,
-  };
-}
 
 export async function GET(request: Request) {
   const user = await getAuthUser(request).catch(() => null);
@@ -79,43 +69,14 @@ export async function PUT(request: Request) {
   }
 
   try {
-    let apiConfiguration = await getRuntimeApiConfiguration(user.id);
-    let readiness = await getAgentRuntimeSettings({
-      forceRefresh: true,
-      ...apiConfiguration,
-    });
-
-    // The runtime probe can take several seconds. If the user saves or removes
-    // the shared API configuration while it is running, remap readiness against
-    // the latest setting before persisting the choice.
-    if (parsed.data.provider === "claude" || parsed.data.provider === "hermes") {
-      const latestApiConfiguration = await getRuntimeApiConfiguration(user.id);
-      if (
-        latestApiConfiguration.claudeApiConfigured !==
-        apiConfiguration.claudeApiConfigured
-      ) {
-        apiConfiguration = latestApiConfiguration;
-        readiness = await getAgentRuntimeSettings(apiConfiguration);
-      }
-    }
-
-    if (!readiness.runtimes?.[parsed.data.provider].ready) {
+    const result = await selectReadyAgentRuntime(user.id, parsed.data.provider);
+    if (!result.selected) {
       return NextResponse.json(
-        { error: "runtime_not_ready", settings: readiness },
+        { error: "runtime_not_ready", settings: result.settings },
         { status: 409, headers: noStoreHeaders },
       );
     }
-
-    writeAgentRuntimePreference(parsed.data.provider);
-    const settings = {
-      ...readiness,
-      preference: parsed.data.provider,
-      effective: {
-        provider: parsed.data.provider,
-        source: "preference" as const,
-      },
-    };
-    return NextResponse.json(settings, { headers: noStoreHeaders });
+    return NextResponse.json(result.settings, { headers: noStoreHeaders });
   } catch (error) {
     console.error("[Agent Runtime Preferences] Failed to save state", error);
     return NextResponse.json(

--- a/apps/web/components/agent-runtime-settings.tsx
+++ b/apps/web/components/agent-runtime-settings.tsx
@@ -14,10 +14,7 @@ import {
   canSaveAgentRuntime,
   isSelectableAgentRuntime,
 } from "@/lib/ai/native-agent/runtime-contract";
-import {
-  CODEX_LOGIN_COMMAND,
-  getCodexInstallCommand,
-} from "@/lib/ai/native-agent/runtime-installation";
+import { getCodexInstallCommand } from "@/lib/ai/native-agent/runtime-installation";
 import { notifyAiSettingsChanged } from "@/lib/ai/notify-ai-settings-changed";
 import { isTauri, openUrl } from "@/lib/tauri";
 import { cn, fetchWithAuth } from "@/lib/utils";
@@ -48,7 +45,6 @@ const runtimeOptions: Array<{
     descriptionKey: "settings.agentRuntimeCodexDescription",
     descriptionFallback: "Use your local Codex CLI installation and account.",
     docsUrl: "https://learn.chatgpt.com/docs/codex/cli",
-    loginCommand: CODEX_LOGIN_COMMAND,
   },
   {
     provider: "opencode",
@@ -82,6 +78,13 @@ const runtimeOptions: Array<{
   },
 ];
 
+class ExpectedAgentRuntimeApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExpectedAgentRuntimeApiError";
+  }
+}
+
 export function AgentRuntimeSettings() {
   const { t } = useTranslation();
   const [desktop, setDesktop] = useState<boolean | null>(null);
@@ -90,6 +93,9 @@ export function AgentRuntimeSettings() {
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [codexSetupStage, setCodexSetupStage] = useState<
+    "installing" | "logging_in" | null
+  >(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const loadRequestId = useRef(0);
   const loadAbortController = useRef<AbortController | null>(null);
@@ -180,27 +186,68 @@ export function AgentRuntimeSettings() {
     [],
   );
 
-  const saveSelection = async () => {
+  const selectRuntime = async (
+    provider: SelectableAgentRuntime,
+    withCodexSetup = false,
+  ) => {
+    const codexStatus = state?.runtimes?.codex.status;
+    const canSetupCodex =
+      provider === "codex" &&
+      (codexStatus === "login_required" ||
+        (codexStatus === "not_installed" && state?.platform === "windows"));
     if (
       savingRef.current ||
       !state ||
-      !draft ||
-      !canSaveAgentRuntime(state, draft)
+      (!withCodexSetup && !canSaveAgentRuntime(state, provider)) ||
+      (withCodexSetup && !canSetupCodex)
     ) {
       return;
     }
+    const codexNeedsInstall = codexStatus === "not_installed";
+    let codexSetupPhase: "install" | "login" = codexNeedsInstall
+      ? "install"
+      : "login";
     ++loadRequestId.current;
     loadAbortController.current?.abort();
     loadAbortController.current = null;
     setLoading(false);
     setRefreshing(false);
     savingRef.current = true;
-    setSaving(true);
+    if (withCodexSetup) {
+      setCodexSetupStage(codexNeedsInstall ? "installing" : "logging_in");
+    } else setSaving(true);
     try {
-      const response = await fetchWithAuth("/api/preferences/agent-runtime", {
-        method: "PUT",
-        body: JSON.stringify({ provider: draft }),
-      });
+      let response: Response;
+      if (withCodexSetup) {
+        if (codexNeedsInstall) {
+          const installResponse = await fetchWithAuth(
+            "/api/preferences/agent-runtime/codex/install",
+            {
+              method: "POST",
+              headers: { "X-Requested-With": "OpenLoomiDesktop" },
+            },
+          );
+          if (!installResponse.ok) {
+            throw new ExpectedAgentRuntimeApiError(
+              `Codex install HTTP ${installResponse.status}`,
+            );
+          }
+          codexSetupPhase = "login";
+          setCodexSetupStage("logging_in");
+        }
+        response = await fetchWithAuth(
+          "/api/preferences/agent-runtime/codex/login",
+          {
+            method: "POST",
+            headers: { "X-Requested-With": "OpenLoomiDesktop" },
+          },
+        );
+      } else {
+        response = await fetchWithAuth("/api/preferences/agent-runtime", {
+          method: "PUT",
+          body: JSON.stringify({ provider }),
+        });
+      }
       const payload = (await response.json().catch(() => null)) as
         | AgentRuntimeSettingsResponse
         | { error?: string; settings?: AgentRuntimeSettingsResponse }
@@ -215,41 +262,76 @@ export function AgentRuntimeSettings() {
           setState(payload.settings);
           toast({
             type: "error",
-            description: t(
-              "settings.agentRuntimeNotReadyError",
-              "The selected runtime is no longer ready. Complete setup and check again.",
-            ),
+            description: withCodexSetup
+              ? t(
+                  "settings.agentRuntimeCodexLoginError",
+                  "Could not sign in or enable Codex. Try again.",
+                )
+              : t(
+                  "settings.agentRuntimeNotReadyError",
+                  "The selected runtime is no longer ready. Complete setup and check again.",
+                ),
           });
           return;
         }
-        throw new Error(`HTTP ${response.status}`);
+        throw new ExpectedAgentRuntimeApiError(`HTTP ${response.status}`);
       }
       if (!payload || !("editable" in payload)) {
         throw new Error("Invalid runtime settings response");
       }
       const nextState = payload;
       setState(nextState);
-      setDraft(draft);
+      setDraft(provider);
       notifyAiSettingsChanged();
       toast({
         type: "success",
-        description: t(
-          "settings.agentRuntimeSaved",
-          "Agent runtime updated for new tasks.",
-        ),
+        description: withCodexSetup
+          ? codexNeedsInstall
+            ? t(
+                "settings.agentRuntimeCodexInstallSuccess",
+                "Codex CLI is installed, signed in, and selected.",
+              )
+            : t(
+                "settings.agentRuntimeCodexLoginSuccess",
+                "Codex CLI is signed in and selected.",
+              )
+          : t(
+              "settings.agentRuntimeSaved",
+              "Agent runtime updated for new tasks.",
+            ),
       });
     } catch (error) {
-      console.error("[Agent Runtime Settings] Failed to save state", error);
+      const logMessage = withCodexSetup
+        ? codexSetupPhase === "install"
+          ? "[Agent Runtime Settings] Codex installation did not complete"
+          : "[Agent Runtime Settings] Codex sign-in did not complete"
+        : "[Agent Runtime Settings] Failed to save state";
+      if (error instanceof ExpectedAgentRuntimeApiError) {
+        console.warn(`${logMessage}: ${error.message}`);
+      } else {
+        console.error(logMessage, error);
+      }
       toast({
         type: "error",
-        description: t(
-          "settings.agentRuntimeSaveError",
-          "Failed to update the agent runtime.",
-        ),
+        description: withCodexSetup
+          ? codexSetupPhase === "install"
+            ? t(
+                "settings.agentRuntimeCodexInstallError",
+                "Could not install Codex CLI automatically. Use the manual instructions below, then try again.",
+              )
+            : t(
+                "settings.agentRuntimeCodexLoginError",
+                "Could not sign in or enable Codex. Try again.",
+              )
+          : t(
+              "settings.agentRuntimeSaveError",
+              "Failed to update the agent runtime.",
+            ),
       });
     } finally {
       savingRef.current = false;
       setSaving(false);
+      setCodexSetupStage(null);
       if (pendingReloadRef.current) {
         pendingReloadRef.current = false;
         void loadState();
@@ -308,9 +390,16 @@ export function AgentRuntimeSettings() {
     }
   };
 
+  const setupAndUseCodex = () => void selectRuntime("codex", true);
+
+  const saveSelection = () => {
+    if (draft) void selectRuntime(draft);
+  };
+
   const selectedOption = draft
     ? runtimeOptions.find((option) => option.provider === draft)
     : undefined;
+  const busy = saving || codexSetupStage !== null || loading || refreshing;
 
   if (desktop !== true) return null;
 
@@ -379,7 +468,7 @@ export function AgentRuntimeSettings() {
                   type="button"
                   variant="outline"
                   size="sm"
-                  disabled={saving || loading || refreshing}
+                  disabled={busy}
                   onClick={clearSelection}
                   className="shrink-0"
                 >
@@ -408,8 +497,7 @@ export function AgentRuntimeSettings() {
                       selected
                         ? "border-primary/50 bg-primary/5 ring-1 ring-primary/15"
                         : "border-border bg-background hover:border-foreground/20 hover:bg-muted/30",
-                      (saving || loading || refreshing) &&
-                        "pointer-events-none opacity-60",
+                      busy && "pointer-events-none opacity-60",
                     )}
                   >
                     <input
@@ -417,7 +505,7 @@ export function AgentRuntimeSettings() {
                       name="agent-runtime"
                       value={option.provider}
                       checked={selected}
-                      disabled={saving || loading || refreshing}
+                      disabled={busy}
                       onChange={() => setDraft(option.provider)}
                       className="sr-only"
                     />
@@ -468,11 +556,13 @@ export function AgentRuntimeSettings() {
                 probe={state.runtimes[draft]}
                 platform={state.platform}
                 active={state.effective.provider === draft}
-                busy={saving || loading || refreshing}
+                busy={busy}
                 refreshing={refreshing}
+                codexSetupStage={codexSetupStage}
                 canSave={canSaveAgentRuntime(state, draft)}
                 onRefresh={() => loadState(true)}
                 onSave={saveSelection}
+                onCodexSetup={setupAndUseCodex}
               />
             )}
           </>
@@ -535,9 +625,11 @@ function RuntimeSetupPanel({
   active,
   busy,
   refreshing,
+  codexSetupStage,
   canSave,
   onRefresh,
   onSave,
+  onCodexSetup,
 }: {
   option: (typeof runtimeOptions)[number];
   probe: AgentRuntimePublicProbe;
@@ -545,13 +637,22 @@ function RuntimeSetupPanel({
   active: boolean;
   busy: boolean;
   refreshing: boolean;
+  codexSetupStage: "installing" | "logging_in" | null;
   canSave: boolean;
   onRefresh: () => void;
   onSave: () => void;
+  onCodexSetup: () => void;
 }) {
   const { t } = useTranslation();
   const showGuide =
     probe.status === "not_installed" || probe.status === "unverified";
+  const codexNeedsInstall =
+    option.provider === "codex" &&
+    probe.status === "not_installed" &&
+    platform === "windows";
+  const showCodexSetup =
+    option.provider === "codex" &&
+    (probe.status === "login_required" || codexNeedsInstall);
   return (
     <div
       className="rounded-lg border border-border bg-background p-4 sm:p-5"
@@ -601,18 +702,54 @@ function RuntimeSetupPanel({
             />
             {t("settings.agentRuntimeCheckAgain", "Re-detect")}
           </Button>
-          <Button
-            type="button"
-            size="sm"
-            disabled={!canSave || busy}
-            onClick={onSave}
-          >
-            {active
-              ? t("settings.agentRuntimeInUse", "In use")
-              : t("settings.agentRuntimeUse", "Use {{runtime}}", {
-                  runtime: option.name,
-                })}
-          </Button>
+          {showCodexSetup ? (
+            <Button
+              type="button"
+              size="sm"
+              disabled={busy}
+              onClick={onCodexSetup}
+            >
+              {codexSetupStage && (
+                <RemixIcon
+                  name="loader_2"
+                  size="size-4"
+                  className="animate-spin"
+                />
+              )}
+              {codexSetupStage === "installing"
+                ? t(
+                    "settings.agentRuntimeCodexInstallWaiting",
+                    "Installing Codex CLI; browser sign-in will open next…",
+                  )
+                : codexSetupStage === "logging_in"
+                  ? t(
+                      "settings.agentRuntimeCodexLoginWaiting",
+                      "Finish signing in in your browser…",
+                    )
+                  : codexNeedsInstall
+                    ? t(
+                        "settings.agentRuntimeCodexInstallAndLogin",
+                        "Install and sign in to Codex",
+                      )
+                    : t(
+                        "settings.agentRuntimeCodexLogin",
+                        "Sign in and use Codex",
+                      )}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              disabled={!canSave || busy}
+              onClick={onSave}
+            >
+              {active
+                ? t("settings.agentRuntimeInUse", "In use")
+                : t("settings.agentRuntimeUse", "Use {{runtime}}", {
+                    runtime: option.name,
+                  })}
+            </Button>
+          )}
         </div>
       </div>
     </div>
@@ -666,6 +803,17 @@ function RuntimeSetupSummary({
           {t(
             "settings.agentRuntimeClaudeAuthenticationDescription",
             "Save an Anthropic-compatible API configuration below. If this OS account already has Claude authentication, check again to reuse it.",
+          )}
+        </p>
+      );
+    }
+
+    if (option.provider === "codex") {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "settings.agentRuntimeCodexLoginDescription",
+            "OpenLoomi will run Codex CLI's browser sign-in. After you finish signing in with ChatGPT, Codex will be checked and selected automatically.",
           )}
         </p>
       );
@@ -741,18 +889,28 @@ function CodexInstallSteps({
       ? "PowerShell"
       : t("settings.agentRuntimeTerminal", "Terminal");
   const checkAgain = t("settings.agentRuntimeCheckAgain", "Re-detect");
-  const useCodex = t("settings.agentRuntimeUse", "Use {{runtime}}", {
-    runtime: "Codex CLI",
-  });
-  const inUse = t("settings.agentRuntimeInUse", "In use");
+  const loginCodex = t(
+    "settings.agentRuntimeCodexLogin",
+    "Sign in and use Codex",
+  );
 
   return (
     <div className="space-y-3">
+      {platform === "windows" && (
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "settings.agentRuntimeCodexAutoInstallDescription",
+            "Selecting “Install and sign in to Codex” downloads and runs OpenAI's official installer for this Windows account, updates the user PATH, and then opens Codex's browser sign-in.",
+          )}
+        </p>
+      )}
       <p className="text-sm font-medium text-foreground">
-        {t(
-          "settings.agentRuntimeCodexInstallTitle",
-          "Install and sign in to Codex CLI",
-        )}
+        {platform === "windows"
+          ? t(
+              "settings.agentRuntimeCodexManualInstallTitle",
+              "Manual installation (fallback)",
+            )
+          : t("settings.agentRuntimeCodexInstallTitle", "Install Codex CLI")}
       </p>
       <ol className="list-decimal space-y-3 pl-5 text-sm text-muted-foreground">
         <li>
@@ -783,21 +941,11 @@ function CodexInstallSteps({
             )}
           </p>
         </li>
-        <li className="space-y-2 pl-1">
-          <p>
-            {t(
-              "settings.agentRuntimeCodexInstallSignIn",
-              "After the installer returns to {{terminal}}, close that window and open a new one. Run this command and finish signing in in your browser. When sign-in succeeds, you can close the browser page and {{terminal}}.",
-              { terminal },
-            )}
-          </p>
-          <CopyCommand command={CODEX_LOGIN_COMMAND} />
-        </li>
         <li>
           {t(
             "settings.agentRuntimeCodexInstallReturn",
-            "Return here and select {{checkAction}}. Once Codex CLI is ready, select {{useAction}} if it does not already show {{inUse}}. You do not need to restart OpenLoomi.",
-            { checkAction: checkAgain, useAction: useCodex, inUse },
+            "After installation, return here and select {{checkAction}}. When Codex CLI is found, select {{loginAction}} to finish in your browser and enable it automatically.",
+            { checkAction: checkAgain, loginAction: loginCodex },
           )}
         </li>
       </ol>

--- a/apps/web/i18n/locales/en-US.ts
+++ b/apps/web/i18n/locales/en-US.ts
@@ -414,7 +414,24 @@ const en = {
       "Run this command in a terminal, finish signing in, then check again.",
     agentRuntimeSetupDescription:
       "Run this command in a terminal, complete setup, then check again.",
-    agentRuntimeCodexInstallTitle: "Install and sign in to Codex CLI",
+    agentRuntimeCodexLoginDescription:
+      "OpenLoomi will run Codex CLI's browser sign-in. After you finish signing in with ChatGPT, Codex will be checked and selected automatically.",
+    agentRuntimeCodexLogin: "Sign in and use Codex",
+    agentRuntimeCodexLoginWaiting: "Finish signing in in your browser…",
+    agentRuntimeCodexLoginSuccess: "Codex CLI is signed in and selected.",
+    agentRuntimeCodexLoginError:
+      "Could not sign in or enable Codex. Try again.",
+    agentRuntimeCodexInstallAndLogin: "Install and sign in to Codex",
+    agentRuntimeCodexInstallWaiting:
+      "Installing Codex CLI; browser sign-in will open next…",
+    agentRuntimeCodexInstallSuccess:
+      "Codex CLI is installed, signed in, and selected.",
+    agentRuntimeCodexInstallError:
+      "Could not install Codex CLI automatically. Use the manual instructions below, then try again.",
+    agentRuntimeCodexAutoInstallDescription:
+      "Selecting “Install and sign in to Codex” downloads and runs OpenAI's official installer for this Windows account, updates the user PATH, and then opens Codex's browser sign-in.",
+    agentRuntimeCodexManualInstallTitle: "Manual installation (fallback)",
+    agentRuntimeCodexInstallTitle: "Install Codex CLI",
     agentRuntimeCodexInstallOpenTerminal: "Open {{terminal}}.",
     agentRuntimeCodexInstallRunInstaller:
       "Copy and run the official install command.",
@@ -422,10 +439,8 @@ const en = {
       'When "Start Codex now? [y/N]" appears at the end, press Enter to keep the default N. Do not start Codex yet.',
     agentRuntimeCodexInstallExitAccidentalLaunch:
       'If you already selected y and see "Hooks need review", select "3. Continue without trusting". After Codex opens, enter /exit or press Ctrl+C to close it.',
-    agentRuntimeCodexInstallSignIn:
-      "After the installer returns to {{terminal}}, close that window and open a new one. Run this command and finish signing in in your browser. When sign-in succeeds, you can close the browser page and {{terminal}}.",
     agentRuntimeCodexInstallReturn:
-      "Return here and select {{checkAction}}. Once Codex CLI is ready, select {{useAction}} if it does not already show {{inUse}}. You do not need to restart OpenLoomi.",
+      "After installation, return here and select {{checkAction}}. When Codex CLI is found, select {{loginAction}} to finish in your browser and enable it automatically.",
     agentRuntimeTerminal: "Terminal",
     agentRuntimeClaudeUnavailableDescription:
       "OpenLoomi could not load its built-in Claude runtime. Update or repair the desktop app, then check again.",

--- a/apps/web/i18n/locales/zh-Hans.ts
+++ b/apps/web/i18n/locales/zh-Hans.ts
@@ -395,17 +395,30 @@ const zh = {
       "请在终端运行以下命令并完成登录，然后重新检查。",
     agentRuntimeSetupDescription:
       "请在终端运行以下命令并完成配置，然后重新检查。",
-    agentRuntimeCodexInstallTitle: "安装并登录 Codex CLI",
+    agentRuntimeCodexLoginDescription:
+      "OpenLoomi 将启动 Codex CLI 的浏览器登录流程；完成 ChatGPT 登录后，会自动检测并启用 Codex。",
+    agentRuntimeCodexLogin: "登录并使用 Codex",
+    agentRuntimeCodexLoginWaiting: "请在浏览器中完成登录…",
+    agentRuntimeCodexLoginSuccess: "Codex CLI 已登录并设为当前运行时。",
+    agentRuntimeCodexLoginError: "无法登录或启用 Codex，请重试。",
+    agentRuntimeCodexInstallAndLogin: "一键安装并登录 Codex",
+    agentRuntimeCodexInstallWaiting:
+      "正在安装 Codex CLI，随后会打开浏览器登录…",
+    agentRuntimeCodexInstallSuccess: "Codex CLI 已安装、登录并设为当前运行时。",
+    agentRuntimeCodexInstallError:
+      "无法自动安装 Codex CLI。请按下方手动说明安装后重试。",
+    agentRuntimeCodexAutoInstallDescription:
+      "点击“一键安装并登录 Codex”会为当前 Windows 账号下载并运行 OpenAI 官方安装器、更新用户 PATH，然后打开 Codex 浏览器登录。",
+    agentRuntimeCodexManualInstallTitle: "手动安装（备用）",
+    agentRuntimeCodexInstallTitle: "安装 Codex CLI",
     agentRuntimeCodexInstallOpenTerminal: "打开 {{terminal}}。",
     agentRuntimeCodexInstallRunInstaller: "复制并运行以下官方安装命令。",
     agentRuntimeCodexInstallSkipLaunch:
       "安装结束时如果出现“Start Codex now? [y/N]”，直接按 Enter，保持默认选项 N；此时不要启动 Codex。",
     agentRuntimeCodexInstallExitAccidentalLaunch:
       "如果已经误选 y，并看到“Hooks need review”，请选择“3. Continue without trusting”。进入 Codex 后输入 /exit（或按 Ctrl+C）将其关闭。",
-    agentRuntimeCodexInstallSignIn:
-      "安装程序返回 {{terminal}} 后，关闭这个窗口，再打开一个新的 {{terminal}}。运行以下命令并在浏览器中完成登录；提示登录成功后，可以关闭浏览器页面和 {{terminal}}。",
     agentRuntimeCodexInstallReturn:
-      "回到这里点击“{{checkAction}}”。确认 Codex CLI 已就绪后，如果尚未显示“{{inUse}}”，再点击“{{useAction}}”。无需重启 OpenLoomi。",
+      "安装完成后回到这里点击“{{checkAction}}”。检测到 Codex CLI 后，点击“{{loginAction}}”，在浏览器完成登录即可自动启用。",
     agentRuntimeTerminal: "终端",
     agentRuntimeClaudeUnavailableDescription:
       "OpenLoomi 无法加载内置 Claude 运行组件。请更新或修复桌面应用，然后重新检查。",

--- a/apps/web/lib/ai/native-agent/codex-install.ts
+++ b/apps/web/lib/ai/native-agent/codex-install.ts
@@ -1,0 +1,155 @@
+import "server-only";
+
+import type { ChildProcess } from "node:child_process";
+import { homedir, platform } from "node:os";
+import { win32 } from "node:path";
+
+import spawn from "cross-spawn";
+
+import {
+  buildAgentCliSearchPath,
+  shouldDetachCliProcess,
+  terminateCliProcessTree,
+  trackCliProcess,
+} from "@/lib/ai/extensions/agent/cli-process";
+import { resolveCodexCommand } from "@/lib/ai/extensions/agent/codex/command-resolver";
+import {
+  buildCodexProcessEnvironment,
+  readProcessEnvironmentValue,
+} from "./codex-process-environment";
+import { CODEX_WINDOWS_INSTALLER_URL } from "./runtime-installation";
+
+const CODEX_INSTALL_TIMEOUT_MS = 8 * 60 * 1000;
+const CODEX_INSTALL_SCRIPT = `Invoke-RestMethod -Uri '${CODEX_WINDOWS_INSTALLER_URL}' | Invoke-Expression`;
+
+export type CodexInstallResult =
+  | { status: "completed" }
+  | { status: "failed" }
+  | { status: "powershell_unavailable" }
+  | { status: "timed_out" }
+  | { status: "unsupported" }
+  | { status: "verification_failed" };
+
+const installGlobal = globalThis as typeof globalThis & {
+  __openLoomiCodexInstall?: Promise<CodexInstallResult>;
+};
+
+/** Install the official standalone Windows bundle once for this OS account. */
+export function runCodexInstall(): Promise<CodexInstallResult> {
+  if (platform() !== "win32") {
+    return Promise.resolve({ status: "unsupported" });
+  }
+
+  const activeInstall = installGlobal.__openLoomiCodexInstall;
+  if (activeInstall) return activeInstall;
+
+  const pending = launchCodexInstall();
+  installGlobal.__openLoomiCodexInstall = pending;
+  const clearActiveInstall = () => {
+    if (installGlobal.__openLoomiCodexInstall === pending) {
+      Reflect.deleteProperty(installGlobal, "__openLoomiCodexInstall");
+    }
+  };
+  void pending.then(clearActiveInstall, clearActiveInstall);
+  return pending;
+}
+
+function launchCodexInstall(): Promise<CodexInstallResult> {
+  const searchPath = buildAgentCliSearchPath();
+  try {
+    resolveCodexCommand({ searchPath });
+    return Promise.resolve({ status: "completed" });
+  } catch {
+    // The setup button is idempotent: only install when no complete Codex
+    // bundle is currently discoverable.
+  }
+  const configuredLocalAppData =
+    readProcessEnvironmentValue("LOCALAPPDATA")?.trim();
+  const defaultLocalAppData = win32.join(homedir(), "AppData", "Local");
+  const localAppData =
+    configuredLocalAppData && win32.isAbsolute(configuredLocalAppData)
+      ? configuredLocalAppData
+      : defaultLocalAppData;
+  const configuredWindowsRoot =
+    readProcessEnvironmentValue("SYSTEMROOT")?.trim() ||
+    readProcessEnvironmentValue("WINDIR")?.trim();
+  const windowsRoot =
+    configuredWindowsRoot && win32.isAbsolute(configuredWindowsRoot)
+      ? configuredWindowsRoot
+      : "C:\\Windows";
+  const powershell = win32.join(
+    windowsRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  const environment = buildCodexProcessEnvironment(searchPath, {
+    omit: ["CODEX_INSTALL_DIR"],
+    overrides: {
+      CODEX_INSTALLER_USE_RELEASES_OPENAI_COM: "1",
+      CODEX_NON_INTERACTIVE: "1",
+      CODEX_RELEASE: "latest",
+      LOCALAPPDATA: localAppData,
+      OS: "Windows_NT",
+    },
+  });
+
+  return new Promise((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(
+        powershell,
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          CODEX_INSTALL_SCRIPT,
+        ],
+        {
+          detached: shouldDetachCliProcess(),
+          env: environment,
+          shell: false,
+          stdio: "ignore",
+          windowsHide: true,
+        },
+      );
+    } catch {
+      resolve({ status: "powershell_unavailable" });
+      return;
+    }
+
+    let settled = false;
+    const settle = (result: CodexInstallResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      terminateCliProcessTree(child);
+      settle({ status: "timed_out" });
+    }, CODEX_INSTALL_TIMEOUT_MS);
+    timer.unref?.();
+
+    trackCliProcess(child);
+    child.once("error", () => settle({ status: "powershell_unavailable" }));
+    child.once("close", (code) => {
+      if (code !== 0) {
+        settle({ status: "failed" });
+        return;
+      }
+      try {
+        // The installer updates the persisted user PATH, not this Node process.
+        // Rebuild the desktop search path and require a complete Codex bundle.
+        resolveCodexCommand({ searchPath: buildAgentCliSearchPath() });
+        settle({ status: "completed" });
+      } catch {
+        settle({ status: "verification_failed" });
+      }
+    });
+  });
+}

--- a/apps/web/lib/ai/native-agent/codex-login.ts
+++ b/apps/web/lib/ai/native-agent/codex-login.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import type { ChildProcess } from "node:child_process";
+
+import spawn from "cross-spawn";
+
+import {
+  buildAgentCliSearchPath,
+  shouldDetachCliProcess,
+  terminateCliProcessTree,
+  trackCliProcess,
+} from "@/lib/ai/extensions/agent/cli-process";
+import { resolveCodexCommand } from "@/lib/ai/extensions/agent/codex/command-resolver";
+import { buildCodexProcessEnvironment } from "./codex-process-environment";
+
+const CODEX_LOGIN_TIMEOUT_MS = 9 * 60 * 1000;
+
+export type CodexLoginResult =
+  | { status: "completed" }
+  | { status: "failed" }
+  | { status: "timed_out" }
+  | { status: "unavailable" };
+
+const loginGlobal = globalThis as typeof globalThis & {
+  __openLoomiCodexLogin?: Promise<CodexLoginResult>;
+};
+
+/** Run the CLI-owned browser sign-in flow once for this OS account. */
+export function runCodexLogin(): Promise<CodexLoginResult> {
+  const activeLogin = loginGlobal.__openLoomiCodexLogin;
+  if (activeLogin) return activeLogin;
+
+  const pending = launchCodexLogin();
+  loginGlobal.__openLoomiCodexLogin = pending;
+  const clearActiveLogin = () => {
+    if (loginGlobal.__openLoomiCodexLogin === pending) {
+      Reflect.deleteProperty(loginGlobal, "__openLoomiCodexLogin");
+    }
+  };
+  void pending.then(clearActiveLogin, clearActiveLogin);
+  return pending;
+}
+
+function launchCodexLogin(): Promise<CodexLoginResult> {
+  const searchPath = buildAgentCliSearchPath();
+  let command: string;
+  try {
+    command = resolveCodexCommand({
+      configuredCommand: process.env.OPENLOOMI_AGENT_CODEX_COMMAND,
+      searchPath,
+    });
+  } catch {
+    return Promise.resolve({ status: "unavailable" });
+  }
+
+  return new Promise((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(command, ["login"], {
+        detached: shouldDetachCliProcess(),
+        env: buildCodexProcessEnvironment(searchPath),
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      resolve({ status: "failed" });
+      return;
+    }
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      terminateCliProcessTree(child);
+      settle({ status: "timed_out" });
+    }, CODEX_LOGIN_TIMEOUT_MS);
+    timer.unref?.();
+    const settle = (result: CodexLoginResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    trackCliProcess(child);
+    child.once("error", () => settle({ status: "failed" }));
+    child.once("close", (code) => {
+      settle({ status: code === 0 ? "completed" : "failed" });
+    });
+  });
+}

--- a/apps/web/lib/ai/native-agent/codex-process-environment.ts
+++ b/apps/web/lib/ai/native-agent/codex-process-environment.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { buildCliEnvironment } from "@/lib/ai/extensions/agent/cli-process";
+
+const CODEX_PROCESS_EXTRA_ENV_KEYS = [
+  "ALL_PROXY",
+  "BROWSER",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "DISPLAY",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "WAYLAND_DISPLAY",
+  "XDG_RUNTIME_DIR",
+] as const;
+const CODEX_PROCESS_ENV_KEYS = new Set<string>([
+  "CODEX_CA_CERTIFICATE",
+  "CODEX_HOME",
+  "COMSPEC",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LC_ALL",
+  "NODE_ENV",
+  "PATH",
+  "PATHEXT",
+  "SHELL",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  ...CODEX_PROCESS_EXTRA_ENV_KEYS,
+]);
+const SECRET_ENV_NAME =
+  /(?:^|_)(?:API_KEY|AUTH_TOKEN|ACCESS_TOKEN|REFRESH_TOKEN|TOKEN|SECRET|PASSWORD)$|^DATABASE_URL$/i;
+
+export function buildCodexProcessEnvironment(
+  searchPath: string,
+  options: {
+    omit?: readonly string[];
+    overrides?: Record<string, string>;
+  } = {},
+): NodeJS.ProcessEnv {
+  const environment = buildCliEnvironment({ PATH: searchPath });
+
+  for (const key of CODEX_PROCESS_EXTRA_ENV_KEYS) {
+    const value = readProcessEnvironmentValue(key);
+    if (value) setEnvironmentValue(environment, key, value);
+  }
+  for (const key of Object.keys(environment)) {
+    if (
+      !CODEX_PROCESS_ENV_KEYS.has(key.toUpperCase()) ||
+      SECRET_ENV_NAME.test(key)
+    ) {
+      delete environment[key];
+    }
+  }
+  for (const key of options.omit ?? []) {
+    deleteEnvironmentValue(environment, key);
+  }
+  setEnvironmentValue(environment, "PATH", searchPath);
+  for (const [key, value] of Object.entries(options.overrides ?? {})) {
+    setEnvironmentValue(environment, key, value);
+  }
+
+  return environment;
+}
+
+export function readProcessEnvironmentValue(name: string): string | undefined {
+  const normalizedName = name.toUpperCase();
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.toUpperCase() === normalizedName) return value;
+  }
+  return undefined;
+}
+
+function setEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  name: string,
+  value: string,
+): void {
+  deleteEnvironmentValue(environment, name);
+  environment[name] = value;
+}
+
+function deleteEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): void {
+  const normalizedName = name.toUpperCase();
+  for (const key of Object.keys(environment)) {
+    if (key.toUpperCase() === normalizedName) delete environment[key];
+  }
+}

--- a/apps/web/lib/ai/native-agent/runtime-installation.ts
+++ b/apps/web/lib/ai/native-agent/runtime-installation.ts
@@ -2,9 +2,11 @@ import type { AgentRuntimeSettingsResponse } from "./runtime-contract";
 
 type AgentRuntimePlatform = AgentRuntimeSettingsResponse["platform"];
 
+export const CODEX_WINDOWS_INSTALLER_URL =
+  "https://chatgpt.com/codex/install.ps1";
+
 const CODEX_INSTALL_COMMANDS: Record<AgentRuntimePlatform, string> = {
-  windows:
-    'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+  windows: `powershell -ExecutionPolicy ByPass -c "irm ${CODEX_WINDOWS_INSTALLER_URL} | iex"`,
   macos: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
   linux: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
 };

--- a/apps/web/lib/ai/native-agent/runtime-selection.ts
+++ b/apps/web/lib/ai/native-agent/runtime-selection.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import type {
+  AgentRuntimeSettingsResponse,
+  SelectableAgentRuntime,
+} from "./runtime-contract";
+import { writeAgentRuntimePreference } from "./runtime-preference";
+import { getAgentRuntimeSettings } from "./runtime-settings";
+import { getUserLlmProviderConfig } from "../user-llm-api-settings";
+
+export async function getRuntimeApiConfiguration(userId: string) {
+  const anthropicApiConfigured = Boolean(
+    await getUserLlmProviderConfig({
+      userId,
+      providerType: "anthropic_compatible",
+    }),
+  );
+  return {
+    claudeApiConfigured: anthropicApiConfigured,
+    hermesApiConfigured: anthropicApiConfigured,
+  };
+}
+
+export async function selectReadyAgentRuntime(
+  userId: string,
+  provider: SelectableAgentRuntime,
+): Promise<
+  | { selected: true; settings: AgentRuntimeSettingsResponse }
+  | { selected: false; settings: AgentRuntimeSettingsResponse }
+> {
+  let apiConfiguration = await getRuntimeApiConfiguration(userId);
+  let readiness = await getAgentRuntimeSettings({
+    forceRefresh: true,
+    ...apiConfiguration,
+  });
+
+  // The runtime probe can take several seconds. If the shared API setting
+  // changes while it runs, remap Claude/Hermes against the latest value.
+  if (provider === "claude" || provider === "hermes") {
+    const latestApiConfiguration = await getRuntimeApiConfiguration(userId);
+    if (
+      latestApiConfiguration.claudeApiConfigured !==
+      apiConfiguration.claudeApiConfigured
+    ) {
+      apiConfiguration = latestApiConfiguration;
+      readiness = await getAgentRuntimeSettings(apiConfiguration);
+    }
+  }
+
+  if (!readiness.runtimes?.[provider].ready) {
+    return { selected: false, settings: readiness };
+  }
+
+  writeAgentRuntimePreference(provider);
+  return {
+    selected: true,
+    settings: {
+      ...readiness,
+      preference: provider,
+      effective: { provider, source: "preference" },
+    },
+  };
+}

--- a/apps/web/tests/api/codex-login.route.test.ts
+++ b/apps/web/tests/api/codex-login.route.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authState = vi.hoisted(() => ({
+  verifiedToken: { id: "user-1" } as { id: string } | null,
+  user: { id: "user-1" } as object | null,
+}));
+const modeState = vi.hoisted(() => ({ tauri: true }));
+const installState = vi.hoisted(() => ({ run: vi.fn() }));
+const loginState = vi.hoisted(() => ({ run: vi.fn() }));
+const selectionState = vi.hoisted(() => ({ select: vi.fn() }));
+
+vi.mock("@/lib/auth/dual-auth", () => ({
+  getAuthUser: vi.fn(async () => authState.user),
+}));
+vi.mock("@/lib/auth/remote-auth-utils", () => ({
+  verifyToken: vi.fn(() => authState.verifiedToken),
+}));
+vi.mock("@/lib/env/constants", () => ({
+  isTauriMode: vi.fn(() => modeState.tauri),
+}));
+vi.mock("@/lib/ai/native-agent/codex-login", () => ({
+  runCodexLogin: loginState.run,
+}));
+vi.mock("@/lib/ai/native-agent/codex-install", () => ({
+  runCodexInstall: installState.run,
+}));
+vi.mock("@/lib/ai/native-agent/runtime-selection", () => ({
+  selectReadyAgentRuntime: selectionState.select,
+}));
+
+const [{ POST: installCodex }, { POST: loginCodex }] = await Promise.all([
+  import("@/app/(chat)/api/preferences/agent-runtime/codex/install/route"),
+  import("@/app/(chat)/api/preferences/agent-runtime/codex/login/route"),
+]);
+
+function request(
+  options: {
+    bearer?: string;
+    desktopHeader?: boolean;
+  } = {},
+) {
+  const headers = new Headers();
+  if (options.bearer) {
+    headers.set("Authorization", `Bearer ${options.bearer}`);
+  }
+  if (options.desktopHeader) {
+    headers.set("X-Requested-With", "OpenLoomiDesktop");
+  }
+  return new Request(
+    "http://localhost/api/preferences/agent-runtime/codex/login",
+    { method: "POST", headers },
+  );
+}
+
+describe("Codex login route", () => {
+  beforeEach(() => {
+    authState.verifiedToken = { id: "user-1" };
+    authState.user = { id: "user-1" };
+    modeState.tauri = true;
+    installState.run.mockReset();
+    installState.run.mockResolvedValue({ status: "completed" });
+    loginState.run.mockReset();
+    loginState.run.mockResolvedValue({ status: "completed" });
+    selectionState.select.mockReset();
+    selectionState.select.mockResolvedValue({
+      selected: true,
+      settings: {
+        platform: "windows",
+        runtimes: {},
+        preference: "codex",
+        effective: { provider: "codex", source: "preference" },
+      },
+    });
+  });
+
+  test("blocks unauthenticated, non-desktop, and cross-site-style requests", async () => {
+    authState.user = null;
+    expect((await installCodex(request({ desktopHeader: true }))).status).toBe(
+      401,
+    );
+
+    authState.user = { id: "user-1" };
+    expect((await loginCodex(request())).status).toBe(403);
+
+    authState.verifiedToken = null;
+    expect(
+      (await installCodex(request({ bearer: "invalid", desktopHeader: true })))
+        .status,
+    ).toBe(401);
+
+    authState.verifiedToken = { id: "user-2" };
+    expect(
+      (await installCodex(request({ bearer: "valid", desktopHeader: true })))
+        .status,
+    ).toBe(401);
+
+    authState.verifiedToken = { id: "user-1" };
+    modeState.tauri = false;
+    expect((await installCodex(request({ desktopHeader: true }))).status).toBe(
+      403,
+    );
+    expect(installState.run).not.toHaveBeenCalled();
+    expect(loginState.run).not.toHaveBeenCalled();
+  });
+
+  test("installs without output, then verifies, logs in, and enables Codex", async () => {
+    const installResponse = await installCodex(
+      request({ desktopHeader: true }),
+    );
+    expect(installResponse.status).toBe(204);
+    expect(installResponse.headers.get("cache-control")).toBe("no-store");
+    expect(await installResponse.text()).toBe("");
+    expect(installState.run).toHaveBeenCalledOnce();
+
+    const loginResponse = await loginCodex(request({ desktopHeader: true }));
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.headers.get("cache-control")).toBe("no-store");
+    expect(await loginResponse.json()).toMatchObject({
+      preference: "codex",
+      effective: { provider: "codex", source: "preference" },
+    });
+    expect(loginState.run).toHaveBeenCalledOnce();
+    expect(selectionState.select).toHaveBeenCalledWith("user-1", "codex");
+
+    installState.run.mockResolvedValueOnce({
+      status: "verification_failed",
+    });
+    const failedVerification = await installCodex(
+      request({ desktopHeader: true }),
+    );
+    expect(failedVerification.status).toBe(409);
+    expect(await failedVerification.json()).toEqual({
+      error: "codex_install_verification_failed",
+    });
+  });
+});

--- a/apps/web/tests/unit/codex-login.test.ts
+++ b/apps/web/tests/unit/codex-login.test.ts
@@ -1,0 +1,194 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const processTools = vi.hoisted(() => ({
+  buildEnvironment: vi.fn(),
+  resolve: vi.fn(),
+  terminate: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: () => "C:\\Users\\test",
+    platform: () => "win32",
+  };
+});
+vi.mock("cross-spawn", () => ({ default: spawnMock }));
+vi.mock("@/lib/ai/extensions/agent/codex/command-resolver", () => ({
+  resolveCodexCommand: processTools.resolve,
+}));
+vi.mock("@/lib/ai/extensions/agent/cli-process", () => ({
+  buildAgentCliSearchPath: vi.fn(() => "C:\\safe-cli-path"),
+  buildCliEnvironment: processTools.buildEnvironment,
+  shouldDetachCliProcess: vi.fn(() => false),
+  terminateCliProcessTree: processTools.terminate,
+  trackCliProcess: processTools.track,
+}));
+
+const [{ runCodexInstall }, { runCodexLogin }] = await Promise.all([
+  import("@/lib/ai/native-agent/codex-install"),
+  import("@/lib/ai/native-agent/codex-login"),
+]);
+
+function childProcess(): ChildProcess {
+  type MutableChildProcess = {
+    -readonly [Key in keyof ChildProcess]: ChildProcess[Key];
+  };
+  const child = new EventEmitter() as MutableChildProcess;
+  child.stdout = null;
+  child.stderr = null;
+  child.stdin = null;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.pid = 1234;
+  child.kill = vi.fn(() => true);
+  return child as ChildProcess;
+}
+
+describe("Codex CLI browser login", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    processTools.buildEnvironment.mockReset();
+    processTools.buildEnvironment.mockReturnValue({
+      AWS_SECRET_ACCESS_KEY: "must-not-reach-login",
+      CODEX_CA_CERTIFICATE: "C:\\certs\\enterprise-ca.pem",
+      CODEX_API_KEY: "must-not-reach-login",
+      CODEX_HOME: "C:\\Users\\test\\.codex",
+      CODEX_INSTALL_DIR: "D:\\unexpected-install-directory",
+      DATABASE_URL: "postgres://must-not-reach-login",
+      OPENAI_API_KEY: "must-not-reach-login",
+      Path: "C:\\unsafe-cli-path",
+      PATH: "C:\\safe-cli-path",
+    });
+    processTools.resolve.mockReset();
+    processTools.resolve.mockReturnValue("C:\\Codex\\codex.exe");
+    processTools.terminate.mockReset();
+    processTools.track.mockReset();
+    vi.stubEnv("CODEX_HOME", "C:\\Users\\test\\.codex");
+    vi.stubEnv("OPENAI_API_KEY", "must-not-reach-login");
+    vi.stubEnv("CODEX_API_KEY", "must-not-reach-login");
+    vi.stubEnv("CODEX_INSTALL_DIR", "D:\\unexpected-install-directory");
+    vi.stubEnv("DATABASE_URL", "postgres://must-not-reach-login");
+    vi.stubEnv("LOCALAPPDATA", "C:\\Users\\test\\AppData\\Local");
+    vi.stubEnv("SYSTEMROOT", "C:\\Windows");
+    Reflect.deleteProperty(globalThis, "__openLoomiCodexInstall");
+    Reflect.deleteProperty(globalThis, "__openLoomiCodexLogin");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  test("spawns only the resolved login command with a restricted environment", async () => {
+    const child = childProcess();
+    spawnMock.mockReturnValue(child);
+
+    const login = runCodexLogin();
+    const concurrent = runCodexLogin();
+
+    expect(concurrent).toBe(login);
+    expect(processTools.resolve).toHaveBeenCalledWith({
+      configuredCommand: process.env.OPENLOOMI_AGENT_CODEX_COMMAND,
+      searchPath: "C:\\safe-cli-path",
+    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      "C:\\Codex\\codex.exe",
+      ["login"],
+      expect.objectContaining({
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      }),
+    );
+    const environment = spawnMock.mock.calls[0]?.[2]?.env;
+    expect(environment).toMatchObject({
+      CODEX_CA_CERTIFICATE: "C:\\certs\\enterprise-ca.pem",
+      CODEX_HOME: "C:\\Users\\test\\.codex",
+      PATH: "C:\\safe-cli-path",
+    });
+    expect(environment).not.toHaveProperty("OPENAI_API_KEY");
+    expect(environment).not.toHaveProperty("CODEX_API_KEY");
+    expect(environment).not.toHaveProperty("DATABASE_URL");
+    expect(processTools.track).toHaveBeenCalledWith(child);
+
+    child.emit("close", 0);
+    await expect(login).resolves.toEqual({ status: "completed" });
+  });
+
+  test("runs the fixed non-interactive installer once and unlocks after timeout", async () => {
+    const installedChild = childProcess();
+    processTools.resolve
+      .mockImplementationOnce(() => {
+        throw new Error("not installed");
+      })
+      .mockReturnValueOnce("C:\\Codex\\codex.exe");
+    spawnMock.mockReturnValueOnce(installedChild);
+
+    const install = runCodexInstall();
+    const concurrent = runCodexInstall();
+
+    expect(concurrent).toBe(install);
+    expect(spawnMock).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Invoke-RestMethod -Uri 'https://chatgpt.com/codex/install.ps1' | Invoke-Expression",
+      ],
+      expect.objectContaining({
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      }),
+    );
+    const environment = spawnMock.mock.calls[0]?.[2]?.env;
+    expect(environment).toMatchObject({
+      CODEX_INSTALLER_USE_RELEASES_OPENAI_COM: "1",
+      CODEX_NON_INTERACTIVE: "1",
+      CODEX_RELEASE: "latest",
+      LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local",
+      OS: "Windows_NT",
+      PATH: "C:\\safe-cli-path",
+    });
+    expect(environment).not.toHaveProperty("CODEX_INSTALL_DIR");
+    expect(environment).not.toHaveProperty("AWS_SECRET_ACCESS_KEY");
+    expect(environment).not.toHaveProperty("OPENAI_API_KEY");
+    expect(environment).not.toHaveProperty("CODEX_API_KEY");
+    expect(environment).not.toHaveProperty("DATABASE_URL");
+    expect(environment).not.toHaveProperty("Path");
+    expect(processTools.track).toHaveBeenCalledWith(installedChild);
+
+    installedChild.emit("close", 0);
+    await expect(install).resolves.toEqual({ status: "completed" });
+    expect(processTools.resolve).toHaveBeenLastCalledWith({
+      searchPath: "C:\\safe-cli-path",
+    });
+
+    vi.useFakeTimers();
+    processTools.resolve.mockImplementationOnce(() => {
+      throw new Error("not installed");
+    });
+    const hangingChild = childProcess();
+    spawnMock.mockReturnValueOnce(hangingChild);
+    const timedOut = runCodexInstall();
+    await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    await expect(timedOut).resolves.toEqual({ status: "timed_out" });
+    expect(processTools.terminate).toHaveBeenCalledWith(hangingChild);
+
+    processTools.resolve.mockReturnValueOnce("C:\\Codex\\codex.exe");
+    await expect(runCodexInstall()).resolves.toEqual({ status: "completed" });
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a one-click Codex CLI setup action to the Agent Runtime settings on Windows.
- Run OpenAI's official standalone installer and verify that a complete Codex bundle is available.
- Start the CLI-owned browser sign-in flow after installation.
- Re-detect and select Codex automatically after sign-in succeeds.
- Support authenticated desktop session cookies while strictly validating Bearer tokens when present.
- Keep manual installation instructions as a fallback and for non-Windows platforms.

## Why

OpenLoomi already supports Codex as a local agent runtime, but users previously had to install the CLI, run `codex login`, return to the application, and select the runtime manually.

This change provides an OAuth-like onboarding flow without OpenLoomi handling ChatGPT credentials or Codex authentication tokens.

## Security

- The setup routes are available only in OpenLoomi Desktop.
- Installation requires an authenticated user and an explicit desktop request header.
- Bearer tokens are signature-verified when present; existing desktop session cookies are also supported.
- The installer uses a fixed OpenAI URL and an absolute Windows PowerShell executable.
- PowerShell runs with `-NoProfile`, `-NonInteractive`, and `shell: false`.
- The child process receives a restricted environment without API keys or application secrets.
- Installation and login processes have timeouts and process-tree cleanup.
- CLI output is not returned to the browser.
- Conflicting installations are not automatically deleted or migrated.

## Validation

- [x] Focused agent-runtime test suite: 40/40 passed
- [x] TypeScript typecheck
- [x] Biome lint
- [x] Prettier check
- [x] `git diff --check`
- [x] Real Windows installation and browser sign-in retry after the authentication fix

Closes #114