### PR TITLE
chore(release): bump download links to v0.9.0

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -63,16 +63,16 @@ OpenLoomiは、オープンソースのAIパートナーです。デスクトッ
 **直接ダウンロード**（エンドユーザー向け）:
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
 </p>
 
 詳細なドキュメントは[こちら](https://openloomi.ai/docs)で確認できます。

--- a/README-zh.md
+++ b/README-zh.md
@@ -64,16 +64,16 @@
 **直接下载**（面向终端用户）：
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
 </p>
 
 完整文档请访问 [openloomi.ai/docs](https://openloomi.ai/docs)。

--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ An always-on desktop **attention agent** â€” the friendly desk companion Loomi â
 **Download directly** (for end users):
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg"><img src="https://img.shields.io/badge/macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg"><img src="https://img.shields.io/badge/macOS_Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe"><img src="https://img.shields.io/badge/Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
-  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb"><img src="https://img.shields.io/badge/Linux_AMD64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.rpm"><img src="https://img.shields.io/badge/Linux_AMD64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AMD64 .rpm"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb"><img src="https://img.shields.io/badge/Linux_ARM64_(.deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .deb"></a>
+  <a href="https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.rpm"><img src="https://img.shields.io/badge/Linux_ARM64_(.rpm)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux ARM64 .rpm"></a>
 </p>
 
 Full documentation: [openloomi.ai/docs](https://openloomi.ai/docs)

--- a/apps/marketing/app/home-client.jsx
+++ b/apps/marketing/app/home-client.jsx
@@ -20,19 +20,19 @@ const data = {
   downloadLinks: {
     macOS: {
       arm64:
-        "https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg",
       amd64:
-        "https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg",
     },
     linux: {
       amd64:
-        "https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb",
       arm64:
-        "https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb",
     },
     windows: {
       amd64:
-        "https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe",
+        "https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe",
       arm64: null,
     },
     github: "https://github.com/melandlabs/openloomi/releases",

--- a/apps/marketing/blogs/why-we-open-sourced-openloomi-ai.md
+++ b/apps/marketing/blogs/why-we-open-sourced-openloomi-ai.md
@@ -161,11 +161,11 @@ Star the repo, read the source, open issues, or fork it — everything lives the
 
 | Platform            | Download                                                                                                   |
 | ------------------- | ---------------------------------------------------------------------------------------------------------- |
-| macOS Apple Silicon | [.dmg](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg) |
-| macOS Intel         | [.dmg](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg)   |
-| Linux AMD64         | [.deb](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb)   |
-| Linux ARM64         | [.deb](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb) |
-| Windows             | [.exe](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe) |
+| macOS Apple Silicon | [.dmg](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg) |
+| macOS Intel         | [.dmg](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg)   |
+| Linux AMD64         | [.deb](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb)   |
+| Linux ARM64         | [.deb](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb) |
+| Windows             | [.exe](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe) |
 
 Or clone and run it yourself:
 

--- a/apps/marketing/content/getting-started.mdx
+++ b/apps/marketing/content/getting-started.mdx
@@ -58,8 +58,8 @@ By the end of this page you should have:
 
 | Option                                                                                                                                        | Notes                                                      |
 | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| [Download .dmg installer (Apple Silicon)](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_aarch64.dmg) | Recommended for M1/M2/M3/M4 Macs — double-click to install |
-| [Download .dmg installer (Intel)](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_macOS_amd64.dmg)           | For Intel Macs                                             |
+| [Download .dmg installer (Apple Silicon)](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_aarch64.dmg) | Recommended for M1/M2/M3/M4 Macs — double-click to install |
+| [Download .dmg installer (Intel)](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_macOS_amd64.dmg)           | For Intel Macs                                             |
 | Homebrew                                                                                                                                      | For developers — see command below                         |
 
 ```bash
@@ -83,14 +83,14 @@ brew upgrade --cask openloomi
 
 | Option                                                                                                                              | Notes                                               |
 | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Download .deb package (x86_64)](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_amd64.deb)  | For x86_64 / AMD64 systems                          |
-| [Download .deb package (ARM64)](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_linux_aarch64.deb) | For ARM64 systems (e.g., Raspberry Pi, ARM servers) |
+| [Download .deb package (x86_64)](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_amd64.deb)  | For x86_64 / AMD64 systems                          |
+| [Download .deb package (ARM64)](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_linux_aarch64.deb) | For ARM64 systems (e.g., Raspberry Pi, ARM servers) |
 
 ```bash
-sudo dpkg -i openloomi_0.8.8_linux_amd64.deb
+sudo dpkg -i openloomi_0.9.0_linux_amd64.deb
 sudo apt-get install -f
 
-# Fix resource path (required for v0.8.8 and earlier)
+# Fix resource path (required for v0.9.0 and earlier)
 sudo ln -sf /usr/lib/openloomi/_up_ /usr/bin/_up_
 
 # Start the application
@@ -121,7 +121,7 @@ openloomi
 
 | Option                                                                                                                        | Notes                                               |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Download .exe installer](https://github.com/melandlabs/openloomi/releases/download/v0.8.8/openloomi_0.8.8_windows_amd64.exe) | Recommended — run the installer to set up OpenLoomi |
+| [Download .exe installer](https://github.com/melandlabs/openloomi/releases/download/v0.9.0/openloomi_0.9.0_windows_amd64.exe) | Recommended — run the installer to set up OpenLoomi |
 | Winget                                                                                                                        | Coming Soon                                         |
 
 <Callout type="warning">


### PR DESCRIPTION
## Summary

Updates all v0.8.8 download URLs and version references to v0.9.0 across README files, marketing app, blog post, and getting-started docs, in preparation for the v0.9.0 release.

## Changes

- README.md, README-ja.md, README-zh.md: bumped all macOS / Windows / Linux download badge URLs from v0.8.8 to v0.9.0
- apps/marketing/app/home-client.jsx: bumped download links for macOS, Linux, and Windows
- apps/marketing/blogs/why-we-open-sourced-openloomi-ai.md: bumped download table links
- apps/marketing/content/getting-started.mdx: bumped download links and the Linux package filename / "required for vX.X.X and earlier" note

## Notes

- Pure version bump — no functional changes
- All 6 files were updated consistently to keep download entry points in sync across locales and surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)